### PR TITLE
chore(agent): add shell efficiency section to appended instructions

### DIFF
--- a/packages/agent/src/adapters/claude/session/instructions.ts
+++ b/packages/agent/src/adapters/claude/session/instructions.ts
@@ -32,5 +32,16 @@ If an MCP tool call is explicitly denied with a message, relay that denial messa
 If an MCP tool call returns an error, treat it as a normal tool error — troubleshoot, retry, or inform the user about the specific error. Do NOT assume it is a permissions issue and do NOT direct the user to any settings page.
 `;
 
+const SHELL_EFFICIENCY = `
+# Shell Efficiency
+
+Optimize for the fewest shell round trips.
+
+- Batch related commands into one Bash invocation using \`&&\` (e.g. \`npm run typecheck && npm run lint && npm test\`).
+- Emit all independent tool calls in the same response.
+- Read multiple files at once.
+- Never rerun a command solely to reproduce output you already have.
+`;
+
 export const APPENDED_INSTRUCTIONS =
-  BRANCH_NAMING + PULL_REQUEST_LINKS + PLAN_MODE + MCP_TOOLS;
+  BRANCH_NAMING + PULL_REQUEST_LINKS + PLAN_MODE + MCP_TOOLS + SHELL_EFFICIENCY;

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -2665,6 +2665,14 @@ When you mention a pull request in any reply or summary, always hyperlink it to 
 (e.g. a Markdown link like [#123](https://github.com/org/repo/pull/123)) rather than plain
 text, so readers can open it directly.`;
 
+    const shellEfficiencyInstructions = `
+## Shell efficiency
+Optimize for the fewest shell round trips.
+- Batch related commands into one Bash invocation using \`&&\` (e.g. \`npm run typecheck && npm run lint && npm test\`).
+- Emit all independent tool calls in the same response.
+- Read multiple files at once.
+- Never rerun a command solely to reproduce output you already have.`;
+
     const whyContextInstruction = `   - Add a brief **Why** to the body — one or two sentences capturing the reason the user asked for this change (the motivation, not a restatement of the diff). Keep it short.`;
     const publicRepoSafetyInstruction = `   - **Public-repo safety.** Treat the target repository as public-readable unless you have verified otherwise. The PR title, description, and commit messages must not contain private operational scale (exact event counts, internal row volumes, customer-usage percentages), customer names / emails / companies, references to internal tickets or incidents, the contents of Slack threads (do not quote or paraphrase what was said), or unreleased roadmap details. Linking to the originating Slack thread is fine and encouraged — Slack links are auth-gated and useful as context — as are channel references like "raised in #team-foo". Describe findings qualitatively ("present on nearly all X events, absent from Y") rather than with quantitative figures pulled from analytics queries — the reasoning that uses those numbers can stay in the thread; the PR copy cannot.`;
     // Slack- and inbox-originated PRs are attributed to PostHog, not the
@@ -2691,7 +2699,7 @@ Do the requested work, but stop with local changes ready for review.
 Important:
 - Do NOT create new commits, push to the branch, or update the pull request unless the user explicitly asks.
 - Do NOT create a new branch or a new pull request.
-${signedCommitInstructions}${prLinkInstructions}
+${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
 `;
       }
 
@@ -2712,7 +2720,7 @@ After completing the requested changes:
 Important:
 - Do NOT create a new branch or a new pull request.
 - Do NOT push fixes for review comments without replying to and resolving each related thread.
-${signedCommitInstructions}${prLinkInstructions}
+${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
 `;
     }
 
@@ -2751,7 +2759,7 @@ ${publishInstructions}
 
 Important:
 - Prefer using MCP tools to answer questions with real data over giving generic advice.
-${signedCommitInstructions}${prLinkInstructions}
+${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
 `;
     }
 
@@ -2763,7 +2771,7 @@ Do the requested work, but stop with local changes ready for review.
 
 Important:
 - Do NOT create a branch, commit, push, or open a pull request unless the user explicitly asks.
-${signedCommitInstructions}${prLinkInstructions}
+${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
 `;
     }
 
@@ -2790,7 +2798,7 @@ ${prFooter}
 
 Important:
 - Always create the PR as a draft. Do not ask for confirmation.
-${signedCommitInstructions}${prLinkInstructions}
+${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
 `;
   }
 

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -605,7 +605,14 @@ When creating pull requests, add the following footer at the end of the PR descr
 *Created with [PostHog Code](https://posthog.com/code?ref=pr)*
 \`\`\`
 
-When you mention a pull request in any reply or summary, always hyperlink it to its full URL (e.g. a Markdown link like [#123](https://github.com/org/repo/pull/123)) rather than plain text, so readers can open it directly.`;
+When you mention a pull request in any reply or summary, always hyperlink it to its full URL (e.g. a Markdown link like [#123](https://github.com/org/repo/pull/123)) rather than plain text, so readers can open it directly.
+
+## Shell efficiency
+Optimize for the fewest shell round trips.
+- Batch related commands into one Bash invocation using \`&&\` (e.g. \`npm run typecheck && npm run lint && npm test\`).
+- Emit all independent tool calls in the same response.
+- Read multiple files at once.
+- Never rerun a command solely to reproduce output you already have.`;
 
     if (channelMode) {
       const localFolders = (knownLocalFolders ?? []).filter(


### PR DESCRIPTION
## Problem

Bash is the single biggest LLM cost line in PostHog Code sessions (in a sampled 30-day window: 16k Bash generations at ~111k avg input tokens each, ~half of all spend). Each tool call re-sends the entire conversation, so sequential one-command-per-call shell usage multiplies full-context round trips.

## Changes

Adds a `SHELL_EFFICIENCY` section to `APPENDED_INSTRUCTIONS` telling the model to batch related commands with `&&`, emit independent tool calls in one response, read multiple files at once, and not rerun commands for output it already has.

Follow-up commits add the same section to the workspace-server local session prompt and the cloud agent-server prompt, so Codex sessions (which don't receive `APPENDED_INSTRUCTIONS`) and cloud runs carry it too.

## How did you test this?

- `pnpm --filter @posthog/agent typecheck` passes.
- Benchmarked with a local eval harness, details below.

<details>
<summary><b>Benchmarks: -19% Bash calls, -12% turns, -15% input tokens, no quality loss</b></summary>

Each run scaffolds a fresh git fixture repo in a temp dir and executes a fixed task through the Claude Agent SDK (`claude-sonnet-4-6`, `settingSources: []` so local config can't contaminate results). Control = no Shell Efficiency section, treatment = this PR's wording. Metrics captured per run: Bash calls, turns, input tokens, cost, task success (with post-hoc verification where applicable).

### Sweep 1: wording comparison (5 synthetic tasks, 4 variants, n=6 each, 120 runs)

| Variant | Bash calls | Turns | Success |
| --- | --- | --- | --- |
| control (no section) | 3.0 | 4.8 | 29/30 |
| bullet list, no example | 2.6 | 4.3 | 29/30 |
| **+ concrete `&&` example (shipped)** | **2.4** | **4.1** | **30/30** |
| "ALWAYS chain" directive | 2.5 | 4.1 | 30/30 |

The concrete example outperformed a more forceful directive; shipped wording is the example variant.

### Sweep 2: real-workload tasks (n=6 each, 36 runs)

Tasks modeled on the top Bash patterns mined from 5k real PostHog Code session commands (grep/search ~17%, git operations ~12%, per-package script runs ~4%).

| Task | Control bash/turns | Treatment bash/turns |
| --- | --- | --- |
| code-search (grep + context) | 1.0 / 2.0 | 1.0 / 2.0 |
| git-workflow (review, stage, commit, verify) | 3.7 / 5.0 | **2.5 / 4.0** |
| multi-package-checks (4 npm scripts) | 4.7 / 5.7 | **4.0 / 5.0** |
| **Overall** | 3.1 / 4.2 | **2.5 / 3.7** |

**-19% Bash calls, -12% turns, -15% input tokens, 36/36 success in both variants.**

Example collapse (git-workflow, typical run):

```
control (4 calls)                      treatment (2 calls)
$ git diff && git status               $ git diff README.md && cat src/discount.js
$ cat src/discount.js                  $ git add ... && git commit -m "..." \
$ git add ... && git commit -m "..."       && git status && git log --oneline -3
$ git status && git log --oneline -3
```

Since each tool call re-sends the full conversation (~111k avg input tokens in production sessions), fewer round trips compounds: the turns reduction is the number that translates to spend.

Known limit: models still run check/build/test scripts individually to attribute failures per step (unchanged across all wordings, including "ALWAYS chain"). Arguably correct behavior; not worth forcing via prompt.

</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
