### PR TITLE
chore(agent): pin rtk signing-flow invariants with tests

### DIFF
--- a/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/packages/agent/src/adapters/claude/session/options.test.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { HookInput, Options } from "@anthropic-ai/claude-agent-sdk";
@@ -139,6 +140,88 @@ describe("buildSessionOptions", () => {
     );
 
     expect(healSpy).not.toHaveBeenCalled();
+  });
+
+  describe("rtk and signed-commit guard ordering", () => {
+    const originalRtk = process.env.POSTHOG_RTK;
+    let dir: string;
+    let binary: string;
+
+    beforeEach(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), "rtk-order-"));
+      binary = path.join(dir, "rtk");
+      fs.writeFileSync(binary, "#!/bin/sh\n");
+      process.env.POSTHOG_RTK = binary;
+    });
+
+    afterEach(() => {
+      if (originalRtk === undefined) {
+        delete process.env.POSTHOG_RTK;
+      } else {
+        process.env.POSTHOG_RTK = originalRtk;
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    const bashInput = (command: string): HookInput =>
+      ({
+        ...(GIT_COMMIT_HOOK_INPUT as object),
+        tool_input: { command },
+      }) as HookInput;
+
+    type PreToolUseOutput = {
+      hookSpecificOutput?: {
+        permissionDecision?: string;
+        updatedInput?: { command?: string };
+      };
+    };
+
+    it("registers the signed-commit guard before the rtk rewrite so the guard evaluates raw commands (cloud)", async () => {
+      const options = buildSessionOptions({
+        ...makeParams(),
+        cloudMode: true,
+      });
+      const hooks = (options.hooks?.PreToolUse ?? []).flatMap(
+        (entry) => entry.hooks ?? [],
+      );
+      const opts = { signal: new AbortController().signal };
+
+      // Identify each hook behaviorally: the guard denies `git commit`, the
+      // rtk hook rewrites `git status`. Their registration order is the
+      // defense-in-depth guarantee that the guard always sees the raw command.
+      let guardIndex = -1;
+      let rtkIndex = -1;
+      for (const [index, hook] of hooks.entries()) {
+        const denyResult = (await hook(
+          bashInput("git commit -m x"),
+          undefined,
+          opts,
+        )) as PreToolUseOutput;
+        if (
+          guardIndex === -1 &&
+          denyResult.hookSpecificOutput?.permissionDecision === "deny"
+        ) {
+          guardIndex = index;
+        }
+
+        const rewriteResult = (await hook(
+          bashInput("git status"),
+          undefined,
+          opts,
+        )) as PreToolUseOutput;
+        if (
+          rtkIndex === -1 &&
+          rewriteResult.hookSpecificOutput?.updatedInput?.command ===
+            `${binary} git status`
+        ) {
+          rtkIndex = index;
+        }
+      }
+
+      expect(guardIndex).toBeGreaterThanOrEqual(0);
+      expect(rtkIndex).toBeGreaterThanOrEqual(0);
+      expect(guardIndex).toBeLessThan(rtkIndex);
+    });
   });
 
   describe("CLAUDE_CODE_EXECUTABLE", () => {

--- a/packages/agent/src/adapters/claude/session/rtk.test.ts
+++ b/packages/agent/src/adapters/claude/session/rtk.test.ts
@@ -31,6 +31,17 @@ describe("rewriteBashForRtk", () => {
     ["git commit -m wip"],
     ["git push origin main"],
     ["git checkout -b feature"],
+    // The cloud signed-commit flow instructs the model to run these raw:
+    // staging before git_signed_commit, and the stale-checkout / rebase
+    // recovery sequence. They must never enter the compressible allowlist.
+    ["git add -A"],
+    ["git stash --include-untracked"],
+    ["git stash pop"],
+    ["git fetch origin main"],
+    ["git reset --hard origin/main"],
+    ["git rebase --continue"],
+    ["git merge origin/master"],
+    ["git cherry-pick abc123"],
     // Commands RTK isn't wrapping in this cut.
     ["npm test"],
     ["cat file.ts"],


### PR DESCRIPTION
## Problem

Cloud runs depend existentially on the signed-git MCP tools: raw `git commit`/`git push` are blocked, and the signed-commit guard plus the rtk rewrite hook (#3096) both act on Bash commands. Their safe interaction is currently an emergent property: the allowlist happens not to include the signing-flow subcommands, and the rtk hook happens to be registered after the guard. Nothing fails if either regresses.

As rtk reach expands (the cloud sandbox image now ships the binary, so every cloud run exercises this path), these invariants should be pinned by tests, not by luck.

## Changes

Tests only, no production code.

- **`rtk.test.ts`**: new rows in the existing exclusion `test.each` covering the exact commands the cloud signing flow instructs the model to run raw - staging (`git add`) and the stale-checkout/rebase recovery sequence (`git stash`, `git stash pop`, `git fetch`, `git reset --hard`, `git rebase --continue`, `git merge`, `git cherry-pick`). Catches a future allowlist expansion silently wrapping them.
- **`options.test.ts`**: a cloud-mode ordering test that identifies the signed-commit guard and the rtk rewrite behaviorally in the registered PreToolUse hook array (the guard denies `git commit`, rtk rewrites `git status`) and asserts the guard comes first. Catches a registration reorder that would let a wrapped command reach the guard, removing one of the two defense layers (the sandbox git shim would remain).