### PR TITLE
Add Cmd+Left/Right as back/forward navigation shortcuts

### DIFF
--- a/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -7,6 +7,10 @@ export const SHORTCUTS = {
   SHORTCUTS_SHEET: "mod+/",
   GO_BACK: "mod+[",
   GO_FORWARD: "mod+]",
+  // Arrow variants must stay outside form fields/editors, where mod+left/right
+  // means jump to line start/end - bind them without enableOnFormTags.
+  GO_BACK_ALT: "mod+left",
+  GO_FORWARD_ALT: "mod+right",
   TOGGLE_LEFT_SIDEBAR: "mod+b",
   TOGGLE_REVIEW_PANEL: "mod+shift+b",
   PREV_TASK: "mod+shift+[,ctrl+shift+tab",
@@ -115,12 +119,14 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     keys: SHORTCUTS.GO_BACK,
     description: "Go back",
     category: "navigation",
+    alternateKeys: SHORTCUTS.GO_BACK_ALT,
   },
   {
     id: "go-forward",
     keys: SHORTCUTS.GO_FORWARD,
     description: "Go forward",
     category: "navigation",
+    alternateKeys: SHORTCUTS.GO_FORWARD_ALT,
   },
   {
     id: "toggle-left-sidebar",
@@ -253,6 +259,8 @@ function formatKey(key: string): string {
   if (k === "escape" || k === "esc") return "Esc";
   if (k === "up" || k === "arrowup") return "↑";
   if (k === "down" || k === "arrowdown") return "↓";
+  if (k === "left" || k === "arrowleft") return "←";
+  if (k === "right" || k === "arrowright") return "→";
   if (k === ",") return ",";
   if (k === "[") return "[";
   if (k === "]") return "]";

--- a/packages/ui/src/shell/GlobalEventHandlers.tsx
+++ b/packages/ui/src/shell/GlobalEventHandlers.tsx
@@ -161,6 +161,10 @@ export function GlobalEventHandlers({
   useHotkeys(SHORTCUTS.SETTINGS, handleOpenSettings, globalOptions);
   useHotkeys(SHORTCUTS.GO_BACK, goBack, globalOptions);
   useHotkeys(SHORTCUTS.GO_FORWARD, goForward, globalOptions);
+  // mod+left/right means jump to line start/end inside inputs and editors, so
+  // the arrow variants skip enableOnFormTags/enableOnContentEditable.
+  useHotkeys(SHORTCUTS.GO_BACK_ALT, goBack, { preventDefault: true });
+  useHotkeys(SHORTCUTS.GO_FORWARD_ALT, goForward, { preventDefault: true });
   const handleToggleReview = useCallback(() => {
     if (!currentTaskId) return;
     const mode = getReviewMode(currentTaskId);


### PR DESCRIPTION
## Summary

Cmd+[ / Cmd+] already navigate back/forward in history, but Cmd+Left / Cmd+Right — the shortcut Chrome and most macOS apps use — did nothing. This adds the arrow variants as alternates for the same `goBackInHistory` / `goForwardInHistory` actions.

## Details

- `GO_BACK_ALT: "mod+left"` and `GO_FORWARD_ALT: "mod+right"` added to `SHORTCUTS`.
- Unlike the bracket shortcuts, the arrow variants are **not** enabled on form tags or contenteditable: inside an input or editor, Cmd+Left/Right means jump to line start/end, so they must not trigger navigation there. (This matches Chrome's behavior.) That's why they get their own `useHotkeys` call instead of being appended to the existing `GO_BACK`/`GO_FORWARD` strings, which are bound with `enableOnFormTags`/`enableOnContentEditable`.
- The shortcuts sheet shows them as alternates (`←`/`→` formatting added to `formatKey`).

## Testing

- `pnpm --filter @posthog/ui typecheck` passes.
- `biome check` on the two changed files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)