### PR TITLE
feat(setup): spend-driven "Optimize your AI usage" discovered task

### DIFF
--- a/packages/core/src/setup/identifiers.ts
+++ b/packages/core/src/setup/identifiers.ts
@@ -1,3 +1,4 @@
+import type { SpendAnalysisResponse } from "@posthog/core/billing/spendAnalysisTypes";
 import type { ActivityEntry } from "@posthog/core/setup/setupState";
 import type { StaleFlagPayload } from "@posthog/core/setup/suggestions";
 import type { DiscoveredTask } from "@posthog/core/setup/types";
@@ -61,6 +62,8 @@ export interface ISetupRunService {
     repoPath: string,
   ): Promise<"initialized" | "not_installed" | "installed_no_init">;
   findStaleFlagSuggestions(repoPath: string): Promise<StaleFlagPayload[]>;
+  /** The user's recent personal LLM spend (default window). Null when unauthenticated or the endpoint is unavailable. */
+  getSpendAnalysis(): Promise<SpendAnalysisResponse | null>;
 
   /** Whether experiment-tier suggestions are enabled (feature flag or dev build). */
   includeExperiments(): boolean;

--- a/packages/core/src/setup/setupRunService.test.ts
+++ b/packages/core/src/setup/setupRunService.test.ts
@@ -91,6 +91,7 @@ function makePort(overrides: Partial<ISetupRunService> = {}): ISetupRunService {
     subscribeSessionEvents: vi.fn(() => ({ unsubscribe: () => {} })),
     detectPosthogInstallState: vi.fn(async () => "not_installed" as const),
     findStaleFlagSuggestions: vi.fn(async () => []),
+    getSpendAnalysis: vi.fn(async () => null),
     includeExperiments: vi.fn(() => false),
     trackDiscoveryStarted: vi.fn(),
     trackDiscoveryCompleted: vi.fn(),
@@ -141,6 +142,49 @@ describe("SetupRunService enricher", () => {
     const ids = store.discoveredTasks.map((t) => t.id);
     expect(ids).toContain("posthog-setup");
     expect(port.findStaleFlagSuggestions).not.toHaveBeenCalled();
+    expect(store.getEnricherStatus(REPO)).toBe("done");
+  });
+
+  it("adds the ai-usage suggestion when spend is above threshold, regardless of install state", async () => {
+    const port = makePort({
+      getSpendAnalysis: vi.fn(async () => ({
+        summary: {
+          date_from: "2026-06-07T00:00:00Z",
+          date_to: "2026-07-07T00:00:00Z",
+          product: null,
+          total_cost_usd: 50,
+          event_count: 100,
+          scoped_cost_usd: 40,
+          scoped_event_count: 80,
+        },
+        by_product: { items: [], truncated: false },
+        by_tool: { items: [], truncated: false },
+        by_model: { items: [], truncated: false },
+      })),
+    });
+    const service = new SetupRunService(port, store, noopLogger);
+
+    service.startEnricherForRepo(REPO);
+    await flush();
+
+    const ids = store.discoveredTasks.map((t) => t.id);
+    expect(ids).toContain("ai-usage-optimization");
+    expect(store.getEnricherStatus(REPO)).toBe("done");
+  });
+
+  it("still completes enrichment when spend analysis fails", async () => {
+    const port = makePort({
+      getSpendAnalysis: vi.fn(async () => {
+        throw new Error("spend endpoint unavailable");
+      }),
+    });
+    const service = new SetupRunService(port, store, noopLogger);
+
+    service.startEnricherForRepo(REPO);
+    await flush();
+
+    const ids = store.discoveredTasks.map((t) => t.id);
+    expect(ids).not.toContain("ai-usage-optimization");
     expect(store.getEnricherStatus(REPO)).toBe("done");
   });
 

--- a/packages/core/src/setup/setupRunService.ts
+++ b/packages/core/src/setup/setupRunService.ts
@@ -10,6 +10,7 @@ import {
   nextActivityId,
 } from "@posthog/core/setup/sessionUpdate";
 import {
+  buildAiUsageSuggestion,
   buildPosthogSetupSuggestion,
   buildSdkHealthSuggestion,
   buildStaleFlagSuggestion,
@@ -117,6 +118,7 @@ export class SetupRunService {
           repoPath: directory,
         });
       }
+      await this.injectAiUsageSuggestion(directory);
       this.store.completeEnrichment(directory);
     } catch (err) {
       this.logger.warn("Enricher run failed", { error: err });
@@ -137,6 +139,23 @@ export class SetupRunService {
       }
     } catch (err) {
       this.logger.warn("Failed to find stale flag suggestions", { error: err });
+    }
+  }
+
+  // Independent of the repo's PostHog install state — the user's own spend is
+  // what makes the suggestion relevant, so it runs on every enricher pass.
+  private async injectAiUsageSuggestion(directory: string): Promise<void> {
+    try {
+      const spend = await this.port.getSpendAnalysis();
+      if (!spend) return;
+      const suggestion = buildAiUsageSuggestion(spend);
+      if (!suggestion) return;
+      this.store.addEnricherSuggestionIfMissing({
+        ...suggestion,
+        repoPath: directory,
+      });
+    } catch (err) {
+      this.logger.warn("Failed to build AI usage suggestion", { error: err });
     }
   }
 

--- a/packages/core/src/setup/suggestions.test.ts
+++ b/packages/core/src/setup/suggestions.test.ts
@@ -1,4 +1,7 @@
+import type { SpendAnalysisResponse } from "@posthog/core/billing/spendAnalysisTypes";
 import {
+  AI_USAGE_MIN_SPEND_USD,
+  buildAiUsageSuggestion,
   buildPosthogSetupSuggestion,
   buildSdkHealthSuggestion,
   buildStaleFlagSuggestion,
@@ -60,6 +63,73 @@ describe("buildSdkHealthSuggestion", () => {
       category: "posthog_setup",
       prompt: "/diagnosing-sdk-health",
     });
+  });
+});
+
+describe("buildAiUsageSuggestion", () => {
+  function makeSpend(
+    overrides: Partial<SpendAnalysisResponse["summary"]> = {},
+    topTool?: Partial<SpendAnalysisResponse["by_tool"]["items"][number]>,
+  ): SpendAnalysisResponse {
+    return {
+      summary: {
+        date_from: "2026-06-07T00:00:00Z",
+        date_to: "2026-07-07T00:00:00Z",
+        product: null,
+        total_cost_usd: 120,
+        event_count: 5000,
+        scoped_cost_usd: 90,
+        scoped_event_count: 4000,
+        ...overrides,
+      },
+      by_product: { items: [], truncated: false },
+      by_tool: {
+        items: topTool
+          ? [
+              {
+                tool: "Bash",
+                generation_count: 900,
+                cost_usd: 45,
+                share_of_scoped: 0.5,
+                avg_input_tokens: 42_000,
+                ...topTool,
+              },
+            ]
+          : [],
+        truncated: false,
+      },
+      by_model: { items: [], truncated: false },
+    };
+  }
+
+  it("returns null below the minimum spend threshold", () => {
+    const data = makeSpend({ scoped_cost_usd: AI_USAGE_MIN_SPEND_USD - 1 });
+    expect(buildAiUsageSuggestion(data)).toBeNull();
+  });
+
+  it("has a stable id so dismissal sticks across re-runs", () => {
+    expect(buildAiUsageSuggestion(makeSpend())?.id).toBe(
+      "ai-usage-optimization",
+    );
+  });
+
+  it("summarizes spend and window in the description", () => {
+    const task = buildAiUsageSuggestion(makeSpend());
+    expect(task?.description).toContain("$90.00");
+    expect(task?.description).toContain("30 days");
+  });
+
+  it("calls out the top tool when it dominates spend", () => {
+    const task = buildAiUsageSuggestion(makeSpend({}, {}));
+    expect(task?.description).toContain("Bash alone drives 50%");
+    expect(task?.description).toContain("42k input tokens per call");
+  });
+
+  it("omits the hotspot line when no tool dominates", () => {
+    const task = buildAiUsageSuggestion(
+      makeSpend({}, { share_of_scoped: 0.2 }),
+    );
+    expect(task?.description).not.toContain("alone drives");
   });
 });
 

--- a/packages/core/src/setup/suggestions.ts
+++ b/packages/core/src/setup/suggestions.ts
@@ -1,3 +1,9 @@
+import {
+  formatTokens,
+  formatUsd,
+  formatWindow,
+} from "@posthog/core/billing/spendAnalysisFormat";
+import type { SpendAnalysisResponse } from "@posthog/core/billing/spendAnalysisTypes";
 import type { DiscoveredTask } from "@posthog/core/setup/types";
 
 export interface StaleFlagPayload {
@@ -29,6 +35,44 @@ export function buildStaleFlagSuggestion(
     file: first?.file,
     lineHint: first?.line,
     prompt: `/cleaning-up-stale-feature-flags Clean up stale flag "${flag.flagKey}"\n\n${recommendation}`,
+  };
+}
+
+// Below this much PostHog Code spend in the analysis window there's nothing
+// meaningful to optimize, so the suggestion stays hidden rather than nagging
+// light users.
+export const AI_USAGE_MIN_SPEND_USD = 5;
+
+// Share of scoped spend a single tool must reach before it's called out as a
+// hotspot in the suggestion description.
+const AI_USAGE_HOTSPOT_SHARE = 0.35;
+
+export function buildAiUsageSuggestion(
+  data: SpendAnalysisResponse,
+): DiscoveredTask | null {
+  const { summary } = data;
+  if (summary.scoped_cost_usd < AI_USAGE_MIN_SPEND_USD) return null;
+
+  const window = formatWindow(summary.date_from, summary.date_to);
+  const topTool = data.by_tool.items[0];
+  const hotspot =
+    topTool?.tool && topTool.share_of_scoped >= AI_USAGE_HOTSPOT_SHARE
+      ? ` ${topTool.tool} alone drives ${Math.round(topTool.share_of_scoped * 100)}% of that, averaging ${formatTokens(topTool.avg_input_tokens)} input tokens per call.`
+      : "";
+
+  return {
+    // Stable id so dismissal sticks across re-runs.
+    id: "ai-usage-optimization",
+    source: "enricher",
+    category: "ai_usage",
+    title: "Optimize your AI usage",
+    description: `You've spent ${formatUsd(summary.scoped_cost_usd)} on PostHog Code in the last ${window}.${hotspot} Repeated workflows, re-explained context, and recurring one-off analyses usually hide easy savings.`,
+    impact:
+      "Token spend compounds quietly: the same context re-sent every session, the same analysis re-run every week. Capturing repeated work as skills and scheduled reports cuts cost — and gets you answers without having to ask.",
+    recommendation:
+      'Click "Implement as new task" — the agent audits your recent sessions and memory files, then proposes concrete changes ranked by impact: new skills for repeated workflows, memory-file edits, and scheduled reports for recurring questions.',
+    prompt:
+      "Audit how I've been using PostHog Code and find ways to get better results for fewer tokens. Review my recent sessions for: repeated workflows worth capturing as a reusable skill, recurring questions better served by a scheduled scout or AI report, memory files (CLAUDE.md, AGENTS.md) that are bloated, stale, or missing context I keep re-explaining, and prompts that ran long or retried because they were under-specified. Deliver a short report of findings ranked by impact — each with the evidence behind it and the estimated saving — then offer to implement the top quick wins.",
   };
 }
 

--- a/packages/core/src/setup/types.ts
+++ b/packages/core/src/setup/types.ts
@@ -16,7 +16,8 @@ export interface DiscoveredTask {
     | "event_tracking"
     | "funnel"
     | "posthog_setup"
-    | "experiment";
+    | "experiment"
+    | "ai_usage";
   source: DiscoveredTaskSource;
   file?: string;
   lineHint?: number;

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -482,7 +482,8 @@ type SetupDiscoveredTaskCategory =
   | "event_tracking"
   | "funnel"
   | "posthog_setup"
-  | "experiment";
+  | "experiment"
+  | "ai_usage";
 
 export interface SetupDiscoveryStartedProperties {
   discovery_task_id: string;

--- a/packages/ui/src/features/canvas/channelTaskSuggestions.ts
+++ b/packages/ui/src/features/canvas/channelTaskSuggestions.ts
@@ -6,6 +6,7 @@ import {
   Cube,
   CurrencyDollar,
   Flask,
+  Gauge,
   Wrench,
 } from "@phosphor-icons/react";
 import type { SuggestedPrompt } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
@@ -71,6 +72,15 @@ export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] = [
     mode: "auto",
     prompt:
       "Interpret the results of an experiment — explain what the metrics show, whether it's significant, and what to do next.\n\n\nUser input:\n- Experiment name or key:\n- What decision are you trying to make (optional):",
+  },
+  {
+    label: "Optimize your AI usage",
+    description: "Cut token spend with skills & memory tuning",
+    icon: Gauge,
+    color: "cyan",
+    mode: "auto",
+    prompt:
+      "Review my recent agent and task usage to find ways to work more efficiently. Look for repeated work a reusable skill would capture, memory files that could be tightened or split, and prompt patterns that burn tokens. Recommend concrete improvements — new skills, memory edits, or best practices — to reduce token cost.\n\n\nUser input:\n- Time period to review (optional):\n- What to prioritize (cost, speed, accuracy — optional):",
   },
   {
     label: "Fix a bug",

--- a/packages/ui/src/features/canvas/channelTaskSuggestions.ts
+++ b/packages/ui/src/features/canvas/channelTaskSuggestions.ts
@@ -75,12 +75,12 @@ export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] = [
   },
   {
     label: "Optimize your AI usage",
-    description: "Cut token spend with skills & memory tuning",
+    description: "Turn repeated work into skills, scouts & savings",
     icon: Gauge,
     color: "cyan",
     mode: "auto",
     prompt:
-      "Review my recent agent and task usage to find ways to work more efficiently. Look for repeated work a reusable skill would capture, memory files that could be tightened or split, and prompt patterns that burn tokens. Recommend concrete improvements — new skills, memory edits, or best practices — to reduce token cost.\n\n\nUser input:\n- Time period to review (optional):\n- What to prioritize (cost, speed, accuracy — optional):",
+      "Audit how I've been using PostHog Code and find ways to get better results for fewer tokens. Review my recent tasks and sessions for: repeated workflows worth capturing as a reusable skill, recurring questions better served by a scheduled scout or AI report, memory files that are bloated, stale, or missing context I keep re-explaining, and prompts that ran long or retried because they were under-specified. Deliver a short report of findings ranked by impact — each with the evidence behind it and the estimated saving — then offer to implement the top quick wins.\n\n\nUser input:\n- Time period to review (optional):\n- What to prioritize (token cost, speed, quality — optional):",
   },
   {
     label: "Fix a bug",

--- a/packages/ui/src/features/canvas/channelTaskSuggestions.ts
+++ b/packages/ui/src/features/canvas/channelTaskSuggestions.ts
@@ -6,7 +6,6 @@ import {
   Cube,
   CurrencyDollar,
   Flask,
-  Gauge,
   Wrench,
 } from "@phosphor-icons/react";
 import type { SuggestedPrompt } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
@@ -72,15 +71,6 @@ export const CHANNEL_TASK_SUGGESTIONS: SuggestedPrompt[] = [
     mode: "auto",
     prompt:
       "Interpret the results of an experiment — explain what the metrics show, whether it's significant, and what to do next.\n\n\nUser input:\n- Experiment name or key:\n- What decision are you trying to make (optional):",
-  },
-  {
-    label: "Optimize your AI usage",
-    description: "Turn repeated work into skills, scouts & savings",
-    icon: Gauge,
-    color: "cyan",
-    mode: "auto",
-    prompt:
-      "Audit how I've been using PostHog Code and find ways to get better results for fewer tokens. Review my recent tasks and sessions for: repeated workflows worth capturing as a reusable skill, recurring questions better served by a scheduled scout or AI report, memory files that are bloated, stale, or missing context I keep re-explaining, and prompts that ran long or retried because they were under-specified. Deliver a short report of findings ranked by impact — each with the evidence behind it and the estimated saving — then offer to implement the top quick wins.\n\n\nUser input:\n- Time period to review (optional):\n- What to prioritize (token cost, speed, quality — optional):",
   },
   {
     label: "Fix a bug",

--- a/packages/ui/src/features/setup/categoryConfig.ts
+++ b/packages/ui/src/features/setup/categoryConfig.ts
@@ -6,6 +6,7 @@ import {
   Flag,
   Flask,
   Funnel,
+  Gauge,
   Lightning,
   Lock,
   Sparkle,
@@ -39,6 +40,7 @@ export const CATEGORY_CONFIG: Record<
   funnel: { icon: Funnel, color: "violet", label: "Funnel" },
   posthog_setup: { icon: Sparkle, color: "violet", label: "PostHog setup" },
   experiment: { icon: Flask, color: "purple", label: "Experiment" },
+  ai_usage: { icon: Gauge, color: "cyan", label: "AI usage" },
 };
 
 // Fallback when a `DiscoveredTask.category` somehow doesn't match the map

--- a/packages/ui/src/features/setup/setupRunServiceImpl.ts
+++ b/packages/ui/src/features/setup/setupRunServiceImpl.ts
@@ -1,4 +1,5 @@
 import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
+import type { SpendAnalysisResponse } from "@posthog/core/billing/spendAnalysisTypes";
 import type {
   DiscoveryFailureReason,
   DiscoverySignalSource,
@@ -153,6 +154,15 @@ export class SetupRunServiceImpl implements ISetupRunService {
     return this.hostClient().enrichment.findStaleFlagSuggestions.query({
       repoPath,
     });
+  }
+
+  // Uses a fresh authenticated client rather than `this.client`: the enricher
+  // path runs before (and independently of) getDiscoveryContext().
+  async getSpendAnalysis(): Promise<SpendAnalysisResponse | null> {
+    const authState = await fetchAuthState();
+    const client = createAuthenticatedClient(authState);
+    if (!client) return null;
+    return client.getPersonalSpendAnalysis();
   }
 
   includeExperiments(): boolean {


### PR DESCRIPTION
## Problem

Requested from a Slack thread: help users improve how they use PostHog Code itself — spot repeated work worth turning into skills, memory files worth tightening, and other ways to reduce token spend. An earlier revision of this PR added a static starter card to the channels new-task screen; a data-driven discovered task is more compelling because it only appears when there's a real win, with the user's own spend as evidence.

## Changes

- New `ai_usage` discovered-task category (enricher-only, like `posthog_setup`), rendered with a Gauge icon in cyan.
- On each enricher pass, `SetupRunService` fetches the user's personal LLM spend analysis via a new `getSpendAnalysis()` port method (authenticated PostHog API client). When recent PostHog Code spend crosses a small threshold, it surfaces an "Optimize your AI usage" suggestion — quoting the user's own spend and the dominant tool hotspot as evidence.
- The one-click prompt audits recent sessions for repeated workflows worth capturing as a skill, recurring questions better served by a scheduled scout/AI report, bloated or stale memory files, and under-specified prompts — delivering an impact-ranked report and offering to implement quick wins.
- Spend-analysis failures are non-fatal: enrichment still completes and the suggestion is simply skipped.

## How did you test this?

- Added unit tests for `buildAiUsageSuggestion` (threshold gating, stable id, spend/window summary, hotspot line) and for the `SetupRunService` enricher path (suggestion added when spend is above threshold; enrichment completes when spend analysis throws).
- `packages/core` full suite: 200 files, 2122 tests passing. Typecheck clean for `@posthog/core`, `@posthog/ui`, `@posthog/shared`. Biome lint clean (zero `noRestrictedImports` in core).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9A53J8RF/p1783413145862959)*
