### PR TITLE
feat(pr-review): native PR review — diffs, comments, checks, approve & merge in-app

### DIFF
--- a/packages/core/src/git/router-schemas.ts
+++ b/packages/core/src/git/router-schemas.ts
@@ -434,99 +434,36 @@ export const updatePrByUrlOutput = z.object({
 });
 export type UpdatePrByUrlOutput = z.infer<typeof updatePrByUrlOutput>;
 
-// getPrInfoByUrl schemas — full PR overview (title/body/branches/stats) for
-// the native in-app PR view. Mirrors workspace-server's git schemas.
-export const getPrInfoByUrlInput = z.object({
-  prUrl: z.string(),
-});
-export const getPrInfoByUrlOutput = z.object({
-  number: z.number(),
-  title: z.string(),
-  body: z.string(),
-  author: z.string().nullable(),
-  state: z.string(),
-  merged: z.boolean(),
-  draft: z.boolean(),
-  /** GitHub computes mergeability asynchronously; null until it settles. */
-  mergeable: z.boolean().nullable(),
-  baseRefName: z.string().nullable(),
-  headRefName: z.string().nullable(),
-  additions: z.number(),
-  deletions: z.number(),
-  changedFiles: z.number(),
-});
-export type PrInfoByUrlOutput = z.infer<typeof getPrInfoByUrlOutput>;
-
-export const approvePrInput = z.object({
-  prUrl: z.string(),
-});
-export const approvePrOutput = z.object({
-  success: z.boolean(),
-  message: z.string(),
-});
-export type ApprovePrOutput = z.infer<typeof approvePrOutput>;
-
-export const prMergeMethodSchema = z.enum(["merge", "squash", "rebase"]);
-export type PrMergeMethod = z.infer<typeof prMergeMethodSchema>;
-
-export const mergePrInput = z.object({
-  prUrl: z.string(),
-  method: prMergeMethodSchema,
-});
-export const mergePrOutput = z.object({
-  success: z.boolean(),
-  message: z.string(),
-});
-export type MergePrOutput = z.infer<typeof mergePrOutput>;
-
-// getPrChecks schemas — CI check runs / commit statuses for a PR, via
-// `gh pr checks`. Mirrors workspace-server's git schemas.
-export const prCheckBucketSchema = z.enum([
-  "fail",
-  "cancel",
-  "pending",
-  "pass",
-  "skipping",
-]);
-export type PrCheckBucket = z.infer<typeof prCheckBucketSchema>;
-
-export const prCheckSchema = z.object({
-  name: z.string(),
-  bucket: prCheckBucketSchema,
-  link: z.string().nullable(),
-  workflow: z.string().nullable(),
-  description: z.string().nullable(),
-});
-export type PrCheck = z.infer<typeof prCheckSchema>;
-
-export const getPrChecksInput = z.object({
-  prUrl: z.string(),
-});
-/** Null means the checks couldn't be fetched; [] means none reported. */
-export const getPrChecksOutput = z.array(prCheckSchema).nullable();
-export type GetPrChecksOutput = z.infer<typeof getPrChecksOutput>;
-
-// getPrComments schemas — conversation (issue) comments on a PR. Inline
-// review comments live in `getPrReviewComments`. Mirrors workspace-server's
-// git schemas.
-export const prConversationCommentSchema = z.object({
-  id: z.number(),
-  author: z.string(),
-  avatarUrl: z.string().nullable(),
-  body: z.string(),
-  createdAt: z.string(),
-  url: z.string().nullable(),
-});
-export type PrConversationComment = z.infer<typeof prConversationCommentSchema>;
-
-export const getPrCommentsInput = z.object({
-  prUrl: z.string(),
-});
-/** Null means the comments couldn't be fetched; [] means none. */
-export const getPrCommentsOutput = z
-  .array(prConversationCommentSchema)
-  .nullable();
-export type GetPrCommentsOutput = z.infer<typeof getPrCommentsOutput>;
+export type {
+  ApprovePrOutput,
+  GetPrChecksOutput,
+  GetPrCommentsOutput,
+  MergePrOutput,
+  PrCheck,
+  PrCheckBucket,
+  PrConversationComment,
+  PrInfoByUrlOutput,
+  PrMergeMethod,
+} from "@posthog/shared";
+// Native PR review schemas (PR overview, approve/merge, CI checks,
+// conversation comments) are defined once in `@posthog/shared`'s git domain
+// and re-exported here for the host router and UI.
+export {
+  approvePrInput,
+  approvePrOutput,
+  getPrChecksInput,
+  getPrChecksOutput,
+  getPrCommentsInput,
+  getPrCommentsOutput,
+  getPrInfoByUrlInput,
+  getPrInfoByUrlOutput,
+  mergePrInput,
+  mergePrOutput,
+  prCheckBucketSchema,
+  prCheckSchema,
+  prConversationCommentSchema,
+  prMergeMethodSchema,
+} from "@posthog/shared";
 
 export const getBranchChangedFilesInput = z.object({
   repo: z.string(),

--- a/packages/core/src/git/router-schemas.ts
+++ b/packages/core/src/git/router-schemas.ts
@@ -506,6 +506,28 @@ export const getPrChecksInput = z.object({
 export const getPrChecksOutput = z.array(prCheckSchema).nullable();
 export type GetPrChecksOutput = z.infer<typeof getPrChecksOutput>;
 
+// getPrComments schemas — conversation (issue) comments on a PR. Inline
+// review comments live in `getPrReviewComments`. Mirrors workspace-server's
+// git schemas.
+export const prConversationCommentSchema = z.object({
+  id: z.number(),
+  author: z.string(),
+  avatarUrl: z.string().nullable(),
+  body: z.string(),
+  createdAt: z.string(),
+  url: z.string().nullable(),
+});
+export type PrConversationComment = z.infer<typeof prConversationCommentSchema>;
+
+export const getPrCommentsInput = z.object({
+  prUrl: z.string(),
+});
+/** Null means the comments couldn't be fetched; [] means none. */
+export const getPrCommentsOutput = z
+  .array(prConversationCommentSchema)
+  .nullable();
+export type GetPrCommentsOutput = z.infer<typeof getPrCommentsOutput>;
+
 export const getBranchChangedFilesInput = z.object({
   repo: z.string(),
   branch: z.string(),

--- a/packages/core/src/git/router-schemas.ts
+++ b/packages/core/src/git/router-schemas.ts
@@ -434,6 +434,51 @@ export const updatePrByUrlOutput = z.object({
 });
 export type UpdatePrByUrlOutput = z.infer<typeof updatePrByUrlOutput>;
 
+// getPrInfoByUrl schemas — full PR overview (title/body/branches/stats) for
+// the native in-app PR view. Mirrors workspace-server's git schemas.
+export const getPrInfoByUrlInput = z.object({
+  prUrl: z.string(),
+});
+export const getPrInfoByUrlOutput = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string(),
+  author: z.string().nullable(),
+  state: z.string(),
+  merged: z.boolean(),
+  draft: z.boolean(),
+  /** GitHub computes mergeability asynchronously; null until it settles. */
+  mergeable: z.boolean().nullable(),
+  baseRefName: z.string().nullable(),
+  headRefName: z.string().nullable(),
+  additions: z.number(),
+  deletions: z.number(),
+  changedFiles: z.number(),
+});
+export type PrInfoByUrlOutput = z.infer<typeof getPrInfoByUrlOutput>;
+
+export const approvePrInput = z.object({
+  prUrl: z.string(),
+});
+export const approvePrOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+export type ApprovePrOutput = z.infer<typeof approvePrOutput>;
+
+export const prMergeMethodSchema = z.enum(["merge", "squash", "rebase"]);
+export type PrMergeMethod = z.infer<typeof prMergeMethodSchema>;
+
+export const mergePrInput = z.object({
+  prUrl: z.string(),
+  method: prMergeMethodSchema,
+});
+export const mergePrOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+export type MergePrOutput = z.infer<typeof mergePrOutput>;
+
 export const getBranchChangedFilesInput = z.object({
   repo: z.string(),
   branch: z.string(),

--- a/packages/core/src/git/router-schemas.ts
+++ b/packages/core/src/git/router-schemas.ts
@@ -479,6 +479,33 @@ export const mergePrOutput = z.object({
 });
 export type MergePrOutput = z.infer<typeof mergePrOutput>;
 
+// getPrChecks schemas — CI check runs / commit statuses for a PR, via
+// `gh pr checks`. Mirrors workspace-server's git schemas.
+export const prCheckBucketSchema = z.enum([
+  "fail",
+  "cancel",
+  "pending",
+  "pass",
+  "skipping",
+]);
+export type PrCheckBucket = z.infer<typeof prCheckBucketSchema>;
+
+export const prCheckSchema = z.object({
+  name: z.string(),
+  bucket: prCheckBucketSchema,
+  link: z.string().nullable(),
+  workflow: z.string().nullable(),
+  description: z.string().nullable(),
+});
+export type PrCheck = z.infer<typeof prCheckSchema>;
+
+export const getPrChecksInput = z.object({
+  prUrl: z.string(),
+});
+/** Null means the checks couldn't be fetched; [] means none reported. */
+export const getPrChecksOutput = z.array(prCheckSchema).nullable();
+export type GetPrChecksOutput = z.infer<typeof getPrChecksOutput>;
+
 export const getBranchChangedFilesInput = z.object({
   repo: z.string(),
   branch: z.string(),

--- a/packages/git/src/gh.ts
+++ b/packages/git/src/gh.ts
@@ -25,7 +25,16 @@ export interface GhExecOptions {
    * MCP tool awaiting it — indefinitely. Omit for no timeout.
    */
   timeoutMs?: number;
+  /**
+   * Max stdout/stderr bytes before the child is killed. Node's execFile
+   * default is 1 MiB, which paginated `gh api` calls (PR files, comments)
+   * blow past on busy PRs — the call then dies with "maxBuffer length
+   * exceeded" instead of returning data.
+   */
+  maxBuffer?: number;
 }
+
+const DEFAULT_MAX_BUFFER = 32 * 1024 * 1024;
 
 export function execGh(
   args: string[],
@@ -37,7 +46,12 @@ export function execGh(
     const child = childProcess.execFile(
       "gh",
       args,
-      { cwd: options.cwd, env, timeout: options.timeoutMs ?? 0 },
+      {
+        cwd: options.cwd,
+        env,
+        timeout: options.timeoutMs ?? 0,
+        maxBuffer: options.maxBuffer ?? DEFAULT_MAX_BUFFER,
+      },
       (error, stdout, stderr) => {
         if (!error) {
           resolve({ stdout, stderr, exitCode: 0 });

--- a/packages/host-router/src/routers/git.router.ts
+++ b/packages/host-router/src/routers/git.router.ts
@@ -10,6 +10,8 @@ import {
   GIT_WORKSPACE_CLIENT,
 } from "@posthog/core/git/identifiers";
 import {
+  approvePrInput,
+  approvePrOutput,
   checkoutBranchInput,
   checkoutBranchOutput,
   cloneRepositoryInput,
@@ -62,6 +64,8 @@ import {
   getPrDetailsByUrlOutput,
   getPrDiffStatsBatchInput,
   getPrDiffStatsBatchOutput,
+  getPrInfoByUrlInput,
+  getPrInfoByUrlOutput,
   getPrReviewCommentsInput,
   getPrReviewCommentsOutput,
   getPrTemplateInput,
@@ -72,6 +76,8 @@ import {
   ghStatusOutput,
   gitStateSnapshotSchema,
   gitStatusOutput,
+  mergePrInput,
+  mergePrOutput,
   openPrInput,
   openPrOutput,
   prStatusInput,
@@ -526,6 +532,34 @@ export const gitRouter = router({
       getWorkspaceClient(ctx.container).git.updatePrByUrl.mutate({
         prUrl: input.prUrl,
         action: input.action,
+      }),
+    ),
+
+  getPrInfoByUrl: publicProcedure
+    .input(getPrInfoByUrlInput)
+    .output(getPrInfoByUrlOutput.nullable())
+    .query(({ ctx, input }) =>
+      getWorkspaceClient(ctx.container).git.getPrInfoByUrl.query({
+        prUrl: input.prUrl,
+      }),
+    ),
+
+  approvePr: publicProcedure
+    .input(approvePrInput)
+    .output(approvePrOutput)
+    .mutation(({ ctx, input }) =>
+      getWorkspaceClient(ctx.container).git.approvePr.mutate({
+        prUrl: input.prUrl,
+      }),
+    ),
+
+  mergePr: publicProcedure
+    .input(mergePrInput)
+    .output(mergePrOutput)
+    .mutation(({ ctx, input }) =>
+      getWorkspaceClient(ctx.container).git.mergePr.mutate({
+        prUrl: input.prUrl,
+        method: input.method,
       }),
     ),
 

--- a/packages/host-router/src/routers/git.router.ts
+++ b/packages/host-router/src/routers/git.router.ts
@@ -60,6 +60,8 @@ import {
   getLocalBranchChangedFilesOutput,
   getPrChangedFilesInput,
   getPrChangedFilesOutput,
+  getPrChecksInput,
+  getPrChecksOutput,
   getPrDetailsByUrlInput,
   getPrDetailsByUrlOutput,
   getPrDiffStatsBatchInput,
@@ -540,6 +542,15 @@ export const gitRouter = router({
     .output(getPrInfoByUrlOutput.nullable())
     .query(({ ctx, input }) =>
       getWorkspaceClient(ctx.container).git.getPrInfoByUrl.query({
+        prUrl: input.prUrl,
+      }),
+    ),
+
+  getPrChecks: publicProcedure
+    .input(getPrChecksInput)
+    .output(getPrChecksOutput)
+    .query(({ ctx, input }) =>
+      getWorkspaceClient(ctx.container).git.getPrChecks.query({
         prUrl: input.prUrl,
       }),
     ),

--- a/packages/host-router/src/routers/git.router.ts
+++ b/packages/host-router/src/routers/git.router.ts
@@ -62,6 +62,8 @@ import {
   getPrChangedFilesOutput,
   getPrChecksInput,
   getPrChecksOutput,
+  getPrCommentsInput,
+  getPrCommentsOutput,
   getPrDetailsByUrlInput,
   getPrDetailsByUrlOutput,
   getPrDiffStatsBatchInput,
@@ -551,6 +553,15 @@ export const gitRouter = router({
     .output(getPrChecksOutput)
     .query(({ ctx, input }) =>
       getWorkspaceClient(ctx.container).git.getPrChecks.query({
+        prUrl: input.prUrl,
+      }),
+    ),
+
+  getPrComments: publicProcedure
+    .input(getPrCommentsInput)
+    .output(getPrCommentsOutput)
+    .query(({ ctx, input }) =>
+      getWorkspaceClient(ctx.container).git.getPrComments.query({
         prUrl: input.prUrl,
       }),
     ),

--- a/packages/shared/src/git-domain.ts
+++ b/packages/shared/src/git-domain.ts
@@ -67,3 +67,105 @@ export type GithubPullRequest = GithubRef;
 // git-interaction UI (PR status menu actions).
 export const prActionTypeSchema = z.enum(["close", "reopen", "ready", "draft"]);
 export type PrActionType = z.infer<typeof prActionTypeSchema>;
+
+// Native PR review schemas (PR overview, approve/merge, CI checks,
+// conversation comments). Defined once here and re-exported by
+// `@posthog/core/git/router-schemas` and workspace-server's git schemas so
+// the tRPC layers on both sides of the boundary share one source of truth.
+
+/** Full PR overview (title/body/branches/stats) for the native in-app PR view. */
+export const getPrInfoByUrlInput = z.object({ prUrl: z.string() });
+
+export const getPrInfoByUrlOutput = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string(),
+  author: z.string().nullable(),
+  state: z.string(),
+  merged: z.boolean(),
+  draft: z.boolean(),
+  /** GitHub computes mergeability asynchronously; null until it settles. */
+  mergeable: z.boolean().nullable(),
+  /**
+   * GitHub's `mergeable_state`: "clean" | "unstable" | "blocked" | "dirty" |
+   * "behind" | "draft" | "unknown". "blocked" means branch protection forbids
+   * the merge for this viewer — e.g. a required approving review is missing
+   * (authors can't approve their own PRs) or required checks are failing.
+   * Kept as a plain string so an undocumented value can't fail the parse.
+   */
+  mergeStateStatus: z.string().catch("unknown"),
+  baseRefName: z.string().nullable(),
+  headRefName: z.string().nullable(),
+  additions: z.number(),
+  deletions: z.number(),
+  changedFiles: z.number(),
+});
+
+export type PrInfoByUrlOutput = z.infer<typeof getPrInfoByUrlOutput>;
+
+export const approvePrInput = z.object({ prUrl: z.string() });
+
+export const approvePrOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+
+export type ApprovePrOutput = z.infer<typeof approvePrOutput>;
+
+export const prMergeMethodSchema = z.enum(["merge", "squash", "rebase"]);
+export type PrMergeMethod = z.infer<typeof prMergeMethodSchema>;
+
+export const mergePrInput = z.object({
+  prUrl: z.string(),
+  method: prMergeMethodSchema,
+});
+
+export const mergePrOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+
+export type MergePrOutput = z.infer<typeof mergePrOutput>;
+
+// CI check runs / commit statuses for a PR, via `gh pr checks`.
+export const prCheckBucketSchema = z.enum([
+  "fail",
+  "cancel",
+  "pending",
+  "pass",
+  "skipping",
+]);
+export type PrCheckBucket = z.infer<typeof prCheckBucketSchema>;
+
+export const prCheckSchema = z.object({
+  name: z.string(),
+  bucket: prCheckBucketSchema,
+  link: z.string().nullable(),
+  workflow: z.string().nullable(),
+  description: z.string().nullable(),
+});
+export type PrCheck = z.infer<typeof prCheckSchema>;
+
+export const getPrChecksInput = z.object({ prUrl: z.string() });
+/** Null means the checks couldn't be fetched; [] means none reported. */
+export const getPrChecksOutput = z.array(prCheckSchema).nullable();
+export type GetPrChecksOutput = z.infer<typeof getPrChecksOutput>;
+
+// Conversation (issue) comments and review summaries on a PR. Inline review
+// comments live in `prReviewThreadSchema` above.
+export const prConversationCommentSchema = z.object({
+  id: z.number(),
+  author: z.string(),
+  avatarUrl: z.string().nullable(),
+  body: z.string(),
+  createdAt: z.string(),
+  url: z.string().nullable(),
+});
+export type PrConversationComment = z.infer<typeof prConversationCommentSchema>;
+
+export const getPrCommentsInput = z.object({ prUrl: z.string() });
+/** Null means the comments couldn't be fetched; [] means none. */
+export const getPrCommentsOutput = z
+  .array(prConversationCommentSchema)
+  .nullable();
+export type GetPrCommentsOutput = z.infer<typeof getPrCommentsOutput>;

--- a/packages/ui/src/features/code-review/components/PatchedFileDiff.tsx
+++ b/packages/ui/src/features/code-review/components/PatchedFileDiff.tsx
@@ -2,7 +2,7 @@ import { type FileDiffMetadata, processFile } from "@pierre/diffs";
 import type { PrCommentThread } from "@posthog/core/code-review/types";
 import { isBinaryFile } from "@posthog/shared";
 import type { ChangedFile } from "@posthog/shared/domain-types";
-import { useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 import { DeferredDiffPlaceholder, DiffFileHeader } from "../reviewShellParts";
 import type { DiffOptions } from "../types";
 import { InteractiveFileDiff } from "./InteractiveFileDiff";
@@ -17,6 +17,8 @@ interface PatchedFileDiffProps {
   externalUrl?: string;
   prUrl?: string | null;
   commentThreads?: Map<number, PrCommentThread>;
+  /** Extra controls in the file header row (e.g. a "Viewed" toggle). */
+  headerTrailing?: ReactNode;
 }
 
 export function PatchedFileDiff({
@@ -29,6 +31,7 @@ export function PatchedFileDiff({
   externalUrl,
   prUrl,
   commentThreads,
+  headerTrailing,
 }: PatchedFileDiffProps) {
   const fileDiff = useMemo((): FileDiffMetadata | undefined => {
     if (!file.patch) return undefined;
@@ -60,6 +63,7 @@ export function PatchedFileDiff({
         collapsed={collapsed}
         onToggle={onToggle}
         externalUrl={externalUrl}
+        headerTrailing={headerTrailing}
       />
     );
   }
@@ -74,6 +78,7 @@ export function PatchedFileDiff({
         collapsed={collapsed}
         onToggle={onToggle}
         externalUrl={externalUrl}
+        headerTrailing={headerTrailing}
       />
     );
   }
@@ -90,6 +95,7 @@ export function PatchedFileDiff({
           fileDiff={fd}
           collapsed={collapsed}
           onToggle={onToggle}
+          trailing={headerTrailing}
         />
       )}
     />

--- a/packages/ui/src/features/code-review/components/PatchedFileDiff.tsx
+++ b/packages/ui/src/features/code-review/components/PatchedFileDiff.tsx
@@ -2,7 +2,7 @@ import { type FileDiffMetadata, processFile } from "@pierre/diffs";
 import type { PrCommentThread } from "@posthog/core/code-review/types";
 import { isBinaryFile } from "@posthog/shared";
 import type { ChangedFile } from "@posthog/shared/domain-types";
-import { type ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 import { DeferredDiffPlaceholder, DiffFileHeader } from "../reviewShellParts";
 import type { DiffOptions } from "../types";
 import { InteractiveFileDiff } from "./InteractiveFileDiff";
@@ -17,8 +17,6 @@ interface PatchedFileDiffProps {
   externalUrl?: string;
   prUrl?: string | null;
   commentThreads?: Map<number, PrCommentThread>;
-  /** Extra controls in the file header row (e.g. a "Viewed" toggle). */
-  headerTrailing?: ReactNode;
 }
 
 export function PatchedFileDiff({
@@ -31,7 +29,6 @@ export function PatchedFileDiff({
   externalUrl,
   prUrl,
   commentThreads,
-  headerTrailing,
 }: PatchedFileDiffProps) {
   const fileDiff = useMemo((): FileDiffMetadata | undefined => {
     if (!file.patch) return undefined;
@@ -63,7 +60,6 @@ export function PatchedFileDiff({
         collapsed={collapsed}
         onToggle={onToggle}
         externalUrl={externalUrl}
-        headerTrailing={headerTrailing}
       />
     );
   }
@@ -78,7 +74,6 @@ export function PatchedFileDiff({
         collapsed={collapsed}
         onToggle={onToggle}
         externalUrl={externalUrl}
-        headerTrailing={headerTrailing}
       />
     );
   }
@@ -95,7 +90,6 @@ export function PatchedFileDiff({
           fileDiff={fd}
           collapsed={collapsed}
           onToggle={onToggle}
-          trailing={headerTrailing}
         />
       )}
     />

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -209,7 +209,6 @@ export function DiffFileHeader({
   onDiscard,
   onStage,
   staged,
-  trailing,
 }: {
   fileDiff: FileDiffMetadata;
   collapsed: boolean;
@@ -218,8 +217,6 @@ export function DiffFileHeader({
   onDiscard?: () => void;
   onStage?: () => void;
   staged?: boolean;
-  /** Extra controls rendered after the action buttons (e.g. a "Viewed" toggle). */
-  trailing?: ReactNode;
 }) {
   const fullPath =
     fileDiff.prevName && fileDiff.prevName !== fileDiff.name
@@ -237,7 +234,7 @@ export function DiffFileHeader({
       collapsed={collapsed}
       onToggle={onToggle}
       trailing={
-        (onStage || onDiscard || onOpenFile || trailing) && (
+        (onStage || onDiscard || onOpenFile) && (
           <span className="ml-auto inline-flex items-center gap-[2px]">
             {onStage && (
               <Tooltip content={staged ? "Unstage" : "Stage"}>
@@ -281,7 +278,6 @@ export function DiffFileHeader({
                 </button>
               </Tooltip>
             )}
-            {trailing}
           </span>
         )
       }
@@ -298,7 +294,6 @@ export function DeferredDiffPlaceholder({
   onToggle,
   onShow,
   externalUrl,
-  headerTrailing,
 }: {
   filePath: string;
   linesAdded: number;
@@ -308,8 +303,6 @@ export function DeferredDiffPlaceholder({
   onToggle: () => void;
   onShow?: () => void;
   externalUrl?: string;
-  /** Extra controls in the header row (e.g. a "Viewed" toggle). */
-  headerTrailing?: ReactNode;
 }) {
   const { dirPath, fileName } = splitFilePath(filePath);
 
@@ -322,7 +315,6 @@ export function DeferredDiffPlaceholder({
         deletions={linesRemoved}
         collapsed={collapsed}
         onToggle={onToggle}
-        trailing={headerTrailing}
       />
       {!collapsed && (
         <div className="w-full border-b border-b-(--gray-5) bg-(--gray-2) p-[16px] text-center text-(--gray-9) text-xs">

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -29,7 +29,7 @@ export {
 
 const STICKY_HEADER_CSS = `[data-diffs-header] { position: sticky; top: 0; z-index: 1; background: var(--gray-2); }`;
 
-function useDiffOptions() {
+export function useDiffOptions() {
   const viewMode = useDiffViewerStore((s) => s.viewMode);
   const wordWrap = useDiffViewerStore((s) => s.wordWrap);
   const loadFullFiles = useDiffViewerStore((s) => s.loadFullFiles);
@@ -209,6 +209,7 @@ export function DiffFileHeader({
   onDiscard,
   onStage,
   staged,
+  trailing,
 }: {
   fileDiff: FileDiffMetadata;
   collapsed: boolean;
@@ -217,6 +218,8 @@ export function DiffFileHeader({
   onDiscard?: () => void;
   onStage?: () => void;
   staged?: boolean;
+  /** Extra controls rendered after the action buttons (e.g. a "Viewed" toggle). */
+  trailing?: ReactNode;
 }) {
   const fullPath =
     fileDiff.prevName && fileDiff.prevName !== fileDiff.name
@@ -234,7 +237,7 @@ export function DiffFileHeader({
       collapsed={collapsed}
       onToggle={onToggle}
       trailing={
-        (onStage || onDiscard || onOpenFile) && (
+        (onStage || onDiscard || onOpenFile || trailing) && (
           <span className="ml-auto inline-flex items-center gap-[2px]">
             {onStage && (
               <Tooltip content={staged ? "Unstage" : "Stage"}>
@@ -278,6 +281,7 @@ export function DiffFileHeader({
                 </button>
               </Tooltip>
             )}
+            {trailing}
           </span>
         )
       }
@@ -294,6 +298,7 @@ export function DeferredDiffPlaceholder({
   onToggle,
   onShow,
   externalUrl,
+  headerTrailing,
 }: {
   filePath: string;
   linesAdded: number;
@@ -303,6 +308,8 @@ export function DeferredDiffPlaceholder({
   onToggle: () => void;
   onShow?: () => void;
   externalUrl?: string;
+  /** Extra controls in the header row (e.g. a "Viewed" toggle). */
+  headerTrailing?: ReactNode;
 }) {
   const { dirPath, fileName } = splitFilePath(filePath);
 
@@ -315,6 +322,7 @@ export function DeferredDiffPlaceholder({
         deletions={linesRemoved}
         collapsed={collapsed}
         onToggle={onToggle}
+        trailing={headerTrailing}
       />
       {!collapsed && (
         <div className="w-full border-b border-b-(--gray-5) bg-(--gray-2) p-[16px] text-center text-(--gray-9) text-xs">

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -209,6 +209,7 @@ export function DiffFileHeader({
   onDiscard,
   onStage,
   staged,
+  trailing,
 }: {
   fileDiff: FileDiffMetadata;
   collapsed: boolean;
@@ -217,6 +218,8 @@ export function DiffFileHeader({
   onDiscard?: () => void;
   onStage?: () => void;
   staged?: boolean;
+  /** Extra controls rendered after the action buttons (e.g. a "Viewed" toggle). */
+  trailing?: ReactNode;
 }) {
   const fullPath =
     fileDiff.prevName && fileDiff.prevName !== fileDiff.name
@@ -234,7 +237,7 @@ export function DiffFileHeader({
       collapsed={collapsed}
       onToggle={onToggle}
       trailing={
-        (onStage || onDiscard || onOpenFile) && (
+        (onStage || onDiscard || onOpenFile || trailing) && (
           <span className="ml-auto inline-flex items-center gap-[2px]">
             {onStage && (
               <Tooltip content={staged ? "Unstage" : "Stage"}>
@@ -278,6 +281,7 @@ export function DiffFileHeader({
                 </button>
               </Tooltip>
             )}
+            {trailing}
           </span>
         )
       }
@@ -294,6 +298,7 @@ export function DeferredDiffPlaceholder({
   onToggle,
   onShow,
   externalUrl,
+  headerTrailing,
 }: {
   filePath: string;
   linesAdded: number;
@@ -303,6 +308,8 @@ export function DeferredDiffPlaceholder({
   onToggle: () => void;
   onShow?: () => void;
   externalUrl?: string;
+  /** Extra controls in the header row (e.g. a "Viewed" toggle). */
+  headerTrailing?: ReactNode;
 }) {
   const { dirPath, fileName } = splitFilePath(filePath);
 
@@ -315,6 +322,13 @@ export function DeferredDiffPlaceholder({
         deletions={linesRemoved}
         collapsed={collapsed}
         onToggle={onToggle}
+        trailing={
+          headerTrailing && (
+            <span className="ml-auto inline-flex items-center">
+              {headerTrailing}
+            </span>
+          )
+        }
       />
       {!collapsed && (
         <div className="w-full border-b border-b-(--gray-5) bg-(--gray-2) p-[16px] text-center text-(--gray-9) text-xs">

--- a/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -49,6 +49,8 @@ interface InboxDetailFrameProps {
     Icon: ComponentType<IconProps>;
     title: string;
   };
+  /** Sections rendered in the main column under the summary (e.g. PR files changed). */
+  belowSummary?: ReactNode;
   /** Optional "Evidence" section icon + title; null hides it. */
   evidenceSection: {
     Icon: ComponentType<IconProps>;
@@ -76,6 +78,7 @@ export function InboxDetailFrame({
   metaSuffix,
   primaryAction,
   summarySection,
+  belowSummary,
   evidenceSection,
   showDismiss = true,
   children,
@@ -173,7 +176,7 @@ export function InboxDetailFrame({
         */}
       <div className="@container mx-auto w-full max-w-[calc(160ch+5rem)] px-6 py-5 text-[13px]">
         <div className="grid @4xl:grid-cols-[minmax(0,80ch)_minmax(0,1fr)] grid-cols-1 gap-5">
-          <div className="min-w-0">
+          <div className="flex min-w-0 flex-col gap-5">
             <DetailSection Icon={SummaryIcon} title={summarySection.title}>
               <SignalReportSummaryMarkdown
                 content={report.summary}
@@ -182,6 +185,7 @@ export function InboxDetailFrame({
                 pending={report.status === "in_progress"}
               />
             </DetailSection>
+            {belowSummary}
           </div>
 
           <div className="flex min-w-0 flex-col gap-5">

--- a/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
@@ -129,7 +129,12 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
     >
       <ReportTasksSection report={report} />
       <SuggestedReviewersSection report={report} />
-      <ReportActivitySection reportId={report.id} />
+      <ReportActivitySection
+        reportId={report.id}
+        // The main column already lists every changed file, so the
+        // per-commit diff toggle in the activity log is redundant here.
+        hideCommitDiffs={Boolean(prRef && report.implementation_pr_url)}
+      />
     </InboxDetailFrame>
   );
 }

--- a/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
@@ -17,6 +17,7 @@ import { ReportTasksSection } from "@posthog/ui/features/inbox/components/Report
 import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components/SuggestedReviewersSection";
 import { ReportImplementationPrLink } from "@posthog/ui/features/inbox/components/utils/ReportImplementationPrLink";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
+import { PrChecksSection } from "@posthog/ui/features/pr-review/PrChecksSection";
 import { PrFilesChangedSection } from "@posthog/ui/features/pr-review/PrFilesChangedSection";
 import { PrReviewActions } from "@posthog/ui/features/pr-review/PrReviewActions";
 import { Text } from "@radix-ui/themes";
@@ -117,6 +118,7 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
         prRef && report.implementation_pr_url ? (
           <>
             <PrFilesChangedSection prUrl={report.implementation_pr_url} />
+            <PrChecksSection prUrl={report.implementation_pr_url} />
             <PrReviewActions prUrl={report.implementation_pr_url} />
           </>
         ) : undefined

--- a/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
@@ -18,6 +18,7 @@ import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components
 import { ReportImplementationPrLink } from "@posthog/ui/features/inbox/components/utils/ReportImplementationPrLink";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
 import { PrChecksSection } from "@posthog/ui/features/pr-review/PrChecksSection";
+import { PrCommentsSection } from "@posthog/ui/features/pr-review/PrCommentsSection";
 import { PrFilesChangedSection } from "@posthog/ui/features/pr-review/PrFilesChangedSection";
 import { PrReviewActions } from "@posthog/ui/features/pr-review/PrReviewActions";
 import { Text } from "@radix-ui/themes";
@@ -118,6 +119,7 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
         prRef && report.implementation_pr_url ? (
           <>
             <PrFilesChangedSection prUrl={report.implementation_pr_url} />
+            <PrCommentsSection prUrl={report.implementation_pr_url} />
             <PrChecksSection prUrl={report.implementation_pr_url} />
             <PrReviewActions prUrl={report.implementation_pr_url} />
           </>

--- a/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestDetail.tsx
@@ -17,6 +17,8 @@ import { ReportTasksSection } from "@posthog/ui/features/inbox/components/Report
 import { SuggestedReviewersSection } from "@posthog/ui/features/inbox/components/SuggestedReviewersSection";
 import { ReportImplementationPrLink } from "@posthog/ui/features/inbox/components/utils/ReportImplementationPrLink";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
+import { PrFilesChangedSection } from "@posthog/ui/features/pr-review/PrFilesChangedSection";
+import { PrReviewActions } from "@posthog/ui/features/pr-review/PrReviewActions";
 import { Text } from "@radix-ui/themes";
 
 interface PullRequestDetailProps {
@@ -111,6 +113,14 @@ function PullRequestDetailContent({ report }: { report: SignalReport }) {
         </>
       }
       summarySection={{ Icon: GitPullRequestIcon, title: "Summary" }}
+      belowSummary={
+        prRef && report.implementation_pr_url ? (
+          <>
+            <PrFilesChangedSection prUrl={report.implementation_pr_url} />
+            <PrReviewActions prUrl={report.implementation_pr_url} />
+          </>
+        ) : undefined
+      }
       evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}
     >
       <ReportTasksSection report={report} />

--- a/packages/ui/src/features/inbox/components/detail/ArtefactCommit.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactCommit.tsx
@@ -9,15 +9,19 @@ import { useState } from "react";
 /**
  * Renders a `commit` artefact: commit metadata plus a collapsible diff of the commit against
  * its parent, fetched lazily (on first expand) from the team's GitHub integration.
+ * `hideDiff` drops the diff toggle — used on the PR detail, where the main
+ * column already shows every changed file.
  */
 export function ArtefactCommit({
   reportId,
   artefactId,
   content,
+  hideDiff = false,
 }: {
   reportId: string;
   artefactId: string;
   content: CommitContent;
+  hideDiff?: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -43,21 +47,23 @@ export function ArtefactCommit({
         </Text>
       ) : null}
 
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        aria-expanded={expanded}
-        className="-mx-1 mt-1.5 flex items-center gap-1 rounded-md px-1 py-0.5 text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-3) hover:text-(--gray-12)"
-      >
-        {expanded ? (
-          <CaretDownIcon size={12} className="shrink-0" />
-        ) : (
-          <CaretRightIcon size={12} className="shrink-0" />
-        )}
-        {expanded ? "Hide diff" : "View diff"}
-      </button>
+      {!hideDiff && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          className="-mx-1 mt-1.5 flex items-center gap-1 rounded-md px-1 py-0.5 text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-3) hover:text-(--gray-12)"
+        >
+          {expanded ? (
+            <CaretDownIcon size={12} className="shrink-0" />
+          ) : (
+            <CaretRightIcon size={12} className="shrink-0" />
+          )}
+          {expanded ? "Hide diff" : "View diff"}
+        </button>
+      )}
 
-      {expanded ? (
+      {expanded && !hideDiff ? (
         <Box className="mt-1.5">
           {diffQuery.isLoading ? (
             <Flex

--- a/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ArtefactLogList.tsx
@@ -241,9 +241,11 @@ function ReviewersBody({ reviewers }: { reviewers: SuggestedReviewer[] }) {
 function ArtefactBody({
   reportId,
   artefact,
+  hideCommitDiffs,
 }: {
   reportId: string;
   artefact: AnySignalReportArtefact;
+  hideCommitDiffs?: boolean;
 }) {
   // Degraded rows carry a plain text preview instead of their type's content
   // shape — render that rather than feeding mismatched content to a typed body.
@@ -289,6 +291,7 @@ function ArtefactBody({
           reportId={reportId}
           artefactId={artefact.id}
           content={artefact.content as CommitContent}
+          hideDiff={hideCommitDiffs}
         />
       );
     case "task_run":
@@ -392,9 +395,11 @@ function ArtefactBody({
 function ArtefactRow({
   reportId,
   artefact,
+  hideCommitDiffs,
 }: {
   reportId: string;
   artefact: AnySignalReportArtefact;
+  hideCommitDiffs?: boolean;
 }) {
   const [showRaw, setShowRaw] = useState(false);
   const location = locationLabel(artefact);
@@ -436,7 +441,11 @@ function ArtefactRow({
           <RelativeTimestamp timestamp={artefact.created_at} />
         </Flex>
       </Flex>
-      <ArtefactBody reportId={reportId} artefact={artefact} />
+      <ArtefactBody
+        reportId={reportId}
+        artefact={artefact}
+        hideCommitDiffs={hideCommitDiffs}
+      />
       {showRaw ? (
         <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap rounded-md border border-(--gray-6) bg-(--gray-2) p-2 font-mono text-(--gray-11) text-[11px]">
           {JSON.stringify(artefact, null, 2)}
@@ -449,9 +458,12 @@ function ArtefactRow({
 export function ArtefactLogList({
   reportId,
   artefacts,
+  hideCommitDiffs,
 }: {
   reportId: string;
   artefacts: AnySignalReportArtefact[];
+  /** Drop the per-commit diff toggle (PR detail shows the full diff already). */
+  hideCommitDiffs?: boolean;
 }) {
   if (artefacts.length === 0) {
     return null;
@@ -469,6 +481,7 @@ export function ArtefactLogList({
           key={artefact.id}
           reportId={reportId}
           artefact={artefact}
+          hideCommitDiffs={hideCommitDiffs}
         />
       ))}
     </Flex>

--- a/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
+++ b/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
@@ -10,7 +10,14 @@ import { Text } from "@radix-ui/themes";
  * wherever it is rendered. Renders nothing while loading or when the report
  * has no artefacts.
  */
-export function ReportActivitySection({ reportId }: { reportId: string }) {
+export function ReportActivitySection({
+  reportId,
+  hideCommitDiffs,
+}: {
+  reportId: string;
+  /** Drop the per-commit diff toggle (PR detail shows the full diff already). */
+  hideCommitDiffs?: boolean;
+}) {
   // The log is a live work record — agents append artefacts while the report is
   // open, so don't let the app-wide 5-minute staleTime sit on it. Poll gently
   // while mounted.
@@ -32,7 +39,11 @@ export function ReportActivitySection({ reportId }: { reportId: string }) {
         </Text>
       }
     >
-      <ArtefactLogList reportId={reportId} artefacts={artefacts} />
+      <ArtefactLogList
+        reportId={reportId}
+        artefacts={artefacts}
+        hideCommitDiffs={hideCommitDiffs}
+      />
     </RightColumnSection>
   );
 }

--- a/packages/ui/src/features/pr-review/PrChecksSection.tsx
+++ b/packages/ui/src/features/pr-review/PrChecksSection.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowSquareOutIcon,
-  CaretDownIcon,
   CheckCircleIcon,
   ChecksIcon,
   CircleNotchIcon,
@@ -10,9 +9,9 @@ import {
 } from "@phosphor-icons/react";
 import type { PrCheck, PrCheckBucket } from "@posthog/core/git/router-schemas";
 import { Spinner } from "@posthog/quill";
-import { Text } from "@radix-ui/themes";
 import { useMemo, useState } from "react";
 import { openExternalUrl } from "../../shell/openExternal";
+import { PrSectionHeader } from "./PrSectionHeader";
 import { usePrChecks } from "./usePrChecks";
 
 /** Display order: failed first, then running, then succeeded, skipped last. */
@@ -64,12 +63,18 @@ export function PrChecksSection({ prUrl }: PrChecksSectionProps) {
 
   if (checksQuery.isLoading) {
     return (
-      <ChecksFrame collapsed onToggle={() => {}}>
-        <span className="inline-flex items-center gap-2 text-[11px] text-gray-10">
-          <Spinner />
-          Loading…
-        </span>
-      </ChecksFrame>
+      <PrSectionHeader
+        Icon={ChecksIcon}
+        title="Checks"
+        collapsed
+        onToggle={() => {}}
+        summary={
+          <span className="inline-flex items-center gap-2 text-[11px] text-gray-10">
+            <Spinner />
+            Loading…
+          </span>
+        }
+      />
     );
   }
 
@@ -92,12 +97,13 @@ export function PrChecksSection({ prUrl }: PrChecksSectionProps) {
 
   return (
     <div className="flex flex-col gap-3">
-      <ChecksFrame
+      <PrSectionHeader
+        Icon={ChecksIcon}
+        title="Checks"
         collapsed={collapsed}
         onToggle={() => setCollapsedOverride(!collapsed)}
-      >
-        <ChecksSummary counts={counts} />
-      </ChecksFrame>
+        summary={<ChecksSummary counts={counts} />}
+      />
       {!collapsed && (
         <div className="overflow-hidden rounded-md border border-(--gray-5)">
           {sorted.map((check, index) => (
@@ -109,44 +115,6 @@ export function PrChecksSection({ prUrl }: PrChecksSectionProps) {
         </div>
       )}
     </div>
-  );
-}
-
-/** Section header, matching the DetailSection chrome but clickable. */
-function ChecksFrame({
-  collapsed,
-  onToggle,
-  children,
-}: {
-  collapsed: boolean;
-  onToggle: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      className="flex w-full min-w-0 cursor-pointer items-center gap-3 border-0 bg-transparent p-0 text-left"
-    >
-      <span className="flex min-w-0 items-center gap-2">
-        <ChecksIcon size={15} weight="bold" className="shrink-0 text-gray-11" />
-        <Text className="truncate font-semibold text-[14px] text-gray-12 tracking-[-0.01em]">
-          Checks
-        </Text>
-      </span>
-      <div className="h-px min-w-4 flex-1 bg-(--gray-5)" />
-      <span className="flex shrink-0 items-center gap-2">
-        {children}
-        <CaretDownIcon
-          size={12}
-          className="text-(--gray-9)"
-          style={{
-            transform: collapsed ? "rotate(-90deg)" : "rotate(0deg)",
-            transition: "transform 0.15s",
-          }}
-        />
-      </span>
-    </button>
   );
 }
 

--- a/packages/ui/src/features/pr-review/PrChecksSection.tsx
+++ b/packages/ui/src/features/pr-review/PrChecksSection.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowSquareOutIcon,
   CheckCircleIcon,
+  CheckIcon,
   ChecksIcon,
   CircleNotchIcon,
   MinusCircleIcon,
@@ -9,12 +10,24 @@ import {
 } from "@phosphor-icons/react";
 import type { PrCheck, PrCheckBucket } from "@posthog/core/git/router-schemas";
 import { Spinner } from "@posthog/quill";
+import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
 import { useMemo, useState } from "react";
 import { openExternalUrl } from "../../shell/openExternal";
-import { PrSectionHeader } from "./PrSectionHeader";
 import { usePrChecks } from "./usePrChecks";
 
 /** Display order: failed first, then running, then succeeded, skipped last. */
+const BUCKET_META: Array<{
+  bucket: PrCheckBucket;
+  label: string;
+  labelClass: string;
+}> = [
+  { bucket: "fail", label: "failed", labelClass: "text-(--red-11)" },
+  { bucket: "cancel", label: "cancelled", labelClass: "text-gray-11" },
+  { bucket: "pending", label: "running", labelClass: "text-(--amber-11)" },
+  { bucket: "pass", label: "successful", labelClass: "text-(--green-11)" },
+  { bucket: "skipping", label: "skipped", labelClass: "text-gray-10" },
+];
+
 const BUCKET_ORDER: Record<PrCheckBucket, number> = {
   fail: 0,
   cancel: 1,
@@ -23,20 +36,23 @@ const BUCKET_ORDER: Record<PrCheckBucket, number> = {
   skipping: 4,
 };
 
+/** Buckets that need attention — shown by default. */
+const DEFAULT_VISIBLE: PrCheckBucket[] = ["fail", "cancel", "pending"];
+
 interface PrChecksSectionProps {
   prUrl: string;
 }
 
 /**
- * Collapsible CI status list for a PR, styled after GitHub's merge-box checks.
- * The header always shows a per-bucket summary; the section starts collapsed
- * when everything is green and expanded when something needs attention.
+ * CI status list for a PR. The header carries one checkbox per status bucket
+ * (failed, running, successful, …) that filters the rows below; only the
+ * attention-worthy buckets (failed, running) are shown by default.
  */
 export function PrChecksSection({ prUrl }: PrChecksSectionProps) {
   const checksQuery = usePrChecks(prUrl);
   const checks = checksQuery.data;
-  const [collapsedOverride, setCollapsedOverride] = useState<boolean | null>(
-    null,
+  const [visibleBuckets, setVisibleBuckets] = useState<Set<PrCheckBucket>>(
+    () => new Set(DEFAULT_VISIBLE),
   );
 
   const sorted = useMemo(
@@ -63,50 +79,61 @@ export function PrChecksSection({ prUrl }: PrChecksSectionProps) {
 
   if (checksQuery.isLoading) {
     return (
-      <PrSectionHeader
-        Icon={ChecksIcon}
-        title="Checks"
-        collapsed
-        onToggle={() => {}}
-        summary={
-          <span className="inline-flex items-center gap-2 text-[11px] text-gray-10">
-            <Spinner />
-            Loading…
-          </span>
-        }
-      />
+      <DetailSection Icon={ChecksIcon} title="Checks">
+        <div className="flex items-center gap-2 py-1 text-[12px] text-gray-10">
+          <Spinner />
+          Loading checks…
+        </div>
+      </DetailSection>
     );
   }
 
-  // Couldn't fetch (null) or nothing reported ([]) — no useful section either
-  // way, but only the fetch failure is worth a line of copy.
-  if (!checks || checks.length === 0) {
-    if (checks === null) {
-      return (
-        <div className="text-[12px] text-gray-10">
+  if (!checks) {
+    return (
+      <DetailSection Icon={ChecksIcon} title="Checks">
+        <div className="py-1 text-[12px] text-gray-10">
           Couldn't load CI checks for this pull request.
         </div>
-      );
-    }
-    return null;
+      </DetailSection>
+    );
   }
 
-  const allQuiet =
-    counts.fail === 0 && counts.cancel === 0 && counts.pending === 0;
-  const collapsed = collapsedOverride ?? allQuiet;
+  if (checks.length === 0) return null;
+
+  const toggleBucket = (bucket: PrCheckBucket) => {
+    setVisibleBuckets((prev) => {
+      const next = new Set(prev);
+      if (next.has(bucket)) next.delete(bucket);
+      else next.add(bucket);
+      return next;
+    });
+  };
+
+  const visible = sorted.filter((check) => visibleBuckets.has(check.bucket));
 
   return (
-    <div className="flex flex-col gap-3">
-      <PrSectionHeader
-        Icon={ChecksIcon}
-        title="Checks"
-        collapsed={collapsed}
-        onToggle={() => setCollapsedOverride(!collapsed)}
-        summary={<ChecksSummary counts={counts} />}
-      />
-      {!collapsed && (
+    <DetailSection
+      Icon={ChecksIcon}
+      title="Checks"
+      rightSlot={
+        <span className="flex items-center gap-1">
+          {BUCKET_META.map(({ bucket, label, labelClass }) =>
+            counts[bucket] > 0 ? (
+              <BucketFilterCheckbox
+                key={bucket}
+                checked={visibleBuckets.has(bucket)}
+                onToggle={() => toggleBucket(bucket)}
+                labelClass={labelClass}
+                label={`${counts[bucket]} ${label}`}
+              />
+            ) : null,
+          )}
+        </span>
+      }
+    >
+      {visible.length > 0 && (
         <div className="overflow-hidden rounded-md border border-(--gray-5)">
-          {sorted.map((check, index) => (
+          {visible.map((check, index) => (
             <CheckRow
               key={`${check.workflow ?? ""}/${check.name}/${index}`}
               check={check}
@@ -114,36 +141,39 @@ export function PrChecksSection({ prUrl }: PrChecksSectionProps) {
           ))}
         </div>
       )}
-    </div>
+    </DetailSection>
   );
 }
 
-function ChecksSummary({ counts }: { counts: Record<PrCheckBucket, number> }) {
-  const parts: React.ReactNode[] = [];
-  const push = (count: number, label: string, className: string) => {
-    if (count === 0) return;
-    parts.push(
-      <span key={label} className={className}>
-        {count} {label}
-      </span>,
-    );
-  };
-  push(counts.fail, "failed", "text-(--red-11)");
-  push(counts.cancel, "cancelled", "text-gray-11");
-  push(counts.pending, "running", "text-(--amber-11)");
-  push(counts.pass, "successful", "text-(--green-11)");
-  push(counts.skipping, "skipped", "text-gray-10");
-
+function BucketFilterCheckbox({
+  checked,
+  onToggle,
+  label,
+  labelClass,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  label: string;
+  labelClass: string;
+}) {
   return (
-    <span className="flex items-center gap-1 text-[11px] tabular-nums">
-      {parts.map((part, index) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: static separator list
-        <span key={index} className="flex items-center gap-1">
-          {index > 0 && <span className="text-(--gray-8)">·</span>}
-          {part}
-        </span>
-      ))}
-    </span>
+    <button
+      type="button"
+      aria-pressed={checked}
+      onClick={onToggle}
+      className="inline-flex shrink-0 cursor-pointer items-center gap-[5px] rounded border-0 bg-transparent px-[5px] py-[2px] text-[11px] hover:bg-gray-4"
+    >
+      <span
+        className={`inline-flex h-[13px] w-[13px] items-center justify-center rounded-[3px] border ${
+          checked
+            ? "border-(--accent-9) bg-(--accent-9) text-white"
+            : "border-(--gray-7)"
+        }`}
+      >
+        {checked && <CheckIcon size={9} weight="bold" />}
+      </span>
+      <span className={`tabular-nums ${labelClass}`}>{label}</span>
+    </button>
   );
 }
 

--- a/packages/ui/src/features/pr-review/PrChecksSection.tsx
+++ b/packages/ui/src/features/pr-review/PrChecksSection.tsx
@@ -1,0 +1,245 @@
+import {
+  ArrowSquareOutIcon,
+  CaretDownIcon,
+  CheckCircleIcon,
+  ChecksIcon,
+  CircleNotchIcon,
+  MinusCircleIcon,
+  ProhibitIcon,
+  XCircleIcon,
+} from "@phosphor-icons/react";
+import type { PrCheck, PrCheckBucket } from "@posthog/core/git/router-schemas";
+import { Spinner } from "@posthog/quill";
+import { Text } from "@radix-ui/themes";
+import { useMemo, useState } from "react";
+import { openExternalUrl } from "../../shell/openExternal";
+import { usePrChecks } from "./usePrChecks";
+
+/** Display order: failed first, then running, then succeeded, skipped last. */
+const BUCKET_ORDER: Record<PrCheckBucket, number> = {
+  fail: 0,
+  cancel: 1,
+  pending: 2,
+  pass: 3,
+  skipping: 4,
+};
+
+interface PrChecksSectionProps {
+  prUrl: string;
+}
+
+/**
+ * Collapsible CI status list for a PR, styled after GitHub's merge-box checks.
+ * The header always shows a per-bucket summary; the section starts collapsed
+ * when everything is green and expanded when something needs attention.
+ */
+export function PrChecksSection({ prUrl }: PrChecksSectionProps) {
+  const checksQuery = usePrChecks(prUrl);
+  const checks = checksQuery.data;
+  const [collapsedOverride, setCollapsedOverride] = useState<boolean | null>(
+    null,
+  );
+
+  const sorted = useMemo(
+    () =>
+      [...(checks ?? [])].sort(
+        (a, b) =>
+          BUCKET_ORDER[a.bucket] - BUCKET_ORDER[b.bucket] ||
+          checkLabel(a).localeCompare(checkLabel(b)),
+      ),
+    [checks],
+  );
+
+  const counts = useMemo(() => {
+    const out: Record<PrCheckBucket, number> = {
+      fail: 0,
+      cancel: 0,
+      pending: 0,
+      pass: 0,
+      skipping: 0,
+    };
+    for (const check of sorted) out[check.bucket]++;
+    return out;
+  }, [sorted]);
+
+  if (checksQuery.isLoading) {
+    return (
+      <ChecksFrame collapsed onToggle={() => {}}>
+        <span className="inline-flex items-center gap-2 text-[11px] text-gray-10">
+          <Spinner />
+          Loading…
+        </span>
+      </ChecksFrame>
+    );
+  }
+
+  // Couldn't fetch (null) or nothing reported ([]) — no useful section either
+  // way, but only the fetch failure is worth a line of copy.
+  if (!checks || checks.length === 0) {
+    if (checks === null) {
+      return (
+        <div className="text-[12px] text-gray-10">
+          Couldn't load CI checks for this pull request.
+        </div>
+      );
+    }
+    return null;
+  }
+
+  const allQuiet =
+    counts.fail === 0 && counts.cancel === 0 && counts.pending === 0;
+  const collapsed = collapsedOverride ?? allQuiet;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <ChecksFrame
+        collapsed={collapsed}
+        onToggle={() => setCollapsedOverride(!collapsed)}
+      >
+        <ChecksSummary counts={counts} />
+      </ChecksFrame>
+      {!collapsed && (
+        <div className="overflow-hidden rounded-md border border-(--gray-5)">
+          {sorted.map((check, index) => (
+            <CheckRow
+              key={`${check.workflow ?? ""}/${check.name}/${index}`}
+              check={check}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Section header, matching the DetailSection chrome but clickable. */
+function ChecksFrame({
+  collapsed,
+  onToggle,
+  children,
+}: {
+  collapsed: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="flex w-full min-w-0 cursor-pointer items-center gap-3 border-0 bg-transparent p-0 text-left"
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        <ChecksIcon size={15} weight="bold" className="shrink-0 text-gray-11" />
+        <Text className="truncate font-semibold text-[14px] text-gray-12 tracking-[-0.01em]">
+          Checks
+        </Text>
+      </span>
+      <div className="h-px min-w-4 flex-1 bg-(--gray-5)" />
+      <span className="flex shrink-0 items-center gap-2">
+        {children}
+        <CaretDownIcon
+          size={12}
+          className="text-(--gray-9)"
+          style={{
+            transform: collapsed ? "rotate(-90deg)" : "rotate(0deg)",
+            transition: "transform 0.15s",
+          }}
+        />
+      </span>
+    </button>
+  );
+}
+
+function ChecksSummary({ counts }: { counts: Record<PrCheckBucket, number> }) {
+  const parts: React.ReactNode[] = [];
+  const push = (count: number, label: string, className: string) => {
+    if (count === 0) return;
+    parts.push(
+      <span key={label} className={className}>
+        {count} {label}
+      </span>,
+    );
+  };
+  push(counts.fail, "failed", "text-(--red-11)");
+  push(counts.cancel, "cancelled", "text-gray-11");
+  push(counts.pending, "running", "text-(--amber-11)");
+  push(counts.pass, "successful", "text-(--green-11)");
+  push(counts.skipping, "skipped", "text-gray-10");
+
+  return (
+    <span className="flex items-center gap-1 text-[11px] tabular-nums">
+      {parts.map((part, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static separator list
+        <span key={index} className="flex items-center gap-1">
+          {index > 0 && <span className="text-(--gray-8)">·</span>}
+          {part}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function CheckRow({ check }: { check: PrCheck }) {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (check.link) openExternalUrl(check.link);
+      }}
+      title={check.link ? "Open in GitHub" : undefined}
+      className="flex w-full cursor-pointer items-center gap-2 border-0 border-b border-b-(--gray-5) bg-transparent px-3 py-[7px] text-left text-[12px] last:border-b-0 hover:bg-gray-2"
+    >
+      <CheckBucketIcon bucket={check.bucket} />
+      <span className="shrink-0 font-medium text-gray-12">
+        {checkLabel(check)}
+      </span>
+      {check.description && (
+        <span className="min-w-0 flex-1 truncate text-gray-10">
+          {check.description}
+        </span>
+      )}
+      {check.link && (
+        <ArrowSquareOutIcon
+          size={12}
+          className="ml-auto shrink-0 text-(--gray-9)"
+        />
+      )}
+    </button>
+  );
+}
+
+function checkLabel(check: PrCheck): string {
+  return check.workflow ? `${check.workflow} / ${check.name}` : check.name;
+}
+
+function CheckBucketIcon({ bucket }: { bucket: PrCheckBucket }) {
+  switch (bucket) {
+    case "fail":
+      return (
+        <XCircleIcon
+          size={14}
+          weight="fill"
+          className="shrink-0 text-(--red-9)"
+        />
+      );
+    case "cancel":
+      return <ProhibitIcon size={14} className="shrink-0 text-(--gray-9)" />;
+    case "pending":
+      return (
+        <CircleNotchIcon
+          size={14}
+          className="shrink-0 animate-spin text-(--amber-9)"
+        />
+      );
+    case "pass":
+      return (
+        <CheckCircleIcon
+          size={14}
+          weight="fill"
+          className="shrink-0 text-(--green-9)"
+        />
+      );
+    case "skipping":
+      return <MinusCircleIcon size={14} className="shrink-0 text-(--gray-8)" />;
+  }
+}

--- a/packages/ui/src/features/pr-review/PrCommentsSection.tsx
+++ b/packages/ui/src/features/pr-review/PrCommentsSection.tsx
@@ -86,15 +86,19 @@ export function PrCommentsSection({ prUrl }: PrCommentsSectionProps) {
   const conversationFailed =
     commentsQuery.isError || commentsQuery.data === null;
   const threadsFailed = threadsQuery.isError;
-  if (conversationFailed && threadsFailed) {
-    return (
-      <div className="text-[12px] text-gray-10">
-        Couldn't load comments for this pull request.
-      </div>
-    );
-  }
 
-  if (items.length === 0) return null;
+  if (items.length === 0) {
+    // A partial failure with nothing else to show must read as an error —
+    // silently hiding the section here would look like "no comments".
+    if (conversationFailed || threadsFailed) {
+      return (
+        <div className="text-[12px] text-gray-10">
+          Couldn't load comments for this pull request.
+        </div>
+      );
+    }
+    return null;
+  }
 
   return (
     <div className="flex flex-col gap-3">

--- a/packages/ui/src/features/pr-review/PrCommentsSection.tsx
+++ b/packages/ui/src/features/pr-review/PrCommentsSection.tsx
@@ -35,9 +35,11 @@ export function PrCommentsSection({ prUrl }: PrCommentsSectionProps) {
   const [collapsed, setCollapsed] = useState(true);
 
   const items = useMemo((): CommentItem[] => {
+    // Conversation items mix issue comments and review summaries, whose ids
+    // come from different GitHub id spaces — key on createdAt too.
     const conversation = (commentsQuery.data ?? []).map(
       (comment): CommentItem => ({
-        key: `issue-${comment.id}`,
+        key: `conv-${comment.id}-${comment.createdAt}`,
         author: comment.author,
         avatarUrl: comment.avatarUrl,
         body: comment.body,
@@ -91,9 +93,16 @@ export function PrCommentsSection({ prUrl }: PrCommentsSectionProps) {
     // A partial failure with nothing else to show must read as an error —
     // silently hiding the section here would look like "no comments".
     if (conversationFailed || threadsFailed) {
+      const detail =
+        (commentsQuery.error ?? threadsQuery.error)?.message ?? null;
       return (
         <div className="text-[12px] text-gray-10">
           Couldn't load comments for this pull request.
+          {detail && (
+            <span className="mt-0.5 block truncate text-(--gray-9) text-[11px]">
+              {detail}
+            </span>
+          )}
         </div>
       );
     }

--- a/packages/ui/src/features/pr-review/PrCommentsSection.tsx
+++ b/packages/ui/src/features/pr-review/PrCommentsSection.tsx
@@ -1,0 +1,166 @@
+import { ArrowSquareOutIcon, ChatCircleIcon } from "@phosphor-icons/react";
+import { Spinner } from "@posthog/quill";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { NestedButton } from "@posthog/ui/primitives/NestedButton";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import { useMemo, useState } from "react";
+import { openExternalUrl } from "../../shell/openExternal";
+import { PrSectionHeader } from "./PrSectionHeader";
+import { usePrComments } from "./usePrComments";
+import { usePrReviewThreads } from "./usePrReviewThreads";
+
+interface CommentItem {
+  key: string;
+  author: string;
+  avatarUrl: string | null;
+  body: string;
+  createdAt: string;
+  url: string | null;
+  /** Set for inline review comments; null for conversation comments. */
+  filePath: string | null;
+  resolved: boolean;
+}
+
+interface PrCommentsSectionProps {
+  prUrl: string;
+}
+
+/**
+ * Collapsed-by-default list of everything said on a PR: conversation
+ * comments plus inline review comments, in chronological order.
+ */
+export function PrCommentsSection({ prUrl }: PrCommentsSectionProps) {
+  const commentsQuery = usePrComments(prUrl);
+  const threadsQuery = usePrReviewThreads(prUrl);
+  const [collapsed, setCollapsed] = useState(true);
+
+  const items = useMemo((): CommentItem[] => {
+    const conversation = (commentsQuery.data ?? []).map(
+      (comment): CommentItem => ({
+        key: `issue-${comment.id}`,
+        author: comment.author,
+        avatarUrl: comment.avatarUrl,
+        body: comment.body,
+        createdAt: comment.createdAt,
+        url: comment.url,
+        filePath: null,
+        resolved: false,
+      }),
+    );
+    const review = (threadsQuery.data ?? []).flatMap((thread) =>
+      thread.comments.map(
+        (comment): CommentItem => ({
+          key: `review-${comment.id}`,
+          author: comment.user.login,
+          avatarUrl: comment.user.avatar_url || null,
+          body: comment.body,
+          createdAt: comment.created_at,
+          url: `${prUrl}#discussion_r${comment.id}`,
+          filePath: thread.filePath,
+          resolved: thread.isResolved,
+        }),
+      ),
+    );
+    return [...conversation, ...review].sort((a, b) =>
+      a.createdAt.localeCompare(b.createdAt),
+    );
+  }, [commentsQuery.data, threadsQuery.data, prUrl]);
+
+  if (commentsQuery.isLoading || threadsQuery.isLoading) {
+    return (
+      <PrSectionHeader
+        Icon={ChatCircleIcon}
+        title="Comments"
+        collapsed
+        onToggle={() => {}}
+        summary={
+          <span className="inline-flex items-center gap-2 text-[11px] text-gray-10">
+            <Spinner />
+            Loading…
+          </span>
+        }
+      />
+    );
+  }
+
+  const conversationFailed =
+    commentsQuery.isError || commentsQuery.data === null;
+  const threadsFailed = threadsQuery.isError;
+  if (conversationFailed && threadsFailed) {
+    return (
+      <div className="text-[12px] text-gray-10">
+        Couldn't load comments for this pull request.
+      </div>
+    );
+  }
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <PrSectionHeader
+        Icon={ChatCircleIcon}
+        title="Comments"
+        collapsed={collapsed}
+        onToggle={() => setCollapsed(!collapsed)}
+        summary={
+          <span className="text-[11px] text-gray-10 tabular-nums">
+            {items.length} comment{items.length === 1 ? "" : "s"}
+          </span>
+        }
+      />
+      {!collapsed && (
+        <div className="overflow-hidden rounded-md border border-(--gray-5)">
+          {items.map((item) => (
+            <CommentRow key={item.key} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CommentRow({ item }: { item: CommentItem }) {
+  return (
+    <div className="flex flex-col gap-1.5 border-b border-b-(--gray-5) px-3 py-2 last:border-b-0">
+      <div className="flex min-w-0 items-center gap-2 text-[11px] text-gray-11">
+        {item.avatarUrl && (
+          <img
+            src={item.avatarUrl}
+            alt=""
+            className="h-4 w-4 shrink-0 rounded-full"
+          />
+        )}
+        <span className="shrink-0 font-medium text-gray-12">{item.author}</span>
+        <RelativeTimestamp timestamp={item.createdAt} className="text-[11px]" />
+        {item.filePath && (
+          <span
+            title={item.filePath}
+            className="min-w-0 truncate font-mono text-[10px] text-gray-10"
+          >
+            {item.filePath}
+          </span>
+        )}
+        {item.resolved && (
+          <span className="shrink-0 rounded-full bg-(--gray-3) px-1.5 py-px text-[10px] text-gray-10">
+            Resolved
+          </span>
+        )}
+        {item.url && (
+          <NestedButton
+            aria-label="Open comment in GitHub"
+            className="ml-auto inline-flex shrink-0 cursor-pointer rounded p-[2px] text-(--gray-9) hover:bg-gray-4"
+            onActivate={() => {
+              if (item.url) openExternalUrl(item.url);
+            }}
+          >
+            <ArrowSquareOutIcon size={12} />
+          </NestedButton>
+        )}
+      </div>
+      <div className="min-w-0 text-pretty break-words text-[12px] text-gray-11 [&_*]:leading-relaxed [&_.rt-Text]:mb-1 [&_li]:mb-0.5 [&_p:last-child]:mb-0">
+        <MarkdownRenderer content={item.body} />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/features/pr-review/PrFilesChangedSection.tsx
+++ b/packages/ui/src/features/pr-review/PrFilesChangedSection.tsx
@@ -4,6 +4,7 @@ import { PatchedFileDiff } from "@posthog/ui/features/code-review/components/Pat
 import { useDiffOptions } from "@posthog/ui/features/code-review/reviewShellParts";
 import { usePrChangedFiles } from "@posthog/ui/features/git-interaction/useGitQueries";
 import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { NestedButton } from "@posthog/ui/primitives/NestedButton";
 import { useMemo, useRef, useState } from "react";
 import {
   fileViewedFingerprint,
@@ -33,7 +34,12 @@ export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
   const [collapseOverrides, setCollapseOverrides] = useState<
     Map<string, boolean>
   >(new Map());
-  const fileContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const fileContainerRefs = useRef<Map<string, HTMLDivElement> | null>(null);
+  // Lazy init so the Map isn't rebuilt (and discarded) on every render.
+  if (fileContainerRefs.current === null) {
+    fileContainerRefs.current = new Map();
+  }
+  const fileContainers = fileContainerRefs.current;
 
   const files = filesQuery.data;
 
@@ -108,12 +114,33 @@ export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
           const collapsed = isCollapsed(file.path);
           const setCollapsed = (next: boolean) =>
             setCollapseOverrides((prev) => new Map(prev).set(file.path, next));
+          // Folding removes a diff that can be taller than the viewport,
+          // which would leave it staring at blank space below — scroll the
+          // folded file back into view. rAF runs after React commits the
+          // collapse but before the browser paints.
+          const collapseAndReveal = () => {
+            setCollapsed(true);
+            requestAnimationFrame(() => {
+              fileContainers
+                .get(file.path)
+                ?.scrollIntoView({ block: "nearest" });
+            });
+          };
+          const handleViewedChange = (next: boolean) => {
+            if (next) {
+              markViewed(prUrl, file.path, fileViewedFingerprint(file));
+              // Fold the file away once it's read, like GitHub.
+              if (!collapsed) collapseAndReveal();
+            } else {
+              unmarkViewed(prUrl, file.path);
+            }
+          };
           return (
             <div
               key={file.path}
               ref={(el) => {
-                if (el) fileContainerRefs.current.set(file.path, el);
-                else fileContainerRefs.current.delete(file.path);
+                if (el) fileContainers.set(file.path, el);
+                else fileContainers.delete(file.path);
               }}
               className="overflow-hidden rounded-md border border-(--gray-5)"
             >
@@ -125,35 +152,25 @@ export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
                 onToggle={() => setCollapsed(!collapsed)}
                 externalUrl={`${prUrl}/files`}
                 prUrl={prUrl}
+                headerTrailing={
+                  collapsed ? (
+                    <ViewedToggle
+                      viewed={viewed}
+                      onChange={handleViewedChange}
+                    />
+                  ) : undefined
+                }
               />
               {!collapsed && (
-                <div className="flex items-center justify-end border-t border-t-(--gray-5) bg-(--gray-2) px-3 py-[4px]">
-                  <ViewedToggle
-                    viewed={viewed}
-                    onChange={(next) => {
-                      if (next) {
-                        markViewed(
-                          prUrl,
-                          file.path,
-                          fileViewedFingerprint(file),
-                        );
-                        // Fold the file away once it's read, like GitHub.
-                        setCollapsed(true);
-                        // The click point was at the bottom of a diff that
-                        // just vanished, which would leave the viewport deep
-                        // in the content below — scroll the folded file back
-                        // into view. rAF runs after React commits the
-                        // collapse but before the browser paints.
-                        requestAnimationFrame(() => {
-                          fileContainerRefs.current
-                            .get(file.path)
-                            ?.scrollIntoView({ block: "nearest" });
-                        });
-                      } else {
-                        unmarkViewed(prUrl, file.path);
-                      }
-                    }}
-                  />
+                <div className="flex items-center justify-end gap-1 border-t border-t-(--gray-5) bg-(--gray-2) px-3 py-[4px]">
+                  <button
+                    type="button"
+                    onClick={collapseAndReveal}
+                    className="cursor-pointer rounded border-0 bg-transparent px-[6px] py-[2px] text-(--accent-9) text-[11px] hover:bg-gray-4"
+                  >
+                    Collapse
+                  </button>
+                  <ViewedToggle viewed={viewed} onChange={handleViewedChange} />
                 </div>
               )}
             </div>
@@ -164,6 +181,10 @@ export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
   );
 }
 
+/**
+ * NestedButton because the collapsed placement sits inside the file header
+ * row, which is itself a `<button>`; it works the same in the plain footer.
+ */
 function ViewedToggle({
   viewed,
   onChange,
@@ -172,11 +193,11 @@ function ViewedToggle({
   onChange: (viewed: boolean) => void;
 }) {
   return (
-    <button
-      type="button"
+    <NestedButton
+      aria-label={viewed ? "Mark as not viewed" : "Mark as viewed"}
       aria-pressed={viewed}
-      onClick={() => onChange(!viewed)}
-      className="inline-flex shrink-0 cursor-pointer items-center gap-[5px] rounded border-0 bg-transparent px-[6px] py-[2px] text-[11px] text-gray-11 hover:bg-gray-4"
+      onActivate={() => onChange(!viewed)}
+      className="inline-flex shrink-0 cursor-pointer items-center gap-[5px] rounded px-[6px] py-[2px] text-[11px] text-gray-11 hover:bg-gray-4"
     >
       <span
         className={`inline-flex h-[13px] w-[13px] items-center justify-center rounded-[3px] border ${
@@ -188,6 +209,6 @@ function ViewedToggle({
         {viewed && <CheckIcon size={9} weight="bold" />}
       </span>
       Viewed
-    </button>
+    </NestedButton>
   );
 }

--- a/packages/ui/src/features/pr-review/PrFilesChangedSection.tsx
+++ b/packages/ui/src/features/pr-review/PrFilesChangedSection.tsx
@@ -4,7 +4,7 @@ import { PatchedFileDiff } from "@posthog/ui/features/code-review/components/Pat
 import { useDiffOptions } from "@posthog/ui/features/code-review/reviewShellParts";
 import { usePrChangedFiles } from "@posthog/ui/features/git-interaction/useGitQueries";
 import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   fileViewedFingerprint,
   isFileViewed,
@@ -33,6 +33,7 @@ export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
   const [collapseOverrides, setCollapseOverrides] = useState<
     Map<string, boolean>
   >(new Map());
+  const fileContainerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const files = filesQuery.data;
 
@@ -110,6 +111,10 @@ export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
           return (
             <div
               key={file.path}
+              ref={(el) => {
+                if (el) fileContainerRefs.current.set(file.path, el);
+                else fileContainerRefs.current.delete(file.path);
+              }}
               className="overflow-hidden rounded-md border border-(--gray-5)"
             >
               <PatchedFileDiff
@@ -134,6 +139,16 @@ export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
                         );
                         // Fold the file away once it's read, like GitHub.
                         setCollapsed(true);
+                        // The click point was at the bottom of a diff that
+                        // just vanished, which would leave the viewport deep
+                        // in the content below — scroll the folded file back
+                        // into view. rAF runs after React commits the
+                        // collapse but before the browser paints.
+                        requestAnimationFrame(() => {
+                          fileContainerRefs.current
+                            .get(file.path)
+                            ?.scrollIntoView({ block: "nearest" });
+                        });
                       } else {
                         unmarkViewed(prUrl, file.path);
                       }

--- a/packages/ui/src/features/pr-review/PrFilesChangedSection.tsx
+++ b/packages/ui/src/features/pr-review/PrFilesChangedSection.tsx
@@ -1,10 +1,9 @@
 import { CheckIcon, GitDiffIcon } from "@phosphor-icons/react";
-import { Spinner } from "@posthog/quill";
+import { Button, Spinner } from "@posthog/quill";
 import { PatchedFileDiff } from "@posthog/ui/features/code-review/components/PatchedFileDiff";
 import { useDiffOptions } from "@posthog/ui/features/code-review/reviewShellParts";
 import { usePrChangedFiles } from "@posthog/ui/features/git-interaction/useGitQueries";
 import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
-import { NestedButton } from "@posthog/ui/primitives/NestedButton";
 import { useMemo, useState } from "react";
 import {
   fileViewedFingerprint,
@@ -17,9 +16,9 @@ interface PrFilesChangedSectionProps {
 }
 
 /**
- * GitHub-style "Files changed" list for a PR: one collapsible diff per file
- * with a "Viewed" toggle. Viewed files default to collapsed; expanding or
- * collapsing by hand overrides that until the viewed state changes again.
+ * GitHub-style "Files changed" list for a PR: one collapsible diff per file,
+ * all collapsed by default. An expanded file gets a footer row with the
+ * "Viewed" toggle; marking a file viewed folds it back up.
  */
 export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
   const filesQuery = usePrChangedFiles(prUrl);
@@ -28,6 +27,9 @@ export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
   const markViewed = usePrViewedFilesStore((s) => s.markViewed);
   const unmarkViewed = usePrViewedFilesStore((s) => s.unmarkViewed);
 
+  // Per-file collapse overrides on top of a section-wide baseline, so
+  // expand/collapse-all is one state flip instead of a map rebuild.
+  const [baselineCollapsed, setBaselineCollapsed] = useState(true);
   const [collapseOverrides, setCollapseOverrides] = useState<
     Map<string, boolean>
   >(new Map());
@@ -70,20 +72,41 @@ export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
     );
   }
 
+  const isCollapsed = (path: string) =>
+    collapseOverrides.get(path) ?? baselineCollapsed;
+  const allExpanded = files.every((file) => !isCollapsed(file.path));
+
+  const setAllCollapsed = (collapsed: boolean) => {
+    setBaselineCollapsed(collapsed);
+    setCollapseOverrides(new Map());
+  };
+
   return (
     <DetailSection
       Icon={GitDiffIcon}
       title={`Files changed (${files.length})`}
       rightSlot={
-        <span className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
-          {viewedCount} / {files.length} viewed
+        <span className="flex items-center gap-2">
+          <span className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
+            {viewedCount} / {files.length} viewed
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setAllCollapsed(allExpanded)}
+          >
+            {allExpanded ? "Collapse all" : "Expand all"}
+          </Button>
         </span>
       }
     >
       <div className="flex flex-col gap-3">
         {files.map((file) => {
           const viewed = isFileViewed(viewedByPr, prUrl, file);
-          const collapsed = collapseOverrides.get(file.path) ?? viewed;
+          const collapsed = isCollapsed(file.path);
+          const setCollapsed = (next: boolean) =>
+            setCollapseOverrides((prev) => new Map(prev).set(file.path, next));
           return (
             <div
               key={file.path}
@@ -94,39 +117,30 @@ export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
                 taskId={prUrl}
                 options={diffOptions}
                 collapsed={collapsed}
-                onToggle={() =>
-                  setCollapseOverrides((prev) =>
-                    new Map(prev).set(file.path, !collapsed),
-                  )
-                }
+                onToggle={() => setCollapsed(!collapsed)}
                 externalUrl={`${prUrl}/files`}
                 prUrl={prUrl}
-                headerTrailing={
+              />
+              {!collapsed && (
+                <div className="flex items-center justify-end border-t border-t-(--gray-5) bg-(--gray-2) px-3 py-[4px]">
                   <ViewedToggle
                     viewed={viewed}
                     onChange={(next) => {
-                      // Drop the manual override so the new viewed state
-                      // decides the collapse (checked → fold, unchecked →
-                      // unfold), matching GitHub.
-                      setCollapseOverrides((prev) => {
-                        if (!prev.has(file.path)) return prev;
-                        const map = new Map(prev);
-                        map.delete(file.path);
-                        return map;
-                      });
                       if (next) {
                         markViewed(
                           prUrl,
                           file.path,
                           fileViewedFingerprint(file),
                         );
+                        // Fold the file away once it's read, like GitHub.
+                        setCollapsed(true);
                       } else {
                         unmarkViewed(prUrl, file.path);
                       }
                     }}
                   />
-                }
-              />
+                </div>
+              )}
             </div>
           );
         })}
@@ -143,11 +157,11 @@ function ViewedToggle({
   onChange: (viewed: boolean) => void;
 }) {
   return (
-    <NestedButton
-      aria-label={viewed ? "Mark as not viewed" : "Mark as viewed"}
+    <button
+      type="button"
       aria-pressed={viewed}
-      className="ml-[6px] inline-flex shrink-0 cursor-pointer items-center gap-[5px] rounded px-[6px] py-[2px] text-[11px] text-gray-11 hover:bg-gray-4"
-      onActivate={() => onChange(!viewed)}
+      onClick={() => onChange(!viewed)}
+      className="inline-flex shrink-0 cursor-pointer items-center gap-[5px] rounded border-0 bg-transparent px-[6px] py-[2px] text-[11px] text-gray-11 hover:bg-gray-4"
     >
       <span
         className={`inline-flex h-[13px] w-[13px] items-center justify-center rounded-[3px] border ${
@@ -159,6 +173,6 @@ function ViewedToggle({
         {viewed && <CheckIcon size={9} weight="bold" />}
       </span>
       Viewed
-    </NestedButton>
+    </button>
   );
 }

--- a/packages/ui/src/features/pr-review/PrFilesChangedSection.tsx
+++ b/packages/ui/src/features/pr-review/PrFilesChangedSection.tsx
@@ -1,0 +1,164 @@
+import { CheckIcon, GitDiffIcon } from "@phosphor-icons/react";
+import { Spinner } from "@posthog/quill";
+import { PatchedFileDiff } from "@posthog/ui/features/code-review/components/PatchedFileDiff";
+import { useDiffOptions } from "@posthog/ui/features/code-review/reviewShellParts";
+import { usePrChangedFiles } from "@posthog/ui/features/git-interaction/useGitQueries";
+import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { NestedButton } from "@posthog/ui/primitives/NestedButton";
+import { useMemo, useState } from "react";
+import {
+  fileViewedFingerprint,
+  isFileViewed,
+  usePrViewedFilesStore,
+} from "./prViewedFilesStore";
+
+interface PrFilesChangedSectionProps {
+  prUrl: string;
+}
+
+/**
+ * GitHub-style "Files changed" list for a PR: one collapsible diff per file
+ * with a "Viewed" toggle. Viewed files default to collapsed; expanding or
+ * collapsing by hand overrides that until the viewed state changes again.
+ */
+export function PrFilesChangedSection({ prUrl }: PrFilesChangedSectionProps) {
+  const filesQuery = usePrChangedFiles(prUrl);
+  const diffOptions = useDiffOptions();
+  const viewedByPr = usePrViewedFilesStore((s) => s.viewedByPr);
+  const markViewed = usePrViewedFilesStore((s) => s.markViewed);
+  const unmarkViewed = usePrViewedFilesStore((s) => s.unmarkViewed);
+
+  const [collapseOverrides, setCollapseOverrides] = useState<
+    Map<string, boolean>
+  >(new Map());
+
+  const files = filesQuery.data;
+
+  const viewedCount = useMemo(
+    () =>
+      (files ?? []).filter((file) => isFileViewed(viewedByPr, prUrl, file))
+        .length,
+    [files, viewedByPr, prUrl],
+  );
+
+  if (filesQuery.isLoading) {
+    return (
+      <DetailSection Icon={GitDiffIcon} title="Files changed">
+        <div className="flex items-center gap-2 py-3 text-[12px] text-gray-10">
+          <Spinner />
+          Loading changed files…
+        </div>
+      </DetailSection>
+    );
+  }
+
+  if (filesQuery.isError || !files) {
+    return (
+      <DetailSection Icon={GitDiffIcon} title="Files changed">
+        <div className="py-3 text-[12px] text-gray-10">
+          Couldn't load the changed files for this pull request.
+        </div>
+      </DetailSection>
+    );
+  }
+
+  if (files.length === 0) {
+    return (
+      <DetailSection Icon={GitDiffIcon} title="Files changed">
+        <div className="py-3 text-[12px] text-gray-10">No changed files.</div>
+      </DetailSection>
+    );
+  }
+
+  return (
+    <DetailSection
+      Icon={GitDiffIcon}
+      title={`Files changed (${files.length})`}
+      rightSlot={
+        <span className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
+          {viewedCount} / {files.length} viewed
+        </span>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        {files.map((file) => {
+          const viewed = isFileViewed(viewedByPr, prUrl, file);
+          const collapsed = collapseOverrides.get(file.path) ?? viewed;
+          return (
+            <div
+              key={file.path}
+              className="overflow-hidden rounded-md border border-(--gray-5)"
+            >
+              <PatchedFileDiff
+                file={file}
+                taskId={prUrl}
+                options={diffOptions}
+                collapsed={collapsed}
+                onToggle={() =>
+                  setCollapseOverrides((prev) =>
+                    new Map(prev).set(file.path, !collapsed),
+                  )
+                }
+                externalUrl={`${prUrl}/files`}
+                prUrl={prUrl}
+                headerTrailing={
+                  <ViewedToggle
+                    viewed={viewed}
+                    onChange={(next) => {
+                      // Drop the manual override so the new viewed state
+                      // decides the collapse (checked → fold, unchecked →
+                      // unfold), matching GitHub.
+                      setCollapseOverrides((prev) => {
+                        if (!prev.has(file.path)) return prev;
+                        const map = new Map(prev);
+                        map.delete(file.path);
+                        return map;
+                      });
+                      if (next) {
+                        markViewed(
+                          prUrl,
+                          file.path,
+                          fileViewedFingerprint(file),
+                        );
+                      } else {
+                        unmarkViewed(prUrl, file.path);
+                      }
+                    }}
+                  />
+                }
+              />
+            </div>
+          );
+        })}
+      </div>
+    </DetailSection>
+  );
+}
+
+function ViewedToggle({
+  viewed,
+  onChange,
+}: {
+  viewed: boolean;
+  onChange: (viewed: boolean) => void;
+}) {
+  return (
+    <NestedButton
+      aria-label={viewed ? "Mark as not viewed" : "Mark as viewed"}
+      aria-pressed={viewed}
+      className="ml-[6px] inline-flex shrink-0 cursor-pointer items-center gap-[5px] rounded px-[6px] py-[2px] text-[11px] text-gray-11 hover:bg-gray-4"
+      onActivate={() => onChange(!viewed)}
+    >
+      <span
+        className={`inline-flex h-[13px] w-[13px] items-center justify-center rounded-[3px] border ${
+          viewed
+            ? "border-(--accent-9) bg-(--accent-9) text-white"
+            : "border-(--gray-7)"
+        }`}
+      >
+        {viewed && <CheckIcon size={9} weight="bold" />}
+      </span>
+      Viewed
+    </NestedButton>
+  );
+}

--- a/packages/ui/src/features/pr-review/PrReviewActions.tsx
+++ b/packages/ui/src/features/pr-review/PrReviewActions.tsx
@@ -74,6 +74,9 @@ export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
 
   const approved = approve.isSuccess && approve.data.success;
   const approveDisabled = !info || approve.isPending || approved;
+  // Failed fetch (null / error) means CI status is unknown — that must lock
+  // the merge too, or a transient gh error would silently unlock red checks.
+  const checksUnavailable = checksQuery.isError || checksQuery.data === null;
   // Same gate as github.com: red checks or conflicts lock the merge button.
   const mergeBlockedReason = draft
     ? null // the draft branch below renders its own note + CTA
@@ -81,9 +84,15 @@ export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
       ? `${failedChecks} check${failedChecks === 1 ? " is" : "s are"} failing — merging is blocked until they pass.`
       : hasConflicts
         ? "This branch has conflicts that must be resolved before merging."
-        : null;
+        : checksUnavailable
+          ? "CI status couldn't be loaded — merging is blocked until checks are known."
+          : null;
   const mergeDisabled =
-    !info || draft || merge.isPending || mergeBlockedReason !== null;
+    !info ||
+    draft ||
+    merge.isPending ||
+    checksQuery.data == null ||
+    mergeBlockedReason !== null;
 
   return (
     <div className="flex flex-wrap items-center gap-2">

--- a/packages/ui/src/features/pr-review/PrReviewActions.tsx
+++ b/packages/ui/src/features/pr-review/PrReviewActions.tsx
@@ -1,0 +1,130 @@
+import {
+  CaretDownIcon,
+  CheckCircleIcon,
+  CheckIcon,
+  GitMergeIcon,
+  XCircleIcon,
+} from "@phosphor-icons/react";
+import type { PrMergeMethod } from "@posthog/core/git/router-schemas";
+import {
+  Button,
+  ButtonGroup,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Spinner,
+} from "@posthog/quill";
+import { useState } from "react";
+import { useApprovePr } from "./useApprovePr";
+import { useMergePr } from "./useMergePr";
+import { usePrInfo } from "./usePrInfo";
+
+const MERGE_METHODS: PrMergeMethod[] = ["merge", "squash", "rebase"];
+
+const MERGE_METHOD_LABELS: Record<PrMergeMethod, string> = {
+  merge: "Merge pull request",
+  squash: "Squash and merge",
+  rebase: "Rebase and merge",
+};
+
+interface PrReviewActionsProps {
+  prUrl: string;
+}
+
+/** Approve + merge controls for a GitHub PR, mirroring the github.com merge box. */
+export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
+  const infoQuery = usePrInfo(prUrl);
+  const approve = useApprovePr(prUrl);
+  const merge = useMergePr(prUrl);
+  const [method, setMethod] = useState<PrMergeMethod>("merge");
+
+  const info = infoQuery.data;
+  const merged = info?.merged ?? false;
+  const closed = !merged && info?.state?.toLowerCase() === "closed";
+  const draft = info?.draft ?? false;
+
+  if (merged || closed) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-(--gray-5) bg-(--gray-2) px-3 py-2 text-[12px] text-gray-11">
+        {merged ? (
+          <>
+            <GitMergeIcon size={14} className="text-(--purple-9)" />
+            This pull request has been merged.
+          </>
+        ) : (
+          <>
+            <XCircleIcon size={14} className="text-(--red-9)" />
+            This pull request is closed.
+          </>
+        )}
+      </div>
+    );
+  }
+
+  const approved = approve.isSuccess && approve.data.success;
+  const approveDisabled = !info || approve.isPending || approved;
+  const mergeDisabled = !info || draft || merge.isPending;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={approveDisabled}
+        onClick={() => approve.mutate({ prUrl })}
+        className="gap-1.5"
+      >
+        {approve.isPending ? (
+          <Spinner />
+        ) : approved ? (
+          <CheckCircleIcon size={13} className="text-(--green-9)" />
+        ) : (
+          <CheckIcon size={13} />
+        )}
+        {approved ? "Approved" : "Approve"}
+      </Button>
+      <ButtonGroup>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          disabled={mergeDisabled}
+          onClick={() => merge.mutate({ prUrl, method })}
+          className="gap-1.5"
+        >
+          {merge.isPending ? <Spinner /> : <GitMergeIcon size={13} />}
+          {MERGE_METHOD_LABELS[method]}
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                aria-label="Choose merge method"
+                disabled={mergeDisabled}
+              >
+                <CaretDownIcon size={12} />
+              </Button>
+            }
+          />
+          <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
+            {MERGE_METHODS.map((m) => (
+              <DropdownMenuItem key={m} onClick={() => setMethod(m)}>
+                {MERGE_METHOD_LABELS[m]}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </ButtonGroup>
+      {draft && (
+        <span className="text-[11px] text-gray-10">
+          Draft pull requests can't be merged.
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/features/pr-review/PrReviewActions.tsx
+++ b/packages/ui/src/features/pr-review/PrReviewActions.tsx
@@ -19,6 +19,7 @@ import { useState } from "react";
 import { useApprovePr } from "./useApprovePr";
 import { useMarkPrReady } from "./useMarkPrReady";
 import { useMergePr } from "./useMergePr";
+import { usePrChecks } from "./usePrChecks";
 import { usePrInfo } from "./usePrInfo";
 
 const MERGE_METHODS: PrMergeMethod[] = ["merge", "squash", "rebase"];
@@ -36,6 +37,9 @@ interface PrReviewActionsProps {
 /** Approve + merge controls for a GitHub PR, mirroring the github.com merge box. */
 export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
   const infoQuery = usePrInfo(prUrl);
+  // Shares the checks section's polling query, so the merge gate follows CI
+  // live: it locks as soon as a check goes red and unlocks on a green rerun.
+  const checksQuery = usePrChecks(prUrl);
   const approve = useApprovePr(prUrl);
   const merge = useMergePr(prUrl);
   const markReady = useMarkPrReady(prUrl);
@@ -45,6 +49,10 @@ export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
   const merged = info?.merged ?? false;
   const closed = !merged && info?.state?.toLowerCase() === "closed";
   const draft = info?.draft ?? false;
+  const failedChecks = (checksQuery.data ?? []).filter(
+    (check) => check.bucket === "fail",
+  ).length;
+  const hasConflicts = info?.mergeable === false;
 
   if (merged || closed) {
     return (
@@ -66,7 +74,16 @@ export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
 
   const approved = approve.isSuccess && approve.data.success;
   const approveDisabled = !info || approve.isPending || approved;
-  const mergeDisabled = !info || draft || merge.isPending;
+  // Same gate as github.com: red checks or conflicts lock the merge button.
+  const mergeBlockedReason = draft
+    ? null // the draft branch below renders its own note + CTA
+    : failedChecks > 0
+      ? `${failedChecks} check${failedChecks === 1 ? " is" : "s are"} failing — merging is blocked until they pass.`
+      : hasConflicts
+        ? "This branch has conflicts that must be resolved before merging."
+        : null;
+  const mergeDisabled =
+    !info || draft || merge.isPending || mergeBlockedReason !== null;
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -139,6 +156,11 @@ export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
             Ready for review
           </Button>
         </>
+      )}
+      {mergeBlockedReason && (
+        <span className="text-(--red-11) text-[11px]">
+          {mergeBlockedReason}
+        </span>
       )}
     </div>
   );

--- a/packages/ui/src/features/pr-review/PrReviewActions.tsx
+++ b/packages/ui/src/features/pr-review/PrReviewActions.tsx
@@ -21,6 +21,7 @@ import { useMarkPrReady } from "./useMarkPrReady";
 import { useMergePr } from "./useMergePr";
 import { usePrChecks } from "./usePrChecks";
 import { usePrInfo } from "./usePrInfo";
+import { useReopenPr } from "./useReopenPr";
 
 const MERGE_METHODS: PrMergeMethod[] = ["merge", "squash", "rebase"];
 
@@ -43,6 +44,7 @@ export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
   const approve = useApprovePr(prUrl);
   const merge = useMergePr(prUrl);
   const markReady = useMarkPrReady(prUrl);
+  const reopen = useReopenPr(prUrl);
   const [method, setMethod] = useState<PrMergeMethod>("merge");
 
   const info = infoQuery.data;
@@ -66,6 +68,17 @@ export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
           <>
             <XCircleIcon size={14} className="text-(--red-9)" />
             This pull request is closed.
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={reopen.isPending}
+              onClick={() => reopen.mutate({ prUrl, action: "reopen" })}
+              className="ml-auto gap-1.5"
+            >
+              {reopen.isPending && <Spinner />}
+              Reopen
+            </Button>
           </>
         )}
       </div>
@@ -77,16 +90,26 @@ export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
   // Failed fetch (null / error) means CI status is unknown — that must lock
   // the merge too, or a transient gh error would silently unlock red checks.
   const checksUnavailable = checksQuery.isError || checksQuery.data === null;
-  // Same gate as github.com: red checks or conflicts lock the merge button.
+  // Branch protection ("blocked") is viewer-aware: it covers repos that
+  // require an approving review — including the PR author, who can't approve
+  // their own PR. Repos without such rules report "clean"/"unstable".
+  const blockedByProtection = info?.mergeStateStatus === "blocked";
+  const behindBase = info?.mergeStateStatus === "behind";
+  // Same gate as github.com: red checks, conflicts, or branch protection
+  // lock the merge button.
   const mergeBlockedReason = draft
     ? null // the draft branch below renders its own note + CTA
     : failedChecks > 0
       ? `${failedChecks} check${failedChecks === 1 ? " is" : "s are"} failing — merging is blocked until they pass.`
       : hasConflicts
         ? "This branch has conflicts that must be resolved before merging."
-        : checksUnavailable
-          ? "CI status couldn't be loaded — merging is blocked until checks are known."
-          : null;
+        : blockedByProtection
+          ? "Branch protection blocks this merge — an approving review from another user may be required."
+          : behindBase
+            ? "This branch is out of date with the base branch and must be updated before merging."
+            : checksUnavailable
+              ? "CI status couldn't be loaded — merging is blocked until checks are known."
+              : null;
   const mergeDisabled =
     !info ||
     draft ||

--- a/packages/ui/src/features/pr-review/PrReviewActions.tsx
+++ b/packages/ui/src/features/pr-review/PrReviewActions.tsx
@@ -17,6 +17,7 @@ import {
 } from "@posthog/quill";
 import { useState } from "react";
 import { useApprovePr } from "./useApprovePr";
+import { useMarkPrReady } from "./useMarkPrReady";
 import { useMergePr } from "./useMergePr";
 import { usePrInfo } from "./usePrInfo";
 
@@ -37,6 +38,7 @@ export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
   const infoQuery = usePrInfo(prUrl);
   const approve = useApprovePr(prUrl);
   const merge = useMergePr(prUrl);
+  const markReady = useMarkPrReady(prUrl);
   const [method, setMethod] = useState<PrMergeMethod>("merge");
 
   const info = infoQuery.data;
@@ -121,9 +123,22 @@ export function PrReviewActions({ prUrl }: PrReviewActionsProps) {
         </DropdownMenu>
       </ButtonGroup>
       {draft && (
-        <span className="text-[11px] text-gray-10">
-          Draft pull requests can't be merged.
-        </span>
+        <>
+          <span className="text-[11px] text-gray-10">
+            Draft pull requests can't be merged.
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={markReady.isPending}
+            onClick={() => markReady.mutate({ prUrl, action: "ready" })}
+            className="gap-1.5"
+          >
+            {markReady.isPending && <Spinner />}
+            Ready for review
+          </Button>
+        </>
       )}
     </div>
   );

--- a/packages/ui/src/features/pr-review/PrSectionHeader.tsx
+++ b/packages/ui/src/features/pr-review/PrSectionHeader.tsx
@@ -1,0 +1,50 @@
+import type { IconProps } from "@phosphor-icons/react";
+import { CaretDownIcon } from "@phosphor-icons/react";
+import { Text } from "@radix-ui/themes";
+import type { ComponentType, ReactNode } from "react";
+
+/**
+ * Clickable section header matching the DetailSection chrome, for the
+ * collapsible PR sections (checks, comments). The right slot stays visible
+ * while collapsed so it can carry a summary.
+ */
+export function PrSectionHeader({
+  Icon,
+  title,
+  collapsed,
+  onToggle,
+  summary,
+}: {
+  Icon: ComponentType<IconProps>;
+  title: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  summary?: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="flex w-full min-w-0 cursor-pointer items-center gap-3 border-0 bg-transparent p-0 text-left"
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        <Icon size={15} weight="bold" className="shrink-0 text-gray-11" />
+        <Text className="truncate font-semibold text-[14px] text-gray-12 tracking-[-0.01em]">
+          {title}
+        </Text>
+      </span>
+      <div className="h-px min-w-4 flex-1 bg-(--gray-5)" />
+      <span className="flex shrink-0 items-center gap-2">
+        {summary}
+        <CaretDownIcon
+          size={12}
+          className="text-(--gray-9)"
+          style={{
+            transform: collapsed ? "rotate(-90deg)" : "rotate(0deg)",
+            transition: "transform 0.15s",
+          }}
+        />
+      </span>
+    </button>
+  );
+}

--- a/packages/ui/src/features/pr-review/PullRequestView.tsx
+++ b/packages/ui/src/features/pr-review/PullRequestView.tsx
@@ -1,0 +1,160 @@
+import {
+  ArrowSquareOutIcon,
+  GitPullRequestIcon,
+  TextAlignLeftIcon,
+} from "@phosphor-icons/react";
+import { parseGithubUrl } from "@posthog/git/utils";
+import {
+  Button,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Spinner,
+} from "@posthog/quill";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { useMemo } from "react";
+import { openExternalUrl } from "../../shell/openExternal";
+import { PrFilesChangedSection } from "./PrFilesChangedSection";
+import { PrReviewActions } from "./PrReviewActions";
+import { usePrInfo } from "./usePrInfo";
+
+interface PullRequestViewProps {
+  prUrl: string;
+}
+
+/**
+ * Native, full-page pull request view: description, files changed (with
+ * GitHub-style "Viewed" tracking) and approve/merge actions — no browser
+ * round-trip. Opened from the sidebar's PR badge.
+ */
+export function PullRequestView({ prUrl }: PullRequestViewProps) {
+  const prRef = useMemo(() => (prUrl ? parseGithubUrl(prUrl) : null), [prUrl]);
+  const isPr = prRef?.kind === "pr";
+  const infoQuery = usePrInfo(isPr ? prUrl : null);
+  const info = infoQuery.data;
+
+  if (!isPr) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <GitPullRequestIcon />
+            </EmptyMedia>
+            <EmptyTitle>No pull request</EmptyTitle>
+            <EmptyDescription>
+              This link doesn't point to a GitHub pull request.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-[100ch] flex-col gap-5 px-6 py-5 text-[13px]">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            <GitPullRequestIcon size={14} className="shrink-0 text-gray-11" />
+            <span className="font-mono text-[12px] text-gray-11">
+              {prRef.owner}/{prRef.repo}#{prRef.number}
+            </span>
+            {info && (
+              <PrStateBadge
+                state={info.state}
+                merged={info.merged}
+                draft={info.draft}
+              />
+            )}
+          </div>
+          <div className="flex items-start justify-between gap-3">
+            <h1 className="min-w-0 font-semibold text-[20px] text-gray-12 leading-snug tracking-[-0.01em]">
+              {info ? (
+                info.title
+              ) : (
+                <span className="inline-flex items-center gap-2 text-gray-10">
+                  <Spinner />
+                  Loading pull request…
+                </span>
+              )}
+            </h1>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => openExternalUrl(prUrl)}
+              className="shrink-0 gap-2"
+            >
+              Open in GitHub
+              <ArrowSquareOutIcon size={12} />
+            </Button>
+          </div>
+          {info && (
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-gray-11">
+              {info.author && <span>{info.author}</span>}
+              {info.baseRefName && info.headRefName && (
+                <>
+                  <span className="text-(--gray-8)">·</span>
+                  <span className="font-mono">
+                    {info.headRefName} → {info.baseRefName}
+                  </span>
+                </>
+              )}
+              <span className="text-(--gray-8)">·</span>
+              <span className="font-mono tabular-nums">
+                <span className="text-(--green-9)">+{info.additions}</span>{" "}
+                <span className="text-(--red-9)">−{info.deletions}</span>
+              </span>
+            </div>
+          )}
+        </div>
+
+        <DetailSection Icon={TextAlignLeftIcon} title="Description">
+          {info?.body.trim() ? (
+            <div className="min-w-0 max-w-[80ch] text-pretty break-words text-[13px] text-gray-11 [&_*]:leading-relaxed [&_.rt-Text]:mb-2 [&_li]:mb-1 [&_p:last-child]:mb-0">
+              <MarkdownRenderer content={info.body} />
+            </div>
+          ) : (
+            <div className="py-1 text-[12px] text-gray-10 italic">
+              No description provided.
+            </div>
+          )}
+        </DetailSection>
+
+        <PrFilesChangedSection prUrl={prUrl} />
+
+        <PrReviewActions prUrl={prUrl} />
+      </div>
+    </div>
+  );
+}
+
+function PrStateBadge({
+  state,
+  merged,
+  draft,
+}: {
+  state: string;
+  merged: boolean;
+  draft: boolean;
+}) {
+  const { label, className } = merged
+    ? { label: "Merged", className: "bg-(--purple-3) text-(--purple-11)" }
+    : state.toLowerCase() === "closed"
+      ? { label: "Closed", className: "bg-(--red-3) text-(--red-11)" }
+      : draft
+        ? { label: "Draft", className: "bg-(--gray-3) text-(--gray-11)" }
+        : { label: "Open", className: "bg-(--green-3) text-(--green-11)" };
+
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 font-medium text-[11px] ${className}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/packages/ui/src/features/pr-review/PullRequestView.tsx
+++ b/packages/ui/src/features/pr-review/PullRequestView.tsx
@@ -18,6 +18,7 @@ import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSecti
 import { useMemo } from "react";
 import { openExternalUrl } from "../../shell/openExternal";
 import { PrChecksSection } from "./PrChecksSection";
+import { PrCommentsSection } from "./PrCommentsSection";
 import { PrFilesChangedSection } from "./PrFilesChangedSection";
 import { PrReviewActions } from "./PrReviewActions";
 import { usePrInfo } from "./usePrInfo";
@@ -127,6 +128,8 @@ export function PullRequestView({ prUrl }: PullRequestViewProps) {
         </DetailSection>
 
         <PrFilesChangedSection prUrl={prUrl} />
+
+        <PrCommentsSection prUrl={prUrl} />
 
         <PrChecksSection prUrl={prUrl} />
 

--- a/packages/ui/src/features/pr-review/PullRequestView.tsx
+++ b/packages/ui/src/features/pr-review/PullRequestView.tsx
@@ -17,6 +17,7 @@ import { MarkdownRenderer } from "@posthog/ui/features/editor/components/Markdow
 import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
 import { useMemo } from "react";
 import { openExternalUrl } from "../../shell/openExternal";
+import { PrChecksSection } from "./PrChecksSection";
 import { PrFilesChangedSection } from "./PrFilesChangedSection";
 import { PrReviewActions } from "./PrReviewActions";
 import { usePrInfo } from "./usePrInfo";
@@ -126,6 +127,8 @@ export function PullRequestView({ prUrl }: PullRequestViewProps) {
         </DetailSection>
 
         <PrFilesChangedSection prUrl={prUrl} />
+
+        <PrChecksSection prUrl={prUrl} />
 
         <PrReviewActions prUrl={prUrl} />
       </div>

--- a/packages/ui/src/features/pr-review/prViewedFilesStore.test.ts
+++ b/packages/ui/src/features/pr-review/prViewedFilesStore.test.ts
@@ -1,0 +1,87 @@
+import type { ChangedFile } from "@posthog/shared/domain-types";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  fileViewedFingerprint,
+  isFileViewed,
+  MAX_TRACKED_PRS,
+  usePrViewedFilesStore,
+} from "./prViewedFilesStore";
+
+const PR_URL = "https://github.com/posthog/code/pull/123";
+
+function file(overrides: Partial<ChangedFile> = {}): ChangedFile {
+  return {
+    path: "src/a.ts",
+    status: "modified",
+    patch: "@@ -1 +1 @@\n-old\n+new",
+    ...overrides,
+  };
+}
+
+describe("prViewedFilesStore", () => {
+  beforeEach(() => {
+    usePrViewedFilesStore.setState({ viewedByPr: {} });
+  });
+
+  it("marks a file viewed and reads it back", () => {
+    const f = file();
+    usePrViewedFilesStore
+      .getState()
+      .markViewed(PR_URL, f.path, fileViewedFingerprint(f));
+
+    const { viewedByPr } = usePrViewedFilesStore.getState();
+    expect(isFileViewed(viewedByPr, PR_URL, f)).toBe(true);
+    expect(isFileViewed(viewedByPr, "https://other", f)).toBe(false);
+  });
+
+  it("drops viewed state when the file's diff changes", () => {
+    const f = file();
+    usePrViewedFilesStore
+      .getState()
+      .markViewed(PR_URL, f.path, fileViewedFingerprint(f));
+
+    const changed = file({ patch: "@@ -1 +1 @@\n-old\n+newer" });
+    const { viewedByPr } = usePrViewedFilesStore.getState();
+    expect(isFileViewed(viewedByPr, PR_URL, changed)).toBe(false);
+  });
+
+  it("unmarks a viewed file", () => {
+    const f = file();
+    const store = usePrViewedFilesStore.getState();
+    store.markViewed(PR_URL, f.path, fileViewedFingerprint(f));
+    usePrViewedFilesStore.getState().unmarkViewed(PR_URL, f.path);
+
+    const { viewedByPr } = usePrViewedFilesStore.getState();
+    expect(isFileViewed(viewedByPr, PR_URL, f)).toBe(false);
+  });
+
+  it.each([
+    ["status change", file({ status: "deleted" })],
+    ["patch change", file({ patch: "@@ -2 +2 @@\n-x\n+y" })],
+    [
+      "line-count change on a patch-less file",
+      file({ patch: undefined, linesAdded: 3, linesRemoved: 1 }),
+    ],
+  ])("fingerprint differs on %s", (_label, changed) => {
+    expect(fileViewedFingerprint(changed)).not.toBe(
+      fileViewedFingerprint(file()),
+    );
+  });
+
+  it("evicts the stalest PR beyond the cap", () => {
+    const f = file();
+    const fingerprint = fileViewedFingerprint(f);
+    for (let i = 0; i < MAX_TRACKED_PRS + 1; i++) {
+      usePrViewedFilesStore
+        .getState()
+        .markViewed(`https://github.com/o/r/pull/${i}`, f.path, fingerprint);
+    }
+
+    const { viewedByPr } = usePrViewedFilesStore.getState();
+    expect(Object.keys(viewedByPr)).toHaveLength(MAX_TRACKED_PRS);
+    expect(viewedByPr["https://github.com/o/r/pull/0"]).toBeUndefined();
+    expect(
+      viewedByPr[`https://github.com/o/r/pull/${MAX_TRACKED_PRS}`],
+    ).toBeDefined();
+  });
+});

--- a/packages/ui/src/features/pr-review/prViewedFilesStore.ts
+++ b/packages/ui/src/features/pr-review/prViewedFilesStore.ts
@@ -1,0 +1,106 @@
+import type { ChangedFile } from "@posthog/shared/domain-types";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/** Cap on tracked PRs so the persisted map can't grow unboundedly. */
+export const MAX_TRACKED_PRS = 50;
+
+interface PrViewedEntry {
+  /** Last write, used to evict the stalest PR past the cap. */
+  updatedAt: number;
+  /** filePath -> fingerprint of the diff when the file was marked viewed. */
+  files: Record<string, string>;
+}
+
+interface PrViewedFilesState {
+  viewedByPr: Record<string, PrViewedEntry>;
+}
+
+interface PrViewedFilesActions {
+  markViewed: (prUrl: string, filePath: string, fingerprint: string) => void;
+  unmarkViewed: (prUrl: string, filePath: string) => void;
+}
+
+type PrViewedFilesStore = PrViewedFilesState & PrViewedFilesActions;
+
+/**
+ * GitHub-style "Viewed" semantics: a file stays viewed only while its diff is
+ * unchanged. The fingerprint captures the patch when the user checks the box;
+ * if the PR gains commits that touch the file, the fingerprint stops matching
+ * and the file drops back to unviewed — same behavior as github.com.
+ */
+export function fileViewedFingerprint(file: ChangedFile): string {
+  const basis = `${file.status}:${
+    file.patch ?? `${file.linesAdded ?? 0}/${file.linesRemoved ?? 0}`
+  }`;
+  // djb2 — cheap and stable; change detection only, not integrity.
+  let hash = 5381;
+  for (let i = 0; i < basis.length; i++) {
+    hash = ((hash << 5) + hash + basis.charCodeAt(i)) | 0;
+  }
+  return String(hash >>> 0);
+}
+
+function evictStalest(
+  viewedByPr: Record<string, PrViewedEntry>,
+): Record<string, PrViewedEntry> {
+  const urls = Object.keys(viewedByPr);
+  if (urls.length <= MAX_TRACKED_PRS) return viewedByPr;
+  let stalest: string | null = null;
+  let stalestAt = Number.POSITIVE_INFINITY;
+  for (const url of urls) {
+    const at = viewedByPr[url]?.updatedAt ?? 0;
+    if (at < stalestAt) {
+      stalest = url;
+      stalestAt = at;
+    }
+  }
+  if (stalest === null) return viewedByPr;
+  const next = { ...viewedByPr };
+  delete next[stalest];
+  return next;
+}
+
+export const usePrViewedFilesStore = create<PrViewedFilesStore>()(
+  persist(
+    (set) => ({
+      viewedByPr: {},
+      markViewed: (prUrl, filePath, fingerprint) =>
+        set((state) => {
+          const entry = state.viewedByPr[prUrl];
+          const next: PrViewedEntry = {
+            updatedAt: Date.now(),
+            files: { ...entry?.files, [filePath]: fingerprint },
+          };
+          return {
+            viewedByPr: evictStalest({
+              ...state.viewedByPr,
+              [prUrl]: next,
+            }),
+          };
+        }),
+      unmarkViewed: (prUrl, filePath) =>
+        set((state) => {
+          const entry = state.viewedByPr[prUrl];
+          if (!entry || !(filePath in entry.files)) return state;
+          const files = { ...entry.files };
+          delete files[filePath];
+          return {
+            viewedByPr: {
+              ...state.viewedByPr,
+              [prUrl]: { updatedAt: Date.now(), files },
+            },
+          };
+        }),
+    }),
+    { name: "pr-viewed-files" },
+  ),
+);
+
+export function isFileViewed(
+  viewedByPr: Record<string, PrViewedEntry>,
+  prUrl: string,
+  file: ChangedFile,
+): boolean {
+  return viewedByPr[prUrl]?.files[file.path] === fileViewedFingerprint(file);
+}

--- a/packages/ui/src/features/pr-review/useApprovePr.ts
+++ b/packages/ui/src/features/pr-review/useApprovePr.ts
@@ -1,0 +1,25 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "../../primitives/toast";
+
+export function useApprovePr(prUrl: string) {
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...trpc.git.approvePr.mutationOptions(),
+    onSuccess: async (result) => {
+      if (!result.success) {
+        toast.error(result.message || "Failed to approve pull request");
+        return;
+      }
+      toast.success("Pull request approved");
+      await queryClient.invalidateQueries(
+        trpc.git.getPrReviewComments.queryFilter({ prUrl }),
+      );
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to approve pull request");
+    },
+  });
+}

--- a/packages/ui/src/features/pr-review/useMarkPrReady.ts
+++ b/packages/ui/src/features/pr-review/useMarkPrReady.ts
@@ -1,0 +1,31 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "../../primitives/toast";
+
+/** Flip a draft PR to "ready for review". */
+export function useMarkPrReady(prUrl: string) {
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...trpc.git.updatePrByUrl.mutationOptions(),
+    onSuccess: async (result) => {
+      if (!result.success) {
+        toast.error(result.message || "Failed to mark as ready for review");
+        return;
+      }
+      toast.success("Marked as ready for review");
+      await Promise.all([
+        queryClient.invalidateQueries(
+          trpc.git.getPrInfoByUrl.queryFilter({ prUrl }),
+        ),
+        queryClient.invalidateQueries(
+          trpc.git.getPrDetailsByUrl.queryFilter({ prUrl }),
+        ),
+      ]);
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to mark as ready for review");
+    },
+  });
+}

--- a/packages/ui/src/features/pr-review/useMergePr.ts
+++ b/packages/ui/src/features/pr-review/useMergePr.ts
@@ -1,0 +1,34 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "../../primitives/toast";
+
+export function useMergePr(prUrl: string) {
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...trpc.git.mergePr.mutationOptions(),
+    onSuccess: async (result) => {
+      if (!result.success) {
+        toast.error(result.message || "Failed to merge pull request");
+        return;
+      }
+      toast.success("Pull request merged");
+      // The PR's state (and everything derived from it) just changed.
+      await Promise.all([
+        queryClient.invalidateQueries(
+          trpc.git.getPrInfoByUrl.queryFilter({ prUrl }),
+        ),
+        queryClient.invalidateQueries(
+          trpc.git.getPrDetailsByUrl.queryFilter({ prUrl }),
+        ),
+        queryClient.invalidateQueries(
+          trpc.git.getPrDiffStatsBatch.pathFilter(),
+        ),
+      ]);
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to merge pull request");
+    },
+  });
+}

--- a/packages/ui/src/features/pr-review/usePrChecks.ts
+++ b/packages/ui/src/features/pr-review/usePrChecks.ts
@@ -1,0 +1,19 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * CI checks for a PR. Polls while the view is mounted and the window is
+ * visible (TanStack pauses intervals for hidden documents by default), so a
+ * running pipeline keeps updating without a manual refresh.
+ */
+export function usePrChecks(prUrl: string | null) {
+  const trpc = useHostTRPC();
+  return useQuery({
+    ...trpc.git.getPrChecks.queryOptions({ prUrl: prUrl as string }),
+    enabled: !!prUrl,
+    staleTime: 10_000,
+    refetchInterval: 15_000,
+    placeholderData: (prev) => prev,
+    retry: 1,
+  });
+}

--- a/packages/ui/src/features/pr-review/usePrComments.ts
+++ b/packages/ui/src/features/pr-review/usePrComments.ts
@@ -1,0 +1,14 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useQuery } from "@tanstack/react-query";
+
+/** Conversation (issue) comments on a PR. */
+export function usePrComments(prUrl: string | null) {
+  const trpc = useHostTRPC();
+  return useQuery({
+    ...trpc.git.getPrComments.queryOptions({ prUrl: prUrl as string }),
+    enabled: !!prUrl,
+    staleTime: 30_000,
+    placeholderData: (prev) => prev,
+    retry: 1,
+  });
+}

--- a/packages/ui/src/features/pr-review/usePrInfo.ts
+++ b/packages/ui/src/features/pr-review/usePrInfo.ts
@@ -1,0 +1,14 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useQuery } from "@tanstack/react-query";
+
+/** Full PR overview (title, body, state, branches, stats) from GitHub. */
+export function usePrInfo(prUrl: string | null) {
+  const trpc = useHostTRPC();
+  return useQuery({
+    ...trpc.git.getPrInfoByUrl.queryOptions({ prUrl: prUrl as string }),
+    enabled: !!prUrl,
+    staleTime: 30_000,
+    placeholderData: (prev) => prev,
+    retry: 1,
+  });
+}

--- a/packages/ui/src/features/pr-review/usePrReviewThreads.ts
+++ b/packages/ui/src/features/pr-review/usePrReviewThreads.ts
@@ -1,0 +1,14 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useQuery } from "@tanstack/react-query";
+
+/** Inline review threads (code comments) on a PR. */
+export function usePrReviewThreads(prUrl: string | null) {
+  const trpc = useHostTRPC();
+  return useQuery({
+    ...trpc.git.getPrReviewComments.queryOptions({ prUrl: prUrl as string }),
+    enabled: !!prUrl,
+    staleTime: 30_000,
+    placeholderData: (prev) => prev,
+    retry: 1,
+  });
+}

--- a/packages/ui/src/features/pr-review/useReopenPr.ts
+++ b/packages/ui/src/features/pr-review/useReopenPr.ts
@@ -1,0 +1,31 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "../../primitives/toast";
+
+/** Reopen a closed (not merged) PR. */
+export function useReopenPr(prUrl: string) {
+  const trpc = useHostTRPC();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...trpc.git.updatePrByUrl.mutationOptions(),
+    onSuccess: async (result) => {
+      if (!result.success) {
+        toast.error(result.message || "Failed to reopen pull request");
+        return;
+      }
+      toast.success("Pull request reopened");
+      await Promise.all([
+        queryClient.invalidateQueries(
+          trpc.git.getPrInfoByUrl.queryFilter({ prUrl }),
+        ),
+        queryClient.invalidateQueries(
+          trpc.git.getPrDetailsByUrl.queryFilter({ prUrl }),
+        ),
+      ]);
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to reopen pull request");
+    },
+  });
+}

--- a/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -3,11 +3,11 @@ import { parseGithubUrl } from "@posthog/git/utils";
 import type { WorkspaceMode } from "@posthog/shared";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { TaskRunStatus } from "@posthog/shared/domain-types";
+import { navigateToPullRequestView } from "@posthog/ui/router/navigationBridge";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DotsCircleSpinner } from "../../../../primitives/DotsCircleSpinner";
 import { NestedButton } from "../../../../primitives/NestedButton";
 import { Tooltip } from "../../../../primitives/Tooltip";
-import { openExternalUrl } from "../../../../shell/openExternal";
 import type { SidebarPrState } from "../../useTaskPrStatus";
 import { SidebarItem } from "../SidebarItem";
 import { ICON_SIZE, TaskIcon } from "./TaskIcon";
@@ -19,7 +19,7 @@ function PrBadge({ url, number }: { url: string; number: number }) {
         aria-label={`Open pull request #${number}`}
         className="flex h-4 shrink-0 cursor-pointer items-center gap-0.5 rounded bg-gray-3 px-1 text-[11px] text-gray-11 transition-colors hover:bg-gray-4 hover:text-gray-12"
         onActivate={() => {
-          openExternalUrl(url);
+          navigateToPullRequestView(url);
         }}
       >
         <GitPullRequest size={10} weight="bold" />

--- a/packages/ui/src/router/navigationBridge.ts
+++ b/packages/ui/src/router/navigationBridge.ts
@@ -26,6 +26,13 @@ export function navigateToTaskDetail(taskId: string): void {
   });
 }
 
+export function navigateToPullRequestView(prUrl: string): void {
+  void getRouterOrNull()?.navigate({
+    to: "/code/pr",
+    search: { prUrl },
+  });
+}
+
 export function navigateToTaskPending(key: string): void {
   void getRouterOrNull()?.navigate({
     to: "/code/tasks/pending/$key",

--- a/packages/ui/src/router/routeTree.gen.ts
+++ b/packages/ui/src/router/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as WebsiteHomeRouteImport } from './routes/website/home'
 import { Route as WebsiteCommandCenterRouteImport } from './routes/website/command-center'
 import { Route as SettingsCategoryRouteImport } from './routes/settings/$category'
 import { Route as FoldersFolderIdRouteImport } from './routes/folders/$folderId'
+import { Route as CodePrRouteImport } from './routes/code/pr'
 import { Route as CodeInboxRouteImport } from './routes/code/inbox'
 import { Route as CodeHomeRouteImport } from './routes/code/home'
 import { Route as CodeArchivedRouteImport } from './routes/code/archived'
@@ -147,6 +148,11 @@ const SettingsCategoryRoute = SettingsCategoryRouteImport.update({
 const FoldersFolderIdRoute = FoldersFolderIdRouteImport.update({
   id: '/folders/$folderId',
   path: '/folders/$folderId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CodePrRoute = CodePrRouteImport.update({
+  id: '/code/pr',
+  path: '/code/pr',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CodeInboxRoute = CodeInboxRouteImport.update({
@@ -427,6 +433,7 @@ export interface FileRoutesByFullPath {
   '/code/archived': typeof CodeArchivedRoute
   '/code/home': typeof CodeHomeRoute
   '/code/inbox': typeof CodeInboxRouteWithChildren
+  '/code/pr': typeof CodePrRoute
   '/folders/$folderId': typeof FoldersFolderIdRoute
   '/settings/$category': typeof SettingsCategoryRoute
   '/website/command-center': typeof WebsiteCommandCenterRoute
@@ -490,6 +497,7 @@ export interface FileRoutesByTo {
   '/skills': typeof SkillsRoute
   '/code/archived': typeof CodeArchivedRoute
   '/code/home': typeof CodeHomeRoute
+  '/code/pr': typeof CodePrRoute
   '/folders/$folderId': typeof FoldersFolderIdRoute
   '/settings/$category': typeof SettingsCategoryRoute
   '/website/command-center': typeof WebsiteCommandCenterRoute
@@ -549,6 +557,7 @@ export interface FileRoutesById {
   '/code/archived': typeof CodeArchivedRoute
   '/code/home': typeof CodeHomeRoute
   '/code/inbox': typeof CodeInboxRouteWithChildren
+  '/code/pr': typeof CodePrRoute
   '/folders/$folderId': typeof FoldersFolderIdRoute
   '/settings/$category': typeof SettingsCategoryRoute
   '/website/command-center': typeof WebsiteCommandCenterRoute
@@ -617,6 +626,7 @@ export interface FileRouteTypes {
     | '/code/archived'
     | '/code/home'
     | '/code/inbox'
+    | '/code/pr'
     | '/folders/$folderId'
     | '/settings/$category'
     | '/website/command-center'
@@ -680,6 +690,7 @@ export interface FileRouteTypes {
     | '/skills'
     | '/code/archived'
     | '/code/home'
+    | '/code/pr'
     | '/folders/$folderId'
     | '/settings/$category'
     | '/website/command-center'
@@ -738,6 +749,7 @@ export interface FileRouteTypes {
     | '/code/archived'
     | '/code/home'
     | '/code/inbox'
+    | '/code/pr'
     | '/folders/$folderId'
     | '/settings/$category'
     | '/website/command-center'
@@ -805,6 +817,7 @@ export interface RootRouteChildren {
   CodeArchivedRoute: typeof CodeArchivedRoute
   CodeHomeRoute: typeof CodeHomeRoute
   CodeInboxRoute: typeof CodeInboxRouteWithChildren
+  CodePrRoute: typeof CodePrRoute
   FoldersFolderIdRoute: typeof FoldersFolderIdRoute
   SettingsCategoryRoute: typeof SettingsCategoryRoute
   CodeIndexRoute: typeof CodeIndexRoute
@@ -918,6 +931,13 @@ declare module '@tanstack/react-router' {
       path: '/folders/$folderId'
       fullPath: '/folders/$folderId'
       preLoaderRoute: typeof FoldersFolderIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/code/pr': {
+      id: '/code/pr'
+      path: '/code/pr'
+      fullPath: '/code/pr'
+      preLoaderRoute: typeof CodePrRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/code/inbox': {
@@ -1497,6 +1517,7 @@ const rootRouteChildren: RootRouteChildren = {
   CodeArchivedRoute: CodeArchivedRoute,
   CodeHomeRoute: CodeHomeRoute,
   CodeInboxRoute: CodeInboxRouteWithChildren,
+  CodePrRoute: CodePrRoute,
   FoldersFolderIdRoute: FoldersFolderIdRoute,
   SettingsCategoryRoute: SettingsCategoryRoute,
   CodeIndexRoute: CodeIndexRoute,

--- a/packages/ui/src/router/routes/code/pr.tsx
+++ b/packages/ui/src/router/routes/code/pr.tsx
@@ -1,0 +1,14 @@
+import { PullRequestView } from "@posthog/ui/features/pr-review/PullRequestView";
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/code/pr")({
+  component: PullRequestRoute,
+  validateSearch: (search: Record<string, unknown>): { prUrl: string } => ({
+    prUrl: typeof search.prUrl === "string" ? search.prUrl : "",
+  }),
+});
+
+function PullRequestRoute() {
+  const { prUrl } = Route.useSearch();
+  return <PullRequestView prUrl={prUrl} />;
+}

--- a/packages/workspace-server/src/services/git/schemas.ts
+++ b/packages/workspace-server/src/services/git/schemas.ts
@@ -475,6 +475,31 @@ export const mergePrOutput = z.object({
 
 export type MergePrOutput = z.infer<typeof mergePrOutput>;
 
+// CI check runs / commit statuses for a PR, via `gh pr checks`.
+// Mirrors `prCheckSchema` in `@posthog/core/git/router-schemas`.
+export const prCheckBucketSchema = z.enum([
+  "fail",
+  "cancel",
+  "pending",
+  "pass",
+  "skipping",
+]);
+export type PrCheckBucket = z.infer<typeof prCheckBucketSchema>;
+
+export const prCheckSchema = z.object({
+  name: z.string(),
+  bucket: prCheckBucketSchema,
+  link: z.string().nullable(),
+  workflow: z.string().nullable(),
+  description: z.string().nullable(),
+});
+export type PrCheck = z.infer<typeof prCheckSchema>;
+
+export const getPrChecksInput = z.object({ prUrl: z.string() });
+/** Null means the checks couldn't be fetched; [] means none reported. */
+export const getPrChecksOutput = z.array(prCheckSchema).nullable();
+export type GetPrChecksOutput = z.infer<typeof getPrChecksOutput>;
+
 export const getPrTemplateInput = directoryPathInput;
 
 export const getPrTemplateOutput = z.object({

--- a/packages/workspace-server/src/services/git/schemas.ts
+++ b/packages/workspace-server/src/services/git/schemas.ts
@@ -428,6 +428,53 @@ export const updatePrByUrlOutput = z.object({
 
 export type UpdatePrByUrlOutput = z.infer<typeof updatePrByUrlOutput>;
 
+// Full PR overview (title/body/branches/stats) for the native in-app PR view.
+// Mirrors `getPrInfoByUrlOutput` in `@posthog/core/git/router-schemas`.
+export const getPrInfoByUrlInput = z.object({ prUrl: z.string() });
+
+export const getPrInfoByUrlOutput = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string(),
+  author: z.string().nullable(),
+  state: z.string(),
+  merged: z.boolean(),
+  draft: z.boolean(),
+  /** GitHub computes mergeability asynchronously; null until it settles. */
+  mergeable: z.boolean().nullable(),
+  baseRefName: z.string().nullable(),
+  headRefName: z.string().nullable(),
+  additions: z.number(),
+  deletions: z.number(),
+  changedFiles: z.number(),
+});
+
+export type PrInfoByUrlOutput = z.infer<typeof getPrInfoByUrlOutput>;
+
+export const approvePrInput = z.object({ prUrl: z.string() });
+
+export const approvePrOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+
+export type ApprovePrOutput = z.infer<typeof approvePrOutput>;
+
+export const prMergeMethod = z.enum(["merge", "squash", "rebase"]);
+export type PrMergeMethod = z.infer<typeof prMergeMethod>;
+
+export const mergePrInput = z.object({
+  prUrl: z.string(),
+  method: prMergeMethod,
+});
+
+export const mergePrOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+
+export type MergePrOutput = z.infer<typeof mergePrOutput>;
+
 export const getPrTemplateInput = directoryPathInput;
 
 export const getPrTemplateOutput = z.object({

--- a/packages/workspace-server/src/services/git/schemas.ts
+++ b/packages/workspace-server/src/services/git/schemas.ts
@@ -428,96 +428,36 @@ export const updatePrByUrlOutput = z.object({
 
 export type UpdatePrByUrlOutput = z.infer<typeof updatePrByUrlOutput>;
 
-// Full PR overview (title/body/branches/stats) for the native in-app PR view.
-// Mirrors `getPrInfoByUrlOutput` in `@posthog/core/git/router-schemas`.
-export const getPrInfoByUrlInput = z.object({ prUrl: z.string() });
-
-export const getPrInfoByUrlOutput = z.object({
-  number: z.number(),
-  title: z.string(),
-  body: z.string(),
-  author: z.string().nullable(),
-  state: z.string(),
-  merged: z.boolean(),
-  draft: z.boolean(),
-  /** GitHub computes mergeability asynchronously; null until it settles. */
-  mergeable: z.boolean().nullable(),
-  baseRefName: z.string().nullable(),
-  headRefName: z.string().nullable(),
-  additions: z.number(),
-  deletions: z.number(),
-  changedFiles: z.number(),
-});
-
-export type PrInfoByUrlOutput = z.infer<typeof getPrInfoByUrlOutput>;
-
-export const approvePrInput = z.object({ prUrl: z.string() });
-
-export const approvePrOutput = z.object({
-  success: z.boolean(),
-  message: z.string(),
-});
-
-export type ApprovePrOutput = z.infer<typeof approvePrOutput>;
-
-export const prMergeMethod = z.enum(["merge", "squash", "rebase"]);
-export type PrMergeMethod = z.infer<typeof prMergeMethod>;
-
-export const mergePrInput = z.object({
-  prUrl: z.string(),
-  method: prMergeMethod,
-});
-
-export const mergePrOutput = z.object({
-  success: z.boolean(),
-  message: z.string(),
-});
-
-export type MergePrOutput = z.infer<typeof mergePrOutput>;
-
-// CI check runs / commit statuses for a PR, via `gh pr checks`.
-// Mirrors `prCheckSchema` in `@posthog/core/git/router-schemas`.
-export const prCheckBucketSchema = z.enum([
-  "fail",
-  "cancel",
-  "pending",
-  "pass",
-  "skipping",
-]);
-export type PrCheckBucket = z.infer<typeof prCheckBucketSchema>;
-
-export const prCheckSchema = z.object({
-  name: z.string(),
-  bucket: prCheckBucketSchema,
-  link: z.string().nullable(),
-  workflow: z.string().nullable(),
-  description: z.string().nullable(),
-});
-export type PrCheck = z.infer<typeof prCheckSchema>;
-
-export const getPrChecksInput = z.object({ prUrl: z.string() });
-/** Null means the checks couldn't be fetched; [] means none reported. */
-export const getPrChecksOutput = z.array(prCheckSchema).nullable();
-export type GetPrChecksOutput = z.infer<typeof getPrChecksOutput>;
-
-// Conversation (issue) comments on a PR. Inline review comments live in
-// `getPrReviewComments`. Mirrors `@posthog/core/git/router-schemas`.
-export const prConversationCommentSchema = z.object({
-  id: z.number(),
-  author: z.string(),
-  avatarUrl: z.string().nullable(),
-  body: z.string(),
-  createdAt: z.string(),
-  url: z.string().nullable(),
-});
-export type PrConversationComment = z.infer<typeof prConversationCommentSchema>;
-
-export const getPrCommentsInput = z.object({ prUrl: z.string() });
-/** Null means the comments couldn't be fetched; [] means none. */
-export const getPrCommentsOutput = z
-  .array(prConversationCommentSchema)
-  .nullable();
-export type GetPrCommentsOutput = z.infer<typeof getPrCommentsOutput>;
+export type {
+  ApprovePrOutput,
+  GetPrChecksOutput,
+  GetPrCommentsOutput,
+  MergePrOutput,
+  PrCheck,
+  PrCheckBucket,
+  PrConversationComment,
+  PrInfoByUrlOutput,
+  PrMergeMethod,
+} from "@posthog/shared";
+// Native PR review schemas (PR overview, approve/merge, CI checks,
+// conversation comments) are defined once in `@posthog/shared`'s git domain
+// and re-exported here for the tRPC procedure definitions and GitService.
+export {
+  approvePrInput,
+  approvePrOutput,
+  getPrChecksInput,
+  getPrChecksOutput,
+  getPrCommentsInput,
+  getPrCommentsOutput,
+  getPrInfoByUrlInput,
+  getPrInfoByUrlOutput,
+  mergePrInput,
+  mergePrOutput,
+  prCheckBucketSchema,
+  prCheckSchema,
+  prConversationCommentSchema,
+  prMergeMethodSchema,
+} from "@posthog/shared";
 
 export const getPrTemplateInput = directoryPathInput;
 

--- a/packages/workspace-server/src/services/git/schemas.ts
+++ b/packages/workspace-server/src/services/git/schemas.ts
@@ -500,6 +500,25 @@ export const getPrChecksInput = z.object({ prUrl: z.string() });
 export const getPrChecksOutput = z.array(prCheckSchema).nullable();
 export type GetPrChecksOutput = z.infer<typeof getPrChecksOutput>;
 
+// Conversation (issue) comments on a PR. Inline review comments live in
+// `getPrReviewComments`. Mirrors `@posthog/core/git/router-schemas`.
+export const prConversationCommentSchema = z.object({
+  id: z.number(),
+  author: z.string(),
+  avatarUrl: z.string().nullable(),
+  body: z.string(),
+  createdAt: z.string(),
+  url: z.string().nullable(),
+});
+export type PrConversationComment = z.infer<typeof prConversationCommentSchema>;
+
+export const getPrCommentsInput = z.object({ prUrl: z.string() });
+/** Null means the comments couldn't be fetched; [] means none. */
+export const getPrCommentsOutput = z
+  .array(prConversationCommentSchema)
+  .nullable();
+export type GetPrCommentsOutput = z.infer<typeof getPrCommentsOutput>;
+
 export const getPrTemplateInput = directoryPathInput;
 
 export const getPrTemplateOutput = z.object({

--- a/packages/workspace-server/src/services/git/service.ts
+++ b/packages/workspace-server/src/services/git/service.ts
@@ -74,6 +74,7 @@ import type {
   PrActionType,
   PrCheck,
   PrCheckBucket,
+  PrConversationComment,
   PrDetailsByUrlOutput,
   PrDiffStats,
   PrInfoByUrlOutput,
@@ -89,6 +90,7 @@ import type {
   SyncOutput,
   UpdatePrByUrlOutput,
 } from "./schemas";
+import { getPrInfoByUrlOutput, prConversationCommentSchema } from "./schemas";
 
 const FETCH_THROTTLE_MS = 30_000;
 /** Max PRs per GraphQL request – stays well under GitHub's complexity ceiling. */
@@ -1005,7 +1007,9 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
         return null;
       }
 
-      return JSON.parse(result.stdout) as PrInfoByUrlOutput;
+      // Zod-parse rather than cast, so a GitHub response-shape change
+      // surfaces here (caught, -> null) instead of leaking bad data.
+      return getPrInfoByUrlOutput.parse(JSON.parse(result.stdout));
     } catch {
       return null;
     }
@@ -1444,39 +1448,45 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
     const pr = parseGithubUrl(prUrl);
     if (pr?.kind !== "pr") return null;
 
-    try {
-      const result = await execGh([
-        "api",
+    // GitHub's conversation tab is two feeds: issue comments and review
+    // summaries ("approved with a comment"). Inline code comments come from
+    // getPrReviewComments separately.
+    const [comments, reviewSummaries] = await Promise.all([
+      this.fetchPrCommentFeed(
         `repos/${pr.owner}/${pr.repo}/issues/${pr.number}/comments`,
-        "--paginate",
-        "--slurp",
-      ]);
+        '.[] | {id, author: (.user.login // "unknown"), avatarUrl: (.user.avatar_url // null), body: (.body // ""), createdAt: .created_at, url: (.html_url // null)}',
+      ),
+      this.fetchPrCommentFeed(
+        `repos/${pr.owner}/${pr.repo}/pulls/${pr.number}/reviews`,
+        '.[] | select(.state != "PENDING") | select((.body // "") != "") | {id, author: (.user.login // "unknown"), avatarUrl: (.user.avatar_url // null), body, createdAt: (.submitted_at // ""), url: (.html_url // null)}',
+      ),
+    ]);
+    return [...comments, ...reviewSummaries];
+  }
 
-      if (result.exitCode !== 0) {
-        return null;
-      }
+  /**
+   * Fetch a paginated comment-shaped feed, slimmed to the schema fields in
+   * gh's jq (full comment objects are mostly boilerplate URLs and can blow
+   * past the exec buffer on busy PRs). `--jq` with `--paginate` emits one
+   * compact JSON object per line. Throws on failure so the renderer can show
+   * why (rate limit, auth, network) instead of a silent empty section.
+   */
+  private async fetchPrCommentFeed(
+    endpoint: string,
+    jq: string,
+  ): Promise<PrConversationComment[]> {
+    const result = await execGh(["api", endpoint, "--paginate", "--jq", jq]);
 
-      const pages = JSON.parse(result.stdout) as Array<
-        Array<{
-          id: number;
-          body?: string;
-          created_at: string;
-          html_url?: string;
-          user?: { login?: string; avatar_url?: string };
-        }>
-      >;
-
-      return pages.flat().map((comment) => ({
-        id: comment.id,
-        author: comment.user?.login ?? "unknown",
-        avatarUrl: comment.user?.avatar_url ?? null,
-        body: comment.body ?? "",
-        createdAt: comment.created_at,
-        url: comment.html_url ?? null,
-      }));
-    } catch {
-      return null;
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Failed to fetch PR comments: ${result.stderr || result.error || "Unknown error"}`,
+      );
     }
+
+    return result.stdout
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .map((line) => prConversationCommentSchema.parse(JSON.parse(line)));
   }
 
   async getPrReviewComments(prUrl: string): Promise<PrReviewThread[]> {

--- a/packages/workspace-server/src/services/git/service.ts
+++ b/packages/workspace-server/src/services/git/service.ts
@@ -55,6 +55,7 @@ import type {
   DetectRepoResult,
   DiscardFileChangesOutput,
   GetCommitConventionsOutput,
+  GetPrChecksOutput,
   GetPrTemplateOutput,
   GhAuthTokenOutput,
   GhStatusOutput,
@@ -70,6 +71,8 @@ import type {
   MergePrOutput,
   OpenPrOutput,
   PrActionType,
+  PrCheck,
+  PrCheckBucket,
   PrDetailsByUrlOutput,
   PrDiffStats,
   PrInfoByUrlOutput,
@@ -136,6 +139,22 @@ function normalizeGraphqlPrState(
       return "closed";
     default:
       return "open";
+  }
+}
+
+/**
+ * Narrow `gh pr checks` bucket values to the schema enum. Unknown values fall
+ * back to "pending" so one odd bucket can never fail the whole checks list.
+ */
+function normalizeCheckBucket(bucket: string | undefined): PrCheckBucket {
+  switch (bucket) {
+    case "fail":
+    case "cancel":
+    case "pass":
+    case "skipping":
+      return bucket;
+    default:
+      return "pending";
   }
 }
 
@@ -1371,6 +1390,52 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
         success: false,
         message: error instanceof Error ? error.message : "Unknown error",
       };
+    }
+  }
+
+  async getPrChecks(prUrl: string): Promise<GetPrChecksOutput> {
+    const pr = parseGithubUrl(prUrl);
+    if (pr?.kind !== "pr") return null;
+
+    try {
+      // `gh pr checks` exits non-zero when checks are failing (1) or pending
+      // (8), so the exit code alone doesn't distinguish "couldn't fetch" from
+      // "fetched, some red" — parse stdout instead.
+      const result = await execGh([
+        "pr",
+        "checks",
+        String(pr.number),
+        "--repo",
+        `${pr.owner}/${pr.repo}`,
+        "--json",
+        "name,bucket,link,workflow,description",
+      ]);
+
+      if (result.stdout.trim()) {
+        const checks = JSON.parse(result.stdout) as Array<{
+          name?: string;
+          bucket?: string;
+          link?: string;
+          workflow?: string;
+          description?: string;
+        }>;
+        return checks.map(
+          (check): PrCheck => ({
+            name: check.name ?? "",
+            bucket: normalizeCheckBucket(check.bucket),
+            link: check.link || null,
+            workflow: check.workflow || null,
+            description: check.description || null,
+          }),
+        );
+      }
+
+      if (result.exitCode === 0) return [];
+      // A PR with no CI configured is not an error state.
+      if ((result.stderr ?? "").includes("no checks reported")) return [];
+      return null;
+    } catch {
+      return null;
     }
   }
 

--- a/packages/workspace-server/src/services/git/service.ts
+++ b/packages/workspace-server/src/services/git/service.ts
@@ -1000,7 +1000,7 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
         "api",
         `repos/${pr.owner}/${pr.repo}/pulls/${pr.number}`,
         "--jq",
-        '{number,title,body: (.body // ""),author: .user.login,state,merged,draft,mergeable,baseRefName: .base.ref,headRefName: .head.ref,additions,deletions,changedFiles: .changed_files}',
+        '{number,title,body: (.body // ""),author: .user.login,state,merged,draft,mergeable,mergeStateStatus: (.mergeable_state // "unknown"),baseRefName: .base.ref,headRefName: .head.ref,additions,deletions,changedFiles: .changed_files}',
       ]);
 
       if (result.exitCode !== 0) {

--- a/packages/workspace-server/src/services/git/service.ts
+++ b/packages/workspace-server/src/services/git/service.ts
@@ -56,6 +56,7 @@ import type {
   DiscardFileChangesOutput,
   GetCommitConventionsOutput,
   GetPrChecksOutput,
+  GetPrCommentsOutput,
   GetPrTemplateOutput,
   GhAuthTokenOutput,
   GhStatusOutput,
@@ -1434,6 +1435,45 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
       // A PR with no CI configured is not an error state.
       if ((result.stderr ?? "").includes("no checks reported")) return [];
       return null;
+    } catch {
+      return null;
+    }
+  }
+
+  async getPrComments(prUrl: string): Promise<GetPrCommentsOutput> {
+    const pr = parseGithubUrl(prUrl);
+    if (pr?.kind !== "pr") return null;
+
+    try {
+      const result = await execGh([
+        "api",
+        `repos/${pr.owner}/${pr.repo}/issues/${pr.number}/comments`,
+        "--paginate",
+        "--slurp",
+      ]);
+
+      if (result.exitCode !== 0) {
+        return null;
+      }
+
+      const pages = JSON.parse(result.stdout) as Array<
+        Array<{
+          id: number;
+          body?: string;
+          created_at: string;
+          html_url?: string;
+          user?: { login?: string; avatar_url?: string };
+        }>
+      >;
+
+      return pages.flat().map((comment) => ({
+        id: comment.id,
+        author: comment.user?.login ?? "unknown",
+        avatarUrl: comment.user?.avatar_url ?? null,
+        body: comment.body ?? "",
+        createdAt: comment.created_at,
+        url: comment.html_url ?? null,
+      }));
     } catch {
       return null;
     }

--- a/packages/workspace-server/src/services/git/service.ts
+++ b/packages/workspace-server/src/services/git/service.ts
@@ -48,6 +48,7 @@ import { TypedEventEmitter } from "@posthog/shared";
 import { injectable } from "inversify";
 import type { SidebarPrState } from "../workspace/schemas";
 import type {
+  ApprovePrOutput,
   ChangedFile,
   CloneProgressPayload,
   CommitOutput,
@@ -66,10 +67,13 @@ import type {
   GitStatusOutput,
   GitSyncStatus,
   HandoffLocalGitState,
+  MergePrOutput,
   OpenPrOutput,
   PrActionType,
   PrDetailsByUrlOutput,
   PrDiffStats,
+  PrInfoByUrlOutput,
+  PrMergeMethod,
   PrReviewComment,
   PrReviewThread,
   PrStatusOutput,
@@ -965,6 +969,28 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
     }
   }
 
+  async getPrInfoByUrl(prUrl: string): Promise<PrInfoByUrlOutput | null> {
+    const pr = parseGithubUrl(prUrl);
+    if (pr?.kind !== "pr") return null;
+
+    try {
+      const result = await execGh([
+        "api",
+        `repos/${pr.owner}/${pr.repo}/pulls/${pr.number}`,
+        "--jq",
+        '{number,title,body: (.body // ""),author: .user.login,state,merged,draft,mergeable,baseRefName: .base.ref,headRefName: .head.ref,additions,deletions,changedFiles: .changed_files}',
+      ]);
+
+      if (result.exitCode !== 0) {
+        return null;
+      }
+
+      return JSON.parse(result.stdout) as PrInfoByUrlOutput;
+    } catch {
+      return null;
+    }
+  }
+
   async getPrChangedFiles(prUrl: string): Promise<ChangedFile[]> {
     const pr = parseGithubUrl(prUrl);
     if (pr?.kind !== "pr") return [];
@@ -1264,6 +1290,70 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
 
       const result = await execGh([
         ...args,
+        "--repo",
+        `${pr.owner}/${pr.repo}`,
+      ]);
+
+      if (result.exitCode !== 0) {
+        return {
+          success: false,
+          message: result.stderr || result.error || "Unknown error",
+        };
+      }
+
+      return { success: true, message: result.stdout };
+    } catch (error) {
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  }
+
+  async approvePr(prUrl: string): Promise<ApprovePrOutput> {
+    const pr = parseGithubUrl(prUrl);
+    if (pr?.kind !== "pr") {
+      return { success: false, message: "Invalid PR URL" };
+    }
+
+    try {
+      const result = await execGh([
+        "pr",
+        "review",
+        String(pr.number),
+        "--approve",
+        "--repo",
+        `${pr.owner}/${pr.repo}`,
+      ]);
+
+      if (result.exitCode !== 0) {
+        return {
+          success: false,
+          message: result.stderr || result.error || "Unknown error",
+        };
+      }
+
+      return { success: true, message: result.stdout };
+    } catch (error) {
+      return {
+        success: false,
+        message: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  }
+
+  async mergePr(prUrl: string, method: PrMergeMethod): Promise<MergePrOutput> {
+    const pr = parseGithubUrl(prUrl);
+    if (pr?.kind !== "pr") {
+      return { success: false, message: "Invalid PR URL" };
+    }
+
+    try {
+      const result = await execGh([
+        "pr",
+        "merge",
+        String(pr.number),
+        `--${method}`,
         "--repo",
         `${pr.owner}/${pr.repo}`,
       ]);

--- a/packages/workspace-server/src/trpc.ts
+++ b/packages/workspace-server/src/trpc.ts
@@ -83,6 +83,8 @@ import {
   getPrChangedFilesInput,
   getPrChecksInput,
   getPrChecksOutput,
+  getPrCommentsInput,
+  getPrCommentsOutput,
   getPrDetailsByUrlInput,
   getPrDetailsByUrlOutput,
   getPrDiffStatsBatchInput,
@@ -576,6 +578,11 @@ export function createAppRouter({
         .input(getPrChecksInput)
         .output(getPrChecksOutput)
         .query(({ input }) => gitService().getPrChecks(input.prUrl)),
+
+      getPrComments: t.procedure
+        .input(getPrCommentsInput)
+        .output(getPrCommentsOutput)
+        .query(({ input }) => gitService().getPrComments(input.prUrl)),
 
       getPrChangedFiles: t.procedure
         .input(getPrChangedFilesInput)

--- a/packages/workspace-server/src/trpc.ts
+++ b/packages/workspace-server/src/trpc.ts
@@ -45,6 +45,8 @@ import {
 } from "./services/fs/schemas";
 import type { FsService } from "./services/fs/service";
 import {
+  approvePrInput,
+  approvePrOutput,
   changedFilesOutput,
   checkoutBranchInput,
   checkoutBranchOutput,
@@ -83,6 +85,8 @@ import {
   getPrDetailsByUrlOutput,
   getPrDiffStatsBatchInput,
   getPrDiffStatsBatchOutput,
+  getPrInfoByUrlInput,
+  getPrInfoByUrlOutput,
   getPrReviewCommentsInput,
   getPrReviewCommentsOutput,
   getPrTemplateInput,
@@ -100,6 +104,8 @@ import {
   syncInput as gitSyncInput,
   syncOutput as gitSyncOutput,
   gitSyncStatusSchema,
+  mergePrInput,
+  mergePrOutput,
   openPrInput,
   openPrOutput,
   prStatusOutput,
@@ -559,6 +565,11 @@ export function createAppRouter({
         .output(getPrDetailsByUrlOutput.nullable())
         .query(({ input }) => gitService().getPrDetailsByUrl(input.prUrl)),
 
+      getPrInfoByUrl: t.procedure
+        .input(getPrInfoByUrlInput)
+        .output(getPrInfoByUrlOutput.nullable())
+        .query(({ input }) => gitService().getPrInfoByUrl(input.prUrl)),
+
       getPrChangedFiles: t.procedure
         .input(getPrChangedFilesInput)
         .output(changedFilesOutput)
@@ -591,6 +602,18 @@ export function createAppRouter({
         .output(updatePrByUrlOutput)
         .mutation(({ input }) =>
           gitService().updatePrByUrl(input.prUrl, input.action),
+        ),
+
+      approvePr: t.procedure
+        .input(approvePrInput)
+        .output(approvePrOutput)
+        .mutation(({ input }) => gitService().approvePr(input.prUrl)),
+
+      mergePr: t.procedure
+        .input(mergePrInput)
+        .output(mergePrOutput)
+        .mutation(({ input }) =>
+          gitService().mergePr(input.prUrl, input.method),
         ),
 
       getPrReviewComments: t.procedure

--- a/packages/workspace-server/src/trpc.ts
+++ b/packages/workspace-server/src/trpc.ts
@@ -81,6 +81,8 @@ import {
   getHeadShaOutput,
   getLocalBranchChangedFilesInput,
   getPrChangedFilesInput,
+  getPrChecksInput,
+  getPrChecksOutput,
   getPrDetailsByUrlInput,
   getPrDetailsByUrlOutput,
   getPrDiffStatsBatchInput,
@@ -569,6 +571,11 @@ export function createAppRouter({
         .input(getPrInfoByUrlInput)
         .output(getPrInfoByUrlOutput.nullable())
         .query(({ input }) => gitService().getPrInfoByUrl(input.prUrl)),
+
+      getPrChecks: t.procedure
+        .input(getPrChecksInput)
+        .output(getPrChecksOutput)
+        .query(({ input }) => gitService().getPrChecks(input.prUrl)),
 
       getPrChangedFiles: t.procedure
         .input(getPrChangedFilesInput)


### PR DESCRIPTION
## What this does

Adds a native pull request review surface to PostHog Code, so a PR can be reviewed, approved, and merged without leaving the app.

<img width="1381" height="1136" alt="2026-07-06 14 13 30" src="https://github.com/user-attachments/assets/eaf2854c-e0af-4f2c-8894-4263ffe243ab" />

<img width="880" height="573" alt="image" src="https://github.com/user-attachments/assets/ab3ee8a1-0e5c-4956-a3ba-639aac580033" />


### Surfaces

- **Inbox PR detail** (`/code/inbox/pulls/$reportId`): below the Responder summary, the PR's changed files, comments, CI checks, and approve/merge actions now render inline.
- **Native PR view** (`/code/pr?prUrl=…`): clicking the `#123` PR badge in the sidebar task list opens an in-app view (state badge, title, author, branches, ± stats, markdown description, then the same files/comments/checks/actions stack) instead of the browser. \"Open in GitHub\" remains as an escape hatch.

### Files changed

- One collapsible diff per file (reusing the existing `PatchedFileDiff` / `@pierre/diffs` machinery, respecting the user's diff settings), all collapsed by default with an **Expand all / Collapse all** button.
- GitHub-style **\"Viewed\" tracking**: an expanded file gets a footer row with a Viewed checkbox; checking it folds the file and scrolls it back into view. Viewed state persists per PR (capped at 50 PRs) and is fingerprinted against the patch, so files touched by new commits drop back to unviewed. Header shows `N / M viewed`.

### Comments

- Collapsed-by-default section merging PR conversation comments and inline review comments chronologically — avatar, author, relative time, file path + Resolved badge for review comments, markdown body, per-comment open-in-GitHub link.

### Checks

- CI status list via `gh pr checks --json`, sorted failed → cancelled → running → succeeded → skipped with colored status icons; rows open the check run in GitHub.
- The header counts are **filter checkboxes** (failed / cancelled / running / successful / skipped); only attention-worthy buckets are shown by default. Polls every 15s while the view is mounted and visible.

### Approve & merge

- **Approve** (`gh pr review --approve`) and a **merge button with method dropdown** (merge / squash / rebase, via `gh pr merge`).
- The merge gate mirrors github.com: red checks or merge conflicts disable the buttons with a red explanation, updating live off the checks poll. Drafts show a note plus a **Ready for review** button. Merged/closed PRs show a status banner.

### Backend

New `GitService` methods on the existing `gh` CLI layer, each exposed through workspace-server and host-router tRPC with mirrored Zod schemas: `getPrInfoByUrl`, `getPrChecks`, `getPrComments`, `approvePr`, `mergePr`.

## Testing

- `pnpm typecheck` — all 22 packages pass
- `biome check` on touched packages — clean
- Unit tests for the viewed-files store (fingerprint invalidation, eviction cap); affected UI suites pass (77 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)