### PR TITLE
fix(context-menu): Remove Array product name from folder prompt

### DIFF
--- a/packages/core/src/context-menu/context-menu.ts
+++ b/packages/core/src/context-menu/context-menu.ts
@@ -238,7 +238,7 @@ export class ContextMenuService {
         {
           confirm: {
             title: "Remove Folder",
-            message: `Remove "${folderName}" from Array?`,
+            message: `Remove "${folderName}"?`,
             detail:
               "This will clean up any worktrees but keep your folder and tasks intact.",
             confirmLabel: "Remove",


### PR DESCRIPTION
## Problem

The remove folder confirmation still referred to the product as "Array".

## Changes

Renamed the remove folder confirmation message from `Remove "$foldername" from Array?` to `Remove "$foldername"?`.

## How did you test this?

Manually

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
