### PR TITLE
feat(cloud): custom sandbox base images

### DIFF
--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -183,7 +183,9 @@ function buildEnvironment(gateway?: GatewayEnv): Record<string, string> {
     }),
     ...(gateway?.openaiBaseUrl && { OPENAI_BASE_URL: gateway.openaiBaseUrl }),
     ...(gateway?.openaiApiKey && { OPENAI_API_KEY: gateway.openaiApiKey }),
-    ELECTRON_RUN_AS_NODE: "1",
+    ...((process.versions.electron || process.env.ELECTRON_RUN_AS_NODE) && {
+      ELECTRON_RUN_AS_NODE: "1",
+    }),
     CLAUDE_CODE_ENABLE_ASK_USER_QUESTION_TOOL: "true",
     // Offload all MCP tools by default
     ENABLE_TOOL_SEARCH: "auto:0",

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -54,6 +54,7 @@ import type {
   PriorityJudgmentArtefact,
   RepoSelectionArtefact,
   SafetyJudgmentArtefact,
+  SandboxCustomImage,
   SandboxEnvironment,
   SandboxEnvironmentInput,
   Signal,
@@ -119,6 +120,13 @@ export class SeatPaymentFailedError extends Error {
   constructor(message?: string) {
     super(message ?? "Payment failed");
     this.name = "SeatPaymentFailedError";
+  }
+}
+
+export class SandboxCustomImagesDisabledError extends Error {
+  constructor(message?: string) {
+    super(message ?? "Custom sandbox images are not enabled");
+    this.name = "SandboxCustomImagesDisabledError";
   }
 }
 
@@ -478,6 +486,7 @@ interface CloudRunOptions {
   model?: string;
   reasoningLevel?: string;
   sandboxEnvironmentId?: string;
+  customImageId?: string;
   prAuthorshipMode?: PrAuthorshipMode;
   autoPublish?: boolean;
   runSource?: CloudRunSource;
@@ -549,6 +558,9 @@ function buildCloudRunRequestBody(
   }
   if (options?.sandboxEnvironmentId) {
     body.sandbox_environment_id = options.sandboxEnvironmentId;
+  }
+  if (options?.customImageId) {
+    body.custom_image_id = options.customImageId;
   }
   if (options?.prAuthorshipMode) {
     body.pr_authorship_mode = options.prAuthorshipMode;
@@ -4459,6 +4471,155 @@ export class PostHogAPIClient {
     if (!response.ok) {
       throw new Error(
         `Failed to delete sandbox environment: ${response.statusText}`,
+      );
+    }
+  }
+
+  async listSandboxCustomImages(): Promise<SandboxCustomImage[]> {
+    const teamId = await this.getTeamId();
+    const url = new URL(
+      `${this.api.baseUrl}/api/projects/${teamId}/sandbox_custom_images/`,
+    );
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: `/api/projects/${teamId}/sandbox_custom_images/`,
+    });
+    if (!response.ok) {
+      if (response.status === 403) {
+        const errorData = (await response.json().catch(() => ({}))) as {
+          detail?: string;
+        };
+        throw new SandboxCustomImagesDisabledError(errorData.detail);
+      }
+      throw new Error(
+        `Failed to fetch sandbox custom images: ${response.statusText}`,
+      );
+    }
+    const data = (await response.json()) as {
+      results?: SandboxCustomImage[];
+    };
+    return data.results ?? [];
+  }
+
+  async createSandboxCustomImage(input: {
+    name: string;
+    description?: string;
+    repository?: string | null;
+    private?: boolean;
+  }): Promise<SandboxCustomImage> {
+    const teamId = await this.getTeamId();
+    const url = new URL(
+      `${this.api.baseUrl}/api/projects/${teamId}/sandbox_custom_images/`,
+    );
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url,
+      path: `/api/projects/${teamId}/sandbox_custom_images/`,
+      overrides: {
+        body: JSON.stringify(input),
+      },
+    });
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => ({}))) as {
+        detail?: string;
+      };
+      throw new Error(
+        errorData.detail ??
+          `Failed to create sandbox custom image: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as SandboxCustomImage;
+  }
+
+  async getSandboxCustomImage(id: string): Promise<SandboxCustomImage> {
+    const teamId = await this.getTeamId();
+    const url = new URL(
+      `${this.api.baseUrl}/api/projects/${teamId}/sandbox_custom_images/${id}/`,
+    );
+    const response = await this.api.fetcher.fetch({
+      method: "get",
+      url,
+      path: `/api/projects/${teamId}/sandbox_custom_images/${id}/`,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch sandbox custom image: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as SandboxCustomImage;
+  }
+
+  async ensureSandboxCustomImageBuilderTask(
+    id: string,
+  ): Promise<SandboxCustomImage> {
+    const teamId = await this.getTeamId();
+    const url = new URL(
+      `${this.api.baseUrl}/api/projects/${teamId}/sandbox_custom_images/${id}/builder_task/`,
+    );
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url,
+      path: `/api/projects/${teamId}/sandbox_custom_images/${id}/builder_task/`,
+      overrides: {
+        body: JSON.stringify({}),
+      },
+    });
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => ({}))) as {
+        detail?: string;
+      };
+      throw new Error(
+        errorData.detail ??
+          `Failed to open image builder session: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as SandboxCustomImage;
+  }
+
+  async buildSandboxCustomImage(
+    id: string,
+    specYaml?: string | null,
+  ): Promise<SandboxCustomImage> {
+    const teamId = await this.getTeamId();
+    const url = new URL(
+      `${this.api.baseUrl}/api/projects/${teamId}/sandbox_custom_images/${id}/build/`,
+    );
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url,
+      path: `/api/projects/${teamId}/sandbox_custom_images/${id}/build/`,
+      overrides: {
+        body: JSON.stringify(
+          specYaml === undefined ? {} : { spec_yaml: specYaml },
+        ),
+      },
+    });
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => ({}))) as {
+        detail?: string;
+      };
+      throw new Error(
+        errorData.detail ??
+          `Failed to build sandbox custom image: ${response.statusText}`,
+      );
+    }
+    return (await response.json()) as SandboxCustomImage;
+  }
+
+  async deleteSandboxCustomImage(id: string): Promise<void> {
+    const teamId = await this.getTeamId();
+    const url = new URL(
+      `${this.api.baseUrl}/api/projects/${teamId}/sandbox_custom_images/${id}/`,
+    );
+    const response = await this.api.fetcher.fetch({
+      method: "delete",
+      url,
+      path: `/api/projects/${teamId}/sandbox_custom_images/${id}/`,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to delete sandbox custom image: ${response.statusText}`,
       );
     }
   }

--- a/packages/api-client/src/sandbox-custom-images.test.ts
+++ b/packages/api-client/src/sandbox-custom-images.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PostHogAPIClient,
+  SandboxCustomImagesDisabledError,
+} from "./posthog-client";
+
+function makeClient(fetch: ReturnType<typeof vi.fn>): PostHogAPIClient {
+  const client = new PostHogAPIClient(
+    "http://localhost:8000",
+    async () => "token",
+    async () => "token",
+    123,
+  );
+  (
+    client as unknown as {
+      api: { baseUrl: string; fetcher: { fetch: typeof fetch } };
+    }
+  ).api = { baseUrl: "http://localhost:8000", fetcher: { fetch } };
+  return client;
+}
+
+describe("PostHogAPIClient sandbox custom images", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps a 403 on list to SandboxCustomImagesDisabledError", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      json: async () => ({ detail: "not enabled" }),
+    });
+    await expect(
+      makeClient(fetch).listSandboxCustomImages(),
+    ).rejects.toBeInstanceOf(SandboxCustomImagesDisabledError);
+  });
+
+  it("does not map a non-403 list error to the disabled error", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Server Error",
+      json: async () => ({ detail: "boom" }),
+    });
+    const promise = makeClient(fetch).listSandboxCustomImages();
+    await expect(promise).rejects.toThrow();
+    await expect(promise).rejects.not.toBeInstanceOf(
+      SandboxCustomImagesDisabledError,
+    );
+  });
+
+  it.each([
+    ["undefined spec", undefined, {}],
+    ["null spec", null, { spec_yaml: null }],
+    ["string spec", "version: 1", { spec_yaml: "version: 1" }],
+  ])("builds with %s body", async (_name, specYaml, expectedBody) => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "im-1" }),
+    });
+
+    await makeClient(fetch).buildSandboxCustomImage("im-1", specYaml);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overrides: { body: JSON.stringify(expectedBody) },
+      }),
+    );
+  });
+});

--- a/packages/core/src/settings/sandboxEnvironmentForm.ts
+++ b/packages/core/src/settings/sandboxEnvironmentForm.ts
@@ -15,6 +15,7 @@ export interface SandboxEnvironmentFormState {
   include_default_domains: boolean;
   environment_variables_text: string;
   private: boolean;
+  custom_image_id: string | null;
 }
 
 export function isValidDomain(domain: string): boolean {
@@ -71,6 +72,7 @@ export function emptyForm(): SandboxEnvironmentFormState {
     include_default_domains: true,
     environment_variables_text: "",
     private: true,
+    custom_image_id: null,
   };
 }
 
@@ -84,6 +86,7 @@ export function formFromEnv(
     include_default_domains: env.include_default_domains,
     environment_variables_text: "",
     private: env.private,
+    custom_image_id: env.custom_image_id ?? null,
   };
 }
 
@@ -100,6 +103,7 @@ export function buildSandboxEnvironmentInput(
     include_default_domains: isCustom ? form.include_default_domains : false,
     private: form.private,
     repositories: [],
+    custom_image_id: form.custom_image_id,
     ...(form.environment_variables_text.trim()
       ? { environment_variables: envVars }
       : {}),

--- a/packages/core/src/sidebar/groupTasks.test.ts
+++ b/packages/core/src/sidebar/groupTasks.test.ts
@@ -220,6 +220,37 @@ describe("groupByRepository", () => {
     expect(groups[0]?.name).toBe("Other");
   });
 
+  it("routes image-builder tasks to a pinned 'Custom images' group above 'Other'", () => {
+    const tasks: TestTask[] = [
+      { id: "t1", repository: null, originProduct: "image_builder" },
+      {
+        id: "t2",
+        repository: {
+          fullPath: "posthog/code",
+          name: "code",
+          organization: "PostHog",
+        },
+        originProduct: "image_builder",
+      },
+      task("t3"),
+      task("t4", {
+        fullPath: "posthog/posthog",
+        name: "posthog",
+        organization: "PostHog",
+      }),
+    ];
+
+    const groups = groupByRepository(tasks, []);
+
+    expect(groups.map((g) => g.id)).toEqual([
+      "posthog/posthog",
+      "custom-images",
+      "other",
+    ]);
+    expect(groups[1]?.name).toBe("Custom images");
+    expect(groups[1]?.tasks.map((t) => t.id)).toEqual(["t1", "t2"]);
+  });
+
   it("keeps the bare name for a group without an organization when others collide", () => {
     const tasks: TestTask[] = [
       task("t1", {

--- a/packages/core/src/sidebar/groupTasks.ts
+++ b/packages/core/src/sidebar/groupTasks.ts
@@ -13,7 +13,10 @@ export interface TaskRepositoryInfo {
 
 export interface GroupableTask {
   repository: TaskRepositoryInfo | null;
+  originProduct?: string;
 }
+
+export const CUSTOM_IMAGES_GROUP_ID = "custom-images";
 
 export interface TaskGroup<T extends GroupableTask> {
   id: string;
@@ -69,8 +72,13 @@ export function groupByRepository<T extends GroupableTask>(
 
   for (const task of tasks) {
     const repository = task.repository;
-    const groupId = repository?.fullPath ?? "other";
-    const groupName = repository?.name ?? "Other";
+    const isImageBuilder = task.originProduct === "image_builder";
+    const groupId = isImageBuilder
+      ? CUSTOM_IMAGES_GROUP_ID
+      : (repository?.fullPath ?? "other");
+    const groupName = isImageBuilder
+      ? "Custom images"
+      : (repository?.name ?? "Other");
 
     let group = groupMap.get(groupId);
     if (!group) {
@@ -106,25 +114,27 @@ export function groupByRepository<T extends GroupableTask>(
     }
   }
 
-  // The "other" group (tasks without a resolvable repository) always sorts to
-  // the bottom, regardless of the alphabetical or persisted folder order.
-  const pinOtherLast = (a: TaskGroup<T>, b: TaskGroup<T>): number | null => {
-    const aOther = a.id === "other";
-    const bOther = b.id === "other";
-    if (aOther && bOther) return 0;
-    if (aOther) return 1;
-    if (bOther) return -1;
-    return null;
+  // Custom-images and "other" always sort last, in that order.
+  const pinnedRank = (group: TaskGroup<T>): number => {
+    if (group.id === CUSTOM_IMAGES_GROUP_ID) return 1;
+    if (group.id === "other") return 2;
+    return 0;
+  };
+  const pinSpecialLast = (a: TaskGroup<T>, b: TaskGroup<T>): number | null => {
+    const aRank = pinnedRank(a);
+    const bRank = pinnedRank(b);
+    if (aRank === 0 && bRank === 0) return null;
+    return aRank - bRank;
   };
 
   if (folderOrder.length === 0) {
     return groups.sort(
-      (a, b) => pinOtherLast(a, b) ?? a.name.localeCompare(b.name),
+      (a, b) => pinSpecialLast(a, b) ?? a.name.localeCompare(b.name),
     );
   }
 
   return groups.sort((a, b) => {
-    const pinned = pinOtherLast(a, b);
+    const pinned = pinSpecialLast(a, b);
     if (pinned !== null) return pinned;
     const aIndex = folderOrder.indexOf(a.id);
     const bIndex = folderOrder.indexOf(b.id);

--- a/packages/core/src/task-detail/taskCreationApiClient.ts
+++ b/packages/core/src/task-detail/taskCreationApiClient.ts
@@ -13,6 +13,7 @@ export interface CreateTaskRunClientOptions {
   model?: string;
   reasoningLevel?: string;
   sandboxEnvironmentId?: string;
+  customImageId?: string;
   prAuthorshipMode?: PrAuthorshipMode;
   autoPublish?: boolean;
   runSource?: CloudRunSource;

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -400,6 +400,7 @@ export class TaskCreationSaga extends Saga<
             model: input.model,
             reasoningLevel: input.reasoningLevel,
             sandboxEnvironmentId: input.sandboxEnvironmentId,
+            customImageId: input.customImageId,
             prAuthorshipMode,
             autoPublish: input.cloudAutoPublish,
             runSource: input.cloudRunSource ?? "manual",

--- a/packages/core/src/task-detail/taskInput.ts
+++ b/packages/core/src/task-detail/taskInput.ts
@@ -21,6 +21,7 @@ export interface PrepareTaskInputOptions {
   reasoningLevel?: string;
   environmentId?: string | null;
   sandboxEnvironmentId?: string;
+  customImageId?: string;
   signalReportId?: string;
   additionalDirectories?: string[];
   channelContext?: string;
@@ -57,6 +58,7 @@ export function prepareTaskInput(
     reasoningLevel: options.reasoningLevel,
     environmentId: options.environmentId ?? undefined,
     sandboxEnvironmentId: options.sandboxEnvironmentId,
+    customImageId: options.customImageId,
     cloudPrAuthorshipMode:
       options.signalReportId && isCloud ? "user" : undefined,
     cloudRunSource:

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -168,6 +168,9 @@ export interface SandboxEnvironment {
   has_environment_variables: boolean;
   private: boolean;
   effective_domains: string[];
+  custom_image_id: string | null;
+  custom_image_name: string | null;
+  custom_image_status: string | null;
   created_by?: UserBasic | null;
   created_at: string;
   updated_at: string;
@@ -181,6 +184,54 @@ export interface SandboxEnvironmentInput {
   repositories?: string[];
   environment_variables?: Record<string, string>;
   private?: boolean;
+  custom_image_id?: string | null;
+}
+
+export type SandboxCustomImageStatus =
+  | "draft"
+  | "scanning"
+  | "scan_failed"
+  | "building"
+  | "build_failed"
+  | "ready"
+  | "archived";
+
+export function isImageBuildInProgress(
+  status: SandboxCustomImageStatus,
+): boolean {
+  return status === "scanning" || status === "building";
+}
+
+export function isImageBuildFailed(status: SandboxCustomImageStatus): boolean {
+  return status === "scan_failed" || status === "build_failed";
+}
+
+export interface SandboxCustomImageScanFinding {
+  severity: string;
+  detail: string;
+}
+
+export interface SandboxCustomImage {
+  id: string;
+  name: string;
+  description: string;
+  status: SandboxCustomImageStatus;
+  version: number;
+  modal_image_name: string;
+  repository: string;
+  private: boolean;
+  spec: Record<string, unknown>;
+  spec_yaml: string;
+  scan_result: {
+    passed?: boolean;
+    findings?: SandboxCustomImageScanFinding[];
+  };
+  error: string;
+  build_log: string;
+  builder_task_id: string | null;
+  created_by?: UserBasic | null;
+  created_at: string;
+  updated_at: string;
 }
 
 interface CloudTaskUpdateBase {

--- a/packages/shared/src/task-creation-domain.ts
+++ b/packages/shared/src/task-creation-domain.ts
@@ -35,6 +35,7 @@ export interface TaskCreationInput {
   reasoningLevel?: string;
   environmentId?: string;
   sandboxEnvironmentId?: string;
+  customImageId?: string;
   cloudPrAuthorshipMode?: PrAuthorshipMode;
   cloudRunSource?: CloudRunSource;
   /**

--- a/packages/ui/src/features/git-interaction/components/CloudGitInteractionHeader.tsx
+++ b/packages/ui/src/features/git-interaction/components/CloudGitInteractionHeader.tsx
@@ -107,6 +107,7 @@ export function CloudGitInteractionHeader({
   };
 
   if (!cloudHandoffEnabled) return null;
+  if (task.origin_product === "image_builder") return null;
 
   const inProgress = session?.handoffInProgress ?? false;
 

--- a/packages/ui/src/features/integrations/useCloudRepoPicker.ts
+++ b/packages/ui/src/features/integrations/useCloudRepoPicker.ts
@@ -1,0 +1,52 @@
+import {
+  useUserGithubRepositories,
+  useUserRepositoryIntegration,
+} from "@posthog/ui/features/integrations/useIntegrations";
+import { toast } from "@posthog/ui/primitives/toast";
+import { useCallback, useState } from "react";
+
+export function useCloudRepoPicker() {
+  const {
+    repositories,
+    isLoadingRepos,
+    isRefreshingRepos,
+    refreshRepositories,
+  } = useUserRepositoryIntegration();
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const {
+    repositories: visibleCloudRepositories,
+    isPending: cloudRepositoriesLoading,
+    hasMore,
+    loadMore,
+  } = useUserGithubRepositories(searchQuery, isOpen);
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    setIsOpen(open);
+    if (!open) {
+      setSearchQuery("");
+    }
+  }, []);
+
+  const handleRefresh = useCallback(() => {
+    void refreshRepositories().catch((error) => {
+      toast.error("Failed to refresh repositories", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      });
+    });
+  }, [refreshRepositories]);
+
+  return {
+    repositories: isOpen ? visibleCloudRepositories : repositories,
+    isLoading: isLoadingRepos || (isOpen && cloudRepositoriesLoading),
+    isRefreshing: isRefreshingRepos,
+    onRefresh: handleRefresh,
+    open: isOpen,
+    onOpenChange: handleOpenChange,
+    searchQuery,
+    onSearchQueryChange: setSearchQuery,
+    hasMore,
+    onLoadMore: loadMore,
+  };
+}

--- a/packages/ui/src/features/sessions/components/ImageBuilderBuildButton.tsx
+++ b/packages/ui/src/features/sessions/components/ImageBuilderBuildButton.tsx
@@ -1,0 +1,47 @@
+import {
+  isImageBuildFailed,
+  isImageBuildInProgress,
+} from "@posthog/shared/domain-types";
+import { imageFailureDetail } from "@posthog/ui/features/settings/sections/environments/imageBuildWatcher";
+import { useSandboxCustomImages } from "@posthog/ui/features/settings/sections/environments/useSandboxCustomImages";
+import { Button, Flex, Text } from "@radix-ui/themes";
+
+export function ImageBuilderBuildButton({ taskId }: { taskId: string }) {
+  const { images, buildMutation } = useSandboxCustomImages();
+  const image = images.find((img) => img.builder_task_id === taskId);
+  if (!image) return null;
+
+  const inProgress = isImageBuildInProgress(image.status);
+  const isFailed = isImageBuildFailed(image.status);
+
+  return (
+    <Flex align="center" gap="2" className="shrink-0">
+      {inProgress ? (
+        <Text color="gray" className="text-[12px]">
+          {image.status === "scanning" ? "scanning…" : "building…"}
+        </Text>
+      ) : image.status === "ready" ? (
+        <Text color="green" className="text-[12px]">
+          ready · v{image.version}
+        </Text>
+      ) : isFailed ? (
+        <Text
+          color="red"
+          className="text-[12px]"
+          title={imageFailureDetail(image)}
+        >
+          {image.status === "scan_failed" ? "scan failed" : "build failed"}
+        </Text>
+      ) : null}
+      <Button
+        size="1"
+        variant="soft"
+        onClick={() => buildMutation.mutate({ id: image.id })}
+        loading={buildMutation.isPending}
+        disabled={inProgress || buildMutation.isPending}
+      >
+        Save & build
+      </Button>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/sessions/components/SessionFooter.tsx
+++ b/packages/ui/src/features/sessions/components/SessionFooter.tsx
@@ -8,6 +8,7 @@ import {
 import type { ContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { DiffStatsChip } from "./DiffStatsChip";
+import { ImageBuilderBuildButton } from "./ImageBuilderBuildButton";
 import { SlotMachineLever } from "./SlotMachineLever";
 
 interface SessionFooterProps {
@@ -41,6 +42,9 @@ export function SessionFooter({
 }: SessionFooterProps) {
   const rightSide = (
     <Flex align="center" gap="3" className="ml-auto shrink-0">
+      {task?.origin_product === "image_builder" && (
+        <ImageBuilderBuildButton taskId={task.id} />
+      )}
       {task && <DiffStatsChip task={task} />}
       <ContextUsageIndicator usage={usage ?? null} />
     </Flex>

--- a/packages/ui/src/features/settings/sections/environments/CloudEnvironmentsSettings.tsx
+++ b/packages/ui/src/features/settings/sections/environments/CloudEnvironmentsSettings.tsx
@@ -1,4 +1,11 @@
-import { ArrowLeft, PencilSimple, Plus, Trash } from "@phosphor-icons/react";
+import {
+  ArrowLeft,
+  Lock,
+  PencilSimple,
+  Plus,
+  Trash,
+  X,
+} from "@phosphor-icons/react";
 import {
   buildSandboxEnvironmentInput,
   emptyForm,
@@ -7,23 +14,45 @@ import {
   validateDomains,
   validateEnvVars,
 } from "@posthog/core/settings/sandboxEnvironmentForm";
-import type {
-  NetworkAccessLevel,
-  SandboxEnvironment,
+import {
+  isImageBuildFailed,
+  isImageBuildInProgress,
+  type NetworkAccessLevel,
+  type SandboxCustomImage,
+  type SandboxCustomImageStatus,
+  type SandboxEnvironment,
 } from "@posthog/shared/domain-types";
+import { useHandleOpenTask } from "@posthog/ui/features/deep-links/useHandleOpenTask";
+import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
+import { useCloudRepoPicker } from "@posthog/ui/features/integrations/useCloudRepoPicker";
 import { useSettingsPageStore } from "@posthog/ui/features/settings/stores/settingsPageStore";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import {
+  AlertDialog,
   Badge,
   Button,
   Checkbox,
   Flex,
+  IconButton,
   Text,
   TextArea,
   TextField,
 } from "@radix-ui/themes";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type ComponentProps,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "../../../../primitives/toast";
+import { imageFailureDetail } from "./imageBuildWatcher";
+import { SettingsSelect, type SettingsSelectOption } from "./SettingsSelect";
+import {
+  useSandboxCustomImageDetail,
+  useSandboxCustomImages,
+} from "./useSandboxCustomImages";
 import { useSandboxEnvironments } from "./useSandboxEnvironments";
 
 const NETWORK_ACCESS_OPTIONS: {
@@ -110,6 +139,147 @@ function NetworkAccessSelect({
   );
 }
 
+interface ImageFormState {
+  name: string;
+  description: string;
+  repository: string | null;
+  private: boolean;
+}
+
+const IMAGE_STATUS_COLORS: Record<
+  SandboxCustomImageStatus,
+  ComponentProps<typeof Badge>["color"]
+> = {
+  draft: "gray",
+  scanning: "blue",
+  building: "blue",
+  scan_failed: "red",
+  build_failed: "red",
+  ready: "green",
+  archived: "gray",
+};
+
+function imageLabel(image: SandboxCustomImage): string {
+  return `${image.name}${image.status !== "ready" ? ` (${image.status})` : ""}`;
+}
+
+function BuildLogPane({
+  image,
+  onClose,
+}: {
+  image: SandboxCustomImage;
+  onClose: () => void;
+}) {
+  const { data, isLoading } = useSandboxCustomImageDetail(image.id);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
+  const buildLog = data?.build_log ?? "";
+  const status = data?.status ?? image.status;
+  const isScanning = status === "scanning";
+  const isBuilding = status === "building";
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-run as the log grows to keep the scroll pinned
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && stickToBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [buildLog]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    stickToBottomRef.current =
+      el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  }, []);
+
+  if (isLoading) {
+    return (
+      <Text color="gray" className="text-[13px]">
+        Loading build log...
+      </Text>
+    );
+  }
+
+  if (!buildLog) {
+    return (
+      <Text color="gray" className="text-[13px]">
+        {isScanning
+          ? "Security scan in progress — build output will stream once the build starts."
+          : isBuilding
+            ? "Waiting for build output…"
+            : "No build log yet."}
+      </Text>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="1">
+      <Flex align="center" justify="between">
+        <Flex align="center" gap="2">
+          <Text color="gray" className="text-[12px]">
+            Build log
+          </Text>
+          {isBuilding && (
+            <Flex align="center" gap="1">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-(--blue-9)" />
+              <Text color="blue" className="text-[12px]">
+                building — streaming
+              </Text>
+            </Flex>
+          )}
+        </Flex>
+        <IconButton
+          variant="ghost"
+          size="1"
+          color="gray"
+          onClick={onClose}
+          aria-label="Close build log"
+        >
+          <X size={12} />
+        </IconButton>
+      </Flex>
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="max-h-[320px] overflow-auto rounded-2 border border-gray-6 bg-gray-2 p-2"
+      >
+        <pre className="m-0 whitespace-pre-wrap break-words font-[var(--code-font-family)] text-gray-12 text-xs">
+          {buildLog}
+        </pre>
+      </div>
+    </Flex>
+  );
+}
+
+function BaseImageSelect({
+  value,
+  images,
+  onChange,
+}: {
+  value: string | null;
+  images: SandboxCustomImage[];
+  onChange: (v: string | null) => void;
+}) {
+  const options: SettingsSelectOption[] = [
+    { value: null, label: "Default" },
+    ...images.map((img) => ({
+      value: img.id,
+      label: imageLabel(img),
+      disabled: img.status !== "ready",
+    })),
+  ];
+
+  return (
+    <SettingsSelect
+      value={value}
+      options={options}
+      onChange={onChange}
+      ariaLabel="Base image"
+    />
+  );
+}
+
 export function CloudEnvironmentsSettings() {
   const {
     environments,
@@ -118,6 +288,17 @@ export function CloudEnvironmentsSettings() {
     updateMutation,
     deleteMutation,
   } = useSandboxEnvironments();
+  const {
+    images,
+    customImagesEnabled,
+    customImagesDisabled,
+    createMutation: createImageMutation,
+    buildMutation,
+    builderTaskMutation,
+    deleteMutation: deleteImageMutation,
+  } = useSandboxCustomImages();
+  const handleOpenTask = useHandleOpenTask();
+  const repoPickerProps = useCloudRepoPicker();
   const consumeInitialAction = useSettingsPageStore(
     (s) => s.consumeInitialAction,
   );
@@ -125,6 +306,16 @@ export function CloudEnvironmentsSettings() {
   const [editingEnv, setEditingEnv] = useState<SandboxEnvironment | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [form, setForm] = useState<FormState>(emptyForm());
+  const [imageForm, setImageForm] = useState<ImageFormState | null>(null);
+  const [editingSpecImageId, setEditingSpecImageId] = useState<string | null>(
+    null,
+  );
+  const [specDraft, setSpecDraft] = useState("");
+  const [deleteConfirmImage, setDeleteConfirmImage] =
+    useState<SandboxCustomImage | null>(null);
+  const [viewingLogImageId, setViewingLogImageId] = useState<string | null>(
+    null,
+  );
 
   useEffect(() => {
     const action = consumeInitialAction();
@@ -184,6 +375,9 @@ export function CloudEnvironmentsSettings() {
       domainValidation.domains,
       envVarValidation.vars,
     );
+    if (customImagesDisabled) {
+      delete payload.custom_image_id;
+    }
 
     if (editingEnv) {
       await updateMutation.mutateAsync({ id: editingEnv.id, ...payload });
@@ -197,6 +391,7 @@ export function CloudEnvironmentsSettings() {
     hasValidationErrors,
     domainValidation,
     envVarValidation,
+    customImagesDisabled,
     createMutation,
     updateMutation,
     closeForm,
@@ -207,6 +402,59 @@ export function CloudEnvironmentsSettings() {
     await deleteMutation.mutateAsync(editingEnv.id);
     closeForm();
   }, [editingEnv, deleteMutation, closeForm]);
+
+  const openCreateImage = useCallback(() => {
+    setImageForm({
+      name: "",
+      description: "",
+      repository: null,
+      private: false,
+    });
+  }, []);
+
+  const patchImageForm = useCallback((patch: Partial<ImageFormState>) => {
+    setImageForm((current) => (current ? { ...current, ...patch } : current));
+  }, []);
+
+  const handleCreateImage = useCallback(async () => {
+    if (!imageForm) return;
+    const image = await createImageMutation.mutateAsync({
+      name: imageForm.name.trim(),
+      ...(imageForm.description.trim()
+        ? { description: imageForm.description.trim() }
+        : {}),
+      ...(imageForm.repository ? { repository: imageForm.repository } : {}),
+      ...(imageForm.private ? { private: true } : {}),
+    });
+    setImageForm(null);
+    if (image.builder_task_id) {
+      void handleOpenTask(image.builder_task_id);
+    }
+  }, [imageForm, createImageMutation, handleOpenTask]);
+
+  const handleOpenBuilder = useCallback(
+    async (image: SandboxCustomImage) => {
+      const updated = await builderTaskMutation.mutateAsync(image.id);
+      if (updated.builder_task_id) {
+        void handleOpenTask(updated.builder_task_id);
+      }
+    },
+    [builderTaskMutation, handleOpenTask],
+  );
+
+  const handleSaveSpec = useCallback(
+    async (image: SandboxCustomImage) => {
+      await buildMutation.mutateAsync({ id: image.id, specYaml: specDraft });
+      setEditingSpecImageId(null);
+    },
+    [buildMutation, specDraft],
+  );
+
+  const confirmDeleteImage = useCallback(() => {
+    if (!deleteConfirmImage) return;
+    deleteImageMutation.mutate(deleteConfirmImage.id);
+    setDeleteConfirmImage(null);
+  }, [deleteConfirmImage, deleteImageMutation]);
 
   if (isFormOpen) {
     return (
@@ -245,6 +493,25 @@ export function CloudEnvironmentsSettings() {
             placeholder="e.g. Dev 1"
           />
         </Flex>
+
+        {customImagesEnabled && (
+          <Flex direction="column" gap="1">
+            <Text className="font-medium text-sm">Base image</Text>
+            <Text color="gray" className="text-[13px]">
+              The sandbox image sessions in this environment start from.{" "}
+              <Text color="gray" className="font-medium text-[13px]">
+                Default
+              </Text>{" "}
+              is the standard image; custom images must finish building before
+              they can be selected.
+            </Text>
+            <BaseImageSelect
+              value={form.custom_image_id}
+              images={images}
+              onChange={(v) => setForm((f) => ({ ...f, custom_image_id: v }))}
+            />
+          </Flex>
+        )}
 
         <Flex direction="column" gap="1">
           <Text className="font-medium text-sm">Network access</Text>
@@ -486,6 +753,13 @@ export function CloudEnvironmentsSettings() {
                         {env.allowed_domains.length !== 1 ? "s" : ""}
                       </Text>
                     )}
+                  {customImagesEnabled &&
+                    env.custom_image_id &&
+                    env.custom_image_name && (
+                      <Badge size="1" color="gray" variant="soft">
+                        image: {env.custom_image_name}
+                      </Badge>
+                    )}
                 </Flex>
               </Flex>
               <Button
@@ -500,6 +774,323 @@ export function CloudEnvironmentsSettings() {
             </Flex>
           ))}
         </Flex>
+      )}
+
+      {customImagesEnabled && (
+        <>
+          <Flex justify="between" align="center" pt="2">
+            <Text className="font-medium text-[13px]">Custom images</Text>
+            <Button size="1" variant="outline" onClick={openCreateImage}>
+              <Plus size={12} />
+              New custom image
+            </Button>
+          </Flex>
+
+          <Text color="gray" className="text-[13px]">
+            A custom image is a sandbox base image with your own tools and
+            dependencies pre-installed. Creating one starts a builder session
+            where you describe what the image should include; once built, pick
+            it as the base image of an environment.
+          </Text>
+
+          {imageForm && (
+            <Flex
+              direction="column"
+              gap="3"
+              p="3"
+              className="rounded-2 border border-gray-6"
+            >
+              <Flex direction="column" gap="1">
+                <Text className="font-medium text-sm">Name</Text>
+                <TextField.Root
+                  size="2"
+                  value={imageForm?.name ?? ""}
+                  onChange={(e) => patchImageForm({ name: e.target.value })}
+                  placeholder="e.g. Playwright + Node 22"
+                />
+              </Flex>
+              <Flex direction="column" gap="1">
+                <Text className="font-medium text-sm">Description</Text>
+                <TextArea
+                  size="2"
+                  rows={3}
+                  value={imageForm?.description ?? ""}
+                  onChange={(e) =>
+                    patchImageForm({ description: e.target.value })
+                  }
+                  placeholder="What should this image include?"
+                />
+              </Flex>
+              <Flex direction="column" gap="1">
+                <Text className="font-medium text-sm">
+                  Verify a repository (optional)
+                </Text>
+                <Text color="gray" className="text-[13px]">
+                  The builder will make sure this repo's dependencies can be
+                  brought up on the image.
+                </Text>
+                <div className="w-fit">
+                  <GitHubRepoPicker
+                    value={imageForm?.repository ?? null}
+                    onChange={(repository) => patchImageForm({ repository })}
+                    {...repoPickerProps}
+                  />
+                </div>
+              </Flex>
+              <Flex align="center" gap="2">
+                <Checkbox
+                  size="1"
+                  checked={imageForm?.private ?? false}
+                  onCheckedChange={(checked) =>
+                    patchImageForm({ private: checked === true })
+                  }
+                />
+                <Text color="gray" className="text-[13px]">
+                  Only visible to me
+                </Text>
+              </Flex>
+              <Flex gap="2" justify="end">
+                <Button
+                  color="gray"
+                  variant="outline"
+                  size="1"
+                  onClick={() => setImageForm(null)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="1"
+                  onClick={handleCreateImage}
+                  loading={createImageMutation.isPending}
+                  disabled={
+                    !imageForm?.name.trim() || createImageMutation.isPending
+                  }
+                >
+                  Create image
+                </Button>
+              </Flex>
+            </Flex>
+          )}
+
+          {images.length === 0 ? (
+            !imageForm && (
+              <Text color="gray" className="text-[13px]">
+                No custom images yet. Create one to pre-install tools your cloud
+                sessions need.
+              </Text>
+            )
+          ) : (
+            <Flex direction="column">
+              {images.map((image, i) => {
+                const inProgress = isImageBuildInProgress(image.status);
+                const isFailed = isImageBuildFailed(image.status);
+                const isBuildingThis =
+                  buildMutation.isPending &&
+                  buildMutation.variables?.id === image.id;
+                const isEditingSpec = editingSpecImageId === image.id;
+                const isViewingLog = viewingLogImageId === image.id;
+                const hasBuildLog =
+                  image.version > 0 ||
+                  image.status === "ready" ||
+                  image.status === "build_failed" ||
+                  inProgress;
+                return (
+                  <Flex
+                    key={image.id}
+                    direction="column"
+                    py="3"
+                    px="1"
+                    gap="2"
+                    style={{
+                      borderBottom:
+                        i < images.length - 1
+                          ? "1px solid var(--gray-5)"
+                          : undefined,
+                    }}
+                  >
+                    <Flex align="center" justify="between" gap="3">
+                      <Flex
+                        direction="column"
+                        gap="1"
+                        className="min-w-0 flex-1"
+                      >
+                        <Flex align="center" gap="1">
+                          <Text className="font-medium text-sm">
+                            {image.name}
+                          </Text>
+                          {image.private && (
+                            <Lock size={12} className="shrink-0 text-gray-10" />
+                          )}
+                        </Flex>
+                        <Flex align="center" gap="2">
+                          <Badge
+                            size="1"
+                            color={IMAGE_STATUS_COLORS[image.status]}
+                            variant="soft"
+                          >
+                            {image.status}
+                          </Badge>
+                          {image.version > 0 && (
+                            <Text color="gray" className="text-[13px]">
+                              v{image.version}
+                            </Text>
+                          )}
+                          {image.repository && (
+                            <Text color="gray" className="truncate text-[13px]">
+                              {image.repository}
+                            </Text>
+                          )}
+                        </Flex>
+                        {isFailed && (
+                          <Text color="red" className="text-[13px]">
+                            {imageFailureDetail(image)}
+                          </Text>
+                        )}
+                      </Flex>
+                      <Flex align="center" gap="2" className="shrink-0">
+                        <Button
+                          size="1"
+                          variant="ghost"
+                          color="gray"
+                          onClick={() => void handleOpenBuilder(image)}
+                          loading={
+                            builderTaskMutation.isPending &&
+                            builderTaskMutation.variables === image.id
+                          }
+                          disabled={builderTaskMutation.isPending}
+                        >
+                          {image.status === "ready" ? "Update" : "Open builder"}
+                        </Button>
+                        <Button
+                          size="1"
+                          variant="ghost"
+                          color="gray"
+                          onClick={() => {
+                            setEditingSpecImageId(image.id);
+                            setSpecDraft(image.spec_yaml);
+                          }}
+                          disabled={inProgress || isEditingSpec}
+                        >
+                          Edit spec
+                        </Button>
+                        {hasBuildLog && (
+                          <Button
+                            size="1"
+                            variant="ghost"
+                            color="gray"
+                            onClick={() =>
+                              setViewingLogImageId(
+                                isViewingLog ? null : image.id,
+                              )
+                            }
+                          >
+                            Build log
+                          </Button>
+                        )}
+                        <Button
+                          size="1"
+                          variant="ghost"
+                          onClick={() => buildMutation.mutate({ id: image.id })}
+                          loading={isBuildingThis}
+                          disabled={
+                            inProgress ||
+                            buildMutation.isPending ||
+                            isEditingSpec
+                          }
+                        >
+                          Save & build
+                        </Button>
+                        <Button
+                          size="1"
+                          variant="ghost"
+                          color="red"
+                          onClick={() => setDeleteConfirmImage(image)}
+                          disabled={deleteImageMutation.isPending}
+                        >
+                          <Trash size={14} />
+                        </Button>
+                      </Flex>
+                    </Flex>
+                    {isEditingSpec && (
+                      <Flex direction="column" gap="2">
+                        <TextArea
+                          size="2"
+                          rows={10}
+                          value={specDraft}
+                          onChange={(e) => setSpecDraft(e.target.value)}
+                          placeholder="Image spec (YAML)"
+                          className="font-[var(--code-font-family)] [&_textarea]:text-xs"
+                        />
+                        <Flex gap="2" justify="end">
+                          <Button
+                            color="gray"
+                            variant="outline"
+                            size="1"
+                            onClick={() => setEditingSpecImageId(null)}
+                          >
+                            Cancel
+                          </Button>
+                          <Button
+                            size="1"
+                            onClick={() => void handleSaveSpec(image)}
+                            loading={isBuildingThis}
+                            disabled={
+                              inProgress ||
+                              buildMutation.isPending ||
+                              !specDraft.trim()
+                            }
+                          >
+                            Save & build
+                          </Button>
+                        </Flex>
+                      </Flex>
+                    )}
+                    {isViewingLog && (
+                      <BuildLogPane
+                        image={image}
+                        onClose={() => setViewingLogImageId(null)}
+                      />
+                    )}
+                  </Flex>
+                );
+              })}
+            </Flex>
+          )}
+
+          <AlertDialog.Root
+            open={deleteConfirmImage !== null}
+            onOpenChange={(open) => {
+              if (!open) setDeleteConfirmImage(null);
+            }}
+          >
+            <AlertDialog.Content maxWidth="420px" size="1">
+              <AlertDialog.Title className="text-sm">
+                Delete custom image?
+              </AlertDialog.Title>
+              <AlertDialog.Description>
+                <Text color="gray" className="text-[13px]">
+                  Environments using "{deleteConfirmImage?.name}" fall back to
+                  the default image.
+                </Text>
+              </AlertDialog.Description>
+              <Flex justify="end" gap="3" mt="3">
+                <AlertDialog.Cancel>
+                  <Button variant="soft" color="gray" size="1">
+                    Cancel
+                  </Button>
+                </AlertDialog.Cancel>
+                <Button
+                  variant="solid"
+                  color="red"
+                  size="1"
+                  onClick={confirmDeleteImage}
+                >
+                  Delete
+                </Button>
+              </Flex>
+            </AlertDialog.Content>
+          </AlertDialog.Root>
+        </>
       )}
     </Flex>
   );

--- a/packages/ui/src/features/settings/sections/environments/SettingsSelect.tsx
+++ b/packages/ui/src/features/settings/sections/environments/SettingsSelect.tsx
@@ -1,0 +1,51 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@posthog/quill";
+
+export interface SettingsSelectOption {
+  value: string | null;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+}
+
+export function SettingsSelect({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  placeholder,
+}: {
+  value: string | null;
+  options: SettingsSelectOption[];
+  onChange: (value: string | null) => void;
+  ariaLabel: string;
+  placeholder?: string;
+}) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(next: string | null) => onChange(next)}
+      items={options.map((o) => ({ value: o.value, label: o.label }))}
+    >
+      <SelectTrigger size="sm" aria-label={ariaLabel} className="w-full">
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent align="start" side="bottom" sideOffset={6}>
+        {options.map((option) => (
+          <SelectItem
+            key={option.value ?? "__default__"}
+            value={option.value}
+            disabled={option.disabled}
+          >
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/packages/ui/src/features/settings/sections/environments/imageBuildWatcher.test.ts
+++ b/packages/ui/src/features/settings/sections/environments/imageBuildWatcher.test.ts
@@ -1,0 +1,91 @@
+import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
+import type { SandboxCustomImage } from "@posthog/shared/domain-types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const notifySpy = vi.fn();
+vi.mock("@posthog/di/container", () => ({
+  resolveServiceOptional: () => ({ notify: notifySpy }),
+}));
+vi.mock("@posthog/ui/features/notifications/notifications", () => ({
+  NotificationBus: class {},
+}));
+
+import { watchImageBuild } from "./imageBuildWatcher";
+
+const POLL_MS = 5000;
+
+function clientReturning(images: Partial<SandboxCustomImage>[]): {
+  client: PostHogAPIClient;
+  list: ReturnType<typeof vi.fn>;
+} {
+  const list = vi.fn().mockResolvedValue(images);
+  return {
+    client: { listSandboxCustomImages: list } as unknown as PostHogAPIClient,
+    list,
+  };
+}
+
+describe("watchImageBuild", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    notifySpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stops and notifies exactly once when the image reaches a terminal state", async () => {
+    const onTerminal = vi.fn();
+    const { client, list } = clientReturning([
+      { id: "im-ready", status: "ready", name: "img", version: 1 },
+    ]);
+
+    watchImageBuild(client, "im-ready", onTerminal);
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+
+    expect(onTerminal).toHaveBeenCalledTimes(1);
+    expect(notifySpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * 3);
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps polling while in progress without notifying", async () => {
+    const { client, list } = clientReturning([
+      { id: "im-building", status: "building", name: "img", version: 0 },
+    ]);
+
+    watchImageBuild(client, "im-building");
+    await vi.advanceTimersByTimeAsync(POLL_MS * 3);
+
+    expect(list).toHaveBeenCalledTimes(3);
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores a second watcher for an already-watched image", async () => {
+    const { client, list } = clientReturning([
+      { id: "im-dup", status: "building", name: "img", version: 0 },
+    ]);
+
+    watchImageBuild(client, "im-dup");
+    watchImageBuild(client, "im-dup");
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops after the consecutive-error limit and makes no further calls", async () => {
+    const list = vi.fn().mockRejectedValue(new Error("boom"));
+    const client = {
+      listSandboxCustomImages: list,
+    } as unknown as PostHogAPIClient;
+
+    watchImageBuild(client, "im-err");
+    await vi.advanceTimersByTimeAsync(POLL_MS * 3);
+    expect(list).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * 3);
+    expect(list).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/ui/src/features/settings/sections/environments/imageBuildWatcher.ts
+++ b/packages/ui/src/features/settings/sections/environments/imageBuildWatcher.ts
@@ -1,0 +1,91 @@
+import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
+import { resolveServiceOptional } from "@posthog/di/container";
+import {
+  isImageBuildFailed,
+  isImageBuildInProgress,
+  type SandboxCustomImage,
+} from "@posthog/shared/domain-types";
+import { NotificationBus } from "@posthog/ui/features/notifications/notifications";
+
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLLS = 720;
+const MAX_CONSECUTIVE_ERRORS = 3;
+
+const activeWatchers = new Set<string>();
+
+export function imageFailureDetail(image: SandboxCustomImage): string {
+  if (image.status === "scan_failed") {
+    const highFindings = (image.scan_result?.findings ?? [])
+      .filter((finding) => finding.severity === "high")
+      .map((finding) => finding.detail);
+    if (highFindings.length > 0) return highFindings.join("; ");
+  }
+  return image.error || "Something went wrong";
+}
+
+function notifyBuildResult(image: SandboxCustomImage): void {
+  const bus = resolveServiceOptional<NotificationBus>(NotificationBus);
+  if (!bus) return;
+  const target = image.builder_task_id
+    ? ({ kind: "task", taskId: image.builder_task_id } as const)
+    : undefined;
+  if (image.status === "ready") {
+    bus.notify({
+      body: `Image "${image.name}" is ready (v${image.version})`,
+      target,
+      toast: { level: "success" },
+    });
+    return;
+  }
+  bus.notify({
+    body: `Image "${image.name}" build failed: ${imageFailureDetail(image).split("\n")[0]}`,
+    target,
+    toast: { level: "error" },
+  });
+}
+
+export function watchImageBuild(
+  client: PostHogAPIClient,
+  imageId: string,
+  onTerminal?: () => void,
+): void {
+  if (activeWatchers.has(imageId)) return;
+  activeWatchers.add(imageId);
+
+  let polls = 0;
+  let consecutiveErrors = 0;
+
+  const timer = setInterval(() => {
+    polls += 1;
+    client
+      .listSandboxCustomImages()
+      .then((images) => {
+        consecutiveErrors = 0;
+        const image = images.find((candidate) => candidate.id === imageId);
+        if (!image) {
+          stop();
+          return;
+        }
+        if (isImageBuildInProgress(image.status)) {
+          if (polls >= MAX_POLLS) stop();
+          return;
+        }
+        stop();
+        onTerminal?.();
+        if (image.status === "ready" || isImageBuildFailed(image.status)) {
+          notifyBuildResult(image);
+        }
+      })
+      .catch(() => {
+        consecutiveErrors += 1;
+        if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS || polls >= MAX_POLLS) {
+          stop();
+        }
+      });
+  }, POLL_INTERVAL_MS);
+
+  function stop(): void {
+    clearInterval(timer);
+    activeWatchers.delete(imageId);
+  }
+}

--- a/packages/ui/src/features/settings/sections/environments/useSandboxCustomImages.ts
+++ b/packages/ui/src/features/settings/sections/environments/useSandboxCustomImages.ts
@@ -1,0 +1,151 @@
+import { SandboxCustomImagesDisabledError } from "@posthog/api-client/posthog-client";
+import {
+  isImageBuildInProgress,
+  type SandboxCustomImage,
+} from "@posthog/shared/domain-types";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuthenticatedMutation } from "../../../../hooks/useAuthenticatedMutation";
+import { useAuthenticatedQuery } from "../../../../hooks/useAuthenticatedQuery";
+import { toast } from "../../../../primitives/toast";
+import { watchImageBuild } from "./imageBuildWatcher";
+import { sandboxEnvKeys } from "./useSandboxEnvironments";
+
+const sandboxCustomImageKeys = {
+  list: ["sandbox-custom-images", "list"] as const,
+  detail: (id: string) => ["sandbox-custom-images", "detail", id] as const,
+};
+
+export function useSandboxCustomImageDetail(imageId: string) {
+  return useAuthenticatedQuery(
+    sandboxCustomImageKeys.detail(imageId),
+    (client) => client.getSandboxCustomImage(imageId),
+    {
+      refetchInterval: (query) => {
+        const status = query.state.data?.status;
+        return status && isImageBuildInProgress(status) ? 2500 : false;
+      },
+    },
+  );
+}
+
+export function useSandboxCustomImages() {
+  const queryClient = useQueryClient();
+
+  const {
+    data: images,
+    isLoading,
+    error,
+  } = useAuthenticatedQuery(
+    sandboxCustomImageKeys.list,
+    (client) => client.listSandboxCustomImages(),
+    {
+      retry: (failureCount, error) =>
+        !(error instanceof SandboxCustomImagesDisabledError) &&
+        failureCount < 3,
+      refetchInterval: (query) => {
+        if (query.state.error instanceof SandboxCustomImagesDisabledError) {
+          return false;
+        }
+        return query.state.data?.some((image) =>
+          isImageBuildInProgress(image.status),
+        )
+          ? 5000
+          : false;
+      },
+      refetchIntervalInBackground: true,
+    },
+  );
+
+  const customImagesEnabled = images !== undefined;
+  const customImagesDisabled =
+    error instanceof SandboxCustomImagesDisabledError;
+
+  const onImageMutated = (image: SandboxCustomImage): void => {
+    queryClient.setQueryData(sandboxCustomImageKeys.detail(image.id), image);
+    queryClient.invalidateQueries({ queryKey: sandboxCustomImageKeys.list });
+  };
+
+  const createMutation = useAuthenticatedMutation(
+    (
+      client,
+      input: {
+        name: string;
+        description?: string;
+        repository?: string | null;
+        private?: boolean;
+      },
+    ) => client.createSandboxCustomImage(input),
+    {
+      onSuccess: (image) => {
+        toast.success("Custom image created");
+        onImageMutated(image);
+      },
+      onError: (error: Error) => {
+        toast.error(error.message || "Failed to create custom image");
+      },
+    },
+  );
+
+  const buildMutation = useAuthenticatedMutation(
+    (client, { id, specYaml }: { id: string; specYaml?: string | null }) =>
+      client.buildSandboxCustomImage(id, specYaml).then((image) => {
+        watchImageBuild(client, image.id, () => {
+          queryClient.invalidateQueries({
+            queryKey: sandboxCustomImageKeys.list,
+          });
+        });
+        return image;
+      }),
+    {
+      onSuccess: (image) => {
+        toast.success("Build started");
+        onImageMutated(image);
+      },
+      onError: (error: Error) => {
+        toast.error(error.message || "Failed to build custom image");
+      },
+    },
+  );
+
+  const builderTaskMutation = useAuthenticatedMutation(
+    (client, id: string) => client.ensureSandboxCustomImageBuilderTask(id),
+    {
+      onSuccess: (image) => {
+        onImageMutated(image);
+      },
+      onError: (error: Error) => {
+        toast.error(error.message || "Failed to open image builder session");
+      },
+    },
+  );
+
+  const deleteMutation = useAuthenticatedMutation(
+    (client, id: string) => client.deleteSandboxCustomImage(id),
+    {
+      onSuccess: (_result, id) => {
+        toast.success("Custom image deleted");
+        queryClient.removeQueries({
+          queryKey: sandboxCustomImageKeys.detail(id),
+        });
+        queryClient.invalidateQueries({
+          queryKey: sandboxCustomImageKeys.list,
+        });
+        queryClient.invalidateQueries({ queryKey: sandboxEnvKeys.list });
+      },
+      onError: (error: Error) => {
+        toast.error(error.message || "Failed to delete custom image");
+      },
+    },
+  );
+
+  return {
+    images: images ?? [],
+    isLoading,
+    customImagesEnabled,
+    customImagesDisabled,
+    createMutation,
+    buildMutation,
+    builderTaskMutation,
+    deleteMutation,
+  };
+}

--- a/packages/ui/src/features/settings/sections/environments/useSandboxEnvironments.ts
+++ b/packages/ui/src/features/settings/sections/environments/useSandboxEnvironments.ts
@@ -4,7 +4,7 @@ import { useAuthenticatedMutation } from "../../../../hooks/useAuthenticatedMuta
 import { useAuthenticatedQuery } from "../../../../hooks/useAuthenticatedQuery";
 import { toast } from "../../../../primitives/toast";
 
-const sandboxEnvKeys = {
+export const sandboxEnvKeys = {
   list: ["sandbox-environments", "list"] as const,
 };
 

--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -1,7 +1,7 @@
 import { PointerSensor } from "@dnd-kit/dom";
 import type { DragDropEvents } from "@dnd-kit/react";
 import { DragDropProvider } from "@dnd-kit/react";
-import { GitBranch } from "@phosphor-icons/react";
+import { GitBranch, Wrench } from "@phosphor-icons/react";
 import {
   folderGroupId,
   groupTasksByRelativeDate,
@@ -285,7 +285,13 @@ export function TaskListView({
                   <SidebarSection
                     id={group.id}
                     label={folder?.name ?? group.name}
-                    icon={<GitBranch size={14} className="text-gray-10" />}
+                    icon={
+                      group.id === "custom-images" ? (
+                        <Wrench size={14} className="text-gray-10" />
+                      ) : (
+                        <GitBranch size={14} className="text-gray-10" />
+                      )
+                    }
                     isExpanded={isExpanded}
                     onToggle={() => toggleSection(group.id)}
                     addSpacingBefore={false}

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -229,6 +229,9 @@ export function TaskInput({
   const [selectedCloudEnvId, setSelectedCloudEnvId] = useState<string | null>(
     null,
   );
+  const [selectedCustomImageId, setSelectedCustomImageId] = useState<
+    string | null
+  >(null);
   const [activeReportAssociation, setActiveReportAssociation] = useState(
     reportAssociation ?? null,
   );
@@ -782,6 +785,10 @@ export function TaskInput({
       effectiveWorkspaceMode === "cloud" && selectedCloudEnvId
         ? selectedCloudEnvId
         : undefined,
+    customImageId:
+      effectiveWorkspaceMode === "cloud" && selectedCustomImageId
+        ? selectedCustomImageId
+        : undefined,
     signalReportId: activeReportAssociation?.reportId,
     channelContext: includeChannelContext ? channelContext : undefined,
     channelName,
@@ -1017,6 +1024,8 @@ export function TaskInput({
                   onChange={setWorkspaceMode}
                   selectedCloudEnvironmentId={selectedCloudEnvId}
                   onCloudEnvironmentChange={setSelectedCloudEnvId}
+                  selectedCustomImageId={selectedCustomImageId}
+                  onCustomImageChange={setSelectedCustomImageId}
                   size="1"
                 />
                 {!allowNoRepo && workspaceMode === "worktree" && (

--- a/packages/ui/src/features/task-detail/components/WorkspaceModeSelect.tsx
+++ b/packages/ui/src/features/task-detail/components/WorkspaceModeSelect.tsx
@@ -2,6 +2,7 @@ import {
   ArrowsSplit,
   CaretDown,
   Cloud,
+  Cube,
   Laptop,
   Plus,
 } from "@phosphor-icons/react";
@@ -24,6 +25,7 @@ import type { WorkspaceMode } from "@posthog/shared";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { useCallback, useMemo, useState } from "react";
 import { useFeatureFlag } from "../../feature-flags/useFeatureFlag";
+import { useSandboxCustomImages } from "../../settings/sections/environments/useSandboxCustomImages";
 import { useSandboxEnvironments } from "../../settings/sections/environments/useSandboxEnvironments";
 
 export type { WorkspaceMode };
@@ -36,6 +38,8 @@ interface WorkspaceModeSelectProps {
   overrideModes?: WorkspaceMode[];
   selectedCloudEnvironmentId?: string | null;
   onCloudEnvironmentChange?: (envId: string | null) => void;
+  selectedCustomImageId?: string | null;
+  onCustomImageChange?: (imageId: string | null) => void;
 }
 
 const LOCAL_MODES: {
@@ -67,12 +71,20 @@ export function WorkspaceModeSelect({
   overrideModes,
   selectedCloudEnvironmentId,
   onCloudEnvironmentChange,
+  selectedCustomImageId,
+  onCustomImageChange,
 }: WorkspaceModeSelectProps) {
   const cloudModeEnabled =
     useFeatureFlag("twig-cloud-mode-toggle") || import.meta.env.DEV;
 
   const { environments } = useSandboxEnvironments();
+  const { images, customImagesEnabled } = useSandboxCustomImages();
   const [menuOpen, setMenuOpen] = useState(false);
+
+  const readyImages = useMemo(
+    () => images.filter((image) => image.status === "ready"),
+    [images],
+  );
 
   const handleAddEnvironment = useCallback(() => {
     setMenuOpen(false);
@@ -96,12 +108,19 @@ export function WorkspaceModeSelect({
     return environments.find((e) => e.id === selectedCloudEnvironmentId)?.name;
   }, [value, selectedCloudEnvironmentId, environments]);
 
+  const selectedImageName = useMemo(() => {
+    if (value !== "cloud" || !selectedCustomImageId) return null;
+    return images.find((img) => img.id === selectedCustomImageId)?.name;
+  }, [value, selectedCustomImageId, images]);
+
   const triggerLabel = useMemo(() => {
     if (value === "cloud") {
-      return selectedEnvName ? `Cloud · ${selectedEnvName}` : "Cloud";
+      return ["Cloud", selectedEnvName, selectedImageName]
+        .filter(Boolean)
+        .join(" · ");
     }
     return LOCAL_MODES.find((m) => m.mode === value)?.label ?? "Worktree";
-  }, [value, selectedEnvName]);
+  }, [value, selectedEnvName, selectedImageName]);
 
   const triggerIcon = useMemo(() => {
     if (value === "cloud") return CLOUD_ICON;
@@ -144,6 +163,7 @@ export function WorkspaceModeSelect({
               onClick={() => {
                 onChange(item.mode);
                 onCloudEnvironmentChange?.(null);
+                onCustomImageChange?.(null);
               }}
               render={
                 <ItemMenuItem size="xs" className="w-full">
@@ -240,6 +260,66 @@ export function WorkspaceModeSelect({
                             : env.network_access_level === "trusted"
                               ? "Trusted sources only"
                               : `${env.allowed_domains.length} allowed domain${env.allowed_domains.length !== 1 ? "s" : ""}`}
+                        </ItemDescription>
+                      </ItemContent>
+                    </ItemMenuItem>
+                  }
+                />
+              ))}
+            </DropdownMenuGroup>
+          </>
+        )}
+
+        {showCloud && customImagesEnabled && readyImages.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <div className="flex items-center justify-between px-2 py-1">
+              <MenuLabel className="p-0">Base image</MenuLabel>
+            </div>
+
+            <DropdownMenuGroup>
+              <DropdownMenuItem
+                onClick={() => {
+                  onChange("cloud");
+                  onCustomImageChange?.(null);
+                }}
+                render={
+                  <ItemMenuItem size="xs" className="w-full">
+                    <ItemMedia variant="icon" className="mt-2 ml-2">
+                      <span>
+                        <Cube size={14} weight="regular" />
+                      </span>
+                    </ItemMedia>
+                    <ItemContent variant="menuItem">
+                      <ItemTitle>Default</ItemTitle>
+                      <ItemDescription className="whitespace-nowrap leading-none">
+                        Standard sandbox image
+                      </ItemDescription>
+                    </ItemContent>
+                  </ItemMenuItem>
+                }
+              />
+
+              {readyImages.map((image) => (
+                <DropdownMenuItem
+                  key={`custom-image-${image.id}`}
+                  onClick={() => {
+                    onChange("cloud");
+                    onCustomImageChange?.(image.id);
+                  }}
+                  render={
+                    <ItemMenuItem size="xs" className="w-full">
+                      <ItemMedia variant="icon" className="mt-2 ml-2">
+                        <span>
+                          <Cube size={14} weight="regular" />
+                        </span>
+                      </ItemMedia>
+                      <ItemContent variant="menuItem">
+                        <ItemTitle>{image.name}</ItemTitle>
+                        <ItemDescription className="whitespace-nowrap leading-none">
+                          {image.version > 0
+                            ? `Custom image · v${image.version}`
+                            : "Custom image"}
                         </ItemDescription>
                       </ItemContent>
                     </ItemMenuItem>

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -69,6 +69,7 @@ interface UseTaskCreationOptions {
   reasoningLevel?: string;
   environmentId?: string | null;
   sandboxEnvironmentId?: string;
+  customImageId?: string;
   signalReportId?: string;
   channelContext?: string;
   channelName?: string;
@@ -163,6 +164,7 @@ export function useTaskCreation({
   reasoningLevel,
   environmentId,
   sandboxEnvironmentId,
+  customImageId,
   signalReportId,
   channelContext,
   channelName,
@@ -319,6 +321,7 @@ export function useTaskCreation({
           reasoningLevel,
           environmentId,
           sandboxEnvironmentId,
+          customImageId,
           signalReportId,
           additionalDirectories,
           channelContext,
@@ -479,6 +482,7 @@ export function useTaskCreation({
       reasoningLevel,
       environmentId,
       sandboxEnvironmentId,
+      customImageId,
       signalReportId,
       additionalDirectories,
       channelContext,


### PR DESCRIPTION
## Problem

Backend support for custom sandbox base images is landing in PostHog/posthog#68620, PostHog/posthog#68621, and PostHog/posthog#68622. The desktop app needs the UI: manage images, watch builds, and pick an image per environment or per run.

<img width="1246" height="746" alt="ph_code_custom_images_2" src="https://github.com/user-attachments/assets/d4481066-e22b-46b4-9cda-ab06beeff706" />
<img width="1520" height="832" alt="ph_code_custom_images" src="https://github.com/user-attachments/assets/b00a4a49-a291-4426-b85a-4a0736c11065" />

## Changes

- Cloud settings gains a "Custom images" section: create an image (opens its interactive builder session), edit the spec, save and build, delete, and a live-tailing build log pane. Environments get a "Base image" select.
- Task composer can pick a custom base image per run; image-builder sessions get their own sidebar group and a build button in the session footer.
- Polling that matches build lifetimes: detail/list queries poll only while scanning/building, the list keeps polling in the background, and a component-independent watcher fires an OS notification when a build finishes (polling the light list endpoint, not the 200 KB build log). All image mutations seed the react-query detail cache through one helper, so panes never sit on stale terminal state.
- `ELECTRON_RUN_AS_NODE` is now only injected into Claude session env when actually spawning from Electron. In cloud sandboxes the agent-server runs under plain node, and the leaked variable broke any Electron app the agent tried to launch in its workspace.

Everything is hidden unless the backend reports custom images enabled (typed 403 detection on the list endpoint).
