### PR TITLE
fix(codex): bundle the native codex binary in the packaged app

### DIFF
--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -196,6 +196,16 @@ jobs:
             echo "OK: $bin"
           done
 
+          # The native codex CLI must ship as a sibling of codex-acp, or the
+          # app-server harness silently falls back to codex-acp in production.
+          for f in codex rg; do
+            if [[ ! -f "$RESOURCES/app.asar.unpacked/.vite/build/codex-acp/$f" ]]; then
+              echo "FAIL: codex-acp/$f missing in bundled binaries"
+              exit 1
+            fi
+            echo "OK: codex-acp/$f"
+          done
+
       - name: Install Playwright
         run: pnpm --filter code exec playwright install
 

--- a/apps/code/vite-main-plugins.mts
+++ b/apps/code/vite-main-plugins.mts
@@ -569,6 +569,10 @@ export function copyCodexAcpBinaries(): Plugin {
       const sourceDir = join(__dirname, "resources/codex-acp");
       const binaries = [
         { name: "codex-acp", winName: "codex-acp.exe" },
+        // The native codex CLI must ship next to codex-acp: the app-server
+        // sub-adapter resolves it as a sibling and silently falls back to
+        // codex-acp when it's missing.
+        { name: "codex", winName: "codex.exe" },
         { name: "rg", winName: "rg.exe" },
       ];
 


### PR DESCRIPTION
The app-server harness resolves the native codex CLI as a sibling of the
bundled codex-acp binary, but packaging only staged codex-acp and rg — so
production always logged nativeBinaryFound:false and silently fell back to
codex-acp even with the codex-app-server flag on. Stage the binary and make
the release verifier assert it (and rg) exist file-level.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>