### PR TITLE
fix(usage): Show reset time when limit is exceeded

### DIFF
--- a/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -479,7 +479,9 @@ function UsageMeter({ label, bucket, color }: UsageMeterProps) {
         color={color === "red" ? "red" : undefined}
       />
       <Text className="text-(--gray-9) text-[13px]">
-        {bucket.exceeded ? "Limit exceeded" : formatResetTime(bucket.reset_at)}
+        {bucket.exceeded
+          ? `Limit exceeded. ${formatResetTime(bucket.reset_at)}`
+          : formatResetTime(bucket.reset_at)}
       </Text>
     </Flex>
   );

--- a/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -479,9 +479,7 @@ function UsageMeter({ label, bucket, color }: UsageMeterProps) {
         color={color === "red" ? "red" : undefined}
       />
       <Text className="text-(--gray-9) text-[13px]">
-        {bucket.exceeded
-          ? `Limit exceeded. ${formatResetTime(bucket.reset_at)}`
-          : formatResetTime(bucket.reset_at)}
+        {`${bucket.exceeded ? "Limit exceeded. " : ""}${formatResetTime(bucket.reset_at)}`}
       </Text>
     </Flex>
   );


### PR DESCRIPTION
## Problem

When a usage bucket hits 100%, the Usage card in settings swaps the reset time for a bare "Limit exceeded" label. That's exactly when users most need to know when they get unblocked. Reported by a user whose daily meter showed a reset time yesterday and only "Limit exceeded" today.

## Changes

`UsageMeter` now keeps the reset time when a bucket is exceeded: "Limit exceeded. Resets in 3h 12m" instead of just "Limit exceeded". This matches `UsageLimitModal`, which already appends the reset time to its description. `reset_at` is a required field on the bucket so it's always available.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` (also re-run by the pre-commit hook)
- `biome check` on the changed file
- No unit tests cover this component; the change reuses `formatResetTime`, which is covered by `usageDisplay.test.ts`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?