### PR TITLE
fix(lint): replace non-null assertions failing biome ci on main

### DIFF
--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -1387,7 +1387,10 @@ export class AgentServer {
     });
 
     this.sessionReadyBootMs = Math.round(process.uptime() * 1000);
-    this.sessionInitMs = Math.max(0, Date.now() - this.barrierReleasedAtMs!);
+    this.sessionInitMs = Math.max(
+      0,
+      Date.now() - (this.barrierReleasedAtMs ?? Date.now()),
+    );
     this.logger.debug("Session initialized successfully", {
       bootMs: this.sessionReadyBootMs,
       sessionInitMs: this.sessionInitMs,

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -538,7 +538,8 @@ export class SkillsService {
     const MAX_RESOLVED_SKILLS = 50;
 
     while (queue.length > 0) {
-      const ref = queue.shift()!;
+      const ref = queue.shift();
+      if (!ref) break;
       const key = `${ref.source}:${ref.path}`;
       if (seen.has(key)) continue;
       if (resolved.length >= MAX_RESOLVED_SKILLS) {


### PR DESCRIPTION
## Summary

The required `quality` check (`biome ci .`) is currently **red on `main`**, which blocks the Trunk merge queue for every PR. Two `lint/style/noNonNullAssertion` errors are the cause:

- `packages/workspace-server/src/services/skills/skills.ts:541` — `const ref = queue.shift()!;`
- `packages/agent/src/server/agent-server.ts:1390` — `Date.now() - this.barrierReleasedAtMs!`

## Fix

- **skills.ts**: `queue.shift()` now assigns without `!` and breaks early if it somehow returns `undefined` — behavior-preserving given the `while (queue.length > 0)` guard.
- **agent-server.ts**: fall back to `Date.now()` when `barrierReleasedAtMs` is unset (yields `0`) instead of asserting non-null; also removes a latent `NaN` when the field was never set.

No behavior change on the happy paths. `biome ci .` now reports 0 errors; affected packages typecheck.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*