### PR TITLE
fix(canvas): decode unicode escapes in freeform sandbox JSX text

### DIFF
--- a/packages/ui/src/features/canvas/freeform/sandboxRuntime.test.ts
+++ b/packages/ui/src/features/canvas/freeform/sandboxRuntime.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSandboxDocument,
+  decodeJsxUnicodeEscapes,
+} from "./sandboxRuntime";
+
+describe("decodeJsxUnicodeEscapes", () => {
+  it.each([
+    {
+      name: "decodes 4-hex escapes",
+      input: "Survey started Jun 20, 2026 \\u00b7 live \\u00b7 data",
+      expected: "Survey started Jun 20, 2026 · live · data",
+    },
+    { name: "decodes braced code points", input: "\\u{1F600}", expected: "😀" },
+    {
+      name: "decodes surrogate pairs",
+      input: "\\ud83d\\ude00",
+      expected: "😀",
+    },
+    {
+      name: "decodes braced escapes shorter than 4 digits",
+      input: "\\u{b7}",
+      expected: "·",
+    },
+    {
+      name: "leaves out-of-range code points intact",
+      input: "\\u{110000}",
+      expected: "\\u{110000}",
+    },
+    {
+      name: "leaves incomplete escapes intact",
+      input: "\\u00 and \\uZZZZ",
+      expected: "\\u00 and \\uZZZZ",
+    },
+    {
+      name: "leaves already-decoded text untouched",
+      input: "plain · text",
+      expected: "plain · text",
+    },
+    {
+      name: "decodes valid escapes next to invalid ones",
+      input: "\\u00b7 then \\u{110000}",
+      expected: "· then \\u{110000}",
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(decodeJsxUnicodeEscapes(input)).toBe(expected);
+  });
+});
+
+describe("buildSandboxDocument", () => {
+  it("inlines the unicode-escape decoder into the bootstrap", () => {
+    const html = buildSandboxDocument("edit");
+    expect(html).toContain(
+      "const decodeUnicodeEscapes = function decodeJsxUnicodeEscapes(",
+    );
+    expect(html).toContain("jsxUnicodeEscapesPlugin");
+  });
+});

--- a/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
+++ b/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
@@ -269,6 +269,40 @@ export function buildSandboxDocument(
       ),
     );
 
+    // JSX text and attribute strings never process \\uXXXX escapes (they render
+    // verbatim, e.g. "\\u00b7" instead of "·"), but generated canvases still
+    // contain them despite the prompt rules — decode at transpile time so both
+    // new and already-saved canvases render the real characters. Escapes inside
+    // JS string/template literals are untouched (Babel already decoded those).
+    const decodeUnicodeEscapes = (value) =>
+      value.replace(
+        /\\\\u\\{([0-9a-fA-F]{1,6})\\}|\\\\u([0-9a-fA-F]{4})/g,
+        (match, braced, plain) => {
+          try {
+            return String.fromCodePoint(parseInt(braced || plain, 16));
+          } catch {
+            return match;
+          }
+        },
+      );
+    const jsxUnicodeEscapesPlugin = () => ({
+      visitor: {
+        JSXText(path) {
+          path.node.value = decodeUnicodeEscapes(path.node.value);
+        },
+        JSXAttribute(path) {
+          const v = path.node.value;
+          if (v && v.type === "StringLiteral") {
+            const decoded = decodeUnicodeEscapes(v.value);
+            if (decoded !== v.value) {
+              v.value = decoded;
+              v.extra = undefined; // drop stale raw so the decoded value is emitted
+            }
+          }
+        },
+      },
+    });
+
     let root = null;
     // mount() is async and is called once per streamed code snapshot, so several
     // runs overlap on their awaits. Without ordering, a slower EARLIER (partial,
@@ -282,6 +316,7 @@ export function buildSandboxDocument(
       try {
         const out = Babel.transform(code, {
           filename: "canvas.tsx",
+          plugins: [jsxUnicodeEscapesPlugin],
           presets: [
             ["react", { runtime: "automatic" }],
             ["typescript", { isTSX: true, allExtensions: true, onlyRemoveTypeImports: true }],

--- a/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
+++ b/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
@@ -127,6 +127,22 @@ const TAILWIND_V3 = `<script src="https://cdn.tailwindcss.com"></script>
   } } };
 </script>`;
 
+// Decodes literal \uXXXX / \u{...} escape sequences in a string. Exported for
+// tests; its source is interpolated into the sandbox bootstrap below so the
+// iframe runs this exact implementation.
+export function decodeJsxUnicodeEscapes(value: string): string {
+  return value.replace(
+    /\\u\{([0-9a-fA-F]{1,6})\}|\\u([0-9a-fA-F]{4})/g,
+    (match, braced, plain) => {
+      try {
+        return String.fromCodePoint(Number.parseInt(braced || plain, 16));
+      } catch {
+        return match;
+      }
+    },
+  );
+}
+
 export function buildSandboxDocument(
   mode: SandboxMode,
   // The PostHog host, when in-iframe analytics/replay is enabled. Opens CSP for
@@ -274,21 +290,14 @@ export function buildSandboxDocument(
     // contain them despite the prompt rules — decode at transpile time so both
     // new and already-saved canvases render the real characters. Escapes inside
     // JS string/template literals are untouched (Babel already decoded those).
-    const decodeUnicodeEscapes = (value) =>
-      value.replace(
-        /\\\\u\\{([0-9a-fA-F]{1,6})\\}|\\\\u([0-9a-fA-F]{4})/g,
-        (match, braced, plain) => {
-          try {
-            return String.fromCodePoint(parseInt(braced || plain, 16));
-          } catch {
-            return match;
-          }
-        },
-      );
+    const decodeUnicodeEscapes = ${decodeJsxUnicodeEscapes.toString()};
     const jsxUnicodeEscapesPlugin = () => ({
       visitor: {
         JSXText(path) {
-          path.node.value = decodeUnicodeEscapes(path.node.value);
+          const decoded = decodeUnicodeEscapes(path.node.value);
+          if (decoded !== path.node.value) {
+            path.node.value = decoded;
+          }
         },
         JSXAttribute(path) {
           const v = path.node.value;


### PR DESCRIPTION
## Problem

Freeform canvases render literal `\uXXXX` escape sequences in visible text (e.g. "Survey started Jun 20, 2026 · live") instead of the decoded characters. Generated canvas source sometimes contains these escapes in JSX text, and JSX doesn't process them — so they show up verbatim, including in canvases that were already saved with escapes baked in.

## Changes

Added a small Babel pre-pass to the sandbox bootstrap in `sandboxRuntime.ts` that decodes `\uXXXX` / `\u{...}` escapes in JSX text nodes and JSX attribute string values before the JSX transform runs. Escapes inside real JS string/template literals are untouched (Babel already decodes those). Because it runs at transpile time in the iframe, it fixes both newly generated and previously saved canvases — no migration needed.

## How did you test this?

- Ran the plugin through `@babel/standalone@7.26.4` (the pinned sandbox version) against a repro including the reported string — `\u00b7` decodes to `·`, attribute values decode, and `\u{...}` code points / surrogate pairs work; escapes in JS string literals and invalid sequences are left intact.
- `pnpm --filter @posthog/ui typecheck`, biome lint, and all 1232 `@posthog/ui` unit tests pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
