### PR TITLE
feat(autoresearch): improve new-task composer controls (GROW-124)

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -993,6 +993,28 @@ export interface ClaudeSessionImportFailedProperties {
   failed_step?: string;
 }
 
+/** Fired when a user arms autoresearch mode on the new-task composer. */
+export interface AutoresearchArmedProperties {
+  /** Hands-off mode auto-applied on arm so the unattended loop isn't blocked on permission prompts. */
+  default_mode: "bypassPermissions" | "acceptEdits";
+  workspace_mode?: "local" | "worktree" | "cloud";
+}
+
+/** Fired when an armed autoresearch task is submitted and its run kicks off. */
+export interface AutoresearchRunStartedProperties {
+  direction: "maximize" | "minimize";
+  /** Whether the user set a target metric value to stop early at. */
+  has_target: boolean;
+  max_iterations: number;
+  /** Build and measure stages differ, so each iteration splits into a build turn and a measure turn. */
+  stages_split: boolean;
+  implement_model?: string;
+  measure_model?: string;
+  implement_effort?: string;
+  measure_effort?: string;
+  workspace_mode?: "local" | "worktree" | "cloud";
+}
+
 // Event names as constants
 export const ANALYTICS_EVENTS = {
   // App lifecycle
@@ -1150,6 +1172,10 @@ export const ANALYTICS_EVENTS = {
   DASHBOARD_ACTION: "Dashboard action",
   CANVAS_PROMPT_SENT: "Canvas prompt sent",
   CONTEXT_ACTION: "Context action",
+
+  // Autoresearch events
+  AUTORESEARCH_ARMED: "Autoresearch armed",
+  AUTORESEARCH_RUN_STARTED: "Autoresearch run started",
 } as const;
 
 // Event property mapping
@@ -1302,6 +1328,10 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.DASHBOARD_ACTION]: DashboardActionProperties;
   [ANALYTICS_EVENTS.CANVAS_PROMPT_SENT]: CanvasPromptSentProperties;
   [ANALYTICS_EVENTS.CONTEXT_ACTION]: ContextActionProperties;
+
+  // Autoresearch events
+  [ANALYTICS_EVENTS.AUTORESEARCH_ARMED]: AutoresearchArmedProperties;
+  [ANALYTICS_EVENTS.AUTORESEARCH_RUN_STARTED]: AutoresearchRunStartedProperties;
 };
 
 /**

--- a/packages/ui/src/features/autoresearch/AutoresearchComposerControls.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchComposerControls.tsx
@@ -22,8 +22,11 @@ interface AutoresearchComposerControlsProps {
 }
 
 /**
- * Autoresearch settings rendered inside the composer box (its header addon)
- * while the mode is armed — one input view, not a widget attached under it.
+ * Autoresearch settings shown as a bar above the composer while the mode is
+ * armed. It reads as one sentence — "Optimize to maximize until it reaches N
+ * or after K iterations using <model>" — so each control explains itself in
+ * place; tooltips on the labels add the detail.
+ *
  * There is deliberately no metric or instructions field: the prompt IS the
  * optimization brief, and the agent names the metric in its reports.
  *
@@ -39,44 +42,63 @@ export function AutoresearchComposerControls({
   onExit,
 }: AutoresearchComposerControlsProps) {
   return (
-    <div className="flex w-full flex-wrap items-center gap-x-2 gap-y-1 text-[12px]">
-      <span className="flex shrink-0 items-center gap-1 font-medium text-violet-11">
-        <ChartLineUp size={13} />
-        Autoresearch
+    <div className="flex w-full flex-wrap items-center gap-x-2 gap-y-1.5 text-[12px]">
+      <Tooltip content="Runs an autonomous optimization loop: it measures a baseline from your brief, then edits the code and re-measures each round — keeping changes that move the metric and reverting the ones that don't. It stops when the metric reaches your target or hits the iteration cap, whichever comes first.">
+        <span className="flex shrink-0 cursor-help items-center gap-1 font-medium text-violet-11">
+          <ChartLineUp size={13} />
+          Autoresearch
+        </span>
+      </Tooltip>
+
+      {/* The goal: which way to push the metric the brief describes. */}
+      <span className="flex items-center gap-1.5 whitespace-nowrap text-(--gray-11)">
+        <Tooltip content="Whether the agent should drive the metric from your brief up or down.">
+          <span className="cursor-help">Optimize to</span>
+        </Tooltip>
+        <Select.Root
+          size="1"
+          value={draft.direction}
+          onValueChange={(value) =>
+            onChange({ direction: value as AutoresearchDirection })
+          }
+          disabled={disabled}
+        >
+          <Select.Trigger variant="soft" aria-label="Optimization direction" />
+          <Select.Content>
+            <Select.Item value="maximize">maximize</Select.Item>
+            <Select.Item value="minimize">minimize</Select.Item>
+          </Select.Content>
+        </Select.Root>
       </span>
-      <Select.Root
-        size="1"
-        value={draft.direction}
-        onValueChange={(value) =>
-          onChange({ direction: value as AutoresearchDirection })
-        }
-        disabled={disabled}
-      >
-        <Select.Trigger variant="soft" aria-label="Optimization direction" />
-        <Select.Content>
-          <Select.Item value="maximize">Maximize</Select.Item>
-          <Select.Item value="minimize">Minimize</Select.Item>
-        </Select.Content>
-      </Select.Root>
-      <TextField.Root
-        size="1"
-        className="w-24"
-        value={draft.targetValue === null ? "" : String(draft.targetValue)}
-        onChange={(event) => {
-          const raw = event.target.value.trim();
-          const numeric = Number(raw);
-          onChange({
-            targetValue:
-              raw === "" || !Number.isFinite(numeric) ? null : numeric,
-          });
-        }}
-        placeholder="Target"
-        inputMode="decimal"
-        aria-label="Target value (optional)"
-        disabled={disabled}
-      />
-      <span className="flex items-center gap-1 text-(--gray-11)">
-        ≤
+
+      {/* Two stop conditions, whichever comes first: the metric hits the
+          target value, or the run exhausts its iteration budget. Only the
+          label text is wrapped in a tooltip — never the input — so focusing
+          the field to type doesn't pop the tooltip open. */}
+      <span className="flex items-center gap-1.5 whitespace-nowrap text-(--gray-11)">
+        <Tooltip content="Finish early once the metric reaches this value. Leave blank to always run the full iteration budget.">
+          <span className="cursor-help">until it reaches</span>
+        </Tooltip>
+        <TextField.Root
+          size="1"
+          className="w-24"
+          value={draft.targetValue === null ? "" : String(draft.targetValue)}
+          onChange={(event) => {
+            const raw = event.target.value.trim();
+            const numeric = Number(raw);
+            onChange({
+              targetValue:
+                raw === "" || !Number.isFinite(numeric) ? null : numeric,
+            });
+          }}
+          placeholder="optional"
+          inputMode="decimal"
+          aria-label="Target metric value to stop at (optional)"
+          disabled={disabled}
+        />
+      </span>
+      <span className="flex items-center gap-1.5 whitespace-nowrap text-(--gray-11)">
+        or after
         <TextField.Root
           size="1"
           className="w-14"
@@ -89,18 +111,28 @@ export function AutoresearchComposerControls({
             })
           }
           inputMode="numeric"
-          aria-label="Iteration budget"
+          aria-label="Maximum iterations"
           disabled={disabled}
         />
-        iterations
+        <Tooltip content="Hard cap on build-and-measure rounds before the run stops.">
+          <span className="cursor-help">iterations</span>
+        </Tooltip>
       </span>
-      <StagesPopover
-        draft={draft}
-        modelOptions={modelOptions}
-        effortOptions={effortOptions}
-        disabled={disabled}
-        onChange={onChange}
-      />
+
+      {/* The engine: model + effort per stage. */}
+      <span className="flex items-center gap-1.5 whitespace-nowrap text-(--gray-11)">
+        <Tooltip content="Model and reasoning effort the loop runs on. Set the build and measure stages to different models to measure with a cheaper one.">
+          <span className="cursor-help">using</span>
+        </Tooltip>
+        <StagesPopover
+          draft={draft}
+          modelOptions={modelOptions}
+          effortOptions={effortOptions}
+          disabled={disabled}
+          onChange={onChange}
+        />
+      </span>
+
       <span className="ml-auto flex shrink-0 items-center">
         <Tooltip content="Exit autoresearch mode">
           <button

--- a/packages/ui/src/features/message-editor/components/ModeSelector.tsx
+++ b/packages/ui/src/features/message-editor/components/ModeSelector.tsx
@@ -1,11 +1,13 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
-import { CaretDown } from "@phosphor-icons/react";
+import { CaretDown, ChartLineUp } from "@phosphor-icons/react";
 import {
   Button,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
@@ -19,6 +21,16 @@ interface ModeSelectorProps {
   onChange: (value: string) => void;
   allowBypassPermissions: boolean;
   disabled?: boolean;
+  /**
+   * When provided, an "Autoresearch" toggle renders as the last item of the
+   * menu (new-task composer only). It arms/disarms the autonomous iteration
+   * loop; `active` drives its checkmark. Applied after the menu closes, like a
+   * mode change, so the composer doesn't relayout under the closing menu.
+   */
+  autoresearch?: {
+    active: boolean;
+    onToggle: () => void;
+  };
 }
 
 export function ModeSelector({
@@ -26,9 +38,11 @@ export function ModeSelector({
   onChange,
   allowBypassPermissions,
   disabled,
+  autoresearch,
 }: ModeSelectorProps) {
   const [open, setOpen] = useState(false);
   const pendingValueRef = useRef<string | null>(null);
+  const pendingAutoresearchRef = useRef(false);
   const displayOption = useRetainedConfigOption(modeOption);
 
   if (!displayOption || displayOption.type !== "select") return null;
@@ -58,9 +72,14 @@ export function ModeSelector({
       open={open}
       onOpenChange={setOpen}
       onOpenChangeComplete={(isOpen) => {
-        if (!isOpen && pendingValueRef.current !== null) {
+        if (isOpen) return;
+        if (pendingValueRef.current !== null) {
           onChange(pendingValueRef.current);
           pendingValueRef.current = null;
+        }
+        if (pendingAutoresearchRef.current) {
+          pendingAutoresearchRef.current = false;
+          autoresearch?.onToggle();
         }
       }}
     >
@@ -107,6 +126,23 @@ export function ModeSelector({
             );
           })}
         </DropdownMenuRadioGroup>
+        {autoresearch && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuCheckboxItem
+              checked={autoresearch.active}
+              onCheckedChange={() => {
+                pendingAutoresearchRef.current = true;
+                setOpen(false);
+              }}
+            >
+              <span className="text-violet-11">
+                <ChartLineUp size={12} />
+              </span>
+              <span className="whitespace-nowrap">Autoresearch</span>
+            </DropdownMenuCheckboxItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -40,6 +40,14 @@ export interface PromptInputProps {
   modeOption?: SessionConfigOption;
   onModeChange?: (value: string) => void;
   allowBypassPermissions?: boolean;
+  /**
+   * When provided, the mode dropdown gains an "Autoresearch" toggle as its
+   * last item (new-task composer only). `active` drives its checkmark.
+   */
+  autoresearch?: {
+    active: boolean;
+    onToggle: () => void;
+  };
   // capabilities
   enableBashMode?: boolean;
   enableCommands?: boolean;
@@ -94,6 +102,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       modeOption,
       onModeChange,
       allowBypassPermissions = false,
+      autoresearch,
       enableBashMode = false,
       enableCommands = true,
       modelSelector,
@@ -395,6 +404,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
                       onChange={onModeChange}
                       allowBypassPermissions={allowBypassPermissions}
                       disabled={disabled}
+                      autoresearch={autoresearch}
                     />
                   )}
                   {modelSelector && <span>{modelSelector}</span>}

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -9,12 +9,14 @@ import { isValidConfigValue } from "@posthog/core/task-detail/configOptions";
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { ButtonGroup } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import type { TaskInputReportAssociation } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { useTaskInputPrefillStore } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { navigateToInbox } from "@posthog/ui/router/navigationBridge";
 import { useAppView } from "@posthog/ui/router/useAppView";
+import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
@@ -695,6 +697,10 @@ export function TaskInput({
     if (modeOption && isValidConfigValue(modeOption, autonomousMode)) {
       setConfigOption(modeOption.id, autonomousMode);
     }
+    track(ANALYTICS_EVENTS.AUTORESEARCH_ARMED, {
+      default_mode: autonomousMode,
+      workspace_mode: workspaceMode,
+    });
   }, [
     sessionId,
     currentModel,
@@ -702,6 +708,7 @@ export function TaskInput({
     allowBypassPermissions,
     modeOption,
     setConfigOption,
+    workspaceMode,
   ]);
 
   // The preview config can still be loading when the user arms the mode;
@@ -800,16 +807,32 @@ export function TaskInput({
     // Stages ride through as configured; identical stages mean a single-turn
     // loop, any difference makes the run split. Unresolved fields fall back
     // to the composer's values so the recorded config is concrete.
-    autoresearchPendingRun.set({
+    const resolvedRun = {
       ...draft,
       implementModel: draft.implementModel ?? currentModel ?? null,
       measureModel: draft.measureModel ?? currentModel ?? null,
       implementEffort: draft.implementEffort ?? currentReasoningLevel ?? null,
       measureEffort: draft.measureEffort ?? currentReasoningLevel ?? null,
+    };
+    autoresearchPendingRun.set({
+      ...resolvedRun,
       instructions: contentToXml(content).trim(),
     });
     const submitted = await handleSubmit(override);
     if (submitted) {
+      track(ANALYTICS_EVENTS.AUTORESEARCH_RUN_STARTED, {
+        direction: resolvedRun.direction,
+        has_target: resolvedRun.targetValue !== null,
+        max_iterations: resolvedRun.maxIterations,
+        stages_split:
+          resolvedRun.implementModel !== resolvedRun.measureModel ||
+          resolvedRun.implementEffort !== resolvedRun.measureEffort,
+        implement_model: resolvedRun.implementModel ?? undefined,
+        measure_model: resolvedRun.measureModel ?? undefined,
+        implement_effort: resolvedRun.implementEffort ?? undefined,
+        measure_effort: resolvedRun.measureEffort ?? undefined,
+        workspace_mode: effectiveWorkspaceMode,
+      });
       useAutoresearchDraftStore.getState().clearDraft(sessionId);
       useDraftStore.getState().actions.setDraft(sessionId, null);
       try {
@@ -821,7 +844,14 @@ export function TaskInput({
       autoresearchPendingRun.clear();
     }
     return submitted;
-  }, [canSubmit, currentModel, currentReasoningLevel, handleSubmit, sessionId]);
+  }, [
+    canSubmit,
+    currentModel,
+    currentReasoningLevel,
+    effectiveWorkspaceMode,
+    handleSubmit,
+    sessionId,
+  ]);
 
   const submitTask = autoresearchDraft
     ? handleAutoresearchSubmit

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -1,4 +1,4 @@
-import { ChartLineUp, FileText, X } from "@phosphor-icons/react";
+import { FileText, X } from "@phosphor-icons/react";
 import type { AutoresearchService } from "@posthog/core/autoresearch/autoresearch";
 import { AUTORESEARCH_SERVICE } from "@posthog/core/autoresearch/identifiers";
 import { buildKickoffPreamble } from "@posthog/core/autoresearch/prompts";
@@ -15,7 +15,7 @@ import type { TaskInputReportAssociation } from "@posthog/ui/features/task-detai
 import { useTaskInputPrefillStore } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { navigateToInbox } from "@posthog/ui/router/navigationBridge";
 import { useAppView } from "@posthog/ui/router/useAppView";
-import { Box, Button, Flex, Text, Tooltip } from "@radix-ui/themes";
+import { Box, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -686,7 +686,23 @@ export function TaskInput({
       implementEffort: currentReasoningLevel ?? null,
       measureEffort: currentReasoningLevel ?? null,
     });
-  }, [sessionId, currentModel, currentReasoningLevel]);
+    // The loop iterates unattended, so a permission prompt would stall it.
+    // Default to the most hands-off mode available: bypass when the user has
+    // enabled it, otherwise accept-edits.
+    const autonomousMode = allowBypassPermissions
+      ? "bypassPermissions"
+      : "acceptEdits";
+    if (modeOption && isValidConfigValue(modeOption, autonomousMode)) {
+      setConfigOption(modeOption.id, autonomousMode);
+    }
+  }, [
+    sessionId,
+    currentModel,
+    currentReasoningLevel,
+    allowBypassPermissions,
+    modeOption,
+    setConfigOption,
+  ]);
 
   // The preview config can still be loading when the user arms the mode;
   // backfill the stage fields once the composer's model/effort resolve so
@@ -1083,26 +1099,6 @@ export function TaskInput({
                     disabled={isCreatingTask}
                   />
                 )}
-                {autoresearchService && autoresearchEnabled && (
-                  <Tooltip
-                    content={
-                      autoresearchDraft
-                        ? "Exit autoresearch mode"
-                        : "Create this task in autoresearch mode: the prompt becomes the optimization brief"
-                    }
-                  >
-                    <Button
-                      size="1"
-                      variant={autoresearchDraft ? "soft" : "ghost"}
-                      color={autoresearchDraft ? undefined : "gray"}
-                      onClick={handleAutoresearchToggle}
-                      disabled={isCreatingTask}
-                    >
-                      <ChartLineUp size={14} />
-                      Autoresearch
-                    </Button>
-                  </Tooltip>
-                )}
                 {cloudRegion === "dev" && (
                   <Flex align="center" gap="1" className="shrink-0">
                     <span
@@ -1117,6 +1113,26 @@ export function TaskInput({
               </Flex>
 
               <Flex direction="column" gap="0">
+                {autoresearchDraft && (
+                  <div className="mb-2 rounded-md border border-violet-6 bg-violet-2 px-2.5 py-1.5">
+                    <AutoresearchComposerControls
+                      draft={autoresearchDraft}
+                      modelOptions={autoresearchModelOptions}
+                      effortOptions={autoresearchEffortOptions}
+                      disabled={isCreatingTask}
+                      onChange={(patch) =>
+                        useAutoresearchDraftStore
+                          .getState()
+                          .updateDraft(sessionId, patch)
+                      }
+                      onExit={() =>
+                        useAutoresearchDraftStore
+                          .getState()
+                          .clearDraft(sessionId)
+                      }
+                    />
+                  </div>
+                )}
                 <PromptInput
                   ref={editorRef}
                   sessionId={promptSessionId}
@@ -1124,26 +1140,6 @@ export function TaskInput({
                     autoresearchDraft
                       ? "What should the agent optimize? Describe the goal, how to measure it, and any constraints — it measures a baseline, then iterates."
                       : `What do you want to ship? ${hints}`
-                  }
-                  headerAddon={
-                    autoresearchDraft ? (
-                      <AutoresearchComposerControls
-                        draft={autoresearchDraft}
-                        modelOptions={autoresearchModelOptions}
-                        effortOptions={autoresearchEffortOptions}
-                        disabled={isCreatingTask}
-                        onChange={(patch) =>
-                          useAutoresearchDraftStore
-                            .getState()
-                            .updateDraft(sessionId, patch)
-                        }
-                        onExit={() =>
-                          useAutoresearchDraftStore
-                            .getState()
-                            .clearDraft(sessionId)
-                        }
-                      />
-                    ) : undefined
                   }
                   editorHeight="large"
                   disabled={isCreatingTask}
@@ -1161,6 +1157,14 @@ export function TaskInput({
                   modeOption={modeOption}
                   onModeChange={handleModeChange}
                   allowBypassPermissions={allowBypassPermissions}
+                  autoresearch={
+                    autoresearchService && autoresearchEnabled
+                      ? {
+                          active: !!autoresearchDraft,
+                          onToggle: handleAutoresearchToggle,
+                        }
+                      : undefined
+                  }
                   enableCommands
                   enableBashMode={false}
                   modelSelector={


### PR DESCRIPTION
## What

Polish pass on the **autoresearch** mode in the new-task composer (follow-up to the autoresearch feature, GROW-103).

### 1. Autoresearch moved into the agent-mode dropdown
- Removed the standalone "Autoresearch" toolbar button.
- It's now the last item of the mode dropdown (after a separator), as a checkbox toggle applied on menu close — the same deferral the mode radio items use, so the composer doesn't relayout under the closing menu.
- Arming it defaults the agent mode to the most hands-off option available — `bypassPermissions` when the user has it enabled, otherwise `acceptEdits` — since an unattended iteration loop would stall on permission prompts.

### 2. Fixed the target/iterations inputs stealing focus on click
- Root cause: they lived inside the composer's `InputGroup`, whose click handler refocuses the editor on any non-button click, so clicking an input bounced focus straight to the prompt.
- Fixed structurally by relocating them (see #3) into the outer container, which already respects focusable elements.

### 3. Controls moved outside the input box
- The autoresearch controls now render as a bar **between the dropdown row and the prompt input**, instead of inside the composer's header addon.

### 4. Controls rewritten to be self-explanatory
- Before: a bare `Maximize`, an unlabeled `Target` box, a stray `≤ 10 iterations`, and a `Claude Opus 4.8 · Max` line that didn't look clickable.
- After: reads as one sentence — **Optimize to `maximize` until it reaches `[optional]` or after `[10]` iterations using `[model]`** — with a tooltip on each label and an explainer on the Autoresearch chip. Tooltips wrap only plain label spans (never the inputs) to avoid reintroducing focus flicker.

## Feature-flag gating
Both new surfaces stay behind `useAutoresearchEnabled()` (staff-gated flag; always on in dev):
- The dropdown toggle is passed to `PromptInput`/`ModeSelector` only when `autoresearchService && autoresearchEnabled`.
- The controls bar renders only when `autoresearchDraft` is set, which is forced `null` while the flag is off.
- `ModeSelector` and `PromptInput` stay flag-agnostic; the gate lives solely in `TaskInput`.

## Files
- `packages/ui/src/features/message-editor/components/ModeSelector.tsx`
- `packages/ui/src/features/message-editor/components/PromptInput.tsx`
- `packages/ui/src/features/task-detail/components/TaskInput.tsx`
- `packages/ui/src/features/autoresearch/AutoresearchComposerControls.tsx`

## Testing
- `pnpm typecheck` (full monorepo, 22/22) and Biome lint pass on all changed files.
- ⚠️ **Not yet driven in the running app** — live check of the focus fix, the dropdown toggle applying the hands-off mode, and tooltip/label wrapping still pending.

Fixes GROW-124

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*