### PR TITLE
feat(workspace): auto-unlink linked branches that no longer exist

### DIFF
--- a/packages/git/src/queries.test.ts
+++ b/packages/git/src/queries.test.ts
@@ -1,9 +1,10 @@
 import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createGitClient } from "./client";
 import {
+  anyBranchRefExists,
   type ChangedFileInfo,
   computeDiffStatsFromFiles,
   detectDefaultBranch,
@@ -503,5 +504,40 @@ describe("remoteBranchExists", () => {
       "/nonexistent/path/to/remote",
     ]);
     expect(await remoteBranchExists(repoDir, "main")).toBe(false);
+  });
+});
+
+describe("anyBranchRefExists", () => {
+  let repoDir: string;
+
+  // Builds refs via plumbing (commit-tree + update-ref) so the fixture also
+  // works in sandboxes where `git commit` is unavailable.
+  beforeEach(async () => {
+    repoDir = await mkdtemp(path.join(tmpdir(), "posthog-code-refs-"));
+    const git = createGitClient(repoDir);
+    await git.init(["--initial-branch", "main"]);
+    await git.addConfig("user.name", "Test");
+    await git.addConfig("user.email", "test@example.com");
+    const tree = (
+      await git.raw(["hash-object", "-w", "-t", "tree", devNull])
+    ).trim();
+    const sha = (await git.raw(["commit-tree", tree, "-m", "seed"])).trim();
+    await git.raw(["update-ref", "refs/heads/feat/local", sha]);
+    await git.raw(["update-ref", "refs/remotes/upstream/feat/remote", sha]);
+    await git.raw(["update-ref", "refs/tags/feat/tag-only", sha]);
+  });
+
+  afterEach(async () => {
+    await rm(repoDir, { recursive: true, force: true });
+  });
+
+  it.each([
+    { branch: "feat/local", expected: true },
+    { branch: "feat/remote", expected: true },
+    { branch: "feat/gone", expected: false },
+    // A tag with the name does not resurrect a deleted branch.
+    { branch: "feat/tag-only", expected: false },
+  ])("returns $expected for '$branch'", async ({ branch, expected }) => {
+    expect(await anyBranchRefExists(repoDir, branch)).toBe(expected);
   });
 });

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -225,6 +225,34 @@ export async function branchExists(
 }
 
 /**
+ * True when the branch exists as a local branch or as a remote-tracking
+ * ref on any remote. Unlike `branchExists`, a tag or raw commit-ish with
+ * the same name does not count, and nothing reaches the network — a
+ * remote branch only counts once it has been fetched.
+ */
+export async function anyBranchRefExists(
+  baseDir: string,
+  branchName: string,
+  options?: CreateGitClientOptions,
+): Promise<boolean> {
+  const manager = getGitOperationManager();
+  return manager.executeRead(
+    baseDir,
+    async (git) => {
+      const refs = await git.raw([
+        "for-each-ref",
+        "--count=1",
+        "--format=%(refname)",
+        `refs/heads/${branchName}`,
+        `refs/remotes/*/${branchName}`,
+      ]);
+      return refs.trim().length > 0;
+    },
+    { signal: options?.abortSignal },
+  );
+}
+
+/**
  * Checks whether a branch exists on the remote without fetching it.
  * Uses `git ls-remote --heads`, which is read-only and reaches the remote.
  */

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -166,8 +166,9 @@ export interface AgentFileActivityProperties {
   branch_name: string | null;
 }
 
-// Branch link events
-type BranchLinkSource = "agent" | "user" | "unknown";
+// Branch link events. "auto" marks self-healing unlinks of branches that no
+// longer exist anywhere (e.g. deleted after a PR merge).
+type BranchLinkSource = "agent" | "user" | "auto" | "unknown";
 
 export interface BranchLinkedProperties {
   task_id: string;

--- a/packages/workspace-server/src/db/repositories/workspace-repository.mock.ts
+++ b/packages/workspace-server/src/db/repositories/workspace-repository.mock.ts
@@ -109,7 +109,15 @@ export function createMockWorkspaceRepository(): MockWorkspaceRepository {
         workspaces.delete(id);
       }
     },
-    updateLinkedBranch: () => {},
+    updateLinkedBranch: (taskId, linkedBranch) => {
+      const w = findLiveByTaskId(taskId);
+      if (!w) return;
+      workspaces.set(w.id, {
+        ...w,
+        linkedBranch,
+        updatedAt: new Date().toISOString(),
+      });
+    },
     updatePinnedAt: () => {},
     updateLastViewedAt: () => {},
     updateLastActivityAt: () => {},

--- a/packages/workspace-server/src/services/workspace/workspace.test.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.test.ts
@@ -296,31 +296,35 @@ describe("WorkspaceService", () => {
       vi.mocked(mocks.analytics.track).mockClear();
     }
 
-    it("unlinks a mismatched branch that has no refs left", async () => {
+    it.each([
+      { branch: "feat/gone", refExists: false, expected: null },
+      { branch: "feat/alive", refExists: true, expected: "feat/alive" },
+    ])(
+      "linkedBranch is $expected when refExists=$refExists",
+      async ({ branch, refExists, expected }) => {
+        seedLinkedTask(branch);
+        vi.mocked(anyBranchRefExists).mockResolvedValue(refExists);
+
+        const workspace = await service.getWorkspace("t1");
+
+        expect(workspace?.linkedBranch).toBe(expected);
+      },
+    );
+
+    it("emits, tracks, and persists the unlink when refs are gone", async () => {
       seedLinkedTask("feat/gone");
       vi.mocked(anyBranchRefExists).mockResolvedValue(false);
       const emitted = vi.fn();
       service.on(WorkspaceServiceEvent.LinkedBranchChanged, emitted);
 
-      const workspace = await service.getWorkspace("t1");
+      await service.getWorkspace("t1");
 
-      expect(workspace?.linkedBranch).toBeNull();
       expect(emitted).toHaveBeenCalledWith({ taskId: "t1", branchName: null });
       expect(mocks.analytics.track).toHaveBeenCalledWith(
         ANALYTICS_EVENTS.BRANCH_UNLINKED,
         expect.objectContaining({ task_id: "t1", source: "auto" }),
       );
       expect(mocks.workspaceRepo.findByTaskId("t1")?.linkedBranch).toBeNull();
-    });
-
-    it("keeps a mismatched branch that still has a ref", async () => {
-      seedLinkedTask("feat/alive");
-      vi.mocked(anyBranchRefExists).mockResolvedValue(true);
-
-      const workspace = await service.getWorkspace("t1");
-
-      expect(workspace?.linkedBranch).toBe("feat/alive");
-      expect(mocks.analytics.track).not.toHaveBeenCalled();
     });
 
     it("skips the check when on the linked branch", async () => {

--- a/packages/workspace-server/src/services/workspace/workspace.test.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.test.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { RootLogger } from "@posthog/di/logger";
 import {
+  anyBranchRefExists,
   branchExists,
   getCurrentBranch,
   getDefaultBranch,
@@ -35,6 +36,7 @@ vi.mock("@posthog/git/queries", async (importOriginal) => {
     getDefaultBranch: vi.fn(),
     getCurrentBranch: vi.fn(),
     branchExists: vi.fn(),
+    anyBranchRefExists: vi.fn(),
     remoteBranchExists: vi.fn(),
     hasTrackedFiles: vi.fn(),
   };
@@ -255,6 +257,89 @@ describe("WorkspaceService", () => {
         ANALYTICS_EVENTS.BRANCH_UNLINKED,
         expect.objectContaining({ task_id: "task-1", source: "user" }),
       );
+    });
+  });
+
+  describe("getWorkspace (stale linked branch healing)", () => {
+    const tempDirs: string[] = [];
+
+    beforeEach(() => {
+      vi.mocked(anyBranchRefExists).mockReset();
+    });
+
+    afterEach(() => {
+      for (const dir of tempDirs.splice(0)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    /** A fake worktree checkout whose HEAD points at `branch`. */
+    function mkWorktreeOn(branch: string): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "stale-link-"));
+      tempDirs.push(dir);
+      fs.mkdirSync(path.join(dir, ".git"));
+      fs.writeFileSync(
+        path.join(dir, ".git", "HEAD"),
+        `ref: refs/heads/${branch}\n`,
+      );
+      return dir;
+    }
+
+    function seedLinkedTask(linkedBranch: string, currentBranch = "main") {
+      seedWorktreeTask(mocks, {
+        taskId: "t1",
+        repoPath: "/code/myrepo",
+        name: "wt",
+        worktreePath: mkWorktreeOn(currentBranch),
+      });
+      service.linkBranch("t1", linkedBranch, "user");
+      vi.mocked(mocks.analytics.track).mockClear();
+    }
+
+    it("unlinks a mismatched branch that has no refs left", async () => {
+      seedLinkedTask("feat/gone");
+      vi.mocked(anyBranchRefExists).mockResolvedValue(false);
+      const emitted = vi.fn();
+      service.on(WorkspaceServiceEvent.LinkedBranchChanged, emitted);
+
+      const workspace = await service.getWorkspace("t1");
+
+      expect(workspace?.linkedBranch).toBeNull();
+      expect(emitted).toHaveBeenCalledWith({ taskId: "t1", branchName: null });
+      expect(mocks.analytics.track).toHaveBeenCalledWith(
+        ANALYTICS_EVENTS.BRANCH_UNLINKED,
+        expect.objectContaining({ task_id: "t1", source: "auto" }),
+      );
+      expect(mocks.workspaceRepo.findByTaskId("t1")?.linkedBranch).toBeNull();
+    });
+
+    it("keeps a mismatched branch that still has a ref", async () => {
+      seedLinkedTask("feat/alive");
+      vi.mocked(anyBranchRefExists).mockResolvedValue(true);
+
+      const workspace = await service.getWorkspace("t1");
+
+      expect(workspace?.linkedBranch).toBe("feat/alive");
+      expect(mocks.analytics.track).not.toHaveBeenCalled();
+    });
+
+    it("skips the check when on the linked branch", async () => {
+      seedLinkedTask("main", "main");
+
+      const workspace = await service.getWorkspace("t1");
+
+      expect(workspace?.linkedBranch).toBe("main");
+      expect(anyBranchRefExists).not.toHaveBeenCalled();
+    });
+
+    it("keeps the link when the staleness check fails", async () => {
+      seedLinkedTask("feat/unknown");
+      vi.mocked(anyBranchRefExists).mockRejectedValue(new Error("git broke"));
+
+      const workspace = await service.getWorkspace("t1");
+
+      expect(workspace?.linkedBranch).toBe("feat/unknown");
+      expect(mocks.analytics.track).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -7,6 +7,7 @@ import {
 } from "@posthog/di/logger";
 import { createGitClient } from "@posthog/git/client";
 import {
+  anyBranchRefExists,
   branchExists,
   getCurrentBranch,
   getDefaultBranch,
@@ -157,6 +158,8 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
 
   private creatingWorkspaces = new Map<string, Promise<WorkspaceInfo>>();
   private branchWatcherInitialized = false;
+  /** Tasks with an in-flight staleness check, so reads don't stack git calls. */
+  private staleLinkChecks = new Set<string>();
 
   private findTaskAssociation(taskId: string): TaskAssociation | null {
     const workspace = this.workspaceRepo.findByTaskId(taskId);
@@ -384,7 +387,10 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     this.log.info("Linked branch to task", { taskId, branchName, source });
   }
 
-  public unlinkBranch(taskId: string, source?: "agent" | "user"): void {
+  public unlinkBranch(
+    taskId: string,
+    source?: "agent" | "user" | "auto",
+  ): void {
     this.workspaceRepo.updateLinkedBranch(taskId, null);
     this.emit(WorkspaceServiceEvent.LinkedBranchChanged, {
       taskId,
@@ -395,6 +401,43 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
       source: source ?? "unknown",
     });
     this.log.info("Unlinked branch from task", { taskId, source });
+  }
+
+  /**
+   * Drops a linked branch whose branch no longer exists anywhere — no local
+   * branch and no remote-tracking ref (the usual end state after a PR merge
+   * plus branch deletion). Such a link can never match the working tree
+   * again, so keeping it only produces wrong-branch warnings on every send.
+   * Returns true when the link was removed.
+   */
+  private async unlinkStaleLinkedBranch(
+    taskId: string,
+    linkedBranch: string,
+    repoPath: string,
+  ): Promise<boolean> {
+    if (this.staleLinkChecks.has(taskId)) return false;
+    this.staleLinkChecks.add(taskId);
+    try {
+      if (await anyBranchRefExists(repoPath, linkedBranch)) return false;
+      // Re-read: the link may have changed while the git check ran.
+      const row = this.workspaceRepo.findByTaskId(taskId);
+      if ((row?.linkedBranch ?? null) !== linkedBranch) return false;
+      this.log.info("Linked branch has no remaining refs, unlinking", {
+        taskId,
+        linkedBranch,
+      });
+      this.unlinkBranch(taskId, "auto");
+      return true;
+    } catch (error) {
+      this.log.warn("Failed to check linked branch staleness", {
+        taskId,
+        linkedBranch,
+        error,
+      });
+      return false;
+    } finally {
+      this.staleLinkChecks.delete(taskId);
+    }
   }
 
   private getLocalWorktreePathIfExists(
@@ -1080,7 +1123,7 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     }
 
     const dbRow = this.workspaceRepo.findByTaskId(taskId);
-    const linkedBranch = dbRow?.linkedBranch ?? null;
+    let linkedBranch = dbRow?.linkedBranch ?? null;
 
     if (assoc.mode === "cloud") {
       return {
@@ -1114,6 +1157,21 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
         await this.getLocalWorktreePathIfExists(folderPath);
       const branchPath = localWorktreePath ?? folderPath;
       branchName = await getBranchFromPath(branchPath);
+    }
+
+    // Only a mismatched link can be stale: being on the linked branch proves
+    // it exists, and without a current branch nothing warns anyway.
+    if (
+      linkedBranch &&
+      branchName &&
+      linkedBranch !== branchName &&
+      (await this.unlinkStaleLinkedBranch(
+        taskId,
+        linkedBranch,
+        worktreePath ?? folderPath,
+      ))
+    ) {
+      linkedBranch = null;
     }
 
     return {


### PR DESCRIPTION
## Problem

Nothing ever cleans up a task's `linkedBranch` when its branch is deleted — the usual end state after a PR merge. Returning to a finished task and asking a follow-up from `main` triggers the wrong-branch warning on **every send**, about a branch that can never be checked out again. Production data suggests this stale-link case drives much of the ~59% "continue anyway" rate on the mismatch dialog (1,249 dialogs in the last 60 days).

## Change

`getWorkspace` now self-heals stale links:

- New `anyBranchRefExists` query in `@posthog/git`: true when the branch exists as a local head **or** a remote-tracking ref on any remote (`for-each-ref refs/heads/<b> refs/remotes/*/<b>`). No network — a deleted remote branch stops counting once the user's refs know about it; tags and raw commit-ishes don't count.
- When the linked branch mismatches the current branch and no ref remains, the link is dropped via the existing `unlinkBranch`, with a new `"auto"` source on the `Branch unlinked` analytics event.
- Being *on* the linked branch proves it exists, so only mismatched reads pay the extra ref lookup; an in-flight guard keeps concurrent reads from stacking git calls, and the linked state is re-read after the git check to avoid racing a concurrent re-link.

Also makes the mock workspace repository's `updateLinkedBranch` persist (was a no-op) so service tests can exercise link state.

## Tests

- `workspace.test.ts`: parameterised refExists → linkedBranch outcome, focused side-effects test (event + analytics + persisted null), skips the check when on the linked branch, keeps the link if the git check throws.
- `queries.test.ts`: `anyBranchRefExists` local ref / remote-tracking ref on a non-`origin` remote / missing branch / tag-only name (plumbing-based fixture, no `git commit` needed).

Stack:
1. **→ this PR** — auto-unlink stale linked branches
2. #3183 — replace the modal with a non-blocking pre-send banner (also deletes the dialog whose Switch action was broken; that fix was #3179, closed unmerged in favor of this stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)