### PR TITLE
feat(mcp): add Basic Auth support for custom MCP server connectors

### DIFF
--- a/apps/mobile/src/app/mcp-servers/add-custom.tsx
+++ b/apps/mobile/src/app/mcp-servers/add-custom.tsx
@@ -50,6 +50,12 @@ export default function AddCustomMcpServerScreen() {
     setError(null);
     if (!name.trim()) return setError("Name is required");
     if (!url.trim()) return setError("URL is required");
+    if (
+      authType === "basic" &&
+      Boolean(username.trim()) !== Boolean(password)
+    ) {
+      return setError("Username and password are both required");
+    }
 
     setSubmitting(true);
     try {

--- a/apps/mobile/src/app/mcp-servers/add-custom.tsx
+++ b/apps/mobile/src/app/mcp-servers/add-custom.tsx
@@ -25,6 +25,7 @@ const AUTH_OPTIONS: { value: McpAuthType; label: string }[] = [
   { value: "none", label: "None" },
   { value: "api_key", label: "API key" },
   { value: "oauth", label: "OAuth" },
+  { value: "basic", label: "Basic Auth" },
 ];
 
 export default function AddCustomMcpServerScreen() {
@@ -39,6 +40,8 @@ export default function AddCustomMcpServerScreen() {
   const [apiKey, setApiKey] = useState("");
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -63,6 +66,9 @@ export default function AddCustomMcpServerScreen() {
           authType === "oauth" && clientSecret.trim()
             ? clientSecret.trim()
             : undefined,
+        username:
+          authType === "basic" && username.trim() ? username.trim() : undefined,
+        password: authType === "basic" && password ? password : undefined,
       });
       await installations.refetch();
       router.back();
@@ -171,6 +177,28 @@ export default function AddCustomMcpServerScreen() {
                 value={clientSecret}
                 onChangeText={setClientSecret}
                 placeholder="OAuth client secret"
+                secureTextEntry
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+            </>
+          ) : null}
+
+          {authType === "basic" ? (
+            <>
+              <FieldLabel>Username</FieldLabel>
+              <FieldInput
+                value={username}
+                onChangeText={setUsername}
+                placeholder="Enter username"
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+              <FieldLabel>Password</FieldLabel>
+              <FieldInput
+                value={password}
+                onChangeText={setPassword}
+                placeholder="Enter password"
                 secureTextEntry
                 autoCapitalize="none"
                 autoCorrect={false}

--- a/apps/mobile/src/features/mcp/components/McpServerRow.tsx
+++ b/apps/mobile/src/features/mcp/components/McpServerRow.tsx
@@ -11,7 +11,7 @@ interface McpServerRowProps {
   title: string;
   subtitle?: string;
   description?: string;
-  authType?: "api_key" | "oauth" | "none";
+  authType?: "api_key" | "oauth" | "basic" | "none";
   badge?: ReactNode;
   isStdio?: boolean;
   needsReauth?: boolean;
@@ -20,9 +20,10 @@ interface McpServerRowProps {
   onPress: () => void;
 }
 
-function authBadge(auth?: "api_key" | "oauth" | "none") {
+function authBadge(auth?: "api_key" | "oauth" | "basic" | "none") {
   if (auth === "oauth") return "OAuth";
   if (auth === "api_key") return "API key";
+  if (auth === "basic") return "Basic Auth";
   return null;
 }
 

--- a/apps/mobile/src/features/mcp/types.ts
+++ b/apps/mobile/src/features/mcp/types.ts
@@ -1,7 +1,7 @@
 // Shared types for MCP server installations and marketplace templates.
 // Mirrors the PostHog cloud REST schema (see `apps/code/src/renderer/api/generated.ts`).
 
-export type McpAuthType = "api_key" | "oauth" | "none";
+export type McpAuthType = "api_key" | "oauth" | "basic" | "none";
 
 export type McpApprovalState = "approved" | "needs_approval" | "do_not_use";
 
@@ -81,6 +81,8 @@ export interface InstallCustomMcpServerOptions {
   description?: string;
   client_id?: string;
   client_secret?: string;
+  username?: string;
+  password?: string;
   install_source?: McpInstallSource;
   posthog_code_callback_url?: string;
 }

--- a/packages/api-client/src/generated.ts
+++ b/packages/api-client/src/generated.ts
@@ -9348,7 +9348,9 @@ export namespace Schemas {
     values?: (unknown | null) | undefined;
   };
   export type InsightsToolCall = { query: string; insight_type: InsightTypeEnum };
-  export type InstallCustomAuthTypeEnum = "api_key" | "oauth";
+  // TODO: hand-patched ahead of a real `pnpm typed-openapi` regen — the
+  // posthog/posthog backend PR adding "basic" hasn't deployed yet.
+  export type InstallCustomAuthTypeEnum = "api_key" | "oauth" | "basic";
   export type InstallSourceEnum = "posthog" | "posthog-code";
   export type InstallCustom = {
     name: string;
@@ -9358,6 +9360,8 @@ export namespace Schemas {
     description?: string | undefined;
     client_id?: string | undefined;
     client_secret?: string | undefined;
+    username?: string | undefined;
+    password?: string | undefined;
     install_source?: (InstallSourceEnum & unknown) | undefined;
     posthog_code_callback_url?: string | undefined;
   };
@@ -9706,7 +9710,9 @@ export namespace Schemas {
     created_by: UserBasic & unknown;
     updated_at: string | null;
   };
-  export type MCPAuthTypeEnum = "api_key" | "oauth";
+  // TODO: hand-patched ahead of a real `pnpm typed-openapi` regen — the
+  // posthog/posthog backend PR adding "basic" hasn't deployed yet.
+  export type MCPAuthTypeEnum = "api_key" | "oauth" | "basic";
   export type MCPServerInstallation = {
     id: string;
     template_id: string | null;

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -3884,6 +3884,8 @@ export class PostHogAPIClient {
     description?: string;
     client_id?: string;
     client_secret?: string;
+    username?: string;
+    password?: string;
     install_source?: "posthog" | "posthog-code";
     posthog_code_callback_url?: string;
   }): Promise<McpServerInstallation | Schemas.OAuthRedirectResponse> {

--- a/packages/core/src/mcp-servers/customServerForm.test.ts
+++ b/packages/core/src/mcp-servers/customServerForm.test.ts
@@ -17,6 +17,8 @@ function values(
     apiKey: "",
     clientId: "",
     clientSecret: "",
+    username: "",
+    password: "",
     ...overrides,
   };
 }
@@ -87,5 +89,29 @@ describe("buildCustomServerRequest", () => {
     );
     expect(apiKeyReq.client_id).toBeUndefined();
     expect(apiKeyReq.client_secret).toBeUndefined();
+  });
+
+  it("includes username/password only for basic auth when both are present", () => {
+    const req = buildCustomServerRequest(
+      values({ authType: "basic", username: " user ", password: "pass" }),
+    );
+    expect(req.username).toBe("user");
+    expect(req.password).toBe("pass");
+
+    expect(
+      buildCustomServerRequest(
+        values({ authType: "oauth", username: "user", password: "pass" }),
+      ).username,
+    ).toBeUndefined();
+    expect(
+      buildCustomServerRequest(
+        values({ authType: "basic", username: "", password: "pass" }),
+      ).username,
+    ).toBeUndefined();
+    expect(
+      buildCustomServerRequest(
+        values({ authType: "basic", username: "user", password: "" }),
+      ).password,
+    ).toBeUndefined();
   });
 });

--- a/packages/core/src/mcp-servers/customServerForm.test.ts
+++ b/packages/core/src/mcp-servers/customServerForm.test.ts
@@ -50,6 +50,38 @@ describe("canSubmitCustomServer", () => {
     );
     expect(canSubmitCustomServer({ name: "X", url: "nope" })).toBe(false);
   });
+
+  it.each([
+    ["both empty", "", "", true],
+    ["both present", "user", "pass", true],
+    ["username only", "user", "", false],
+    ["password only", "", "pass", false],
+  ])(
+    "for basic auth with %s, returns %s",
+    (_label, username, password, expected) => {
+      expect(
+        canSubmitCustomServer({
+          name: "X",
+          url: "https://x.com",
+          authType: "basic",
+          username,
+          password,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("ignores username/password pairing for non-basic auth types", () => {
+    expect(
+      canSubmitCustomServer({
+        name: "X",
+        url: "https://x.com",
+        authType: "oauth",
+        username: "user",
+        password: "",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("buildCustomServerRequest", () => {
@@ -91,27 +123,26 @@ describe("buildCustomServerRequest", () => {
     expect(apiKeyReq.client_secret).toBeUndefined();
   });
 
-  it("includes username/password only for basic auth when both are present", () => {
+  it("includes username/password for basic auth when both are present", () => {
     const req = buildCustomServerRequest(
       values({ authType: "basic", username: " user ", password: "pass" }),
     );
     expect(req.username).toBe("user");
     expect(req.password).toBe("pass");
-
-    expect(
-      buildCustomServerRequest(
-        values({ authType: "oauth", username: "user", password: "pass" }),
-      ).username,
-    ).toBeUndefined();
-    expect(
-      buildCustomServerRequest(
-        values({ authType: "basic", username: "", password: "pass" }),
-      ).username,
-    ).toBeUndefined();
-    expect(
-      buildCustomServerRequest(
-        values({ authType: "basic", username: "user", password: "" }),
-      ).password,
-    ).toBeUndefined();
   });
+
+  it.each([
+    ["oauth", "user", "pass"],
+    ["basic", "", "pass"],
+    ["basic", "user", ""],
+  ] as const)(
+    "excludes username/password when authType is %s with username=%j password=%j",
+    (authType, username, password) => {
+      const req = buildCustomServerRequest(
+        values({ authType, username, password }),
+      );
+      expect(req.username).toBeUndefined();
+      expect(req.password).toBeUndefined();
+    },
+  );
 });

--- a/packages/core/src/mcp-servers/customServerForm.ts
+++ b/packages/core/src/mcp-servers/customServerForm.ts
@@ -29,9 +29,16 @@ export function isValidMcpUrl(url: string): boolean {
 }
 
 export function canSubmitCustomServer(
-  values: Pick<CustomServerFormValues, "name" | "url">,
+  values: Pick<CustomServerFormValues, "name" | "url"> &
+    Partial<Pick<CustomServerFormValues, "authType" | "username" | "password">>,
 ): boolean {
-  return values.name.trim() !== "" && isValidMcpUrl(values.url);
+  if (values.name.trim() === "" || !isValidMcpUrl(values.url)) return false;
+  if (values.authType === "basic") {
+    const hasUsername = Boolean(values.username?.trim());
+    const hasPassword = Boolean(values.password);
+    if (hasUsername !== hasPassword) return false;
+  }
+  return true;
 }
 
 export function buildCustomServerRequest(

--- a/packages/core/src/mcp-servers/customServerForm.ts
+++ b/packages/core/src/mcp-servers/customServerForm.ts
@@ -8,6 +8,8 @@ export interface CustomServerFormValues {
   apiKey: string;
   clientId: string;
   clientSecret: string;
+  username: string;
+  password: string;
 }
 
 export interface CustomServerRequest {
@@ -18,6 +20,8 @@ export interface CustomServerRequest {
   api_key?: string;
   client_id?: string;
   client_secret?: string;
+  username?: string;
+  password?: string;
 }
 
 export function isValidMcpUrl(url: string): boolean {
@@ -46,6 +50,9 @@ export function buildCustomServerRequest(
       : {}),
     ...(values.authType === "oauth" && values.clientSecret.trim()
       ? { client_secret: values.clientSecret.trim() }
+      : {}),
+    ...(values.authType === "basic" && values.username.trim() && values.password
+      ? { username: values.username.trim(), password: values.password }
       : {}),
   };
 }

--- a/packages/core/src/mcp-servers/installFlow.test.ts
+++ b/packages/core/src/mcp-servers/installFlow.test.ts
@@ -94,6 +94,35 @@ describe("installCustomWithOAuth", () => {
     });
     expect(result).toEqual({ error: "denied" });
   });
+
+  it("forwards username/password for basic auth", async () => {
+    const oauth = makeOAuth();
+    const client: InstallFlowClient = {
+      installMcpTemplate: vi.fn(),
+      installCustomMcpServer: vi.fn().mockResolvedValue(installedInstallation),
+      authorizeMcpInstallation: vi.fn(),
+    };
+
+    await installCustomWithOAuth(client, oauth, {
+      name: "N",
+      url: "https://x",
+      description: "d",
+      auth_type: "basic",
+      username: "user",
+      password: "pass",
+    });
+
+    expect(client.installCustomMcpServer).toHaveBeenCalledWith({
+      name: "N",
+      url: "https://x",
+      description: "d",
+      auth_type: "basic",
+      username: "user",
+      password: "pass",
+      install_source: "posthog-code",
+      posthog_code_callback_url: "cb://here",
+    });
+  });
 });
 
 describe("reauthorizeWithOAuth", () => {

--- a/packages/core/src/mcp-servers/installFlow.ts
+++ b/packages/core/src/mcp-servers/installFlow.ts
@@ -24,6 +24,8 @@ export interface InstallFlowClient {
     api_key?: string;
     client_id?: string;
     client_secret?: string;
+    username?: string;
+    password?: string;
     install_source?: "posthog" | "posthog-code";
     posthog_code_callback_url?: string;
   }): Promise<InstallResult>;
@@ -80,6 +82,8 @@ export async function installCustomWithOAuth(
     api_key?: string;
     client_id?: string;
     client_secret?: string;
+    username?: string;
+    password?: string;
   },
 ): Promise<OAuthCallbackResult> {
   const { callbackUrl } = await oauth.getCallbackUrl();

--- a/packages/ui/src/features/mcp-server-manager/AddCustomServerForm.tsx
+++ b/packages/ui/src/features/mcp-server-manager/AddCustomServerForm.tsx
@@ -25,6 +25,8 @@ interface AddCustomServerFormProps {
     api_key?: string;
     client_id?: string;
     client_secret?: string;
+    username?: string;
+    password?: string;
   }) => void;
   /** Prefill the form (e.g. the agent builder's connect_mcp punch-out supplies a
    *  suggested name/url). The user can still edit every field before connecting. */
@@ -57,6 +59,8 @@ export function AddCustomServerForm({
   const [apiKey, setApiKey] = useState("");
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   const canSubmit = canSubmitCustomServer({ name, url }) && !pending;
@@ -74,6 +78,8 @@ export function AddCustomServerForm({
           apiKey,
           clientId,
           clientSecret,
+          username,
+          password,
         }),
       );
     },
@@ -86,6 +92,8 @@ export function AddCustomServerForm({
       apiKey,
       clientId,
       clientSecret,
+      username,
+      password,
       onSubmit,
     ],
   );
@@ -161,12 +169,17 @@ export function AddCustomServerForm({
               onValueChange={(val) => {
                 setAuthType(val as McpAuthType);
                 if (val !== "api_key") setApiKey("");
+                if (val !== "basic") {
+                  setUsername("");
+                  setPassword("");
+                }
               }}
             >
               <Select.Trigger />
               <Select.Content>
                 <Select.Item value="oauth">OAuth</Select.Item>
                 <Select.Item value="api_key">API key</Select.Item>
+                <Select.Item value="basic">Basic Auth</Select.Item>
               </Select.Content>
             </Select.Root>
           </Flex>
@@ -181,6 +194,29 @@ export function AddCustomServerForm({
                 type="password"
               />
             </Flex>
+          )}
+
+          {authType === "basic" && (
+            <>
+              <Flex direction="column" gap="1">
+                <Text className="font-medium text-sm">Username</Text>
+                <TextField.Root
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  placeholder="Enter username"
+                  spellCheck={false}
+                />
+              </Flex>
+              <Flex direction="column" gap="1">
+                <Text className="font-medium text-sm">Password</Text>
+                <TextField.Root
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter password"
+                  type="password"
+                />
+              </Flex>
+            </>
           )}
 
           {authType === "oauth" && (

--- a/packages/ui/src/features/mcp-server-manager/AddCustomServerForm.tsx
+++ b/packages/ui/src/features/mcp-server-manager/AddCustomServerForm.tsx
@@ -63,7 +63,9 @@ export function AddCustomServerForm({
   const [password, setPassword] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
 
-  const canSubmit = canSubmitCustomServer({ name, url }) && !pending;
+  const canSubmit =
+    canSubmitCustomServer({ name, url, authType, username, password }) &&
+    !pending;
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {

--- a/packages/ui/src/features/mcp-server-manager/useMcpConnect.ts
+++ b/packages/ui/src/features/mcp-server-manager/useMcpConnect.ts
@@ -44,6 +44,8 @@ export interface CustomServerInput {
   api_key?: string;
   client_id?: string;
   client_secret?: string;
+  username?: string;
+  password?: string;
 }
 
 /**

--- a/packages/ui/src/features/mcp-servers/hooks/useMcpServers.ts
+++ b/packages/ui/src/features/mcp-servers/hooks/useMcpServers.ts
@@ -142,6 +142,8 @@ export function useMcpServers() {
         api_key?: string;
         client_id?: string;
         client_secret?: string;
+        username?: string;
+        password?: string;
       },
     ) => installCustomWithOAuth(client, oauth, vars),
     {


### PR DESCRIPTION
## Summary
- Adds a `"basic"` auth type (username/password) to the custom MCP server install form, install flow, and mobile's custom-install screen, alongside the existing OAuth/API Key options.
- Some third-party MCP servers (e.g. DataForSEO's remote MCP server) require standard HTTP Basic Auth (`Authorization: Basic base64(username:password)`), which the existing `api_key` type can't produce (it always sends `Bearer <key>`).
- Client-side only: the outbound `Authorization` header is built server-side by the PostHog backend's MCP Store proxy. This PR hand-patches the generated API client types ahead of a real `pnpm typed-openapi` regen, and is inert until the backend recognizes `"basic"`.

## Depends on
- PostHog/posthog#68672 — adds `"basic"` to `AUTH_TYPE_CHOICES`, accepts `username`/`password` on the custom-install endpoint, and builds the Basic auth header in the MCP Store proxy. This PR should land and deploy before merging this one (selecting "Basic Auth" before that ships would 400).
- Originating feature request: PostHog/posthog#68653

## Changes
- `packages/api-client`: widen `McpAuthType`/`InstallCustomAuthTypeEnum` to include `"basic"`; add `username`/`password` to the install request shape.
- `packages/core/src/mcp-servers`: thread `username`/`password` through `customServerForm.ts` and `installFlow.ts`, with new test coverage.
- `packages/ui/src/features/mcp-server-manager` and `mcp-servers`: add the "Basic Auth" option with Username/Password fields to the Add Custom Server form, wired through both places it's consumed.
- `apps/mobile`: mirror the same auth type and fields in the native "Add Custom Server" screen.

## Test plan
- [x] `pnpm --filter @posthog/core test` — 196 files / 1982 tests passing
- [x] `pnpm --filter @posthog/core typecheck`
- [x] `pnpm --filter @posthog/ui typecheck`
- [x] `pnpm --filter @posthog/api-client typecheck`
- [x] `pnpm --filter mobile test` — 52 files / 394 tests passing
- [x] `pnpm biome check` on all touched files
- [ ] End-to-end verification against DataForSEO once PostHog/posthog#68672 is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)