### PR TITLE
feat(local-mcp): forward importable local MCP servers into cloud runs

### DIFF
--- a/docs/cloud-mcp-import.md
+++ b/docs/cloud-mcp-import.md
@@ -1,0 +1,171 @@
+# Importing local MCP servers into cloud task runs
+
+Status: client side implemented behind the `posthog-code-local-mcp-import`
+feature flag. The Django side (spec below) is not implemented; until it lands,
+the backend ignores the extra creation-payload field and cloud runs behave as
+before.
+
+## Problem
+
+A local task run gets all of the user's MCP servers: the PostHog MCP plus
+`MCPServerInstallation` records (built by `AgentAuthAdapter.buildMcpServers` in
+`packages/workspace-server/src/services/agent/auth-adapter.ts`), and — for the
+Claude adapter — the user's own servers from `~/.claude.json`
+(`loadUserClaudeJsonMcpServers` in
+`packages/agent/src/adapters/claude/session/mcp-config.ts`).
+
+A cloud run's sandbox only gets what the backend bakes into the agent server's
+`--mcpServers` flag at spawn (`remoteMcpServerSchema` in
+`packages/agent/src/server/schemas.ts`: `http`/`sse` + `url` + `headers`). The
+sandbox never reads `~/.claude.json`, so tasks that need the user's own MCP
+servers (Grafana, Sentry, internal tools, ...) force the user back to local
+runs.
+
+This document covers **import**: forwarding url-based servers that are
+reachable from the public internet. Servers that are not importable (stdio, or
+private-network URLs) need the desktop **relay** — see
+[cloud-mcp-relay.md](./cloud-mcp-relay.md).
+
+## What the client does
+
+1. **Read** — `LocalMcpService`
+   (`packages/workspace-server/src/services/local-mcp/local-mcp.ts`) reads
+   `~/.claude.json` through `loadUserClaudeJsonMcpServerEntries` (extracted
+   from the Claude adapter's loader so both share one parser) and normalizes
+   each entry to a `LocalMcpServerDescriptor` (`@posthog/shared`). stdio `env`
+   values are dropped at this boundary — they routinely hold secrets the
+   renderer has no use for.
+
+2. **Classify** — `LocalMcpImportService`
+   (`packages/core/src/local-mcp/localMcpImport.ts`) classifies each server:
+
+   | Server | Availability | Why |
+   | --- | --- | --- |
+   | `http`/`sse` with a public URL | `importable` | The sandbox can reach it directly. |
+   | `http`/`sse` on localhost, RFC1918, CGNAT (100.64/10, incl. Tailscale IPs), link-local, IPv6 ULA, `.local`/`.internal`/`.lan`/`.home`/`.home.arpa`/`.ts.net`, or a dotless intranet name | `requires_desktop` | Only reachable from the user's machine or network. |
+   | `stdio` | `requires_desktop` | A local process; nothing to forward. |
+   | Unparseable URL / non-http(s) scheme / unrecognized shape | `unsupported` | Can't run anywhere. |
+
+   The heuristic errs toward private: a public server misclassified as private
+   just stays desktop-only, while the reverse would ship an unreachable server
+   (or leak headers) to the sandbox.
+
+3. **Show** — the cloud task composer renders `LocalMcpServersButton`
+   (`packages/ui/src/features/task-detail/components/LocalMcpServersButton.tsx`),
+   a list of the user's servers annotated "Available in cloud" / "Requires
+   your machine" / "Not available in cloud".
+
+4. **Send** — importable servers are included in the run-creation payload
+   (`imported_mcp_servers` in `buildCloudRunRequestBody`,
+   `packages/api-client/src/posthog-client.ts`) in exactly the shape the agent
+   server's `remoteMcpServerSchema` accepts, so the backend can pass them
+   through to `--mcpServers` without transformation.
+
+Project-scoped (`projects[cwd].mcpServers`) entries are currently only picked
+up when a `cwd` is passed; cloud task creation selects a GitHub repository
+rather than a local checkout, so cloud runs import user-scoped servers only.
+Mapping repository → local checkout to include project-scoped servers is a
+follow-up.
+
+## Wire format
+
+`POST /api/projects/{project_id}/tasks/{task_id}/runs/` gains one optional
+field:
+
+```json
+{
+  "imported_mcp_servers": [
+    {
+      "type": "http",
+      "name": "grafana",
+      "url": "https://mcp.grafana.example.com/mcp",
+      "headers": [{ "name": "Authorization", "value": "Bearer ..." }]
+    }
+  ]
+}
+```
+
+`type` is `"http" | "sse"`. `headers` may be empty.
+
+## Django-side spec (not implemented in this repo)
+
+The `posthog/posthog` repo owns run creation and sandbox provisioning. To
+support the field:
+
+**Validation** (reject the run creation with 400 on violation):
+
+- ≤ 20 servers; `name` non-empty, ≤ 64 chars, unique within the list.
+- `url` must parse, scheme `http`/`https`, host must not be loopback /
+  RFC1918 / link-local / CGNAT / IPv6 ULA (re-validate server-side; the
+  client's classification is a UX aid, not a security boundary). This matters
+  because the sandbox egresses from PostHog infrastructure: a private URL
+  here is a user-controlled SSRF vector against whatever the sandbox network
+  can reach.
+- Each header value ≤ 4 KB; whole field ≤ 32 KB serialized.
+- Names must not collide with the reserved `posthog` server or with the names
+  of the project's `MCPServerInstallation`-derived servers; on collision the
+  imported server is dropped (installations win) and the run is still created.
+
+**Storage**: header values are credentials (`Authorization: Bearer ...`).
+Store them like other run secrets — encrypted at rest, write-only (never
+echoed back from the run detail API), and excluded from logs/analytics.
+
+**Spawn**: append the validated list to the `--mcpServers` array after the
+PostHog MCP and installation-derived servers. No other transformation — the
+payload shape is already `remoteMcpServerSchema`.
+
+**Adapter caveat**: codex-acp hard-fails on unreachable MCP servers, which is
+why the desktop prunes them for local Codex sessions
+(`filterReachableMcpServers` in
+`packages/workspace-server/src/services/agent/agent.ts`). The sandbox agent
+server does no such pruning. Either restrict `imported_mcp_servers` to
+`runtime_adapter == "claude"` initially, or add an equivalent reachability
+probe to the sandbox before session start for Codex runs.
+
+## Auth: header staleness and rotation
+
+Headers are captured at launch. For servers whose tokens expire mid-run, the
+rotation mechanism already exists on the sandbox side: the `refresh_session`
+command (`refreshSessionParamsSchema`,
+`packages/agent/src/server/schemas.ts`) pushes a fresh `mcpServers` list into
+a running session, and the Claude adapter tears down and rebuilds the query
+with the new list (`refreshSession` in
+`packages/agent/src/adapters/claude/claude-agent.ts`).
+
+What's missing is the client half — today the desktop never sends
+`refresh_session` for cloud runs (`sendCommandInput` in
+`packages/core/src/cloud-task/schemas.ts` stops at `set_config_option`).
+Design:
+
+1. Add `refresh_session` to the core cloud-task command schema and a
+   `CloudTaskService` method that posts it through the existing
+   `/runs/{run}/command/` endpoint with the full replacement `mcpServers`
+   list (the agent server treats the list as authoritative; an empty list is
+   a no-op by design, so "remove every imported server" cannot be expressed —
+   acceptable for rotation).
+2. Django: allow `refresh_session` through the command endpoint's method
+   allowlist, apply the same validation as `imported_mcp_servers`, forward
+   verbatim, and do not persist the params (they contain fresh credentials).
+3. Desktop trigger: re-read `~/.claude.json` when it changes (the
+   workspace-server already has file watchers) and push the updated list to
+   active cloud runs.
+
+**Why this ships as a documented follow-up rather than code**: static headers
+in `~/.claude.json` carry no expiry metadata, and OAuth-backed servers
+managed by Claude Code keep their tokens in Claude's credential store — not
+in `mcpServers.headers` — so those servers aren't importable this way at all
+(they surface as headerless imports that 401 in the sandbox; the relay in
+[cloud-mcp-relay.md](./cloud-mcp-relay.md) covers them properly). For the
+static-header servers we can import, there is nothing to watch except the
+file itself, which is the trigger described above.
+
+## Follow-ups
+
+- Codex local config (`~/.codex/config.toml` `mcp_servers`) as a second
+  source; needs a TOML parser, skipped for now.
+- Project-scoped `~/.claude.json` servers for cloud runs (repository → local
+  checkout mapping).
+- `${VAR}` environment-variable expansion in header values (Claude Code
+  expands these at session start; the import currently forwards them
+  literally, so such servers will 401 until expanded).
+- The `refresh_session` client path described above.

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -2,6 +2,7 @@ import "./generated.augment";
 import { isSupportedReasoningEffort } from "@posthog/agent/adapters/reasoning-effort";
 import type { PermissionMode } from "@posthog/agent/execution-mode";
 import type {
+  CloudMcpServerImport,
   CloudRunSource,
   PrAuthorshipMode,
   SeatData,
@@ -482,6 +483,11 @@ interface CloudRunOptions {
   signalReportId?: string;
   initialPermissionMode?: PermissionMode;
   homeQuickAction?: string;
+  /**
+   * Local url-based MCP servers to make available inside the sandbox. The
+   * backend merges these into the agent server's `--mcpServers` at spawn.
+   */
+  importedMcpServers?: CloudMcpServerImport[];
 }
 
 interface CreateTaskRunOptions extends CloudRunOptions {
@@ -562,6 +568,9 @@ function buildCloudRunRequestBody(
   }
   if (options?.homeQuickAction) {
     body.home_quick_action = options.homeQuickAction;
+  }
+  if (options?.importedMcpServers?.length) {
+    body.imported_mcp_servers = options.importedMcpServers;
   }
 
   return body;

--- a/packages/core/src/task-detail/taskCreationApiClient.ts
+++ b/packages/core/src/task-detail/taskCreationApiClient.ts
@@ -1,4 +1,8 @@
-import type { CloudRunSource, PrAuthorshipMode } from "@posthog/shared";
+import type {
+  CloudMcpServerImport,
+  CloudRunSource,
+  PrAuthorshipMode,
+} from "@posthog/shared";
 import type { Task, TaskRun } from "@posthog/shared/domain-types";
 
 export interface CreateTaskRunClientOptions {
@@ -14,6 +18,7 @@ export interface CreateTaskRunClientOptions {
   signalReportId?: string;
   initialPermissionMode?: string;
   homeQuickAction?: string;
+  importedMcpServers?: CloudMcpServerImport[];
 }
 
 export interface StartTaskRunClientOptions {

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -404,6 +404,7 @@ export class TaskCreationSaga extends Saga<
             runSource: input.cloudRunSource ?? "manual",
             signalReportId: input.signalReportId,
             homeQuickAction: input.homeQuickActionLabel,
+            importedMcpServers: input.importedMcpServers,
             initialPermissionMode:
               input.executionMode ??
               (cloudAdapter === "codex" ? "auto" : "plan"),

--- a/packages/core/src/task-detail/taskInput.ts
+++ b/packages/core/src/task-detail/taskInput.ts
@@ -1,5 +1,9 @@
 import { buildCloudTaskDescription } from "@posthog/core/editor/cloud-prompt";
-import type { TaskCreationInput, WorkspaceMode } from "@posthog/shared";
+import type {
+  CloudMcpServerImport,
+  TaskCreationInput,
+  WorkspaceMode,
+} from "@posthog/shared";
 import type { ExecutionMode } from "@posthog/shared/domain-types";
 
 export interface PrepareTaskInputOptions {
@@ -24,6 +28,7 @@ export interface PrepareTaskInputOptions {
   channelId?: string;
   customInstructions?: string;
   allowNoRepo?: boolean;
+  importedMcpServers?: CloudMcpServerImport[];
 }
 
 export function prepareTaskInput(
@@ -63,6 +68,7 @@ export function prepareTaskInput(
     channelId: options.channelId,
     customInstructions: isCloud ? options.customInstructions : undefined,
     allowNoRepo: options.allowNoRepo,
+    importedMcpServers: isCloud ? options.importedMcpServers : undefined,
   };
 }
 

--- a/packages/shared/src/flags.ts
+++ b/packages/shared/src/flags.ts
@@ -12,3 +12,6 @@ export const DISCOVERY_RUN_FLAG = "posthog-code-discovery-run";
 export const PROJECT_BLUEBIRD_FLAG = "project-bluebird";
 export const TASKS_PREWARM_SANDBOX_FLAG = "tasks-prewarm-sandbox";
 export const GLM_MODEL_FLAG = "posthog-code-glm-model";
+// Gates forwarding the user's local (~/.claude.json) url-based MCP servers
+// into cloud task runs.
+export const LOCAL_MCP_IMPORT_FLAG = "posthog-code-local-mcp-import";

--- a/packages/shared/src/task-creation-domain.ts
+++ b/packages/shared/src/task-creation-domain.ts
@@ -1,6 +1,7 @@
 import type { CloudRunSource, PrAuthorshipMode } from "./cloud";
 import type { Task } from "./domain-types";
 import type { ExecutionMode } from "./exec-types";
+import type { CloudMcpServerImport } from "./local-mcp-domain";
 import type { WorkspaceMode } from "./workspace";
 import type { Workspace } from "./workspace-domain";
 
@@ -55,6 +56,12 @@ export interface TaskCreationInput {
    * first message instead, to avoid double-injecting.
    */
   customInstructions?: string;
+  /**
+   * Local (~/.claude.json) MCP servers classified as importable, forwarded to
+   * the cloud sandbox in the run-creation payload. Cloud-only; local sessions
+   * already read the user's config directly.
+   */
+  importedMcpServers?: CloudMcpServerImport[];
   /**
    * When true, the task may be created without a repo/branch. Used by the
    * channels "generic chat box": the agent decides at runtime whether it needs

--- a/packages/ui/src/features/task-detail/components/LocalMcpServersButton.tsx
+++ b/packages/ui/src/features/task-detail/components/LocalMcpServersButton.tsx
@@ -1,0 +1,76 @@
+import { Plugs } from "@phosphor-icons/react";
+import type { LocalMcpCloudClassification } from "@posthog/core/local-mcp/localMcpImport";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  MenuLabel,
+} from "@posthog/quill";
+
+const AVAILABILITY_LABELS: Record<
+  LocalMcpCloudClassification["availability"],
+  string
+> = {
+  importable: "Available in cloud",
+  requires_desktop: "Requires your machine",
+  unsupported: "Not available in cloud",
+};
+
+interface LocalMcpServersButtonProps {
+  servers: LocalMcpCloudClassification[];
+  disabled?: boolean;
+}
+
+/**
+ * Shows which of the user's local MCP servers will be available inside the
+ * cloud sandbox for this run, and why the rest won't.
+ */
+export function LocalMcpServersButton({
+  servers,
+  disabled,
+}: LocalMcpServersButtonProps) {
+  if (servers.length === 0) return null;
+  const importable = servers.filter((s) => s.availability === "importable");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label="Local MCP servers in cloud"
+            disabled={disabled}
+          >
+            <Plugs size={14} weight="regular" className="shrink-0" />
+            <span className="font-medium tabular-nums">
+              {importable.length}/{servers.length}
+            </span>
+          </Button>
+        }
+      />
+      <DropdownMenuContent
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        className="min-w-[280px]"
+      >
+        <MenuLabel>Your MCP servers in this cloud run</MenuLabel>
+        {servers.map((server) => (
+          <div
+            key={server.name}
+            className="flex items-center gap-3 px-2 py-1.5 text-sm"
+          >
+            <span className="min-w-0 flex-1 truncate" title={server.name}>
+              {server.name}
+            </span>
+            <span className="shrink-0 text-muted-foreground text-xs">
+              {AVAILABILITY_LABELS[server.availability]}
+            </span>
+          </div>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -79,11 +79,13 @@ import {
   areReposReady,
   useInitialRepoSelectionFromFolderId,
 } from "../hooks/useInitialRepoSelectionFromFolderId";
+import { useLocalMcpCloudServers } from "../hooks/useLocalMcpCloudServers";
 import { usePreviewConfig } from "../hooks/usePreviewConfig";
 import { useTaskCreation } from "../hooks/useTaskCreation";
 import { useWarmTask } from "../hooks/useWarmTask";
 import { CloudGithubMissingNotice } from "./CloudGithubMissingNotice";
 import { NewTaskSuggestions } from "./ContinueCliSessions";
+import { LocalMcpServersButton } from "./LocalMcpServersButton";
 import {
   type SuggestedPrompt,
   SuggestedPromptCard,
@@ -756,6 +758,17 @@ export function TaskInput({
     [autoresearchService],
   );
 
+  const localMcpServers = useLocalMcpCloudServers(
+    effectiveWorkspaceMode === "cloud",
+  );
+  const importedMcpServers = useMemo(
+    () =>
+      localMcpServers.flatMap((server) =>
+        server.remote ? [server.remote] : [],
+      ),
+    [localMcpServers],
+  );
+
   const {
     isCreatingTask,
     canSubmit,
@@ -786,6 +799,7 @@ export function TaskInput({
     channelContext: includeChannelContext ? channelContext : undefined,
     channelName,
     allowNoRepo,
+    importedMcpServers,
   });
 
   // Wraps the prompt in the autoresearch kickoff: protocol preamble first,
@@ -1120,6 +1134,12 @@ export function TaskInput({
                       anchor={buttonGroupRef}
                     />
                   </ButtonGroup>
+                )}
+                {workspaceMode === "cloud" && (
+                  <LocalMcpServersButton
+                    servers={localMcpServers}
+                    disabled={isCreatingTask}
+                  />
                 )}
                 {!allowNoRepo && workspaceMode !== "cloud" && (
                   <AdditionalDirectoriesButton

--- a/packages/ui/src/features/task-detail/hooks/useLocalMcpCloudServers.ts
+++ b/packages/ui/src/features/task-detail/hooks/useLocalMcpCloudServers.ts
@@ -1,0 +1,35 @@
+import { LOCAL_MCP_IMPORT_SERVICE } from "@posthog/core/local-mcp/identifiers";
+import type {
+  LocalMcpCloudClassification,
+  LocalMcpImportService,
+} from "@posthog/core/local-mcp/localMcpImport";
+import { useServiceOptional } from "@posthog/di/react";
+import { LOCAL_MCP_IMPORT_FLAG } from "@posthog/shared";
+import { useQuery } from "@tanstack/react-query";
+import { useFeatureFlag } from "../../feature-flags/useFeatureFlag";
+
+/**
+ * The user's local (~/.claude.json) MCP servers classified by cloud
+ * availability. Empty on hosts without a local workspace (web/mobile — the
+ * service is only bound on desktop) and while the feature flag is off.
+ */
+export function useLocalMcpCloudServers(
+  enabled: boolean,
+): LocalMcpCloudClassification[] {
+  const service = useServiceOptional<LocalMcpImportService>(
+    LOCAL_MCP_IMPORT_SERVICE,
+  );
+  const flagEnabled = useFeatureFlag(LOCAL_MCP_IMPORT_FLAG);
+
+  const query = useQuery({
+    queryKey: ["local-mcp-cloud-availability"],
+    queryFn: () => {
+      if (!service) return [];
+      return service.getCloudAvailability();
+    },
+    enabled: enabled && flagEnabled && !!service,
+    staleTime: 30_000,
+  });
+
+  return query.data ?? [];
+}

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -12,6 +12,7 @@ import type { HostTrpcClient } from "@posthog/host-router/client";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import {
   ANALYTICS_EVENTS,
+  type CloudMcpServerImport,
   type TaskCreationInput,
   type WorkspaceMode,
 } from "@posthog/shared";
@@ -78,6 +79,8 @@ interface UseTaskCreationOptions {
    * whether it needs one and attaches it lazily.
    */
   allowNoRepo?: boolean;
+  /** Importable local MCP servers to forward into a cloud run's sandbox. */
+  importedMcpServers?: CloudMcpServerImport[];
   onTaskCreated?: (task: Task) => void;
   /**
    * Side effect run with the created task in addition to (not instead of)
@@ -166,6 +169,7 @@ export function useTaskCreation({
   channelName,
   channelId,
   allowNoRepo,
+  importedMcpServers,
   onTaskCreated,
   onTaskCreatedEffect,
 }: UseTaskCreationOptions): UseTaskCreationReturn {
@@ -323,6 +327,7 @@ export function useTaskCreation({
           channelId,
           customInstructions: useSettingsStore.getState().customInstructions,
           allowNoRepo,
+          importedMcpServers,
         });
 
         if (executionMode) {
@@ -482,6 +487,7 @@ export function useTaskCreation({
       channelName,
       channelId,
       allowNoRepo,
+      importedMcpServers,
       clearTaskInputReportAssociation,
       invalidateTasks,
       onTaskCreated,


### PR DESCRIPTION
Part 1b of bringing local MCP servers to cloud task runs. **Stacked on #3231** (config reading + classification) — review that first; this PR's own diff is the creation-payload wiring, composer UX, and the Django-side spec. Behind the `posthog-code-local-mcp-import` feature flag.

## What

- **Creation payload**: cloud run creation (`buildCloudRunRequestBody`) gains an optional `imported_mcp_servers` field carrying the user's importable local servers in exactly the shape the sandbox agent server's `remoteMcpServerSchema` accepts, so the backend can merge them into `--mcpServers` without transformation. Threaded `TaskInput` → `useTaskCreation` → `prepareTaskInput` → `TaskCreationSaga` → `createTaskRun`, cloud-only. Until the Django half lands the backend ignores the field, so this degrades gracefully (and the flag defaults off anyway).
- **UX**: when the composer is in cloud mode, a `LocalMcpServersButton` lists the user's local MCP servers annotated "Available in cloud" / "Requires your machine" / "Not available in cloud".
- **`docs/cloud-mcp-import.md`**: the design doc, including the precise Django-side spec (validation incl. server-side SSRF re-checks, encrypted write-only header storage, `--mcpServers` merge rules, codex-acp reachability caveat) and the header-rotation design built on the existing `refresh_session` command.

## Why rotation ships as a design, not code

`~/.claude.json` static headers carry no expiry metadata to watch, and OAuth-backed servers managed by Claude Code keep tokens in Claude's credential store, not in `mcpServers.headers` — so those aren't importable this way at all (the relay design covers them). Static headers ship first; the doc specifies the `refresh_session` client path (today the desktop never sends that command for cloud runs — `sendCommandInput` in `packages/core/src/cloud-task/schemas.ts` stops at `set_config_option`, a small discrepancy from the task brief) plus the Django allowlist change.

## Notes for reviewers

- Cloud runs currently import **user-scoped** servers only: cloud task creation picks a GitHub repository, not a local checkout, so there's no `cwd` to key `projects[cwd].mcpServers` off. Documented follow-up.
- Codex config (`~/.codex/config.toml`) import and `${VAR}` header expansion are documented follow-ups.

## Validation

`pnpm typecheck` / `pnpm lint` green; all suites touched by this PR pass (remaining full-suite failures are pre-existing sandbox-environment failures, identical on a clean checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)