### PR TITLE
docs(agents): persist durable state to cloud, not localStorage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,19 @@ For each new file or meaningful change:
    - Domain fact read by business logic: core store.
    - Pure view state: UI store.
 
+## Persisting State
+
+PostHog Code has no local database. Durable, account-scoped state (settings, custom instructions, saved preferences) persists to PostHog cloud through `@posthog/api-client`, called from a `core` service. It is not `localStorage` and not host-local files. Cloud persistence is what makes state survive a reinstall and sync to the user's other machines.
+
+`localStorage` and host-local files are for device-local, ephemeral view state only. If a user would be surprised to lose it after switching machines or reinstalling, it is account state and belongs in the cloud.
+
+| State | Home |
+| --- | --- |
+| Account/durable (settings, custom instructions, preferences that should sync) | PostHog cloud via `@posthog/api-client`, from a `core` service |
+| Device-local ephemeral view state (panel sizes, last-open tab, dismissed hints) | UI store or host-local storage |
+
+Do not default to `localStorage` because the repo has no database of its own. The database is PostHog cloud, reached through `api-client`.
+
 ## Forbidden Patterns
 
 - Business logic in store actions.
@@ -113,6 +126,7 @@ For each new file or meaningful change:
 - Bespoke clients that wrap `trpcClient.x` one-to-one.
 - `*Port`, `*_PORT`, or `ports.ts` naming.
 - Business logic in `apps/<host>`.
+- Persisting account-scoped or durable state to `localStorage` or host-local files instead of PostHog cloud via `@posthog/api-client`.
 
 ## Host Boundary
 


### PR DESCRIPTION
## Problem

PostHog Code has no local database of its own, so agents building persistence default to `localStorage` or host-local files. That's the wrong home for anything account-scoped: it doesn't survive a reinstall and doesn't follow the user to another machine. This is the same root cause behind the custom-instructions-clearing complaint raised in a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783459196822899?thread_ts=1783459196.822899&cid=C09G8Q32R6F). The database exists, it's just remote (PostHog cloud, reached through `@posthog/api-client`), and agents don't reach for it by default.

## Changes

Adds a **Persisting State** section and a **Forbidden Patterns** entry to `AGENTS.md` (`CLAUDE.md` symlinks to it). It's a decision rule, not a blanket ban: `localStorage` and host-local files stay correct for device-local ephemeral view state (panel sizes, last-open tab, dismissed hints). Anything account-scoped or durable (settings, custom instructions, preferences that should sync) persists to PostHog cloud via `@posthog/api-client` from a `core` service.

Refs PostHog/posthog#76201.

## How did you test this?

Docs-only change. Nothing to run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?