### PR TITLE
chore(stamphog): Raise auto-review line ceiling to 1000

### DIFF
--- a/tools/pr-approval-agent/README.md
+++ b/tools/pr-approval-agent/README.md
@@ -58,7 +58,7 @@ Deny-list (hard gate)
   │
   ▼
 Size ceiling (hard gate)
-  - >500 lines or >20 files → too large for auto-review
+  - >1000 lines or >20 files → too large for auto-review
   │
   ▼
 Tier classification

--- a/tools/pr-approval-agent/gates.py
+++ b/tools/pr-approval-agent/gates.py
@@ -525,7 +525,7 @@ def detect_ownership(files: list[str], rules: list[CodeownersRule]) -> dict:
 # ── Tier assignment ──────────────────────────────────────────────
 
 
-MAX_LINES = 500
+MAX_LINES = 1000
 MAX_FILES = 20
 
 


### PR DESCRIPTION
## Problem

Stamphog hard-refuses any PR over 500 changed lines, and team-code PRs keep landing just over that. Per Julian, this repo owns its copy of the agent so the limit is ours to tune. Upstream's `.stamphog/policy.yml` config doesn't apply here yet: our copy predates it and hardcodes the gate.

## Changes

Raise `MAX_LINES` from 500 to 1000 in `tools/pr-approval-agent/gates.py` and update the README. `MAX_FILES` stays at 20. The refusal message in `review_pr.py` interpolates the constant, so no other references exist.

## How did you test this?

No tests run. Grepped the tool and workflow for every reference to the ceiling; the constant and one README line are the only two.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?