### PR TITLE
feat(agent): resume codex cloud threads natively on restarts

### DIFF
--- a/packages/agent/src/adapters/codex-app-server/thread-state.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/thread-state.test.ts
@@ -1,0 +1,58 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hasCodexThreadState } from "./thread-state";
+
+const THREAD_ID = "0199a5c3-2f60-7b21-9c39-1d2e3f4a5b6c";
+
+describe("hasCodexThreadState", () => {
+  let codexHome: string;
+
+  beforeEach(async () => {
+    codexHome = await mkdtemp(join(tmpdir(), "codex-home-"));
+    vi.stubEnv("CODEX_HOME", codexHome);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(codexHome, { recursive: true, force: true });
+  });
+
+  const writeRollout = async (threadId: string) => {
+    const dir = join(codexHome, "sessions", "2026", "07", "07");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, `rollout-2026-07-07T10-00-00-${threadId}.jsonl`),
+      "",
+    );
+  };
+
+  it("finds a persisted rollout for the thread id", async () => {
+    await writeRollout(THREAD_ID);
+    await expect(hasCodexThreadState(THREAD_ID)).resolves.toBe(true);
+  });
+
+  it("returns false when only a different thread's rollout exists", async () => {
+    await writeRollout(THREAD_ID);
+    await expect(
+      hasCodexThreadState("11111111-2222-3333-4444-555555555555"),
+    ).resolves.toBe(false);
+  });
+
+  it("returns false when there is no sessions directory", async () => {
+    await expect(hasCodexThreadState(THREAD_ID)).resolves.toBe(false);
+  });
+
+  it("returns false for an empty thread id", async () => {
+    await writeRollout(THREAD_ID);
+    await expect(hasCodexThreadState("")).resolves.toBe(false);
+  });
+
+  it("ignores files that are not rollouts", async () => {
+    const dir = join(codexHome, "sessions", "2026", "07", "07");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, `notes-${THREAD_ID}.jsonl`), "");
+    await expect(hasCodexThreadState(THREAD_ID)).resolves.toBe(false);
+  });
+});

--- a/packages/agent/src/adapters/codex-app-server/thread-state.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/thread-state.test.ts
@@ -28,25 +28,17 @@ describe("hasCodexThreadState", () => {
     );
   };
 
-  it("finds a persisted rollout for the thread id", async () => {
+  it.each([
+    [true, "the persisted thread id", THREAD_ID],
+    [false, "a different thread id", "11111111-2222-3333-4444-555555555555"],
+    [false, "an empty thread id", ""],
+  ])("returns %s querying %s", async (expected, _case, queriedId) => {
     await writeRollout(THREAD_ID);
-    await expect(hasCodexThreadState(THREAD_ID)).resolves.toBe(true);
-  });
-
-  it("returns false when only a different thread's rollout exists", async () => {
-    await writeRollout(THREAD_ID);
-    await expect(
-      hasCodexThreadState("11111111-2222-3333-4444-555555555555"),
-    ).resolves.toBe(false);
+    await expect(hasCodexThreadState(queriedId)).resolves.toBe(expected);
   });
 
   it("returns false when there is no sessions directory", async () => {
     await expect(hasCodexThreadState(THREAD_ID)).resolves.toBe(false);
-  });
-
-  it("returns false for an empty thread id", async () => {
-    await writeRollout(THREAD_ID);
-    await expect(hasCodexThreadState("")).resolves.toBe(false);
   });
 
   it("ignores files that are not rollouts", async () => {

--- a/packages/agent/src/adapters/codex-app-server/thread-state.ts
+++ b/packages/agent/src/adapters/codex-app-server/thread-state.ts
@@ -1,0 +1,25 @@
+import { readdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Whether codex still holds the persisted rollout for `threadId` — written as
+ * `CODEX_HOME/sessions/YYYY/MM/DD/rollout-<timestamp>-<threadId>.jsonl` — i.e.
+ * whether `thread/resume` can restore the thread natively. Mirrors codex's own
+ * CODEX_HOME resolution (env override, else ~/.codex).
+ */
+export async function hasCodexThreadState(threadId: string): Promise<boolean> {
+  if (!threadId) return false;
+  const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
+  const sessionsDir = path.join(codexHome, "sessions");
+  const suffix = `-${threadId}.jsonl`;
+  try {
+    const entries = await readdir(sessionsDir, { recursive: true });
+    return entries.some((entry) => {
+      const name = path.basename(entry.toString());
+      return name.startsWith("rollout-") && name.endsWith(suffix);
+    });
+  } catch {
+    return false;
+  }
+}

--- a/packages/agent/src/adapters/codex-app-server/thread-state.ts
+++ b/packages/agent/src/adapters/codex-app-server/thread-state.ts
@@ -16,7 +16,7 @@ export async function hasCodexThreadState(threadId: string): Promise<boolean> {
   try {
     const entries = await readdir(sessionsDir, { recursive: true });
     return entries.some((entry) => {
-      const name = path.basename(entry.toString());
+      const name = path.basename(entry);
       return name.startsWith("rollout-") && name.endsWith(suffix);
     });
   } catch {

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ContentBlock } from "@agentclientprotocol/sdk";
@@ -1765,6 +1765,78 @@ describe("AgentServer HTTP Mode", () => {
           process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
         }
       }
+    });
+
+    describe("codex", () => {
+      const THREAD_ID = "0199a5c3-2f60-7b21-9c39-1d2e3f4a5b6c";
+      let codexHome: string;
+
+      const payload: JwtPayload = {
+        task_id: "test-task-id",
+        run_id: "test-run-id",
+        team_id: 1,
+        user_id: 1,
+        distinct_id: "test-distinct-id",
+        mode: "interactive",
+      };
+
+      const codexServer = (sessionId: string | null) => {
+        const s = createServer() as unknown as NativeResumeTestServer;
+        s.resumeState = {
+          conversation: [
+            { role: "user", content: [{ type: "text", text: "continue" }] },
+          ],
+          latestGitCheckpoint: null,
+          interrupted: false,
+          logEntryCount: 1,
+          sessionId,
+        };
+        return s;
+      };
+
+      const prepare = (s: NativeResumeTestServer) =>
+        s.prepareNativeResume(
+          payload,
+          createMockApiClient(),
+          createTaskRun({
+            id: "test-run-id",
+            state: { resume_from_run_id: "previous-run" },
+          }),
+          "codex",
+          repo.path,
+          "auto",
+        );
+
+      beforeEach(() => {
+        codexHome = join(repo.path, ".codex-test");
+        vi.stubEnv("CODEX_HOME", codexHome);
+      });
+
+      afterEach(() => {
+        vi.unstubAllEnvs();
+      });
+
+      it("resumes natively when the thread rollout survived in CODEX_HOME", async () => {
+        const dir = join(codexHome, "sessions", "2026", "07", "07");
+        await mkdir(dir, { recursive: true });
+        await writeFile(
+          join(dir, `rollout-2026-07-07T10-00-00-${THREAD_ID}.jsonl`),
+          "",
+        );
+
+        await expect(prepare(codexServer(THREAD_ID))).resolves.toEqual({
+          sessionId: THREAD_ID,
+          warm: true,
+        });
+      });
+
+      it("falls back to summary resume when the thread state is gone", async () => {
+        await expect(prepare(codexServer(THREAD_ID))).resolves.toBeNull();
+      });
+
+      it("falls back to summary resume without a prior session id", async () => {
+        await expect(prepare(codexServer(null))).resolves.toBeNull();
+      });
     });
   });
 

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -1830,12 +1830,11 @@ describe("AgentServer HTTP Mode", () => {
         });
       });
 
-      it("falls back to summary resume when the thread state is gone", async () => {
-        await expect(prepare(codexServer(THREAD_ID))).resolves.toBeNull();
-      });
-
-      it("falls back to summary resume without a prior session id", async () => {
-        await expect(prepare(codexServer(null))).resolves.toBeNull();
+      it.each([
+        ["the thread state is gone", THREAD_ID],
+        ["there is no prior session id", null],
+      ])("falls back to summary resume when %s", async (_case, sessionId) => {
+        await expect(prepare(codexServer(sessionId))).resolves.toBeNull();
       });
     });
   });

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -30,6 +30,7 @@ import {
   hydrateSessionJsonl,
 } from "../adapters/claude/session/jsonl-hydration";
 import type { GatewayEnv } from "../adapters/claude/session/options";
+import { hasCodexThreadState } from "../adapters/codex-app-server/thread-state";
 import {
   type AgentErrorClassification,
   classifyAgentError,
@@ -672,8 +673,6 @@ export class AgentServer {
     cwd: string,
     permissionMode: PermissionMode,
   ): Promise<{ sessionId: string; warm: boolean } | null> {
-    if (runtimeAdapter !== "claude") return null;
-
     const resumeRunId = this.getResumeRunId(preTaskRun);
     if (!resumeRunId) return null;
 
@@ -687,6 +686,22 @@ export class AgentServer {
         resumeRunId,
       });
       return null;
+    }
+
+    if (runtimeAdapter === "codex") {
+      // Codex owns thread persistence in CODEX_HOME (the ACP sessionId is the
+      // codex thread id). The rollout only survives a snapshot restart — there
+      // is no cold hydration equivalent, so a fresh sandbox keeps the summary
+      // fallback while a warm one resumes the thread natively via thread/resume.
+      if (!(await hasCodexThreadState(priorSessionId))) {
+        this.logger.debug(
+          "No codex thread state on disk; using summary resume fallback",
+          { resumeRunId, priorSessionId },
+        );
+        return null;
+      }
+      this.logger.debug("Native codex resume prepared", { priorSessionId });
+      return { sessionId: priorSessionId, warm: true };
     }
 
     let warm = false;
@@ -1309,22 +1324,32 @@ export class AgentServer {
       initialPermissionMode,
     );
 
-    let acpSessionId: string;
+    let acpSessionId: string | null = null;
     if (nativeResume) {
-      await clientConnection.resumeSession({
-        sessionId: nativeResume.sessionId,
-        cwd: sessionCwd,
-        mcpServers: this.config.mcpServers ?? [],
-        _meta: { ...sessionMeta, sessionId: nativeResume.sessionId },
-      });
-      acpSessionId = nativeResume.sessionId;
-      this.nativeResume = nativeResume;
-      this.logger.debug("ACP session resumed", {
-        acpSessionId,
-        runId: payload.run_id,
-        warm: nativeResume.warm,
-      });
-    } else {
+      try {
+        await clientConnection.resumeSession({
+          sessionId: nativeResume.sessionId,
+          cwd: sessionCwd,
+          mcpServers: this.config.mcpServers ?? [],
+          _meta: { ...sessionMeta, sessionId: nativeResume.sessionId },
+        });
+        acpSessionId = nativeResume.sessionId;
+        this.nativeResume = nativeResume;
+        this.logger.debug("ACP session resumed", {
+          acpSessionId,
+          runId: payload.run_id,
+          warm: nativeResume.warm,
+        });
+      } catch (error) {
+        // resumeState is still loaded, so the summary resume path takes over
+        // on the fresh session below.
+        this.logger.warn("Native resume failed; starting a fresh session", {
+          sessionId: nativeResume.sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    if (!acpSessionId) {
       const sessionResponse = await clientConnection.newSession({
         cwd: sessionCwd,
         mcpServers: this.config.mcpServers ?? [],


### PR DESCRIPTION
## Problem

The Codex adapter already supports native resume (`thread/resume` via ACP `resumeSession`), but the cloud agent-server never used it — `prepareNativeResume` hard-returned `null` for anything non-Claude. Every Codex cloud resume therefore started a **fresh** thread and injected the prior conversation as a hidden Markdown blob, losing reasoning context, compaction state, structured tool history, and prompt-cache continuity.

## Change

- `prepareNativeResume` now handles Codex: it finds the prior session id from the run log (for Codex the ACP sessionId *is* the codex thread id) and checks whether the thread's rollout file still exists under `CODEX_HOME/sessions/` via the new `hasCodexThreadState` helper. If so, the server calls `resumeSession` and the codex app-server restores the full thread natively — reasoning items, compaction state and all — with the continuation prompt riding the resumed thread.
- The rollout only survives a snapshot (warm) sandbox restart, and there is no faithful cold-hydration equivalent (rollouts contain encrypted reasoning we can't reconstruct from logs), so a cold sandbox keeps today's Markdown-summary fallback. Warm resumes also skip the redundant git-checkpoint restore, matching Claude's warm path.
- Safety net: if `resumeSession` fails at boot (e.g. a corrupt rollout), the server logs a warning and falls back to a fresh session with the summary resume instead of failing the run. Applies to Claude too, which previously had no fallback there.

## Testing

- 5 new unit tests for the rollout lookup, 3 new agent-server tests covering warm-resume, thread-gone, and no-session-id paths.
- Full `@posthog/agent` suite: 1093 passed; remaining failures are pre-existing on `main` and sandbox-environment artifacts (ambient `GH_TOKEN`, chmod no-op as root).
- `tsc --noEmit` and Biome clean.

## Follow-up (not in this PR)

- Desktop→cloud handoffs could ship the rollout file into the sandbox/checkpoint to make cold restores native too — needs a transport for `CODEX_HOME` state.
- "Can this session be natively resumed" could become an adapter capability instead of per-adapter branching in the server, but Claude's check isn't adapter-self-contained (hydration needs the server's API client), so that refactor is deferred.