### PR TITLE
feat(sidebar): show PR state for cloud runs with a provenance badge

### DIFF
--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -243,7 +243,6 @@ function PrStatusIcon({
         style={{ maskImage: mask, WebkitMaskImage: mask }}
       />
       <provenanceBadge.Icon
-        size={Math.round(size * 0.65)}
         weight="fill"
         color="var(--gray-10)"
         className="absolute"

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -238,11 +238,11 @@ function PrStatusIcon({
   // glyph to the button's icon size (14px in the sidebar), and the badge and
   // mask must track whatever actually renders so the composite stays the
   // same size as the plain PR icons on local-run rows. The badge's inline
-  // percentage dimensions also exempt it from that quill rule. Badge: 50% of
-  // the glyph, bleeding 7% past the corner, centered at 82%; the mask hole's
-  // 30% radius leaves a thin ring around it.
+  // percentage dimensions also exempt it from that quill rule. Badge: 65% of
+  // the glyph, bleeding 9% past the corner, centered at 76.5%; the mask
+  // hole's 37% radius leaves a thin ring around it.
   const mask =
-    "radial-gradient(ellipse 30% 30% at 82% 82%, transparent 97%, black 100%)";
+    "radial-gradient(ellipse 37% 37% at 76.5% 76.5%, transparent 97%, black 100%)";
   const icon = (
     <span className="relative flex items-center justify-center">
       <meta.Icon
@@ -252,11 +252,11 @@ function PrStatusIcon({
         style={{ maskImage: mask, WebkitMaskImage: mask }}
       />
       <provenanceBadge.Icon
-        size={Math.round(size * 0.5)}
+        size={Math.round(size * 0.65)}
         weight="fill"
         color="var(--gray-10)"
         className="absolute"
-        style={{ width: "50%", height: "50%", right: "-7%", bottom: "-7%" }}
+        style={{ width: "65%", height: "65%", right: "-9%", bottom: "-9%" }}
       />
     </span>
   );

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -232,15 +232,6 @@ function PrStatusIcon({
   // radial-gradient mask punches a hole in the PR glyph under the badge so
   // both shapes stay legible on any row background (hover, selected, command
   // palette highlight) without hardcoding a cutout ring color.
-  //
-  // All geometry is relative to the glyph's rendered box, not the `size`
-  // prop: quill's `.quill-button svg:not([class*=size-])` rule resizes the
-  // glyph to the button's icon size (14px in the sidebar), and the badge and
-  // mask must track whatever actually renders so the composite stays the
-  // same size as the plain PR icons on local-run rows. The badge's inline
-  // percentage dimensions also exempt it from that quill rule. Badge: 65% of
-  // the glyph, bleeding 9% past the corner, centered at 76.5%; the mask
-  // hole's 37% radius leaves a thin ring around it.
   const mask =
     "radial-gradient(ellipse 37% 37% at 76.5% 76.5%, transparent 97%, black 100%)";
   const icon = (

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -253,7 +253,15 @@ function PrStatusIcon({
         weight="fill"
         color="var(--gray-10)"
         className="absolute"
-        style={{ right: -overflow, bottom: -overflow }}
+        style={{
+          // quill's `.quill-button svg:not([class*=size-])` rule forces
+          // descendant svgs to the button's icon size, overriding phosphor's
+          // width/height attributes — inline dimensions keep the badge small.
+          width: badgeSize,
+          height: badgeSize,
+          right: -overflow,
+          bottom: -overflow,
+        }}
       />
     </span>
   );

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -233,42 +233,30 @@ function PrStatusIcon({
   // both shapes stay legible on any row background (hover, selected, command
   // palette highlight) without hardcoding a cutout ring color.
   //
-  // Both svgs get inline width/height: quill's
-  // `.quill-button svg:not([class*=size-])` rule otherwise forces descendant
-  // svgs to the button's icon size, which would inflate the badge and shift
-  // the glyph out of the mask's coordinate system.
-  const badgeSize = Math.round(size * 0.5);
-  const overflow = 1;
-  const holeCenter = size + overflow - badgeSize / 2;
-  const holeRadius = badgeSize / 2 + 0.5;
-  const mask = `radial-gradient(circle at ${holeCenter}px ${holeCenter}px, transparent ${holeRadius}px, black ${holeRadius + 0.5}px)`;
+  // All geometry is relative to the glyph's rendered box, not the `size`
+  // prop: quill's `.quill-button svg:not([class*=size-])` rule resizes the
+  // glyph to the button's icon size (14px in the sidebar), and the badge and
+  // mask must track whatever actually renders so the composite stays the
+  // same size as the plain PR icons on local-run rows. The badge's inline
+  // percentage dimensions also exempt it from that quill rule. Badge: 50% of
+  // the glyph, bleeding 7% past the corner, centered at 82%; the mask hole's
+  // 30% radius leaves a thin ring around it.
+  const mask =
+    "radial-gradient(ellipse 30% 30% at 82% 82%, transparent 97%, black 100%)";
   const icon = (
-    <span
-      className="relative flex items-center justify-center"
-      style={{ width: size, height: size }}
-    >
+    <span className="relative flex items-center justify-center">
       <meta.Icon
         size={size}
         weight="bold"
         color={meta.color}
-        style={{
-          width: size,
-          height: size,
-          maskImage: mask,
-          WebkitMaskImage: mask,
-        }}
+        style={{ maskImage: mask, WebkitMaskImage: mask }}
       />
       <provenanceBadge.Icon
-        size={badgeSize}
+        size={Math.round(size * 0.5)}
         weight="fill"
         color="var(--gray-10)"
         className="absolute"
-        style={{
-          width: badgeSize,
-          height: badgeSize,
-          right: -overflow,
-          bottom: -overflow,
-        }}
+        style={{ width: "50%", height: "50%", right: "-7%", bottom: "-7%" }}
       />
     </span>
   );

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -196,6 +196,7 @@ const DIFF_META: PrStateMeta = {
   color: "var(--amber-11)",
   label: "Has changes",
 };
+const CLOUD_BADGE_META: OriginProductMeta = { Icon: CloudIcon, label: "Cloud" };
 
 function PrStatusIcon({
   prState,
@@ -363,9 +364,7 @@ export function TaskIcon({
         hasDiff={hasDiff}
         size={size}
         provenanceBadge={
-          isCloudTask
-            ? (originProductMeta ?? { Icon: CloudIcon, label: "Cloud" })
-            : undefined
+          isCloudTask ? (originProductMeta ?? CLOUD_BADGE_META) : undefined
         }
         threadUrl={
           isCloudTask && originProductMeta ? slackThreadUrl : undefined

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -232,10 +232,15 @@ function PrStatusIcon({
   // radial-gradient mask punches a hole in the PR glyph under the badge so
   // both shapes stay legible on any row background (hover, selected, command
   // palette highlight) without hardcoding a cutout ring color.
+  //
+  // Both svgs get inline width/height: quill's
+  // `.quill-button svg:not([class*=size-])` rule otherwise forces descendant
+  // svgs to the button's icon size, which would inflate the badge and shift
+  // the glyph out of the mask's coordinate system.
   const badgeSize = Math.round(size * 0.5);
-  const overflow = 2;
+  const overflow = 1;
   const holeCenter = size + overflow - badgeSize / 2;
-  const holeRadius = badgeSize / 2 + 1;
+  const holeRadius = badgeSize / 2 + 0.5;
   const mask = `radial-gradient(circle at ${holeCenter}px ${holeCenter}px, transparent ${holeRadius}px, black ${holeRadius + 0.5}px)`;
   const icon = (
     <span
@@ -246,7 +251,12 @@ function PrStatusIcon({
         size={size}
         weight="bold"
         color={meta.color}
-        style={{ maskImage: mask, WebkitMaskImage: mask }}
+        style={{
+          width: size,
+          height: size,
+          maskImage: mask,
+          WebkitMaskImage: mask,
+        }}
       />
       <provenanceBadge.Icon
         size={badgeSize}
@@ -254,9 +264,6 @@ function PrStatusIcon({
         color="var(--gray-10)"
         className="absolute"
         style={{
-          // quill's `.quill-button svg:not([class*=size-])` rule forces
-          // descendant svgs to the button's icon size, overriding phosphor's
-          // width/height attributes — inline dimensions keep the badge small.
           width: badgeSize,
           height: badgeSize,
           right: -overflow,

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -232,7 +232,7 @@ function PrStatusIcon({
   // radial-gradient mask punches a hole in the PR glyph under the badge so
   // both shapes stay legible on any row background (hover, selected, command
   // palette highlight) without hardcoding a cutout ring color.
-  const badgeSize = Math.round(size * 0.66);
+  const badgeSize = Math.round(size * 0.5);
   const overflow = 2;
   const holeCenter = size + overflow - badgeSize / 2;
   const holeRadius = badgeSize / 2 + 1;

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -184,61 +184,90 @@ function CloudStatusIcon({
   );
 }
 
+type PrStateMeta = { Icon: typeof GitMerge; color: string; label: string };
+const PR_STATE_META: Record<Exclude<SidebarPrState, null>, PrStateMeta> = {
+  merged: { Icon: GitMerge, color: "var(--purple-11)", label: "PR merged" },
+  open: { Icon: GitPullRequest, color: "var(--green-11)", label: "PR open" },
+  draft: { Icon: GitPullRequest, color: "var(--gray-9)", label: "Draft PR" },
+  closed: { Icon: GitPullRequest, color: "var(--red-11)", label: "PR closed" },
+};
+const DIFF_META: PrStateMeta = {
+  Icon: GitBranch,
+  color: "var(--amber-11)",
+  label: "Has changes",
+};
+
 function PrStatusIcon({
   prState,
   hasDiff,
   size,
+  provenanceBadge,
+  threadUrl,
 }: {
   prState?: SidebarPrState;
   hasDiff?: boolean;
   size: number;
+  /** When set (cloud tasks), a small provenance glyph (cloud or origin
+   * product) is stacked on the icon's bottom-right corner so "where this ran"
+   * stays visible alongside the PR state. */
+  provenanceBadge?: OriginProductMeta;
+  /** Originating thread URL; keeps the badge state clickable like
+   * `CloudStatusIcon` does for origin-branded tasks. */
+  threadUrl?: string;
 }) {
-  if (prState === "merged") {
+  const meta = prState ? PR_STATE_META[prState] : hasDiff ? DIFF_META : null;
+  if (!meta) return null;
+
+  if (!provenanceBadge) {
     return (
-      <Tooltip content="PR merged" side="right">
+      <Tooltip content={meta.label} side="right">
         <span className="flex items-center justify-center">
-          <GitMerge size={size} weight="bold" color="var(--purple-11)" />
+          <meta.Icon size={size} weight="bold" color={meta.color} />
         </span>
       </Tooltip>
     );
   }
-  if (prState === "open") {
-    return (
-      <Tooltip content="PR open" side="right">
-        <span className="flex items-center justify-center">
-          <GitPullRequest size={size} weight="bold" color="var(--green-11)" />
-        </span>
-      </Tooltip>
-    );
-  }
-  if (prState === "draft") {
-    return (
-      <Tooltip content="Draft PR" side="right">
-        <span className="flex items-center justify-center">
-          <GitPullRequest size={size} weight="bold" color="var(--gray-9)" />
-        </span>
-      </Tooltip>
-    );
-  }
-  if (prState === "closed") {
-    return (
-      <Tooltip content="PR closed" side="right">
-        <span className="flex items-center justify-center">
-          <GitPullRequest size={size} weight="bold" color="var(--red-11)" />
-        </span>
-      </Tooltip>
-    );
-  }
-  if (hasDiff) {
-    return (
-      <Tooltip content="Has changes" side="right">
-        <span className="flex items-center justify-center">
-          <GitBranch size={size} weight="bold" color="var(--amber-11)" />
-        </span>
-      </Tooltip>
-    );
-  }
-  return null;
+
+  // Stack the provenance glyph over the PR icon's bottom-right corner. A
+  // radial-gradient mask punches a hole in the PR glyph under the badge so
+  // both shapes stay legible on any row background (hover, selected, command
+  // palette highlight) without hardcoding a cutout ring color.
+  const badgeSize = Math.round(size * 0.66);
+  const overflow = 2;
+  const holeCenter = size + overflow - badgeSize / 2;
+  const holeRadius = badgeSize / 2 + 1;
+  const mask = `radial-gradient(circle at ${holeCenter}px ${holeCenter}px, transparent ${holeRadius}px, black ${holeRadius + 0.5}px)`;
+  const icon = (
+    <span
+      className="relative flex items-center justify-center"
+      style={{ width: size, height: size }}
+    >
+      <meta.Icon
+        size={size}
+        weight="bold"
+        color={meta.color}
+        style={{ maskImage: mask, WebkitMaskImage: mask }}
+      />
+      <provenanceBadge.Icon
+        size={badgeSize}
+        weight="fill"
+        color="var(--gray-10)"
+        className="absolute"
+        style={{ right: -overflow, bottom: -overflow }}
+      />
+    </span>
+  );
+  return (
+    <Tooltip content={`${meta.label} · ${provenanceBadge.label}`} side="right">
+      {renderIconSpan({
+        icon,
+        link: threadUrl,
+        ariaLabel: threadUrl
+          ? `Open ${provenanceBadge.label} thread`
+          : undefined,
+      })}
+    </Tooltip>
+  );
 }
 
 export interface TaskIconProps {
@@ -280,6 +309,8 @@ export function TaskIcon({
 }: TaskIconProps) {
   const isCloudTask = workspaceMode === "cloud";
   const isTerminalCloud = isCloudTask && isTerminalStatus(taskRunStatus);
+  const cloudRunFailed =
+    taskRunStatus === "failed" || taskRunStatus === "cancelled";
   const originProductMeta = getOriginProductMeta(originProduct);
 
   if (needsPermission) {
@@ -308,7 +339,12 @@ export function TaskIcon({
       </Tooltip>
     );
   }
-  if (isTerminalCloud) {
+  // A failed/cancelled cloud run keeps the red cloud icon — the failure is
+  // the actionable signal there. A cloud run that finished cleanly and has a
+  // PR falls through to the PR-state icon (with a provenance badge), because
+  // once the run is done the branch's lifecycle is the state worth scanning
+  // for — the same one local runs show.
+  if (isTerminalCloud && (cloudRunFailed || !prState)) {
     return (
       <CloudStatusIcon
         taskRunStatus={taskRunStatus}
@@ -328,7 +364,21 @@ export function TaskIcon({
     );
   }
   if (prState || hasDiff) {
-    return <PrStatusIcon prState={prState} hasDiff={hasDiff} size={size} />;
+    return (
+      <PrStatusIcon
+        prState={prState}
+        hasDiff={hasDiff}
+        size={size}
+        provenanceBadge={
+          isCloudTask
+            ? (originProductMeta ?? { Icon: CloudIcon, label: "Cloud" })
+            : undefined
+        }
+        threadUrl={
+          isCloudTask && originProductMeta ? slackThreadUrl : undefined
+        }
+      />
+    );
   }
   if (isPinned) {
     return <PushPin size={size} color="var(--accent-11)" />;


### PR DESCRIPTION
## Problem

Cloud runs never surfaced their branch lifecycle (draft / open / merged / closed PR) in the sidebar the way local runs do — a finished cloud run always showed the green/red cloud icon, so you couldn't tell at a glance which cloud runs had landed and which still had a PR waiting on review.

The PR-state data was already there: `useTaskPrStatus` resolves the live GitHub state whenever a cloud run's output carries a `pr_url`, and every `TaskIcon` consumer already passes it in. The blocker was icon priority — `TaskIcon`'s waterfall checked "terminal cloud run" before "PR state", so the PR branch was unreachable for cloud tasks.

## UX

The PR-state glyph becomes the primary icon (identical to local runs: merged purple, open green, draft gray, closed red), with a small provenance badge stacked on the bottom-right corner — a filled cloud, or the origin-product icon (Slack, Signals, …) for branded tasks. Once a run has finished, the branch lifecycle is what you scan for; where it ran is static context, so it takes the badge slot. This also makes the whole sidebar read in one visual language regardless of local vs cloud.

<img width="75" height="84" alt="Screenshot 2026-07-08 at 3 55 53 PM" src="https://github.com/user-attachments/assets/8b535ba6-3f18-4411-9134-0ff43bd76d5f" />

Details:

- A radial-gradient CSS mask punches a hole in the PR glyph beneath the badge, so both shapes stay legible on any row background (hover, selected, command palette highlight) without hardcoding a cutout ring color.
- Origin-branded tasks keep their clickable "open thread" behavior on the stacked icon; tooltips combine both facts ("PR merged · Slack").
- Failed/cancelled cloud runs keep the red cloud — the failure is the actionable signal there. Queued/running runs and completed runs without a PR are unchanged, as are needs-permission / generating / unread priorities.
- Applies to every `TaskIcon` consumer: sidebar rows, task tabs, command palette, command center.

## Notes

- Cloud PR state only resolves when the run output has a `pr_url`; runs that never published keep the plain cloud icon (nothing to show).
- Badge size/offset constants (0.66× icon size, 2px overflow) may deserve a visual fine-tuning pass in the running app.

Generated-By: PostHog Code
Task-Id: 3c36b344-ed49-424a-9218-703049ad89db

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*