### PR TITLE
feat: label sidebar repo groups by main clone, add worktree chips, fix group new-task prefill

### DIFF
--- a/packages/core/src/sidebar/groupTasks.test.ts
+++ b/packages/core/src/sidebar/groupTasks.test.ts
@@ -354,40 +354,60 @@ describe("groupByRepository", () => {
 });
 
 describe("findGroupFolder", () => {
-  const mainClone = {
+  interface GroupFolder {
+    path: string;
+    remoteUrl: string | null;
+    mainRepoPath?: string | null;
+  }
+
+  const mainClone: GroupFolder = {
     path: "/repos/code",
     remoteUrl: "posthog/code",
     mainRepoPath: null,
   };
-  const worktree = {
+  const worktree: GroupFolder = {
     path: "/repos/code-wt",
     remoteUrl: "posthog/code",
     mainRepoPath: "/repos/code",
   };
-  const unrelated = {
+  const unrelated: GroupFolder = {
     path: "/repos/other",
     remoteUrl: "acme/other",
     mainRepoPath: null,
   };
+  const local: GroupFolder = { path: "/repos/local", remoteUrl: null };
 
-  it("prefers the main clone when a worktree of the same repo was added first", () => {
-    expect(
-      findGroupFolder([worktree, mainClone, unrelated], "posthog/code"),
-    ).toBe(mainClone);
-  });
-
-  it("falls back to the worktree when only it is registered", () => {
-    expect(findGroupFolder([worktree, unrelated], "posthog/code")).toBe(
-      worktree,
-    );
-  });
-
-  it("matches folders without a remote by path", () => {
-    const local = { path: "/repos/local", remoteUrl: null };
-    expect(findGroupFolder([local], "/repos/local")).toBe(local);
-  });
-
-  it("returns undefined when nothing matches", () => {
-    expect(findGroupFolder([unrelated], "posthog/code")).toBeUndefined();
+  it.each<{
+    name: string;
+    folders: GroupFolder[];
+    groupId: string;
+    expected: GroupFolder | undefined;
+  }>([
+    {
+      name: "prefers the main clone when a worktree of the same repo was added first",
+      folders: [worktree, mainClone, unrelated],
+      groupId: "posthog/code",
+      expected: mainClone,
+    },
+    {
+      name: "falls back to the worktree when only it is registered",
+      folders: [worktree, unrelated],
+      groupId: "posthog/code",
+      expected: worktree,
+    },
+    {
+      name: "matches folders without a remote by path",
+      folders: [local],
+      groupId: "/repos/local",
+      expected: local,
+    },
+    {
+      name: "returns undefined when nothing matches",
+      folders: [unrelated],
+      groupId: "posthog/code",
+      expected: undefined,
+    },
+  ])("$name", ({ folders, groupId, expected }) => {
+    expect(findGroupFolder(folders, groupId)).toBe(expected);
   });
 });

--- a/packages/core/src/sidebar/groupTasks.test.ts
+++ b/packages/core/src/sidebar/groupTasks.test.ts
@@ -1,6 +1,7 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
 import {
+  findGroupFolder,
   type GroupableTask,
   getRepositoryInfo,
   groupByRepository,
@@ -349,5 +350,44 @@ describe("groupByRepository", () => {
       "posthog/code",
       "other",
     ]);
+  });
+});
+
+describe("findGroupFolder", () => {
+  const mainClone = {
+    path: "/repos/code",
+    remoteUrl: "posthog/code",
+    mainRepoPath: null,
+  };
+  const worktree = {
+    path: "/repos/code-wt",
+    remoteUrl: "posthog/code",
+    mainRepoPath: "/repos/code",
+  };
+  const unrelated = {
+    path: "/repos/other",
+    remoteUrl: "acme/other",
+    mainRepoPath: null,
+  };
+
+  it("prefers the main clone when a worktree of the same repo was added first", () => {
+    expect(
+      findGroupFolder([worktree, mainClone, unrelated], "posthog/code"),
+    ).toBe(mainClone);
+  });
+
+  it("falls back to the worktree when only it is registered", () => {
+    expect(findGroupFolder([worktree, unrelated], "posthog/code")).toBe(
+      worktree,
+    );
+  });
+
+  it("matches folders without a remote by path", () => {
+    const local = { path: "/repos/local", remoteUrl: null };
+    expect(findGroupFolder([local], "/repos/local")).toBe(local);
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(findGroupFolder([unrelated], "posthog/code")).toBeUndefined();
   });
 });

--- a/packages/core/src/sidebar/groupTasks.ts
+++ b/packages/core/src/sidebar/groupTasks.ts
@@ -60,6 +60,24 @@ export function folderGroupId(folder: {
   return folder.path;
 }
 
+/**
+ * Resolves the folder that represents a sidebar group. Several registered
+ * folders can share one group (a main clone plus linked worktrees of the same
+ * repo all have the same remote); the group is labeled by the main checkout,
+ * so prefer a folder that is not a linked worktree (`mainRepoPath` is set only
+ * on linked worktrees).
+ */
+export function findGroupFolder<
+  F extends {
+    path: string;
+    remoteUrl: string | null;
+    mainRepoPath?: string | null;
+  },
+>(folders: F[], groupId: string): F | undefined {
+  const matches = folders.filter((f) => folderGroupId(f) === groupId);
+  return matches.find((f) => !f.mainRepoPath) ?? matches[0];
+}
+
 export function groupByRepository<T extends GroupableTask>(
   tasks: T[],
   folderOrder: string[],

--- a/packages/git/src/queries.test.ts
+++ b/packages/git/src/queries.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
 import { devNull, tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -12,6 +12,7 @@ import {
   getBranchDiffPatchesByPath,
   getChangedFilesDetailed,
   getGitBusyState,
+  getLinkedWorktreeMainPath,
   remoteBranchExists,
   splitUnifiedDiffByFile,
 } from "./queries";
@@ -539,5 +540,60 @@ describe("anyBranchRefExists", () => {
     { branch: "feat/tag-only", expected: false },
   ])("returns $expected for '$branch'", async ({ branch, expected }) => {
     expect(await anyBranchRefExists(repoDir, branch)).toBe(expected);
+  });
+});
+
+describe("getLinkedWorktreeMainPath", () => {
+  // The `.git` layouts are fabricated with plain fs (no git binary needed):
+  // a linked worktree is just a `.git` *file* whose `gitdir:` line points at
+  // `<main>/.git/worktrees/<name>`.
+  let baseDir: string;
+  let repoDir: string;
+  let worktreeDir: string;
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(path.join(tmpdir(), "posthog-code-wt-"));
+    repoDir = path.join(baseDir, "main-repo");
+    worktreeDir = path.join(baseDir, "my-worktree");
+    await mkdir(path.join(repoDir, ".git", "worktrees", "my-worktree"), {
+      recursive: true,
+    });
+    await mkdir(worktreeDir, { recursive: true });
+    await writeFile(
+      path.join(worktreeDir, ".git"),
+      `gitdir: ${path.join(repoDir, ".git", "worktrees", "my-worktree")}\n`,
+    );
+  });
+
+  afterEach(async () => {
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("returns the main checkout path for a linked worktree", () => {
+    expect(getLinkedWorktreeMainPath(worktreeDir)).toBe(repoDir);
+  });
+
+  it("resolves a relative gitdir against the worktree", async () => {
+    await writeFile(
+      path.join(worktreeDir, ".git"),
+      "gitdir: ../main-repo/.git/worktrees/my-worktree\n",
+    );
+    expect(getLinkedWorktreeMainPath(worktreeDir)).toBe(repoDir);
+  });
+
+  it("returns null for the main checkout (.git is a directory)", () => {
+    expect(getLinkedWorktreeMainPath(repoDir)).toBeNull();
+  });
+
+  it("returns null for a directory that is not a repository", () => {
+    expect(getLinkedWorktreeMainPath(baseDir)).toBeNull();
+  });
+
+  it("returns null for a submodule-style .git file", async () => {
+    await writeFile(
+      path.join(worktreeDir, ".git"),
+      "gitdir: ../main-repo/.git/modules/child\n",
+    );
+    expect(getLinkedWorktreeMainPath(worktreeDir)).toBeNull();
   });
 });

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -1,4 +1,4 @@
-import { createReadStream } from "node:fs";
+import { createReadStream, readFileSync, statSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { isBinaryFile } from "@posthog/shared";
@@ -378,6 +378,36 @@ export async function isGitRepository(
     },
     { signal: options?.abortSignal },
   );
+}
+
+/**
+ * Detects whether `dirPath` is a linked git worktree (created with
+ * `git worktree add`) and returns the root of the main checkout it belongs
+ * to, or null when it isn't one. Works without spawning git: in a linked
+ * worktree `.git` is a file containing `gitdir: <main>/.git/worktrees/<name>`,
+ * while a main checkout has a `.git` directory.
+ */
+export function getLinkedWorktreeMainPath(dirPath: string): string | null {
+  try {
+    const dotGit = path.join(dirPath, ".git");
+    if (!statSync(dotGit).isFile()) return null;
+    const match = readFileSync(dotGit, "utf8").match(/^gitdir:\s*(.+?)\s*$/m);
+    if (!match) return null;
+    const gitDir = path.resolve(dirPath, match[1]);
+    // Expect <main>/.git/worktrees/<name>; anything else (e.g. a submodule's
+    // `.git` file pointing into the parent's modules dir) is not a worktree.
+    const worktreesDir = path.dirname(gitDir);
+    const dotGitDir = path.dirname(worktreesDir);
+    if (
+      path.basename(worktreesDir) !== "worktrees" ||
+      path.basename(dotGitDir) !== ".git"
+    ) {
+      return null;
+    }
+    return path.dirname(dotGitDir);
+  } catch {
+    return null;
+  }
 }
 
 export async function getChangedFiles(

--- a/packages/host-router/src/routers/workspace.router.ts
+++ b/packages/host-router/src/routers/workspace.router.ts
@@ -30,6 +30,8 @@ import {
   linkBranchInput,
   listGitWorktreesInput,
   listGitWorktreesOutput,
+  listRepoCheckoutsInput,
+  listRepoCheckoutsOutput,
   markActivityInput,
   markViewedInput,
   reconcileCloudWorkspacesInput,
@@ -152,6 +154,13 @@ export const workspaceRouter = router({
     .output(listGitWorktreesOutput)
     .query(({ ctx, input }) =>
       getService(ctx.container).listGitWorktrees(input.mainRepoPath),
+    ),
+
+  listRepoCheckouts: publicProcedure
+    .input(listRepoCheckoutsInput)
+    .output(listRepoCheckoutsOutput)
+    .query(({ ctx, input }) =>
+      getService(ctx.container).listRepoCheckouts(input.repoPath),
     ),
 
   getWorktreeSize: publicProcedure

--- a/packages/ui/src/features/folder-picker/FolderPicker.test.tsx
+++ b/packages/ui/src/features/folder-picker/FolderPicker.test.tsx
@@ -10,10 +10,14 @@ vi.mock("@posthog/host-router/react", () => ({
   useHostTRPCClient: () => ({
     os: { selectDirectory: { query: () => selectDirectoryQuery() } },
   }),
+  useHostTRPC: () => ({
+    git: { getCurrentBranch: { queryOptions: () => ({}) } },
+  }),
 }));
 
 vi.mock("@posthog/ui/features/folders/useFolders", () => ({
   useFolders: () => ({
+    folders: [],
     getRecentFolders: () => [],
     getFolderDisplayName: () => null,
     addFolder,
@@ -26,7 +30,12 @@ vi.mock("@posthog/di/react", () => ({
   useService: () => ({ error: vi.fn() }),
 }));
 
-import { FolderPicker } from "./FolderPicker";
+vi.mock("@tanstack/react-query", () => ({
+  useQueries: () => [],
+}));
+
+import type { RegisteredFolder } from "@posthog/ui/features/folders/types";
+import { buildFolderRows, FolderPicker } from "./FolderPicker";
 
 /** A promise we resolve by hand, to hold the picker open mid-flight. */
 function deferred<T>() {
@@ -86,5 +95,78 @@ describe("FolderPicker", () => {
 
     pending.resolve(null);
     await waitFor(() => expect(trigger).not.toBeDisabled());
+  });
+});
+
+describe("buildFolderRows", () => {
+  const folder = (
+    id: string,
+    path: string,
+    mainRepoPath: string | null = null,
+  ): RegisteredFolder => ({
+    id,
+    path,
+    name: id,
+    remoteUrl: "posthog/code",
+    lastAccessed: "2026-07-01T00:00:00Z",
+    createdAt: "2026-07-01T00:00:00Z",
+    mainRepoPath,
+  });
+
+  const main = folder("code", "/repos/code");
+  const wtA = folder("code-a", "/repos/code-a", "/repos/code");
+  const wtB = folder("code-b", "/repos/code-b", "/repos/code");
+  const standalone = folder("other", "/repos/other");
+
+  it.each<{
+    name: string;
+    recents: RegisteredFolder[];
+    all: RegisteredFolder[];
+    expected: Array<{ id: string; isWorktree: boolean; indented: boolean }>;
+  }>([
+    {
+      name: "a recent worktree pulls in its whole family, main first",
+      recents: [wtB],
+      all: [wtA, main, wtB, standalone],
+      expected: [
+        { id: "code", isWorktree: false, indented: false },
+        { id: "code-a", isWorktree: true, indented: true },
+        { id: "code-b", isWorktree: true, indented: true },
+      ],
+    },
+    {
+      name: "families are emitted once even when several members are recent",
+      recents: [wtA, main, standalone],
+      all: [wtA, main, wtB, standalone],
+      expected: [
+        { id: "code", isWorktree: false, indented: false },
+        { id: "code-a", isWorktree: true, indented: true },
+        { id: "code-b", isWorktree: true, indented: true },
+        { id: "other", isWorktree: false, indented: false },
+      ],
+    },
+    {
+      name: "worktrees without a registered main clone stay top-level",
+      recents: [wtA],
+      all: [wtA, wtB, standalone],
+      expected: [
+        { id: "code-a", isWorktree: true, indented: false },
+        { id: "code-b", isWorktree: true, indented: false },
+      ],
+    },
+    {
+      name: "standalone folders stay single rows",
+      recents: [standalone],
+      all: [wtA, main, standalone],
+      expected: [{ id: "other", isWorktree: false, indented: false }],
+    },
+  ])("$name", ({ recents, all, expected }) => {
+    expect(
+      buildFolderRows(recents, all).map((row) => ({
+        id: row.folder.id,
+        isWorktree: row.isWorktree,
+        indented: row.indented,
+      })),
+    ).toEqual(expected);
   });
 });

--- a/packages/ui/src/features/folder-picker/FolderPicker.tsx
+++ b/packages/ui/src/features/folder-picker/FolderPicker.tsx
@@ -4,11 +4,12 @@ import {
   Folder as FolderIcon,
   FolderOpen,
   GitBranch,
+  GitFork,
   X,
 } from "@phosphor-icons/react";
 import { ROOT_LOGGER, type RootLogger } from "@posthog/di/logger";
 import { useService } from "@posthog/di/react";
-import { useHostTRPCClient } from "@posthog/host-router/react";
+import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -25,11 +26,49 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
+import type { RegisteredFolder } from "@posthog/ui/features/folders/types";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
 import { toast } from "@posthog/ui/primitives/toast";
 import { FIELD_TRIGGER_CLASS } from "@posthog/ui/styles/fieldTrigger";
 import { Flex, Text } from "@radix-ui/themes";
-import { type RefObject, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { type RefObject, useMemo, useState } from "react";
+
+interface FolderRow {
+  folder: RegisteredFolder;
+  isWorktree: boolean;
+  /** Rendered nested under its main clone (which is also in the list). */
+  indented: boolean;
+}
+
+/**
+ * Groups recent folders into repo families: a recent checkout pulls in its
+ * main clone and every registered worktree of the same repo, main first,
+ * worktrees indented beneath it. Standalone folders stay single rows.
+ */
+export function buildFolderRows(
+  recentFolders: RegisteredFolder[],
+  allFolders: RegisteredFolder[],
+): FolderRow[] {
+  const familyKey = (f: RegisteredFolder) => f.mainRepoPath ?? f.path;
+  const emitted = new Set<string>();
+  const rows: FolderRow[] = [];
+  for (const recent of recentFolders) {
+    const key = familyKey(recent);
+    if (emitted.has(key)) continue;
+    emitted.add(key);
+    const members = allFolders.filter((f) => familyKey(f) === key);
+    const main = members.find((f) => !f.mainRepoPath);
+    const worktrees = members
+      .filter((f) => f.mainRepoPath)
+      .sort((a, b) => a.name.localeCompare(b.name));
+    if (main) rows.push({ folder: main, isWorktree: false, indented: false });
+    for (const wt of worktrees) {
+      rows.push({ folder: wt, isWorktree: true, indented: !!main });
+    }
+  }
+  return rows;
+}
 
 interface FolderPickerProps {
   value: string;
@@ -47,8 +86,10 @@ export function FolderPicker({
   anchor,
 }: FolderPickerProps) {
   const trpcClient = useHostTRPCClient();
+  const trpc = useHostTRPC();
   const log = useService<RootLogger>(ROOT_LOGGER);
   const {
+    folders,
     getRecentFolders,
     getFolderDisplayName,
     addFolder,
@@ -63,6 +104,23 @@ export function FolderPicker({
 
   const [isOpening, setIsOpening] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+
+  const folderRows = useMemo(
+    () => buildFolderRows(recentFolders, folders),
+    [recentFolders, folders],
+  );
+
+  // Current branch per visible row, so the picker answers "what is checked
+  // out where?" before committing to a folder. Only queried while open.
+  const branchQueries = useQueries({
+    queries: folderRows.map((row) => ({
+      ...trpc.git.getCurrentBranch.queryOptions({
+        directoryPath: row.folder.path,
+      }),
+      enabled: menuOpen,
+      staleTime: 30_000,
+    })),
+  });
   const [pendingRemoval, setPendingRemoval] = useState<{
     id: string;
     name: string;
@@ -196,39 +254,49 @@ export function FolderPicker({
         }
       >
         <MenuLabel>Recent</MenuLabel>
-        {recentFolders.map((folder) => (
-          <DropdownMenuItem
-            key={folder.id}
-            onClick={() => handleSelect(folder.path)}
-            className="group"
-          >
-            <GitBranch size={12} className="shrink-0" />
-            <span
-              className="min-w-0 flex-1 truncate text-left"
-              title={folder.path}
+        {folderRows.map(({ folder, isWorktree, indented }, index) => {
+          const branch = branchQueries[index]?.data ?? null;
+          return (
+            <DropdownMenuItem
+              key={folder.id}
+              onClick={() => handleSelect(folder.path)}
+              className={indented ? "group pl-6" : "group"}
             >
-              {folder.name}
-            </span>
-            <button
-              type="button"
-              aria-label={`Remove ${folder.name} from recents`}
-              className="-mr-1 ml-1 shrink-0 rounded p-0.5 text-(--gray-9) opacity-0 hover:bg-(--gray-4) hover:text-(--gray-12) focus-visible:opacity-100 group-hover:opacity-100"
-              onPointerDown={(e) => e.stopPropagation()}
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                setMenuOpen(false);
-                setPendingRemoval({
-                  id: folder.id,
-                  name: folder.name,
-                  path: folder.path,
-                });
-              }}
-            >
-              <X size={12} />
-            </button>
-          </DropdownMenuItem>
-        ))}
+              {isWorktree ? (
+                <GitFork size={12} className="shrink-0" />
+              ) : (
+                <GitBranch size={12} className="shrink-0" />
+              )}
+              <span
+                className="min-w-0 flex-1 truncate text-left"
+                title={branch ? `${folder.path} — on ${branch}` : folder.path}
+              >
+                {folder.name}
+                {branch ? (
+                  <span className="ml-1 text-muted-foreground">· {branch}</span>
+                ) : null}
+              </span>
+              <button
+                type="button"
+                aria-label={`Remove ${folder.name} from recents`}
+                className="-mr-1 ml-1 shrink-0 rounded p-0.5 text-(--gray-9) opacity-0 hover:bg-(--gray-4) hover:text-(--gray-12) focus-visible:opacity-100 group-hover:opacity-100"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  setMenuOpen(false);
+                  setPendingRemoval({
+                    id: folder.id,
+                    name: folder.name,
+                    path: folder.path,
+                  });
+                }}
+              >
+                <X size={12} />
+              </button>
+            </DropdownMenuItem>
+          );
+        })}
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={handleOpenFilePicker}>
           <FolderOpen size={12} className="shrink-0" />

--- a/packages/ui/src/features/folders/types.ts
+++ b/packages/ui/src/features/folders/types.ts
@@ -5,5 +5,10 @@ export interface RegisteredFolder {
   remoteUrl: string | null;
   lastAccessed: string;
   createdAt: string;
+  /**
+   * Root of the main checkout when this folder is a linked git worktree,
+   * null for a main clone.
+   */
+  mainRepoPath?: string | null;
   exists?: boolean;
 }

--- a/packages/ui/src/features/git-interaction/components/BranchSelector.test.tsx
+++ b/packages/ui/src/features/git-interaction/components/BranchSelector.test.tsx
@@ -165,3 +165,57 @@ describe("BranchSelector cloud mode", () => {
     expect(onCloudBranchCommit).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("BranchSelector checkout context", () => {
+  it.each([
+    {
+      name: "local mode shows which checkout the branch switch applies to",
+      workspaceMode: "local" as const,
+      expectedPrefix: "Branch in",
+    },
+    {
+      name: "worktree mode labels the pick as the base branch for the checkout",
+      workspaceMode: "worktree" as const,
+      expectedPrefix: "Base branch for",
+    },
+  ])("$name", async ({ workspaceMode, expectedPrefix }) => {
+    const user = userEvent.setup();
+    renderInTheme(
+      <BranchSelector
+        repoPath="/repos/code-wt"
+        currentBranch="main"
+        workspaceMode={workspaceMode}
+        onBranchSelect={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Branch" }));
+
+    const contextRow = await screen.findByText(expectedPrefix, {
+      exact: false,
+    });
+    expect(contextRow).toHaveTextContent(`${expectedPrefix} code-wt`);
+    expect(contextRow).toHaveAttribute("title", "/repos/code-wt");
+  });
+
+  it("shows no checkout row in cloud mode (the repo picker sits next to it)", async () => {
+    const user = userEvent.setup();
+    renderInTheme(
+      <BranchSelector
+        repoPath="owner/repo"
+        currentBranch={null}
+        workspaceMode="cloud"
+        cloudBranches={["main"]}
+        cloudBranchesLoading={false}
+        cloudSearchQuery=""
+        onBranchSelect={vi.fn()}
+        onCloudSearchChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Branch" }));
+
+    expect(screen.queryByText("Branch in", { exact: false })).toBeNull();
+    expect(screen.queryByText("Base branch for", { exact: false })).toBeNull();
+  });
+});

--- a/packages/ui/src/features/git-interaction/components/BranchSelector.test.tsx
+++ b/packages/ui/src/features/git-interaction/components/BranchSelector.test.tsx
@@ -21,6 +21,9 @@ vi.mock("@posthog/host-router/react", () => ({
       getAllBranches: { queryOptions: () => ({}) },
       checkoutBranch: { mutationOptions: () => ({}) },
     },
+    workspace: {
+      listRepoCheckouts: { queryOptions: () => ({}) },
+    },
   }),
 }));
 

--- a/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
+++ b/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
@@ -21,6 +21,7 @@ import {
   InputGroupAddon,
   InputGroupButton,
 } from "@posthog/quill";
+import { getFileName } from "@posthog/shared";
 import type {
   GitBusyOperation,
   GitBusyState,
@@ -196,6 +197,11 @@ export function BranchSelector({
       ? busyOperationLabel
       : (displayedBranch ?? "No branch");
 
+  // Which checkout the branch applies to. With several checkouts of the same
+  // repo registered (main clone + worktrees), a bare branch name is ambiguous
+  // — in local mode picking one runs a real checkout in this directory.
+  const checkoutName = !isCloudMode && repoPath ? getFileName(repoPath) : null;
+
   const showSpinner =
     effectiveLoading || (isCloudMode && open && cloudBranchesFetchingMore);
 
@@ -295,7 +301,17 @@ export function BranchSelector({
       filter={isCloudMode ? null : undefined}
     >
       <Tooltip
-        content={disabledReason ?? displayedBranch ?? "Switch branch"}
+        content={
+          disabledReason ??
+          (checkoutName && repoPath ? (
+            <span className="flex flex-col">
+              <span>{displayedBranch ?? "Switch branch"}</span>
+              <span className="text-gray-10">in {repoPath}</span>
+            </span>
+          ) : (
+            (displayedBranch ?? "Switch branch")
+          ))
+        }
         side="bottom"
         open={hovered && !open && !effectiveLoading}
       >
@@ -404,6 +420,16 @@ export function BranchSelector({
             ) : null}
           </InputGroupAddon>
         </ComboboxInput>
+
+        {checkoutName ? (
+          <div
+            className="truncate border-border border-b px-2 py-1.5 text-muted-foreground text-xs"
+            title={repoPath ?? undefined}
+          >
+            {isSelectionOnly ? "Base branch for " : "Branch in "}
+            <span className="font-medium">{checkoutName}</span>
+          </div>
+        ) : null}
 
         {isCloudMode && cloudBranchesFetchingMore ? (
           <LoadingRow label={`Loading more (${branches.length})…`} />

--- a/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
+++ b/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
@@ -27,7 +27,7 @@ import type {
   GitBusyState,
 } from "@posthog/shared/domain-types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { type RefObject, useEffect, useRef, useState } from "react";
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 import { Tooltip } from "../../../primitives/Tooltip";
 import { toast } from "../../../primitives/toast";
 import { invalidateGitBranchQueries } from "../gitCacheKeys";
@@ -154,6 +154,26 @@ export function BranchSelector({
       enabled: !isCloudMode && !!repoPath,
       staleTime: 60_000,
     });
+
+  // Branches already checked out in another checkout of this repo (main clone
+  // or worktree). Git refuses to check those out here, and for worktree mode
+  // it tells the user where a branch already lives.
+  const { data: repoCheckouts = [] } = useQuery({
+    ...trpc.workspace.listRepoCheckouts.queryOptions({
+      repoPath: repoPath as string,
+    }),
+    enabled: open && !isCloudMode && !!repoPath,
+    staleTime: 60_000,
+  });
+  const checkedOutElsewhere = useMemo(() => {
+    const byBranch = new Map<string, string>();
+    for (const checkout of repoCheckouts) {
+      if (checkout.branch) {
+        byBranch.set(checkout.branch, getFileName(checkout.path));
+      }
+    }
+    return byBranch;
+  }, [repoCheckouts]);
 
   const branches = isCloudMode ? (cloudBranches ?? []) : localBranches;
   const effectiveLoading = loading || (isCloudMode && cloudBranchesLoading);
@@ -478,14 +498,22 @@ export function BranchSelector({
               }
               return useInputItem;
             }
+            const elsewhere = checkedOutElsewhere.get(item);
             return (
               <ComboboxItem
                 key={item}
                 value={item}
-                title={item}
+                title={
+                  elsewhere ? `${item} — checked out in ${elsewhere}` : item
+                }
                 className="relative"
               >
-                {item}
+                <span className="min-w-0 flex-1 truncate">{item}</span>
+                {elsewhere ? (
+                  <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
+                    in {elsewhere}
+                  </span>
+                ) : null}
               </ComboboxItem>
             );
           }}

--- a/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -1,4 +1,4 @@
-import { folderGroupId } from "@posthog/core/sidebar/groupTasks";
+import { findGroupFolder } from "@posthog/core/sidebar/groupTasks";
 import { isTaskActivelyRunning } from "@posthog/core/sidebar/taskRunning";
 import { useHostTRPCClient } from "@posthog/host-router/react";
 import { Separator } from "@posthog/quill";
@@ -227,7 +227,7 @@ function SidebarMenuComponent() {
     async (groupId: string, e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      const folder = folders.find((f) => folderGroupId(f) === groupId);
+      const folder = findGroupFolder(folders, groupId);
       if (!folder) return;
       try {
         const result =

--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -12,6 +12,7 @@ import type {
   TaskGroup,
 } from "@posthog/core/sidebar/sidebarData.types";
 import { MenuLabel } from "@posthog/quill";
+import { getFileName } from "@posthog/shared";
 import { builderHog } from "@posthog/ui/assets/hedgehogs";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
 import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
@@ -100,10 +101,7 @@ function TaskRow({
   const worktreeCheckout = useMemo(() => {
     if (workspace?.worktreePath) {
       return {
-        name:
-          workspace.worktreeName ??
-          workspace.worktreePath.split("/").pop() ??
-          workspace.worktreePath,
+        name: workspace.worktreeName ?? getFileName(workspace.worktreePath),
         path: workspace.worktreePath,
       };
     }
@@ -111,7 +109,7 @@ function TaskRow({
       const folder = folders.find((f) => f.path === workspace.folderPath);
       if (folder?.mainRepoPath) {
         return {
-          name: workspace.folderPath.split("/").pop() ?? workspace.folderPath,
+          name: getFileName(workspace.folderPath),
           path: workspace.folderPath,
         };
       }

--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -3,7 +3,7 @@ import type { DragDropEvents } from "@dnd-kit/react";
 import { DragDropProvider } from "@dnd-kit/react";
 import { GitBranch } from "@phosphor-icons/react";
 import {
-  folderGroupId,
+  findGroupFolder,
   groupTasksByRelativeDate,
 } from "@posthog/core/sidebar/groupTasks";
 import { mostRecentRunEnvironment } from "@posthog/core/sidebar/runEnvironment";
@@ -89,9 +89,35 @@ function TaskRow({
   depth?: number;
 }) {
   const workspace = useWorkspace(task.id);
+  const { folders } = useFolders();
   const effectiveMode =
     workspace?.mode ??
     (task.taskRunEnvironment === "cloud" ? "cloud" : undefined);
+
+  // Chip identifying the checkout the task runs in: app-managed worktrees
+  // (worktree mode) and local tasks whose registered folder is itself a
+  // linked worktree of the group's main clone.
+  const worktreeCheckout = useMemo(() => {
+    if (workspace?.worktreePath) {
+      return {
+        name:
+          workspace.worktreeName ??
+          workspace.worktreePath.split("/").pop() ??
+          workspace.worktreePath,
+        path: workspace.worktreePath,
+      };
+    }
+    if (workspace?.mode === "local" && workspace.folderPath) {
+      const folder = folders.find((f) => f.path === workspace.folderPath);
+      if (folder?.mainRepoPath) {
+        return {
+          name: workspace.folderPath.split("/").pop() ?? workspace.folderPath,
+          path: workspace.folderPath,
+        };
+      }
+    }
+    return null;
+  }, [workspace, folders]);
   const { prState, hasDiff } = useTaskPrStatus(task);
   const isArchiving = useArchivingTasksStore((s) =>
     s.archivingTaskIds.has(task.id),
@@ -108,7 +134,8 @@ function TaskRow({
       hideHoverActions={hideHoverActions}
       isEditing={isEditing}
       workspaceMode={effectiveMode}
-      worktreePath={workspace?.worktreePath ?? undefined}
+      worktreeName={worktreeCheckout?.name}
+      worktreePath={worktreeCheckout?.path}
       isSuspended={task.isSuspended}
       isGenerating={task.isGenerating}
       isUnread={task.isUnread}
@@ -277,7 +304,7 @@ export function TaskListView({
           <Flex direction="column">
             {groupedTasks.map((group, index) => {
               const isExpanded = !collapsedSections.has(group.id);
-              const folder = folders.find((f) => folderGroupId(f) === group.id);
+              const folder = findGroupFolder(folders, group.id);
               const groupFolderId =
                 folder?.id ?? group.tasks.find((t) => t.folderId)?.folderId;
               return (

--- a/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -1,4 +1,9 @@
-import { Archive, GitPullRequest, PushPin } from "@phosphor-icons/react";
+import {
+  Archive,
+  GitFork,
+  GitPullRequest,
+  PushPin,
+} from "@phosphor-icons/react";
 import { parseGithubUrl } from "@posthog/git/utils";
 import type { WorkspaceMode } from "@posthog/shared";
 import { formatRelativeTimeShort } from "@posthog/shared";
@@ -29,6 +34,17 @@ function PrBadge({ url, number }: { url: string; number: number }) {
   );
 }
 
+function WorktreeChip({ name, path }: { name: string; path?: string }) {
+  return (
+    <Tooltip content={path ?? name} side="top">
+      <span className="flex h-4 max-w-[96px] shrink-0 items-center gap-0.5 rounded bg-gray-3 px-1 text-[11px] text-gray-11">
+        <GitFork size={10} weight="bold" className="shrink-0" />
+        <span className="truncate">{name}</span>
+      </span>
+    </Tooltip>
+  );
+}
+
 interface TaskItemProps {
   depth?: number;
   taskId: string;
@@ -39,6 +55,9 @@ interface TaskItemProps {
   isArchiving?: boolean;
   hideHoverActions?: boolean;
   workspaceMode?: WorkspaceMode;
+  /** Checkout name shown as a chip when the task runs in a git worktree. */
+  worktreeName?: string;
+  /** Full path of that checkout, surfaced in the chip's tooltip. */
   worktreePath?: string;
   isGenerating?: boolean;
   isUnread?: boolean;
@@ -112,6 +131,8 @@ export function TaskItem({
   isArchiving = false,
   hideHoverActions = false,
   workspaceMode,
+  worktreeName,
+  worktreePath,
   isSuspended = false,
   isGenerating,
   isUnread,
@@ -174,9 +195,14 @@ export function TaskItem({
       />
     ) : null;
 
+  const worktreeChip = worktreeName ? (
+    <WorktreeChip name={worktreeName} path={worktreePath} />
+  ) : null;
+
   const endContent =
-    prBadge || timestampNode || toolbar ? (
+    worktreeChip || prBadge || timestampNode || toolbar ? (
       <>
+        {worktreeChip}
         {prBadge}
         {timestampNode}
         {toolbar}

--- a/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -148,7 +148,10 @@ export function TaskDetail({
           channelId={channelId}
           leafIcon={
             workspaceMode ? (
-              <WorkspaceModeBadge mode={workspaceMode} />
+              <WorkspaceModeBadge
+                mode={workspaceMode}
+                checkoutPath={effectiveRepoPath}
+              />
             ) : undefined
           }
           leafLabel={task.title}
@@ -165,7 +168,10 @@ export function TaskDetail({
             />
           ) : (
             <Flex align="center" gap="2" minWidth="0">
-              <WorkspaceModeBadge mode={workspaceMode} />
+              <WorkspaceModeBadge
+                mode={workspaceMode}
+                checkoutPath={effectiveRepoPath}
+              />
               <Tooltip content={task.title} side="bottom" delayDuration={300}>
                 <Text
                   truncate
@@ -187,6 +193,7 @@ export function TaskDetail({
       trailing,
       isEditingTitle,
       workspaceMode,
+      effectiveRepoPath,
       handleTitleEditSubmit,
       handleTitleEditCancel,
     ],

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -564,6 +564,7 @@ export function TaskInput({
 
   useInitialRepoSelectionFromFolderId({
     folderId: view.folderId,
+    requestId: view.taskInputRequestId,
     folders,
     repositories,
     reposLoaded: areReposReady({

--- a/packages/ui/src/features/task-detail/components/WorkspaceModeBadge.tsx
+++ b/packages/ui/src/features/task-detail/components/WorkspaceModeBadge.tsx
@@ -23,11 +23,27 @@ const MODE_META: Record<
   },
 };
 
-export function WorkspaceModeBadge({ mode }: { mode?: WorkspaceMode }) {
+export function WorkspaceModeBadge({
+  mode,
+  checkoutPath,
+}: {
+  mode?: WorkspaceMode;
+  /** Directory the task runs in, appended to the tooltip for local/worktree tasks. */
+  checkoutPath?: string | null;
+}) {
   if (!mode) return null;
   const { Icon, label, color } = MODE_META[mode];
+  const content =
+    mode !== "cloud" && checkoutPath ? (
+      <span className="flex flex-col">
+        <span>{label}</span>
+        <span className="text-gray-10">{checkoutPath}</span>
+      </span>
+    ) : (
+      label
+    );
   return (
-    <Tooltip content={label} side="bottom" delayDuration={300}>
+    <Tooltip content={content} side="bottom" delayDuration={300}>
       <span className="no-drag flex shrink-0 items-center justify-center">
         <Icon size={13} weight="fill" color={color} />
       </span>

--- a/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.test.ts
+++ b/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.test.ts
@@ -284,6 +284,7 @@ describe("areReposReady", () => {
 
 type HookArgs = {
   folderId: string | undefined;
+  requestId?: string;
   folders: RegisteredFolder[];
   repositories: string[];
   reposLoaded: boolean;
@@ -299,6 +300,7 @@ function renderRepoSelectionHook(initial: HookArgs) {
     (props: HookArgs) =>
       useInitialRepoSelectionFromFolderId({
         folderId: props.folderId,
+        requestId: props.requestId,
         folders: props.folders,
         repositories: props.repositories,
         reposLoaded: props.reposLoaded,
@@ -560,5 +562,43 @@ describe("useInitialRepoSelectionFromFolderId", () => {
       currentMode: "local",
     });
     expect(setWorkspaceMode).not.toHaveBeenCalled();
+  });
+
+  it("re-syncs the same folderId when a new requestId arrives (repeat '+' click)", () => {
+    const folders = [folder("a", "/repos/a", "posthog/a")];
+    const repositories = ["posthog/a"];
+    const { rerender, setSelectedDirectory } = renderRepoSelectionHook({
+      folderId: "a",
+      requestId: "req-1",
+      folders,
+      repositories,
+      reposLoaded: true,
+      currentMode: "local",
+    });
+    expect(setSelectedDirectory).toHaveBeenCalledExactlyOnceWith("/repos/a");
+
+    // Same request re-rendering must not re-apply (user edits stay intact)...
+    rerender({
+      folderId: "a",
+      requestId: "req-1",
+      folders,
+      repositories,
+      reposLoaded: true,
+      currentMode: "local",
+    });
+    expect(setSelectedDirectory).toHaveBeenCalledTimes(1);
+
+    // ...but a fresh click on the same group's "+" issues a new requestId and
+    // must re-select the folder's directory.
+    rerender({
+      folderId: "a",
+      requestId: "req-2",
+      folders,
+      repositories,
+      reposLoaded: true,
+      currentMode: "local",
+    });
+    expect(setSelectedDirectory).toHaveBeenCalledTimes(2);
+    expect(setSelectedDirectory).toHaveBeenLastCalledWith("/repos/a");
   });
 });

--- a/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.ts
+++ b/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.ts
@@ -115,6 +115,13 @@ export function resolveRepoSelectionForFolder({
 
 export interface UseInitialRepoSelectionParams {
   folderId: string | undefined;
+  /**
+   * Identifier of the navigation request that carried the folder prefill. Each
+   * "+" click issues a fresh id, so re-picking the same folder re-applies the
+   * prefill even when the screen stayed mounted (the once-per-request guards
+   * key on it). Without it, guards key on `folderId` alone.
+   */
+  requestId?: string;
   folders: RegisteredFolder[];
   /** Lower-cased `owner/repo` slugs the user can use in cloud mode. */
   repositories: string[];
@@ -145,6 +152,7 @@ export interface UseInitialRepoSelectionParams {
  */
 export function useInitialRepoSelectionFromFolderId({
   folderId,
+  requestId,
   folders,
   repositories,
   reposLoaded,
@@ -171,6 +179,9 @@ export function useInitialRepoSelectionFromFolderId({
       repoModeInitRef.current = undefined;
       return;
     }
+    // A fresh requestId makes this a new prefill request even for the same
+    // folder, so clicking a group's "+" always re-selects its directory.
+    const requestKey = `${requestId ?? ""}:${folderId}`;
     const folder = folders.find((f) => f.id === folderId);
     if (!folder) return;
 
@@ -183,23 +194,24 @@ export function useInitialRepoSelectionFromFolderId({
       mostRecentEnvironment,
     });
 
-    if (dirInitRef.current !== folderId) {
+    if (dirInitRef.current !== requestKey) {
       setSelectedDirectory(selection.directory);
-      dirInitRef.current = folderId;
+      dirInitRef.current = requestKey;
     }
 
     // Defer the cloud/mode decision until the integrations list has loaded.
-    if (reposLoaded && repoModeInitRef.current !== folderId) {
+    if (reposLoaded && repoModeInitRef.current !== requestKey) {
       if (selection.cloudRepository) {
         setSelectedRepository(selection.cloudRepository);
       }
       if (selection.nextMode && selection.nextMode !== currentModeRef.current) {
         switchWorkspaceMode(selection.nextMode);
       }
-      repoModeInitRef.current = folderId;
+      repoModeInitRef.current = requestKey;
     }
   }, [
     folderId,
+    requestId,
     folders,
     repositories,
     reposLoaded,

--- a/packages/ui/src/router/useOpenTask.ts
+++ b/packages/ui/src/router/useOpenTask.ts
@@ -91,7 +91,10 @@ export function openTaskInput(
       ? { folderId: folderIdOrOptions }
       : (folderIdOrOptions ?? {});
 
+  // folderId counts as transient state: each "+" click must get a fresh
+  // requestId so re-picking the same folder re-applies the prefill.
   const hasTransientState =
+    !!options.folderId ||
     !!options.initialPrompt ||
     !!options.initialCloudRepository ||
     !!options.initialModel ||

--- a/packages/workspace-server/src/services/folders/folders.test.ts
+++ b/packages/workspace-server/src/services/folders/folders.test.ts
@@ -60,6 +60,7 @@ vi.mock("@posthog/git/worktree", () => ({
 vi.mock("@posthog/git/queries", () => ({
   isGitRepository: vi.fn(() => Promise.resolve(true)),
   getRemoteUrl: vi.fn(() => Promise.resolve(null)),
+  getLinkedWorktreeMainPath: vi.fn(() => null),
 }));
 
 vi.mock("@posthog/git/sagas/init", () => ({
@@ -69,7 +70,11 @@ vi.mock("@posthog/git/sagas/init", () => ({
 }));
 
 import type { RootLogger } from "@posthog/di/logger";
-import { getRemoteUrl, isGitRepository } from "@posthog/git/queries";
+import {
+  getLinkedWorktreeMainPath,
+  getRemoteUrl,
+  isGitRepository,
+} from "@posthog/git/queries";
 import type { IDialog } from "@posthog/platform/dialog";
 import type { IWorkspaceSettings } from "@posthog/platform/workspace-settings";
 import type { IRepositoryRepository } from "../../db/repositories/repository-repository";
@@ -275,9 +280,35 @@ describe("FoldersService", () => {
           remoteUrl: null,
           lastAccessed: "2024-01-01T00:00:00.000Z",
           createdAt: "2024-01-01T00:00:00.000Z",
+          mainRepoPath: null,
           exists: true,
         },
       ]);
+    });
+
+    it("surfaces the main checkout path for a registered linked worktree", async () => {
+      const repos = [
+        {
+          id: "folder-1",
+          path: "/home/user/project-wt",
+          remoteUrl: "posthog/project",
+          lastAccessedAt: "2024-01-01T00:00:00.000Z",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+      ];
+      mockRepositoryRepo.findAll.mockReturnValue(repos);
+      mockExistsSync.mockReturnValue(true);
+      vi.mocked(getLinkedWorktreeMainPath).mockReturnValue(
+        "/home/user/project",
+      );
+
+      const result = await service.getFolders();
+
+      expect(getLinkedWorktreeMainPath).toHaveBeenCalledWith(
+        "/home/user/project-wt",
+      );
+      expect(result[0].mainRepoPath).toBe("/home/user/project");
     });
 
     it("strips .git suffix from remote repo name in display name (defensive against legacy data)", async () => {

--- a/packages/workspace-server/src/services/folders/folders.ts
+++ b/packages/workspace-server/src/services/folders/folders.ts
@@ -5,7 +5,11 @@ import {
   type RootLogger,
   type ScopedLogger,
 } from "@posthog/di/logger";
-import { getRemoteUrl, isGitRepository } from "@posthog/git/queries";
+import {
+  getLinkedWorktreeMainPath,
+  getRemoteUrl,
+  isGitRepository,
+} from "@posthog/git/queries";
 import { InitRepositorySaga } from "@posthog/git/sagas/init";
 import { parseGithubUrl } from "@posthog/git/utils";
 import { WorktreeManager } from "@posthog/git/worktree";
@@ -128,6 +132,7 @@ export class FoldersService {
         remoteUrl: r.remoteUrl ?? null,
         lastAccessed: r.lastAccessedAt ?? r.createdAt,
         createdAt: r.createdAt,
+        mainRepoPath: getLinkedWorktreeMainPath(r.path),
         exists: fs.existsSync(r.path),
       }));
   }
@@ -209,6 +214,7 @@ export class FoldersService {
       remoteUrl: repo.remoteUrl ?? null,
       lastAccessed: repo.lastAccessedAt ?? repo.createdAt,
       createdAt: repo.createdAt,
+      mainRepoPath: getLinkedWorktreeMainPath(repo.path),
       exists: true,
     };
   }

--- a/packages/workspace-server/src/services/folders/schemas.ts
+++ b/packages/workspace-server/src/services/folders/schemas.ts
@@ -7,6 +7,11 @@ export const registeredFolderSchema = z.object({
   remoteUrl: z.string().nullable(),
   lastAccessed: z.string(),
   createdAt: z.string(),
+  /**
+   * Root of the main checkout when this folder is a linked git worktree
+   * (`git worktree add`), null for a main clone. Computed at list time.
+   */
+  mainRepoPath: z.string().nullable().optional(),
 });
 
 export const registeredFolderWithExistsSchema = registeredFolderSchema.extend({

--- a/packages/workspace-server/src/services/workspace/schemas.ts
+++ b/packages/workspace-server/src/services/workspace/schemas.ts
@@ -214,6 +214,17 @@ export const gitWorktreeEntrySchema = z.object({
 
 export const listGitWorktreesOutput = z.array(gitWorktreeEntrySchema);
 
+export const listRepoCheckoutsInput = z.object({
+  repoPath: z.string(),
+});
+
+export const repoCheckoutSchema = z.object({
+  path: z.string(),
+  branch: z.string().nullable(),
+});
+
+export const listRepoCheckoutsOutput = z.array(repoCheckoutSchema);
+
 export const getWorktreeSizeInput = z.object({
   worktreePath: z.string(),
 });
@@ -317,6 +328,8 @@ export type DeleteWorkspaceInput = z.infer<typeof deleteWorkspaceInput>;
 export type VerifyWorkspaceInput = z.infer<typeof verifyWorkspaceInput>;
 export type GetWorkspaceInfoInput = z.infer<typeof getWorkspaceInfoInput>;
 export type ListGitWorktreesInput = z.infer<typeof listGitWorktreesInput>;
+export type ListRepoCheckoutsInput = z.infer<typeof listRepoCheckoutsInput>;
+export type RepoCheckout = z.infer<typeof repoCheckoutSchema>;
 export type GetWorktreeSizeInput = z.infer<typeof getWorktreeSizeInput>;
 export type DeleteWorktreeInput = z.infer<typeof deleteWorktreeInput>;
 export type WorkspaceErrorPayload = z.infer<typeof workspaceErrorPayload>;

--- a/packages/workspace-server/src/services/workspace/workspace.ts
+++ b/packages/workspace-server/src/services/workspace/workspace.ts
@@ -1449,6 +1449,19 @@ export class WorkspaceService extends TypedEventEmitter<WorkspaceServiceEvents> 
     }));
   }
 
+  /**
+   * Every other checkout of the repo `repoPath` belongs to — the main clone
+   * and all linked worktrees (app-managed or user-created), each with its
+   * checked-out branch. Unlike listGitWorktrees this is plain
+   * `git worktree list` scope, minus `repoPath` itself.
+   */
+  async listRepoCheckouts(
+    repoPath: string,
+  ): Promise<Array<{ path: string; branch: string | null }>> {
+    const others = await listLinkedWorktrees(repoPath);
+    return others.map((wt) => ({ path: wt.worktreePath, branch: wt.branch }));
+  }
+
   async deleteWorktree(
     mainRepoPath: string,
     worktreePath: string,


### PR DESCRIPTION
## Problem

With a git worktree and its main clone both registered as folders, the sidebar's per-repo grouping broke down:

- Adding the main clone after the worktree appeared to do nothing (both collapse into one group, labeled by whichever folder was added first — the worktree).
- Tasks started in the main clone were grouped under the worktree's name.
- Nothing on a task (list row or detail view) indicated which checkout it runs in.
- Clicking "+" (new task) on a group didn't reliably pre-select that group's folder in the dropdowns: the folder resolution was nondeterministic with multiple checkouts, and the prefill applied only once per folder id while the screen stayed mounted, so repeat clicks were silently ignored.

## Changes

- **`@posthog/git`**: new `getLinkedWorktreeMainPath()` — detects a linked worktree and resolves its main checkout path by parsing the `.git` file (no git spawn; submodule-style `.git` files are rejected).
- **`@posthog/workspace-server`**: `FoldersService` exposes `mainRepoPath` on registered folders, computed at list time (no DB migration).
- **`@posthog/core`**: new `findGroupFolder()` prefers the main clone over linked worktrees when resolving the folder that represents a sidebar group.
- **`@posthog/ui`**:
  - Group label, hover tooltip (main checkout path), context menu, and "+" target now use the main clone.
  - Task rows get a fork-icon chip with the worktree folder name (full path on hover) when the task runs in a worktree — both app-managed worktree-mode tasks and local tasks whose registered folder is a linked worktree.
  - Task-detail mode badge tooltip includes the checkout path for local/worktree tasks.
  - `openTaskInput` issues a fresh request id for folder-scoped prefill and the prefill hook keys its apply-once guards on it, so every "+" click re-selects the group's directory (without clobbering user edits within the same request).

- **Folder picker (open local dialog)**: "Recent" now means the repo family — a recent checkout pulls in its main clone and all registered worktrees (main first, worktrees indented with a fork icon), and every row shows its currently checked-out branch (`code-wt · feat/x`).
- **Branch dropdown**: branches already checked out in another checkout of the same repo are marked with "in `<folder>`" (git would refuse the checkout anyway). Backed by a new `workspace.listRepoCheckouts` tRPC procedure (plain `git worktree list` scope, unlike `listGitWorktrees` which only covers app-managed worktrees).

## Testing

- New unit tests: worktree detection (5 cases), `findGroupFolder` (4), repeat-click prefill re-apply, `mainRepoPath` surfacing in the folders service.
- Full green runs: `@posthog/git` queries tests, workspace-server folders tests, core sidebar tests, UI sidebar + task-detail tests; repo-wide `pnpm typecheck`; Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
