### PR TITLE
fix(settings): use replace navigation to skip settings route when viewing usage

### DIFF
--- a/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -13,7 +13,7 @@ import { useSeatStore } from "@posthog/ui/features/billing/seatStore";
 import { UsageMeter } from "@posthog/ui/features/billing/UsageMeter";
 import { useSeat } from "@posthog/ui/features/billing/useSeat";
 import { useUsage } from "@posthog/ui/features/billing/useUsage";
-import { closeSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
+import { useSettingsPageStore } from "@posthog/ui/features/settings/stores/settingsPageStore";
 import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnalysisEnabled";
 import { navigateToUsage } from "@posthog/ui/router/navigationBridge";
 import { track } from "@posthog/ui/shell/analytics";
@@ -329,9 +329,9 @@ export function PlanUsageSettings() {
               size="1"
               variant="ghost"
               onClick={() => {
-                // Leave settings first so back from /usage skips the settings route.
-                closeSettings();
-                navigateToUsage();
+                // Replace the settings route so back from /usage skips it.
+                useSettingsPageStore.getState().reset();
+                navigateToUsage({ replace: true });
               }}
             >
               View usage & spend analysis

--- a/packages/ui/src/router/navigationBridge.ts
+++ b/packages/ui/src/router/navigationBridge.ts
@@ -185,8 +185,8 @@ export function navigateToMcpServers(): void {
   void getRouterOrNull()?.navigate({ to: "/mcp-servers" });
 }
 
-export function navigateToUsage(): void {
-  void getRouterOrNull()?.navigate({ to: "/usage" });
+export function navigateToUsage(options?: { replace?: boolean }): void {
+  void getRouterOrNull()?.navigate({ to: "/usage", replace: options?.replace });
 }
 
 // Channels-space mirrors. These render the same shared views as their /code (or


### PR DESCRIPTION
## Problem

Clicking "View usage & spend analysis" in settings dumped you on the new-task chat input instead of the usage page.

The button called `closeSettings()` (async `history.back()`) then `navigateToUsage()`. The back-navigation won the race and landed on the previous route.

## Changes

- `navigateToUsage()` takes an optional `replace` flag.
- Button now resets the settings store and navigates to `/usage` with `replace: true`, so back from `/usage` still skips settings, with no racing `history.back()`.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` + biome lint pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*