### PR TITLE
test(e2e): route agent e2e through the ci gateway product

### DIFF
--- a/packages/agent/e2e/README.md
+++ b/packages/agent/e2e/README.md
@@ -91,8 +91,8 @@ arm self-skips if it is missing).
 
 | Var | Default | Notes |
 | --- | --- | --- |
-| `POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY` | — | Required. A token the gateway accepts — the `llm_gateway` product takes a personal API key (no OAuth). Without it every arm skips. `run-e2e.sh` reads the local dev key. |
-| `POSTHOG_CODE_E2E_GATEWAY_URL` | `http://localhost:3308/llm_gateway` | Gateway base (codex appends `/v1`). `llm_gateway` accepts a personal API key; `posthog_code` is OAuth-only. |
+| `POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY` | — | Required. A token the gateway accepts — the `ci` product takes a personal API key (no OAuth). Without it every arm skips. `run-e2e.sh` reads the local dev key. |
+| `POSTHOG_CODE_E2E_GATEWAY_URL` | `http://localhost:3308/ci` | Gateway base (codex appends `/v1`). `ci` accepts a personal API key; `posthog_code` is OAuth-only. |
 | `POSTHOG_CODE_E2E_CLAUDE_MODEL` | `claude-haiku-4-5` | Override if the gateway serves a different cheap Claude id. |
 | `POSTHOG_CODE_E2E_CODEX_MODEL` | `gpt-5-mini` | Cheapest codex id the local gateway serves; override if needed. |
 | `POSTHOG_CODE_E2E_CLAUDE_STRONG_MODEL` | `claude-sonnet-4-5` | Stronger Claude id for tests the cheap model can't handle (structured output). |

--- a/packages/agent/e2e/config.ts
+++ b/packages/agent/e2e/config.ts
@@ -13,8 +13,7 @@ export type Adapter = "claude" | "codex";
  */
 // `||` not `??`: CI sets unset vars to "" which should fall back to the default.
 const GATEWAY_URL =
-  process.env.POSTHOG_CODE_E2E_GATEWAY_URL ||
-  "http://localhost:3308/ci";
+  process.env.POSTHOG_CODE_E2E_GATEWAY_URL || "http://localhost:3308/ci";
 const TOKEN = process.env.POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY ?? "";
 
 // This checkout's bundled codex binaries, relative to packages/agent/e2e.

--- a/packages/agent/e2e/config.ts
+++ b/packages/agent/e2e/config.ts
@@ -6,13 +6,15 @@ export type Adapter = "claude" | "codex";
 /**
  * Live e2e configuration, resolved entirely from the environment so no secret is
  * committed. Needs a local llm-gateway and a token in `POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY`; targets
- * the `llm_gateway` product, which accepts a personal API key (no OAuth mint,
- * unlike prod's `posthog_code`). Without the token every arm self-skips.
+ * the `ci` product, which accepts a personal API key (no OAuth mint,
+ * unlike prod's `posthog_code`) and keeps e2e traffic attributed to its own
+ * `ai_product` rather than the catch-all `llm_gateway` bucket. Without the token
+ * every arm self-skips.
  */
 // `||` not `??`: CI sets unset vars to "" which should fall back to the default.
 const GATEWAY_URL =
   process.env.POSTHOG_CODE_E2E_GATEWAY_URL ||
-  "http://localhost:3308/llm_gateway";
+  "http://localhost:3308/ci";
 const TOKEN = process.env.POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY ?? "";
 
 // This checkout's bundled codex binaries, relative to packages/agent/e2e.

--- a/packages/agent/e2e/run-e2e.sh
+++ b/packages/agent/e2e/run-e2e.sh
@@ -2,7 +2,7 @@
 # Run the live golden-path e2e for both adapters (claude + codex).
 #
 # Needs a local llm-gateway (run `./bin/start` in the posthog repo) and a token.
-# The suite targets the gateway's `llm_gateway` product, which accepts a personal
+# The suite targets the gateway's `ci` product, which accepts a personal
 # API key (no OAuth), so if POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY is unset this reads the repo's
 # hardcoded local dev key from ee/settings.py (override the repo with POSTHOG_REPO).
 # That key must be registered in the local DB — run `python manage.py
@@ -25,7 +25,7 @@ if [[ -z "${POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY:-}" ]]; then
     echo "Set POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY, or POSTHOG_REPO to the posthog checkout." >&2
     exit 1
   fi
-  # The `llm_gateway` product accepts personal API keys, so no OAuth mint needed.
+  # The `ci` product accepts personal API keys, so no OAuth mint needed.
   POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY="$(grep -E '^DEV_API_KEY[[:space:]]*=' "$SETTINGS" | head -1 | sed -E 's/^DEV_API_KEY[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
 fi
 
@@ -36,6 +36,6 @@ if [[ -z "${POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY:-}" ]]; then
 fi
 
 export POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY
-echo "token: ${POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY:0:8}…  gateway: ${POSTHOG_CODE_E2E_GATEWAY_URL:-http://localhost:3308/llm_gateway}"
+echo "token: ${POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY:0:8}…  gateway: ${POSTHOG_CODE_E2E_GATEWAY_URL:-http://localhost:3308/ci}"
 cd "$AGENT_DIR"
 pnpm test:e2e "$@"


### PR DESCRIPTION
## Problem

The live agent e2e suite points at the llm-gateway's catch-all `llm_gateway` product. That works, but it mixes e2e traffic in with everything else that falls through to the default bucket, so e2e spend/usage can't be filtered cleanly by `ai_product`.

## Changes

Switch the e2e suite to the dedicated `ci` gateway product. Like `llm_gateway`, `ci` accepts a personal API key (no OAuth mint), so auth is unchanged, but traffic is now attributed to its own `ai_product` bucket.

- Default `POSTHOG_CODE_E2E_GATEWAY_URL` now points at `.../ci`
- `run-e2e.sh` and the e2e README updated to match

Depends on the `ci` product being registered in the llm-gateway: PostHog/posthog#68767. That should merge (and deploy) first, otherwise a run without an explicit `POSTHOG_CODE_E2E_GATEWAY_URL` override would 400.

## How did you test this?

Config and doc change only. The e2e suite needs a live local gateway plus a personal API key, which I (the PostHog Slack app, running Claude) did not run. Verified there are no remaining `llm_gateway` references in the e2e dir beyond the one intentional doc note explaining why `ci` exists.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1783369326757809)*
