### PR TITLE
fix(window): restore post-update fullscreen on the right display without crashing

### DIFF
--- a/apps/code/src/main/services/app-lifecycle/service.test.ts
+++ b/apps/code/src/main/services/app-lifecycle/service.test.ts
@@ -297,17 +297,27 @@ describe("AppLifecycleService", () => {
 
     it("leaves fullscreen and waits for the transition before finishing", async () => {
       mockBrowserWindow.isFullScreen.mockReturnValue(true);
-      mockBrowserWindow.setFullScreen.mockImplementationOnce(() => {
-        const [event, listener] = mockBrowserWindow.once.mock.calls[0] ?? [];
+
+      let leaveListener: (() => void) | undefined;
+      mockBrowserWindow.once.mockImplementationOnce((event, listener) => {
         expect(event).toBe("leave-full-screen");
-        (listener as () => void)();
+        leaveListener = listener as () => void;
       });
 
       const promise = service.shutdownWithoutContainer();
-      await vi.runAllTimersAsync();
-      await promise;
+      let finished = false;
+      void promise.then(() => {
+        finished = true;
+      });
 
+      // Allow teardownNativeResources()'s setImmediate to run so the fullscreen exit is initiated.
+      await vi.advanceTimersByTimeAsync(0);
       expect(mockBrowserWindow.setFullScreen).toHaveBeenCalledWith(false);
+      expect(finished).toBe(false);
+
+      leaveListener?.();
+      await vi.advanceTimersByTimeAsync(100);
+      await promise;
     });
 
     it("does not touch fullscreen when the window is not fullscreen", async () => {

--- a/apps/code/src/main/services/app-lifecycle/service.test.ts
+++ b/apps/code/src/main/services/app-lifecycle/service.test.ts
@@ -15,6 +15,7 @@ const {
   mockProcessExit,
   mockGetFullScreenState,
   mockSetRestoreFullScreenOnNextLaunch,
+  mockBrowserWindow,
 } = vi.hoisted(() => {
   const mockDatabaseService = {
     close: vi.fn(),
@@ -53,6 +54,13 @@ const {
     mockProcessExit: vi.fn() as unknown as (code?: number) => never,
     mockGetFullScreenState: vi.fn(() => false),
     mockSetRestoreFullScreenOnNextLaunch: vi.fn(),
+    mockBrowserWindow: {
+      isDestroyed: vi.fn(() => false),
+      isFullScreen: vi.fn(() => false),
+      setFullScreen: vi.fn(),
+      once: vi.fn(),
+      off: vi.fn(),
+    },
   };
 });
 
@@ -98,6 +106,8 @@ describe("AppLifecycleService", () => {
     vi.useFakeTimers();
     process.exit = mockProcessExit;
     mockWorkspaceService.pendingCreationCount = 0;
+    mockBrowserWindow.isDestroyed.mockReturnValue(false);
+    mockBrowserWindow.isFullScreen.mockReturnValue(false);
     service = new AppLifecycleService(
       mockAppLifecycle as unknown as IAppLifecycle,
       mockDatabaseService as never,
@@ -105,6 +115,7 @@ describe("AppLifecycleService", () => {
       mockWatcherRegistry as never,
       mockProcessTracking as never,
       mockWorkspaceService as never,
+      { getBrowserWindow: () => mockBrowserWindow } as never,
     );
   });
 
@@ -282,6 +293,43 @@ describe("AppLifecycleService", () => {
       await promise;
 
       expect(mockProcessTracking.getSnapshot).toHaveBeenCalled();
+    });
+
+    it("leaves fullscreen and waits for the transition before finishing", async () => {
+      mockBrowserWindow.isFullScreen.mockReturnValue(true);
+      mockBrowserWindow.setFullScreen.mockImplementationOnce(() => {
+        const [event, listener] = mockBrowserWindow.once.mock.calls[0] ?? [];
+        expect(event).toBe("leave-full-screen");
+        (listener as () => void)();
+      });
+
+      const promise = service.shutdownWithoutContainer();
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockBrowserWindow.setFullScreen).toHaveBeenCalledWith(false);
+    });
+
+    it("does not touch fullscreen when the window is not fullscreen", async () => {
+      const promise = service.shutdownWithoutContainer();
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockBrowserWindow.setFullScreen).not.toHaveBeenCalled();
+    });
+
+    it("proceeds when the fullscreen transition never completes", async () => {
+      mockBrowserWindow.isFullScreen.mockReturnValue(true);
+
+      const promise = service.shutdownWithoutContainer();
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockBrowserWindow.setFullScreen).toHaveBeenCalledWith(false);
+      expect(mockBrowserWindow.off).toHaveBeenCalledWith(
+        "leave-full-screen",
+        expect.any(Function),
+      );
     });
   });
 

--- a/apps/code/src/main/services/app-lifecycle/service.ts
+++ b/apps/code/src/main/services/app-lifecycle/service.ts
@@ -2,6 +2,7 @@ import {
   APP_LIFECYCLE_SERVICE,
   type IAppLifecycle,
 } from "@posthog/platform/app-lifecycle";
+import { MAIN_WINDOW_SERVICE } from "@posthog/platform/main-window";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { DATABASE_SERVICE } from "@posthog/workspace-server/db/identifiers";
 import type { DatabaseService } from "@posthog/workspace-server/db/service";
@@ -13,6 +14,7 @@ import type { WatcherRegistryService } from "@posthog/workspace-server/services/
 import type { WorkspaceService } from "@posthog/workspace-server/services/workspace/workspace";
 import { inject, injectable } from "inversify";
 import { WATCHER_REGISTRY_SERVICE, WORKSPACE_SERVICE } from "../../di/tokens";
+import type { ElectronMainWindow } from "../../platform-adapters/electron-main-window";
 import { posthogNodeAnalytics } from "../../platform-adapters/posthog-analytics";
 import { withTimeout } from "../../utils/async";
 import { logger } from "../../utils/logger";
@@ -28,6 +30,8 @@ const log = logger.scope("app-lifecycle");
 export class AppLifecycleService {
   private static readonly SHUTDOWN_TIMEOUT_MS = 3000;
   private static readonly PENDING_CREATION_WAIT_MS = 10_000;
+  private static readonly LEAVE_FULLSCREEN_TIMEOUT_MS = 3000;
+  private static readonly FULLSCREEN_SETTLE_MS = 100;
 
   private _isQuittingForUpdate = false;
   private _isShuttingDown = false;
@@ -45,6 +49,8 @@ export class AppLifecycleService {
     private readonly processTracking: ProcessTrackingService,
     @inject(WORKSPACE_SERVICE)
     private readonly workspaceService: WorkspaceService,
+    @inject(MAIN_WINDOW_SERVICE)
+    private readonly mainWindow: ElectronMainWindow,
   ) {}
 
   get isQuittingForUpdate(): boolean {
@@ -112,6 +118,37 @@ export class AppLifecycleService {
     } catch (error) {
       log.warn("Failed to close database during partial shutdown", error);
     }
+    await this.leaveFullScreenBeforeQuit();
+  }
+
+  /**
+   * Tearing down a window that is still in native macOS fullscreen crashes
+   * AppKit during quit, which macOS surfaces as a "quit unexpectedly" dialog
+   * on the post-update relaunch. Leave fullscreen and wait for the transition
+   * to finish before the updater quits the app. The fullscreen-restore flag
+   * is persisted in setQuittingForUpdate(), before this runs.
+   */
+  private async leaveFullScreenBeforeQuit(): Promise<void> {
+    const window = this.mainWindow.getBrowserWindow();
+    if (!window || window.isDestroyed() || !window.isFullScreen()) {
+      return;
+    }
+
+    log.info("Leaving fullscreen before quit");
+    await new Promise<void>((resolve) => {
+      const finish = (): void => {
+        clearTimeout(fallback);
+        // Let the AppKit transition settle before windows are torn down.
+        setTimeout(resolve, AppLifecycleService.FULLSCREEN_SETTLE_MS);
+      };
+      const fallback = setTimeout(() => {
+        window.off("leave-full-screen", finish);
+        log.warn("Timed out waiting to leave fullscreen before quit");
+        resolve();
+      }, AppLifecycleService.LEAVE_FULLSCREEN_TIMEOUT_MS);
+      window.once("leave-full-screen", finish);
+      window.setFullScreen(false);
+    });
   }
 
   /**

--- a/apps/code/src/main/utils/store.ts
+++ b/apps/code/src/main/utils/store.ts
@@ -1,6 +1,14 @@
 import Store from "electron-store";
 import { getUserDataDir } from "./env";
 
+/** Structurally matches Electron's Rectangle (not imported here — utils stay electron-free). */
+export interface DisplayBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 interface FocusSession {
   mainRepoPath: string;
   worktreePath: string;
@@ -26,6 +34,7 @@ export interface WindowStateSchema {
   isMaximized: boolean;
   zoomLevel: number;
   isFullScreen: boolean;
+  fullScreenDisplayBounds: DisplayBounds | undefined;
   restoreFullScreenOnNextLaunch: boolean;
 }
 
@@ -55,6 +64,7 @@ export const windowStateStore = new Store<WindowStateSchema>({
     isMaximized: true,
     zoomLevel: 0,
     isFullScreen: false,
+    fullScreenDisplayBounds: undefined,
     restoreFullScreenOnNextLaunch: false,
   },
 });
@@ -69,6 +79,18 @@ export function saveFullScreenState(isFullScreen: boolean): void {
 
 export function getFullScreenState(): boolean {
   return windowStateStore.get("isFullScreen", false);
+}
+
+/**
+ * The bounds of the display the window was last fullscreened on, so the
+ * post-update relaunch can restore fullscreen on the same monitor.
+ */
+export function saveFullScreenDisplayBounds(bounds: DisplayBounds): void {
+  windowStateStore.set("fullScreenDisplayBounds", bounds);
+}
+
+export function getFullScreenDisplayBounds(): DisplayBounds | undefined {
+  return windowStateStore.get("fullScreenDisplayBounds", undefined);
 }
 
 /**

--- a/apps/code/src/main/window.ts
+++ b/apps/code/src/main/window.ts
@@ -24,6 +24,8 @@ import { collectMemorySnapshot } from "./utils/crash-diagnostics";
 import { isDevBuild } from "./utils/env";
 import { logger, readChromiumLogTail } from "./utils/logger";
 import {
+  getFullScreenDisplayBounds,
+  saveFullScreenDisplayBounds,
   saveFullScreenState,
   saveZoomLevel,
   setRestoreFullScreenOnNextLaunch,
@@ -57,6 +59,10 @@ function getSavedWindowState(): WindowStateSchema {
     isMaximized: windowStateStore.get("isMaximized", true),
     zoomLevel: windowStateStore.get("zoomLevel", 0),
     isFullScreen: windowStateStore.get("isFullScreen", false),
+    fullScreenDisplayBounds: windowStateStore.get(
+      "fullScreenDisplayBounds",
+      undefined,
+    ),
     restoreFullScreenOnNextLaunch: windowStateStore.get(
       "restoreFullScreenOnNextLaunch",
       false,
@@ -171,6 +177,23 @@ export function createWindow(): void {
   const restoreFullScreen = savedState.restoreFullScreenOnNextLaunch;
   if (restoreFullScreen) {
     setRestoreFullScreenOnNextLaunch(false);
+
+    // setFullScreen(true) fullscreens whichever display the window is on, so
+    // start the hidden window on the display that was fullscreen before the
+    // update. getDisplayMatching falls back to the nearest display if that
+    // monitor is gone.
+    const displayBounds = getFullScreenDisplayBounds();
+    if (displayBounds) {
+      const { workArea } = screen.getDisplayMatching(displayBounds);
+      savedState.width = Math.min(savedState.width, workArea.width);
+      savedState.height = Math.min(savedState.height, workArea.height);
+      savedState.x = Math.round(
+        workArea.x + (workArea.width - savedState.width) / 2,
+      );
+      savedState.y = Math.round(
+        workArea.y + (workArea.height - savedState.height) / 2,
+      );
+    }
   }
 
   let saveTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -290,8 +313,16 @@ export function createWindow(): void {
   mainWindow.on("unmaximize", () => mainWindow && saveWindowState(mainWindow));
   mainWindow.on("close", () => mainWindow && saveWindowState(mainWindow));
 
-  // Live-track fullscreen so the update-quit path can read the current state.
-  mainWindow.on("enter-full-screen", () => saveFullScreenState(true));
+  // Live-track fullscreen (and which display it is on) so the update-quit
+  // path can restore the same monitor after the relaunch.
+  mainWindow.on("enter-full-screen", () => {
+    saveFullScreenState(true);
+    if (mainWindow) {
+      saveFullScreenDisplayBounds(
+        screen.getDisplayMatching(mainWindow.getBounds()).bounds,
+      );
+    }
+  });
   mainWindow.on("leave-full-screen", () => saveFullScreenState(false));
 
   container

--- a/packages/core/src/updates/updates.test.ts
+++ b/packages/core/src/updates/updates.test.ts
@@ -389,14 +389,14 @@ describe("UpdatesService", () => {
       );
 
       const resultPromise = service.installUpdate();
-      await vi.advanceTimersByTimeAsync(15_000);
+      await vi.advanceTimersByTimeAsync(20_000);
 
       await expect(resultPromise).resolves.toEqual({ installed: true });
       expect(mockUpdater.quitAndInstall).toHaveBeenCalled();
       expect(mockLog.warn).toHaveBeenCalledWith(
         "Partial shutdown timed out before update install",
         expect.objectContaining({
-          timeoutMs: 15_000,
+          timeoutMs: 20_000,
           downloadedVersion: "v2.0.0",
         }),
       );

--- a/packages/core/src/updates/updates.ts
+++ b/packages/core/src/updates/updates.ts
@@ -50,10 +50,11 @@ type TransitionContext = {
 export class UpdatesService extends TypedEventEmitter<UpdatesEvents> {
   private static readonly CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
   private static readonly CHECK_TIMEOUT_MS = 60 * 1000; // 1 minute timeout for checks
-  // Must exceed AppLifecycleService.PENDING_CREATION_WAIT_MS (10s) plus
-  // teardown headroom, or the pending-creation wait inside partial shutdown
-  // gets cut off and quitAndInstall proceeds without any teardown at all.
-  private static readonly INSTALL_SHUTDOWN_TIMEOUT_MS = 15_000;
+  // Must exceed AppLifecycleService.PENDING_CREATION_WAIT_MS (10s) plus its
+  // LEAVE_FULLSCREEN_TIMEOUT_MS (3s) plus teardown headroom, or the waits
+  // inside partial shutdown get cut off and quitAndInstall proceeds without
+  // any teardown at all.
+  private static readonly INSTALL_SHUTDOWN_TIMEOUT_MS = 20_000;
 
   @inject(UPDATE_LIFECYCLE_SERVICE)
   private lifecycle!: IUpdateLifecycle;


### PR DESCRIPTION
## Problem

Two bugs in the fullscreen-restore-after-update feature (#3124), reported after it shipped:

1. **Wrong monitor** — a session fullscreened on monitor 2 always reopened fullscreen on monitor 1. The restore flag recorded *that* the window was fullscreen but not *where*. On relaunch the window was created at the last saved *windowed* position (often stale, or undefined → primary display), and `setFullScreen(true)` fullscreens whichever display the window is currently on.
2. **macOS "PostHog quit unexpectedly" dialog** — the update handoff quit the app while the window was still in native fullscreen. Tearing down an NSWindow mid-fullscreen crashes AppKit during quit, and macOS surfaces the crash as the "quit unexpectedly" dialog when the updated build relaunches.

## Fix

- `window.ts` now persists the fullscreen display's bounds on `enter-full-screen` (`fullScreenDisplayBounds` in the window-state store). On a restore launch, the hidden window is placed centered on that display (via `screen.getDisplayMatching`, which falls back to the nearest display if the monitor is gone) *before* `setFullScreen(true)`, so fullscreen lands on the right monitor.
- `AppLifecycleService.shutdownWithoutContainer()` (the partial shutdown that runs before `quitAndInstall`) now leaves fullscreen and waits for the `leave-full-screen` transition — with a 3s fallback timeout and a short AppKit settle delay — so the app never quits mid-fullscreen. The restore flag is persisted earlier in `setQuittingForUpdate()`, so restore behavior is unaffected.
- `INSTALL_SHUTDOWN_TIMEOUT_MS` bumped 15s → 20s to keep headroom for the fullscreen exit inside the partial-shutdown budget.

## Testing

- New unit tests for the leave-fullscreen-before-quit path (happy path, not-fullscreen no-op, transition-timeout fallback).
- `pnpm --filter code typecheck`, `pnpm --filter @posthog/core typecheck`, biome lint on touched files and `packages/core` (zero `noRestrictedImports`), app-lifecycle tests (24/24) and core updates tests (69/69) all pass.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*