### PR TITLE
fix(tasks): File to… adds the task to the channel feed as a thread item

### DIFF
--- a/packages/ui/src/features/canvas/hooks/useFileTaskToChannelFeed.test.ts
+++ b/packages/ui/src/features/canvas/hooks/useFileTaskToChannelFeed.test.ts
@@ -1,0 +1,76 @@
+import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
+import type { TaskChannel } from "@posthog/shared/domain-types";
+import { describe, expect, it, vi } from "vitest";
+import { resolveBackendChannelId } from "./useFileTaskToChannelFeed";
+
+function channel(overrides: Partial<TaskChannel>): TaskChannel {
+  return {
+    id: "c-1",
+    name: "eng",
+    channel_type: "public",
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("resolveBackendChannelId", () => {
+  it("resolves a public channel by its normalized name", async () => {
+    const resolveTaskChannel = vi
+      .fn()
+      .mockResolvedValue(channel({ id: "backend-42", name: "growth-team" }));
+    const client = {
+      getTaskChannels: vi.fn(),
+      resolveTaskChannel,
+    } as unknown as Pick<
+      PostHogAPIClient,
+      "getTaskChannels" | "resolveTaskChannel"
+    >;
+
+    const id = await resolveBackendChannelId(client, "Growth Team");
+
+    expect(id).toBe("backend-42");
+    // Name is normalized to the backend's directory-safe form before resolving.
+    expect(resolveTaskChannel).toHaveBeenCalledWith("growth-team");
+  });
+
+  it("maps the 'me' folder onto the personal channel instead of creating a public one", async () => {
+    const getTaskChannels = vi
+      .fn()
+      .mockResolvedValue([
+        channel({ id: "pub", channel_type: "public", name: "eng" }),
+        channel({ id: "personal-7", channel_type: "personal", name: "me" }),
+      ]);
+    const resolveTaskChannel = vi.fn();
+    const client = {
+      getTaskChannels,
+      resolveTaskChannel,
+    } as unknown as Pick<
+      PostHogAPIClient,
+      "getTaskChannels" | "resolveTaskChannel"
+    >;
+
+    const id = await resolveBackendChannelId(client, "me");
+
+    expect(id).toBe("personal-7");
+    expect(resolveTaskChannel).not.toHaveBeenCalled();
+  });
+
+  it("falls back to resolve-or-create when no personal channel is present", async () => {
+    const getTaskChannels = vi.fn().mockResolvedValue([]);
+    const resolveTaskChannel = vi
+      .fn()
+      .mockResolvedValue(channel({ id: "created", name: "me" }));
+    const client = {
+      getTaskChannels,
+      resolveTaskChannel,
+    } as unknown as Pick<
+      PostHogAPIClient,
+      "getTaskChannels" | "resolveTaskChannel"
+    >;
+
+    const id = await resolveBackendChannelId(client, "me");
+
+    expect(id).toBe("created");
+    expect(resolveTaskChannel).toHaveBeenCalledWith("me");
+  });
+});

--- a/packages/ui/src/features/canvas/hooks/useFileTaskToChannelFeed.ts
+++ b/packages/ui/src/features/canvas/hooks/useFileTaskToChannelFeed.ts
@@ -1,0 +1,73 @@
+import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
+import type { Task } from "@posthog/shared/domain-types";
+import { channelFeedQueryKey } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
+import {
+  normalizeChannelName,
+  PERSONAL_CHANNEL_NAME,
+} from "@posthog/ui/features/canvas/hooks/useTaskChannels";
+import { useAuthenticatedMutation } from "@posthog/ui/hooks/useAuthenticatedMutation";
+import { useQueryClient } from "@tanstack/react-query";
+
+/**
+ * Resolve the backend task channel that a folder channel (by display name)
+ * maps onto, creating the public channel if it doesn't exist yet. Mirrors the
+ * resolution in `useBackendChannel`, but runs imperatively for a channel
+ * chosen at click time (e.g. the "File to…" menu).
+ */
+export async function resolveBackendChannelId(
+  client: Pick<PostHogAPIClient, "getTaskChannels" | "resolveTaskChannel">,
+  channelName: string,
+): Promise<string> {
+  const normalized = normalizeChannelName(channelName);
+  if (normalized === PERSONAL_CHANNEL_NAME) {
+    // Listing lazily provisions the requester's #me channel server-side.
+    const channels = await client.getTaskChannels();
+    const personal = channels.find((c) => c.channel_type === "personal");
+    if (personal) return personal.id;
+  }
+  const channel = await client.resolveTaskChannel(normalized);
+  return channel.id;
+}
+
+/**
+ * Associate an existing task with a channel's backend feed so it shows up as a
+ * thread item in the channel — the feed side `useChannelFeed` reads via
+ * `getTasks({ channel })`. Filing to the desktop file system (see
+ * `useChannelTaskMutations().fileTask`) only powers the Artifacts / Recents
+ * tabs, so both are needed for a task to fully belong to a channel.
+ */
+export function useFileTaskToChannelFeed(): {
+  fileTaskToChannelFeed: (
+    channelName: string,
+    taskId: string,
+  ) => Promise<string>;
+} {
+  const queryClient = useQueryClient();
+  const mutation = useAuthenticatedMutation(
+    async (
+      client,
+      { channelName, taskId }: { channelName: string; taskId: string },
+    ) => {
+      const backendChannelId = await resolveBackendChannelId(
+        client,
+        channelName,
+      );
+      await client.updateTask(taskId, {
+        channel: backendChannelId,
+      } as Partial<Task> as Parameters<typeof client.updateTask>[1]);
+      return backendChannelId;
+    },
+    {
+      onSuccess: (backendChannelId) => {
+        void queryClient.invalidateQueries({
+          queryKey: channelFeedQueryKey(backendChannelId),
+        });
+      },
+    },
+  );
+
+  return {
+    fileTaskToChannelFeed: (channelName: string, taskId: string) =>
+      mutation.mutateAsync({ channelName, taskId }),
+  };
+}

--- a/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -8,6 +8,7 @@ import type { Task } from "@posthog/shared/domain-types";
 import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
+import { useFileTaskToChannelFeed } from "@posthog/ui/features/canvas/hooks/useFileTaskToChannelFeed";
 import { useExternalAppAction } from "@posthog/ui/features/external-apps/useExternalAppAction";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useRestoreTask } from "@posthog/ui/features/suspension/useRestoreTask";
@@ -35,6 +36,7 @@ export function useTaskContextMenu() {
   );
   const { channels } = useChannels({ enabled: bluebirdEnabled });
   const { fileTask } = useChannelTaskMutations();
+  const { fileTaskToChannelFeed } = useFileTaskToChannelFeed();
 
   const showContextMenu = useCallback(
     async (
@@ -120,9 +122,19 @@ export function useTaskContextMenu() {
           case "add-to-command-center":
             onAddToCommandCenter?.();
             break;
-          case "file-to-channel":
+          case "file-to-channel": {
+            // Two sides make a task "belong" to a channel: the desktop
+            // file-system row (Artifacts / Recents tabs) and the backend
+            // channel feed (the Slack-style thread items). File to both so the
+            // task actually appears in the channel, not just its file browser.
+            const channelName = channels.find(
+              (c) => c.id === intent.channelId,
+            )?.name;
             try {
               await fileTask(intent.channelId, task.id, task.title);
+              if (channelName) {
+                await fileTaskToChannelFeed(channelName, task.id);
+              }
             } catch (error) {
               toast.error("Couldn't file task to channel", {
                 description:
@@ -130,6 +142,7 @@ export function useTaskContextMenu() {
               });
             }
             break;
+          }
           case "external-app": {
             const effectivePath = resolveExternalAppPath(
               worktreePath,
@@ -155,6 +168,7 @@ export function useTaskContextMenu() {
       channels,
       deleteWithConfirm,
       fileTask,
+      fileTaskToChannelFeed,
       restoreTask,
       suspendTask,
       hostClient,


### PR DESCRIPTION
## Problem

In the task list, the **File to…** menu option on a task didn't add the task to the channel as a thread item.

**Why:** A channel has two sides. The desktop file-system rows back the channel's *Artifacts / Recents* tabs, while the Slack-style feed (the thread items) is read from `getTasks({ channel })`. "File to…" only wrote the file-system row, so the task never showed up in the channel feed — only in its file browser.

## Changes

- Added `useFileTaskToChannelFeed`, which resolves the folder channel's backend channel by name (resolve-or-create for public channels, mapping the `me` folder onto the personal channel) and sets the task's `channel`, then invalidates the feed query.
- The `file-to-channel` handler in `useTaskContextMenu` now files to **both** sides: the existing folder filing plus the new feed association, so a filed task appears as a thread item in the channel.

## How did you test this?

- Added `useFileTaskToChannelFeed.test.ts` covering public-name resolution, the `me` → personal-channel mapping, and the resolve-or-create fallback — all passing.
- `pnpm --filter @posthog/ui typecheck` and Biome check pass on the changed files; the full `@posthog/ui` unit suite passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*