### PR TITLE
refactor: extract shared Adapter type (claude|codex)

### DIFF
--- a/apps/code/src/renderer/desktop-services.ts
+++ b/apps/code/src/renderer/desktop-services.ts
@@ -49,7 +49,11 @@ import {
   NOTIFICATIONS_SERVICE,
   type NotificationTarget,
 } from "@posthog/platform/notifications";
-import { AUTORESEARCH_FLAG, type CloudRegion } from "@posthog/shared";
+import {
+  type Adapter,
+  AUTORESEARCH_FLAG,
+  type CloudRegion,
+} from "@posthog/shared";
 import {
   AUTH_SIDE_EFFECTS,
   type IAuthSideEffects,
@@ -116,7 +120,7 @@ const reportModelResolverLog = logger.scope("report-model-resolver");
 container.bind<ReportModelResolver>(REPORT_MODEL_RESOLVER).toConstantValue({
   async resolveDefaultModel(
     apiHost: string,
-    adapter: "claude" | "codex",
+    adapter: Adapter,
     preferredModel?: string | null,
   ): Promise<string | undefined> {
     try {

--- a/apps/mobile/src/features/tasks/api.ts
+++ b/apps/mobile/src/features/tasks/api.ts
@@ -1,3 +1,4 @@
+import type { Adapter } from "@posthog/shared";
 import { fetch } from "expo/fetch";
 import {
   authedFetch,
@@ -421,7 +422,7 @@ export interface RunTaskInCloudOptions {
   pendingUserMessage?: string;
   mode?: "interactive" | "background";
   /** Adapter to use on the cloud runner. Currently only "claude" on mobile. */
-  runtimeAdapter?: "claude" | "codex";
+  runtimeAdapter?: Adapter;
   /** Gateway model ID, e.g. "claude-opus-4-8". */
   model?: string;
   /** Reasoning effort: "low" | "medium" | "high" (model-dependent). */

--- a/packages/agent/e2e/config.ts
+++ b/packages/agent/e2e/config.ts
@@ -1,7 +1,8 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import type { Adapter } from "@posthog/shared";
 
-export type Adapter = "claude" | "codex";
+export type { Adapter };
 
 /**
  * Live e2e configuration, resolved entirely from the environment so no secret is

--- a/packages/agent/src/adapters/acp-connection.ts
+++ b/packages/agent/src/adapters/acp-connection.ts
@@ -1,4 +1,5 @@
 import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
+import type { Adapter } from "@posthog/shared";
 import type { SessionLogWriter } from "../session-log-writer";
 import type { PostHogAPIConfig, ProcessSpawnedCallback } from "../types";
 import { Logger } from "../utils/logger";
@@ -13,10 +14,8 @@ import { nativeCodexBinaryPath } from "./codex-app-server/binary-path";
 import { CodexAppServerAgent } from "./codex-app-server/codex-app-server-agent";
 import type { CodexOptions } from "./codex-app-server/spawn";
 
-type AgentAdapter = "claude" | "codex";
-
 export type AcpConnectionConfig = {
-  adapter?: AgentAdapter;
+  adapter?: Adapter;
   logWriter?: SessionLogWriter;
   taskRunId?: string;
   taskId?: string;

--- a/packages/agent/src/adapters/reasoning-effort.ts
+++ b/packages/agent/src/adapters/reasoning-effort.ts
@@ -1,7 +1,6 @@
+import type { Adapter } from "@posthog/shared";
 import { getEffortOptions as getClaudeEffortOptions } from "./claude/session/models";
 import { getReasoningEffortOptions as getCodexReasoningEffortOptions } from "./codex-app-server/models";
-
-export type RuntimeAdapter = "claude" | "codex";
 
 export type SupportedReasoningEffort =
   | "low"
@@ -16,7 +15,7 @@ export interface ReasoningEffortOption {
 }
 
 export function getReasoningEffortOptions(
-  adapter: RuntimeAdapter,
+  adapter: Adapter,
   modelId: string,
 ): ReasoningEffortOption[] | null {
   const options =
@@ -28,7 +27,7 @@ export function getReasoningEffortOptions(
 }
 
 export function isSupportedReasoningEffort(
-  adapter: RuntimeAdapter,
+  adapter: Adapter,
   modelId: string,
   value: string,
 ): value is SupportedReasoningEffort {

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ContentBlock } from "@agentclientprotocol/sdk";
+import type { Adapter } from "@posthog/shared";
 import { zipSync } from "fflate";
 import jwt from "jsonwebtoken";
 import { type SetupServerApi, setupServer } from "msw/node";
@@ -228,9 +229,9 @@ interface TestableServer {
     inboxReportUrl?: string | null,
   ): string | { append: string };
   buildCodexInstructions(systemPrompt: string | { append: string }): string;
-  getRuntimeAdapter(): "claude" | "codex";
+  getRuntimeAdapter(): Adapter;
   buildClaudeCodeSessionMeta(
-    runtimeAdapter: "claude" | "codex",
+    runtimeAdapter: Adapter,
   ): { claudeCode: { options: Record<string, unknown> } } | undefined;
 }
 
@@ -240,7 +241,7 @@ interface NativeResumeTestServer {
     payload: JwtPayload,
     posthogAPI: PostHogAPIClient,
     preTaskRun: TaskRun | null,
-    runtimeAdapter: "claude" | "codex",
+    runtimeAdapter: Adapter,
     cwd: string,
     permissionMode: PermissionMode,
   ): Promise<{ sessionId: string; warm: boolean } | null>;

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -16,6 +16,7 @@ import {
 import { type ServerType, serve } from "@hono/node-server";
 import { execGh } from "@posthog/git/gh";
 import { getCurrentBranch } from "@posthog/git/queries";
+import type { Adapter } from "@posthog/shared";
 import { unzipSync } from "fflate";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -396,7 +397,7 @@ export class AgentServer {
     this.app = this.createApp();
   }
 
-  private getRuntimeAdapter(): "claude" | "codex" {
+  private getRuntimeAdapter(): Adapter {
     return this.config.runtimeAdapter ?? "claude";
   }
 
@@ -669,7 +670,7 @@ export class AgentServer {
     payload: JwtPayload,
     posthogAPI: PostHogAPIClient,
     preTaskRun: TaskRun | null,
-    runtimeAdapter: "claude" | "codex",
+    runtimeAdapter: Adapter,
     cwd: string,
     permissionMode: PermissionMode,
   ): Promise<{ sessionId: string; warm: boolean } | null> {
@@ -2543,7 +2544,7 @@ export class AgentServer {
    * it cannot sit behind a plugins guard.
    */
   private buildClaudeCodeSessionMeta(
-    runtimeAdapter: "claude" | "codex",
+    runtimeAdapter: Adapter,
   ): { claudeCode: { options: Record<string, unknown> } } | undefined {
     const plugins = this.config.claudeCode?.plugins;
     const effort =

--- a/packages/agent/src/server/types.ts
+++ b/packages/agent/src/server/types.ts
@@ -1,3 +1,4 @@
+import type { Adapter } from "@posthog/shared";
 import type { AgentMode } from "../types";
 import type { RemoteMcpServer } from "./schemas";
 
@@ -30,7 +31,7 @@ export interface AgentServerConfig {
   baseBranch?: string;
   claudeCode?: ClaudeCodeConfig;
   allowedDomains?: string[];
-  runtimeAdapter?: "claude" | "codex";
+  runtimeAdapter?: Adapter;
   model?: string;
   reasoningEffort?: "low" | "medium" | "high" | "xhigh" | "max";
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  Adapter,
   GitHandoffCheckpoint,
   HandoffLocalGitState as GitHandoffLocalGitState,
   PostHogAPIConfig,
@@ -49,7 +50,7 @@ export interface ProcessSpawnedCallback {
 
 export interface TaskExecutionOptions {
   repositoryPath?: string;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
   model?: string;
   gatewayUrl?: string;
   codexBinaryPath?: string;

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -2,6 +2,7 @@ import "./generated.augment";
 import { isSupportedReasoningEffort } from "@posthog/agent/adapters/reasoning-effort";
 import type { PermissionMode } from "@posthog/agent/execution-mode";
 import type {
+  Adapter,
   CloudRunSource,
   PrAuthorshipMode,
   SeatData,
@@ -470,10 +471,8 @@ export interface FinalizedTaskArtifactUpload {
   uploaded_at?: string;
 }
 
-type CloudRuntimeAdapter = "claude" | "codex";
-
 interface CloudRunOptions {
-  adapter?: CloudRuntimeAdapter;
+  adapter?: Adapter;
   model?: string;
   reasoningLevel?: string;
   sandboxEnvironmentId?: string;

--- a/packages/core/src/handoff/handoff-saga.ts
+++ b/packages/core/src/handoff/handoff-saga.ts
@@ -1,4 +1,5 @@
 import {
+  type Adapter,
   type GitHandoffCheckpoint,
   type HandoffLocalGitState,
   Saga,
@@ -41,7 +42,7 @@ export interface HandoffSagaDeps extends HandoffBaseDeps {
     projectId: number;
     logUrl: string;
     sessionId?: string;
-    adapter?: "claude" | "codex";
+    adapter?: Adapter;
   }): Promise<{ sessionId: string } | null>;
   closeCloudRun(
     taskId: string,

--- a/packages/core/src/handoff/types.ts
+++ b/packages/core/src/handoff/types.ts
@@ -1,4 +1,8 @@
-import type { HandoffLocalGitState, WorkspaceMode } from "@posthog/shared";
+import type {
+  Adapter,
+  HandoffLocalGitState,
+  WorkspaceMode,
+} from "@posthog/shared";
 
 export type HandoffStep =
   | "fetching_logs"
@@ -17,7 +21,7 @@ export interface HandoffSagaInput {
   apiHost: string;
   teamId: number;
   sessionId?: string;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
   localGitState?: HandoffLocalGitState;
 }
 

--- a/packages/core/src/inbox/identifiers.ts
+++ b/packages/core/src/inbox/identifiers.ts
@@ -1,3 +1,5 @@
+import type { Adapter } from "@posthog/shared";
+
 export const INBOX_BULK_ACTION_SERVICE = Symbol.for(
   "posthog.core.inbox.bulkActionService",
 );
@@ -25,7 +27,7 @@ export interface ReportModelResolver {
    */
   resolveDefaultModel(
     apiHost: string,
-    adapter: "claude" | "codex",
+    adapter: Adapter,
     preferredModel?: string | null,
   ): Promise<string | undefined>;
 }

--- a/packages/core/src/inbox/reportTaskCreation.ts
+++ b/packages/core/src/inbox/reportTaskCreation.ts
@@ -1,4 +1,4 @@
-import type { TaskCreationInput } from "@posthog/shared";
+import type { Adapter, TaskCreationInput } from "@posthog/shared";
 
 /** A selectable choice, either flat or wrapped in a labelled group. */
 export interface PreviewConfigChoice {
@@ -72,7 +72,7 @@ export interface BuildSignalReportTaskInput {
   reportId: string;
   cloudRepository: string;
   githubUserIntegrationId: string;
-  adapter: "claude" | "codex";
+  adapter: Adapter;
   model: string;
   reasoningLevel?: string;
   baseBranch?: string | null;

--- a/packages/core/src/inbox/signalReportTaskService.ts
+++ b/packages/core/src/inbox/signalReportTaskService.ts
@@ -1,4 +1,5 @@
 import {
+  type Adapter,
   type CloudRegion,
   getCloudUrlFromRegion,
   type TaskCreationOutput,
@@ -27,7 +28,7 @@ export interface CreateSignalReportTaskInput {
   githubUserIntegrationId: string | null;
   cloudRegion: CloudRegion | null;
   projectId?: number | null;
-  adapter: "claude" | "codex";
+  adapter: Adapter;
   modelOverride?: string | null;
   reasoningLevel?: string;
   question?: string;

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -328,7 +328,7 @@ export interface ConnectParams {
   repoPath: string;
   initialPrompt?: ContentBlock[];
   executionMode?: ExecutionMode;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
   model?: string;
   reasoningLevel?: string;
   /**
@@ -1276,7 +1276,7 @@ export class SessionService {
     auth: AuthCredentials,
     initialPrompt?: ContentBlock[],
     executionMode?: ExecutionMode,
-    adapter?: "claude" | "codex",
+    adapter?: Adapter,
     model?: string,
     reasoningLevel?: string,
     importedSessionId?: string,

--- a/packages/core/src/task-detail/previewConfig.ts
+++ b/packages/core/src/task-detail/previewConfig.ts
@@ -1,7 +1,6 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { flattenConfigValues } from "@posthog/core/task-detail/configOptions";
-
-export type PreviewAdapter = "claude" | "codex";
+import type { Adapter } from "@posthog/shared";
 
 export interface PreviewSettingsSnapshot {
   defaultInitialTaskMode: string;
@@ -51,7 +50,7 @@ export function clampEffortToAvailable(
 export function deriveInitialConfig(
   options: SessionConfigOption[],
   settings: PreviewSettingsSnapshot,
-  adapter: PreviewAdapter,
+  adapter: Adapter,
 ): SessionConfigOption[] {
   const {
     defaultInitialTaskMode,
@@ -112,7 +111,7 @@ export function deriveInitialConfig(
 }
 
 export interface ApplyConfigChangeArgs {
-  adapter: PreviewAdapter;
+  adapter: Adapter;
   configId: string;
   value: string;
   effortOptions: EffortOption[] | undefined;

--- a/packages/core/src/task-detail/taskCreationApiClient.ts
+++ b/packages/core/src/task-detail/taskCreationApiClient.ts
@@ -1,11 +1,15 @@
-import type { CloudRunSource, PrAuthorshipMode } from "@posthog/shared";
+import type {
+  Adapter,
+  CloudRunSource,
+  PrAuthorshipMode,
+} from "@posthog/shared";
 import type { Task, TaskRun } from "@posthog/shared/domain-types";
 
 export interface CreateTaskRunClientOptions {
   environment?: "local" | "cloud";
   mode?: "interactive" | "background";
   branch?: string | null;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
   model?: string;
   reasoningLevel?: string;
   sandboxEnvironmentId?: string;

--- a/packages/core/src/task-detail/taskInput.ts
+++ b/packages/core/src/task-detail/taskInput.ts
@@ -1,5 +1,9 @@
 import { buildCloudTaskDescription } from "@posthog/core/editor/cloud-prompt";
-import type { TaskCreationInput, WorkspaceMode } from "@posthog/shared";
+import type {
+  Adapter,
+  TaskCreationInput,
+  WorkspaceMode,
+} from "@posthog/shared";
 import type { ExecutionMode } from "@posthog/shared/domain-types";
 
 export interface PrepareTaskInputOptions {
@@ -12,7 +16,7 @@ export interface PrepareTaskInputOptions {
   allowRemoteBranchCheckout?: boolean;
   reuseExistingWorktree?: boolean;
   executionMode?: ExecutionMode;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
   model?: string;
   reasoningLevel?: string;
   environmentId?: string | null;

--- a/packages/shared/src/adapter.ts
+++ b/packages/shared/src/adapter.ts
@@ -1,0 +1,1 @@
+export type Adapter = "claude" | "codex";

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -1,5 +1,7 @@
 // Analytics event types and properties
 
+import type { Adapter } from "./adapter";
+
 export interface PromptHistoryOpenedProperties {
   entry_count: number;
 }
@@ -85,7 +87,7 @@ export interface TaskCreateProperties {
   uses_worktree_link?: boolean;
   /** Worktree mode: repo has a non-empty .worktreeinclude file */
   uses_worktree_include?: boolean;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
 }
 
 export interface TaskViewProperties {

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { Adapter } from "./adapter";
 import type { DismissalReasonOptionValue } from "./dismissal-reasons";
 import type { StoredLogEntry } from "./session-events";
 
@@ -118,7 +119,7 @@ export interface TaskRun {
   task: string; // Task ID
   team: number;
   branch: string | null;
-  runtime_adapter?: "claude" | "codex" | null;
+  runtime_adapter?: Adapter | null;
   model?: string | null;
   reasoning_effort?: "low" | "medium" | "high" | "xhigh" | "max" | null;
   stage?: string | null; // Current stage (e.g., 'research', 'plan', 'build')

--- a/packages/shared/src/handoff-host.ts
+++ b/packages/shared/src/handoff-host.ts
@@ -1,3 +1,4 @@
+import type { Adapter } from "./adapter";
 import type { GitHandoffCheckpoint, HandoffLocalGitState } from "./git-handoff";
 import type { WorkspaceMode } from "./workspace";
 
@@ -21,7 +22,7 @@ export interface HandoffReconnectParams {
   projectId: number;
   logUrl: string;
   sessionId?: string;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
 }
 
 export interface HandoffResumeStateResult {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./adapter";
 export * from "./analytics-events";
 export { type ArchivedTask, archivedTaskSchema } from "./archive-domain";
 export { withTimeout } from "./async";
@@ -178,7 +179,6 @@ export {
   type UserShellExecuteResult,
 } from "./session-events";
 export {
-  type Adapter,
   type AgentSession,
   cycleModeOption,
   flattenSelectOptions,

--- a/packages/shared/src/sessions.ts
+++ b/packages/shared/src/sessions.ts
@@ -6,12 +6,13 @@ import type {
   SessionConfigSelectOption,
   SessionConfigSelectOptions,
 } from "@agentclientprotocol/sdk";
+import type { Adapter } from "./adapter";
 import type { SkillButtonId } from "./analytics-events";
 import type { ExecutionMode } from "./exec-types";
 import type { AcpMessage } from "./session-events";
 import type { TaskRunStatus } from "./task";
 
-export type Adapter = "claude" | "codex";
+export type { Adapter };
 
 export type PermissionRequest = Omit<RequestPermissionRequest, "sessionId"> & {
   taskRunId: string;

--- a/packages/shared/src/task-creation-domain.ts
+++ b/packages/shared/src/task-creation-domain.ts
@@ -1,3 +1,4 @@
+import type { Adapter } from "./adapter";
 import type { CloudRunSource, PrAuthorshipMode } from "./cloud";
 import type { Task } from "./domain-types";
 import type { ExecutionMode } from "./exec-types";
@@ -29,7 +30,7 @@ export interface TaskCreationInput {
   githubIntegrationId?: number;
   githubUserIntegrationId?: string;
   executionMode?: ExecutionMode;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
   model?: string;
   reasoningLevel?: string;
   environmentId?: string;

--- a/packages/ui/src/features/inbox/hooks/resolveDefaultModel.ts
+++ b/packages/ui/src/features/inbox/hooks/resolveDefaultModel.ts
@@ -1,4 +1,5 @@
 import type { ReportModelResolver } from "@posthog/core/inbox/identifiers";
+import type { Adapter } from "@posthog/shared";
 import { logger } from "@posthog/ui/shell/logger";
 import type { QueryClient } from "@tanstack/react-query";
 
@@ -19,7 +20,7 @@ const log = logger.scope("resolve-default-model");
 export async function resolveDefaultModel(
   queryClient: QueryClient,
   apiHost: string,
-  adapter: "claude" | "codex",
+  adapter: Adapter,
   modelResolver: ReportModelResolver,
   preferredModel?: string | null,
 ): Promise<string | undefined> {

--- a/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -10,7 +10,11 @@ import {
   type TaskService,
 } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
-import { ANALYTICS_EVENTS, getCloudUrlFromRegion } from "@posthog/shared";
+import {
+  type Adapter,
+  ANALYTICS_EVENTS,
+  getCloudUrlFromRegion,
+} from "@posthog/shared";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { showOfflineToast } from "@posthog/ui/features/connectivity/connectivityToast";
 import { resolveDefaultModel } from "@posthog/ui/features/inbox/hooks/resolveDefaultModel";
@@ -59,7 +63,7 @@ export interface InboxCloudTaskInputContext {
   cloudRepository: string | null;
   /** Null alongside a null `cloudRepository` (repo-less run). */
   githubUserIntegrationId: string | null;
-  adapter: "claude" | "codex";
+  adapter: Adapter;
   model: string;
   reasoningLevel?: string;
 }

--- a/packages/ui/src/features/message-editor/components/AdapterIndicator.tsx
+++ b/packages/ui/src/features/message-editor/components/AdapterIndicator.tsx
@@ -1,8 +1,9 @@
 import { Robot } from "@phosphor-icons/react";
+import type { Adapter } from "@posthog/shared";
 import { Flex, Text } from "@radix-ui/themes";
 
 interface AdapterIndicatorProps {
-  adapter: "claude" | "codex";
+  adapter: Adapter;
 }
 
 export function AdapterIndicator({ adapter }: AdapterIndicatorProps) {

--- a/packages/ui/src/features/message-editor/suggestions/getSuggestions.test.ts
+++ b/packages/ui/src/features/message-editor/suggestions/getSuggestions.test.ts
@@ -1,4 +1,4 @@
-import type { AcpMessage } from "@posthog/shared";
+import type { AcpMessage, Adapter } from "@posthog/shared";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useSessionStore } from "../../sessions/sessionStore";
 import { useDraftStore } from "../draftStore";
@@ -19,7 +19,7 @@ function seedSessionContext(taskId: string | undefined) {
 
 function seedSessionAvailableCommands(
   commands: { name: string; description: string }[],
-  adapter?: "claude" | "codex",
+  adapter?: Adapter,
 ) {
   const events: AcpMessage[] = [
     {
@@ -69,7 +69,7 @@ interface Scenario {
   name: string;
   contextTaskId?: string;
   sessionCommands?: { name: string; description: string }[];
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
   draftCommands?: EditorAvailableCommand[];
   expectContains: string[];
   expectNotContains?: string[];

--- a/packages/ui/src/features/sessions/components/ModelSelector.tsx
+++ b/packages/ui/src/features/sessions/components/ModelSelector.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
-import { GLM_MODEL_FLAG } from "@posthog/shared";
+import { type Adapter, GLM_MODEL_FLAG } from "@posthog/shared";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { stripGlmModelOption } from "@posthog/ui/features/sessions/modelOptionFilters";
 import {
@@ -28,7 +28,7 @@ interface ModelSelectorProps {
   taskId?: string;
   disabled?: boolean;
   onModelChange?: (modelId: string) => void;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
 }
 
 export function ModelSelector({

--- a/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -9,13 +9,14 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
+import type { Adapter } from "@posthog/shared";
 import { useRef, useState } from "react";
 import { flattenSelectOptions } from "../sessionStore";
 import { useRetainedConfigOption } from "../useRetainedConfigOption";
 
 interface ReasoningLevelSelectorProps {
   thoughtOption?: SessionConfigOption;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
   onChange?: (value: string) => void;
   disabled?: boolean;
   isLoading?: boolean;

--- a/packages/ui/src/features/sessions/sessionAdapterStore.ts
+++ b/packages/ui/src/features/sessions/sessionAdapterStore.ts
@@ -1,13 +1,12 @@
+import type { Adapter } from "@posthog/shared";
 import { electronStorage } from "@posthog/ui/shell/rendererStorage";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-type AdapterType = "claude" | "codex";
-
 interface SessionAdapterState {
-  adaptersByRunId: Record<string, AdapterType>;
-  setAdapter: (taskRunId: string, adapter: AdapterType) => void;
-  getAdapter: (taskRunId: string) => AdapterType | undefined;
+  adaptersByRunId: Record<string, Adapter>;
+  setAdapter: (taskRunId: string, adapter: Adapter) => void;
+  getAdapter: (taskRunId: string) => Adapter | undefined;
   removeAdapter: (taskRunId: string) => void;
 }
 

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -1,5 +1,5 @@
 import type { UserRepositoryIntegrationRef } from "@posthog/core/integrations/repositories";
-import type { ExecutionMode, WorkspaceMode } from "@posthog/shared";
+import type { Adapter, ExecutionMode, WorkspaceMode } from "@posthog/shared";
 import {
   COLLAPSE_MODE_DEFAULT,
   type CollapseMode,
@@ -12,7 +12,7 @@ import { persist } from "zustand/middleware";
 
 export type DefaultRunMode = "local" | "cloud" | "last_used";
 export type LocalWorkspaceMode = "worktree" | "local";
-export type AgentAdapter = "claude" | "codex";
+export type AgentAdapter = Adapter;
 export type DefaultInitialTaskMode = "plan" | "last_used";
 export type DefaultMessagingMode = "queue" | "steer";
 export type DefaultReasoningEffort =

--- a/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -6,7 +6,11 @@ import {
   deriveInitialConfig,
 } from "@posthog/core/task-detail/previewConfig";
 import { useHostTRPCClient } from "@posthog/host-router/react";
-import { GLM_MODEL_FLAG, getCloudUrlFromRegion } from "@posthog/shared";
+import {
+  type Adapter,
+  GLM_MODEL_FLAG,
+  getCloudUrlFromRegion,
+} from "@posthog/shared";
 import { stripGlmModelOption } from "@posthog/ui/features/sessions/modelOptionFilters";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { logger } from "../../../shell/logger";
@@ -40,9 +44,7 @@ function getOptionByCategory(
  *
  * Returns config options as local state with a setter for local updates.
  */
-export function usePreviewConfig(
-  adapter: "claude" | "codex",
-): PreviewConfigResult {
+export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
   const hostClient = useHostTRPCClient();
   const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -11,6 +11,7 @@ import { useService } from "@posthog/di/react";
 import type { HostTrpcClient } from "@posthog/host-router/client";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import {
+  type Adapter,
   ANALYTICS_EVENTS,
   type TaskCreationInput,
   type WorkspaceMode,
@@ -62,7 +63,7 @@ interface UseTaskCreationOptions {
   branch?: string | null;
   editorIsEmpty: boolean;
   executionMode?: ExecutionMode;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
   model?: string;
   reasoningLevel?: string;
   environmentId?: string | null;

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -61,6 +61,7 @@ import {
 } from "@posthog/platform/workspace-settings";
 import {
   type AcpMessage,
+  type Adapter,
   isAuthError,
   serializeError,
   TypedEventEmitter,
@@ -261,7 +262,7 @@ interface SessionConfig {
   logUrl?: string;
   /** The agent's session ID (for resume - SDK session ID for Claude, Codex's session ID for Codex) */
   sessionId?: string;
-  adapter?: "claude" | "codex";
+  adapter?: Adapter;
   /** Permission mode to use for the session */
   permissionMode?: string;
   /** Custom instructions injected into the system prompt */
@@ -1891,7 +1892,7 @@ For git operations while detached:
           } = params as {
             taskRunId: string;
             sessionId: string;
-            adapter: "claude" | "codex";
+            adapter: Adapter;
           };
           const session = this.sessions.get(notifTaskRunId);
           if (session) {
@@ -2205,7 +2206,7 @@ For git operations while detached:
 
   async getPreviewConfigOptions(
     apiHost: string,
-    adapter: "claude" | "codex" = "claude",
+    adapter: Adapter = "claude",
   ): Promise<SessionConfigOption[]> {
     const gatewayUrl = getLlmGatewayUrl(apiHost);
     const gatewayModels = await fetchGatewayModels({ gatewayUrl });


### PR DESCRIPTION
Introduces `packages/shared/src/adapter.ts` as the single source of truth for the "claude" | "codex" runtime-adapter union, previously duplicated (often under different local names: AgentAdapter, AdapterType, RuntimeAdapter, PreviewAdapter, CloudRuntimeAdapter) across core, ui, workspace-server, agent, api-client, and the desktop/mobile apps.

All call sites now import Adapter from @posthog/shared instead of redeclaring the literal union.

