### PR TITLE
fix: show full command in tooltip on truncated tool rows

### DIFF
--- a/packages/ui/src/features/sessions/components/session-update/ExecuteToolView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/ExecuteToolView.tsx
@@ -1,5 +1,6 @@
 import { Terminal } from "@phosphor-icons/react";
 import { compactHomePath } from "@posthog/shared";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { useChatThreadChrome } from "../chat-thread/chatThreadChrome";
 import { ToolRow } from "./ToolRow";
 import {
@@ -51,6 +52,14 @@ export function ExecuteToolView({
   );
   const hasOutput = output.trim().length > 0;
 
+  // Full command in a wrapping mono block so a truncated row still surfaces
+  // exactly what ran on hover, however long it is.
+  const commandTooltip = (
+    <span className="block max-w-md whitespace-pre-wrap break-all font-mono text-xs">
+      {command}
+    </span>
+  );
+
   return (
     <ToolRow
       icon={Terminal}
@@ -64,18 +73,19 @@ export function ExecuteToolView({
       {command &&
         (chatChrome ? (
           <ToolTitle className="min-w-0 shrink truncate font-mono">
-            <span className="block truncate" title={command}>
-              {truncateText(compactHomePath(command), MAX_COMMAND_LENGTH)}
-            </span>
+            <Tooltip content={commandTooltip}>
+              <span className="block truncate">
+                {truncateText(compactHomePath(command), MAX_COMMAND_LENGTH)}
+              </span>
+            </Tooltip>
           </ToolTitle>
         ) : (
           <ToolTitle className="min-w-0 shrink truncate">
-            <span
-              className="block truncate border border-border bg-gray-5 font-mono"
-              title={command}
-            >
-              {truncateText(compactHomePath(command), MAX_COMMAND_LENGTH)}
-            </span>
+            <Tooltip content={commandTooltip}>
+              <span className="block truncate border border-border bg-gray-5 font-mono">
+                {truncateText(compactHomePath(command), MAX_COMMAND_LENGTH)}
+              </span>
+            </Tooltip>
           </ToolTitle>
         ))}
     </ToolRow>

--- a/packages/ui/src/features/sessions/components/session-update/ExecuteToolView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/ExecuteToolView.tsx
@@ -52,8 +52,6 @@ export function ExecuteToolView({
   );
   const hasOutput = output.trim().length > 0;
 
-  // Full command in a wrapping mono block so a truncated row still surfaces
-  // exactly what ran on hover, however long it is.
   const commandTooltip = (
     <span className="block max-w-md whitespace-pre-wrap break-all font-mono text-xs">
       {command}


### PR DESCRIPTION
## Problem

When a tool's terminal command is longer than the row width it gets truncated with an ellipsis, and there was no tooltip to reveal what actually ran. It relied on the native `title` attribute, which is unreliable/absent in-app.

## Changes

- Replaced native `title={command}` on the truncated command row with the `Tooltip` primitive
- Tooltip renders the full command in a wrapping mono block on hover, so a truncated row always surfaces exactly what ran
- Applied to both chrome paths (new chat thread + legacy thread)

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` passes on the changed file
- `biome check` passes on the changed file

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*