### PR TITLE
feat(agent): report per-run token usage to TaskRun.state

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -685,6 +685,139 @@ describe("AgentServer HTTP Mode", () => {
       expect(testServer.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
     });
 
+    function createUsageTestServer() {
+      const testServer = new AgentServer({
+        port,
+        jwtPublicKey: TEST_PUBLIC_KEY,
+        repositoryPath: repo.path,
+        apiUrl: "http://localhost:8000",
+        apiKey: "test-api-key",
+        projectId: 1,
+        mode: "interactive",
+        taskId: "test-task-id",
+        runId: "test-run-id",
+      }) as unknown as {
+        session: { payload: JwtPayload } | null;
+        posthogAPI: { updateTaskRun: ReturnType<typeof vi.fn> };
+        recordTurnUsage(usage: unknown): void;
+      };
+      testServer.posthogAPI = { updateTaskRun: vi.fn(async () => ({})) };
+      testServer.session = {
+        payload: {
+          run_id: "run-1",
+          task_id: "task-1",
+          team_id: 1,
+          user_id: 1,
+          distinct_id: "distinct-id",
+          mode: "interactive",
+        },
+      };
+      return testServer;
+    }
+
+    it("reports cumulative run token usage into TaskRun.state after each settled turn", () => {
+      const testServer = createUsageTestServer();
+      const turnUsage = {
+        inputTokens: 100,
+        outputTokens: 50,
+        cachedReadTokens: 10,
+        cachedWriteTokens: 5,
+        totalTokens: 165,
+      };
+
+      testServer.recordTurnUsage(turnUsage);
+      testServer.recordTurnUsage(turnUsage);
+
+      expect(testServer.posthogAPI.updateTaskRun).toHaveBeenCalledTimes(2);
+      expect(testServer.posthogAPI.updateTaskRun).toHaveBeenNthCalledWith(
+        1,
+        "task-1",
+        "run-1",
+        {
+          state: {
+            token_usage: {
+              input_tokens: 100,
+              output_tokens: 50,
+              cache_read_tokens: 10,
+              cache_write_tokens: 5,
+              thought_tokens: 0,
+              total_tokens: 165,
+              turns: 1,
+            },
+          },
+        },
+      );
+      // The second report carries run-cumulative totals, not per-turn figures.
+      expect(testServer.posthogAPI.updateTaskRun).toHaveBeenLastCalledWith(
+        "task-1",
+        "run-1",
+        {
+          state: {
+            token_usage: {
+              input_tokens: 200,
+              output_tokens: 100,
+              cache_read_tokens: 20,
+              cache_write_tokens: 10,
+              thought_tokens: 0,
+              total_tokens: 330,
+              turns: 2,
+            },
+          },
+        },
+      );
+    });
+
+    it("does not report anything when a turn settles without usage", () => {
+      const testServer = createUsageTestServer();
+
+      testServer.recordTurnUsage(undefined);
+
+      expect(testServer.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
+    });
+
+    it("resets run usage on session cleanup so a later run starts from zero", async () => {
+      const testServer = createUsageTestServer();
+      const turnUsage = {
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      };
+      testServer.recordTurnUsage(turnUsage);
+
+      const cleanupServer = stubSessionCleanup(testServer);
+      await cleanupServer.cleanupSession();
+
+      testServer.session = {
+        payload: {
+          run_id: "run-2",
+          task_id: "task-1",
+          team_id: 1,
+          user_id: 1,
+          distinct_id: "distinct-id",
+          mode: "interactive",
+        },
+      };
+      testServer.recordTurnUsage(turnUsage);
+
+      expect(testServer.posthogAPI.updateTaskRun).toHaveBeenLastCalledWith(
+        "task-1",
+        "run-2",
+        {
+          state: {
+            token_usage: {
+              input_tokens: 100,
+              output_tokens: 50,
+              cache_read_tokens: 0,
+              cache_write_tokens: 0,
+              thought_tokens: 0,
+              total_tokens: 150,
+              turns: 1,
+            },
+          },
+        },
+      );
+    });
+
     function createFailureTestServer() {
       const appendRawLine = vi.fn();
       const testServer = new AgentServer({

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -87,6 +87,7 @@ import {
 } from "./cloud-prompt";
 import { TaskRunEventStreamSender } from "./event-stream-sender";
 import { type JwtPayload, JwtValidationError, validateJwt } from "./jwt";
+import { RunUsageAccumulator } from "./run-usage";
 import {
   handoffLocalGitStateSchema,
   jsonRpcRequestSchema,
@@ -318,6 +319,7 @@ export class AgentServer {
   private eventStreamSender: TaskRunEventStreamSender | null = null;
   private questionRelayedToSlack = false;
   private adapterEmittedTurnComplete = false;
+  private runUsage = new RunUsageAccumulator();
   private detectedPrUrl: string | null = null;
   // Reset per session. `evaluatedPrUrls` dedupes per URL; `prAttributionChain` serializes
   // attributions so the most recently created PR in a run wins.
@@ -957,6 +959,7 @@ export class AgentServer {
           void this.syncCloudBranchMetadata(this.session.payload);
         }
 
+        this.recordTurnUsage(result.usage);
         this.broadcastTurnComplete(result.stopReason);
 
         if (result.stopReason === "end_turn") {
@@ -1670,6 +1673,7 @@ export class AgentServer {
         void this.syncCloudBranchMetadata(payload);
       }
 
+      this.recordTurnUsage(result.usage);
       this.broadcastTurnComplete(result.stopReason);
 
       if (result.stopReason === "end_turn") {
@@ -1821,6 +1825,7 @@ export class AgentServer {
         void this.syncCloudBranchMetadata(payload);
       }
 
+      this.recordTurnUsage(result.usage);
       this.broadcastTurnComplete(result.stopReason);
 
       if (result.stopReason === "end_turn") {
@@ -3619,6 +3624,9 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
 
     this.pendingEvents = [];
     this.lastReportedBranch = null;
+    // Run usage is per run: a later session on this instance (e.g. a resume
+    // with a different run_id) must not inherit the previous run's totals.
+    this.runUsage = new RunUsageAccumulator();
     this.session = null;
   }
 
@@ -3674,6 +3682,24 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
   ): HandoffLocalGitState | null {
     const result = handoffLocalGitStateSchema.safeParse(params.localGitState);
     return result.success ? result.data : null;
+  }
+
+  /**
+   * Accumulates a settled turn's token usage into the run total and reports it
+   * to the backend, merged into `TaskRun.state.token_usage`. Best-effort: a
+   * reporting failure must never affect the turn outcome.
+   */
+  private recordTurnUsage(usage: PromptResponse["usage"]): void {
+    if (!this.runUsage.add(usage)) return;
+    const payload = this.session?.payload;
+    if (!payload) return;
+    void this.posthogAPI
+      .updateTaskRun(payload.task_id, payload.run_id, {
+        state: { token_usage: this.runUsage.snapshot() },
+      })
+      .catch((error) => {
+        this.logger.warn("Failed to report run token usage", error);
+      });
   }
 
   private broadcastTurnComplete(stopReason: string): void {

--- a/packages/agent/src/server/run-usage.test.ts
+++ b/packages/agent/src/server/run-usage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { RunUsageAccumulator } from "./run-usage";
+
+describe("RunUsageAccumulator", () => {
+  test("accumulates across turns and defaults nullable ACP fields to 0", () => {
+    const acc = new RunUsageAccumulator();
+
+    // Claude-shaped turn: cache components present, no thought tokens.
+    expect(
+      acc.add({
+        inputTokens: 100,
+        outputTokens: 50,
+        cachedReadTokens: 10,
+        cachedWriteTokens: 5,
+        totalTokens: 165,
+      }),
+    ).toBe(true);
+    // Codex-shaped turn: null cache writes, reasoning as thought tokens.
+    expect(
+      acc.add({
+        inputTokens: 200,
+        outputTokens: 80,
+        cachedReadTokens: null,
+        cachedWriteTokens: null,
+        thoughtTokens: 40,
+        totalTokens: 320,
+      }),
+    ).toBe(true);
+
+    expect(acc.snapshot()).toEqual({
+      input_tokens: 300,
+      output_tokens: 130,
+      cache_read_tokens: 10,
+      cache_write_tokens: 5,
+      thought_tokens: 40,
+      total_tokens: 485,
+      turns: 2,
+    });
+  });
+
+  test.each([[null], [undefined]])(
+    "ignores a turn that settles with %s usage",
+    (usage) => {
+      const acc = new RunUsageAccumulator();
+      expect(acc.add(usage)).toBe(false);
+      expect(acc.snapshot().turns).toBe(0);
+    },
+  );
+
+  test("snapshot is a copy — later turns don't mutate earlier snapshots", () => {
+    const acc = new RunUsageAccumulator();
+    acc.add({ inputTokens: 1, outputTokens: 1, totalTokens: 2 });
+    const first = acc.snapshot();
+    acc.add({ inputTokens: 1, outputTokens: 1, totalTokens: 2 });
+    expect(first.turns).toBe(1);
+    expect(acc.snapshot().turns).toBe(2);
+  });
+});

--- a/packages/agent/src/server/run-usage.ts
+++ b/packages/agent/src/server/run-usage.ts
@@ -1,0 +1,51 @@
+import type { Usage } from "@agentclientprotocol/sdk";
+
+/**
+ * Cumulative token usage for a task run, shaped for `TaskRun.state.token_usage`
+ * (snake_case, matching the backend's state conventions). `turns` counts the
+ * settled turns that contributed usage, giving consumers a per-turn denominator.
+ */
+export type RunTokenUsage = {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  thought_tokens: number;
+  total_tokens: number;
+  turns: number;
+};
+
+/**
+ * Accumulates per-turn ACP `Usage` into run-level totals. The ACP usage fields
+ * are optional and nullable, so every component defaults to 0 to keep the sums
+ * numeric across adapters (codex reports no cache writes, claude no thought
+ * tokens on some models).
+ */
+export class RunUsageAccumulator {
+  private totals: RunTokenUsage = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    thought_tokens: 0,
+    total_tokens: 0,
+    turns: 0,
+  };
+
+  /** Adds a settled turn's usage. Returns false when there was nothing to add. */
+  add(usage: Usage | null | undefined): boolean {
+    if (!usage) return false;
+    this.totals.input_tokens += usage.inputTokens ?? 0;
+    this.totals.output_tokens += usage.outputTokens ?? 0;
+    this.totals.cache_read_tokens += usage.cachedReadTokens ?? 0;
+    this.totals.cache_write_tokens += usage.cachedWriteTokens ?? 0;
+    this.totals.thought_tokens += usage.thoughtTokens ?? 0;
+    this.totals.total_tokens += usage.totalTokens ?? 0;
+    this.totals.turns += 1;
+    return true;
+  }
+
+  snapshot(): RunTokenUsage {
+    return { ...this.totals };
+  }
+}


### PR DESCRIPTION
## Problem

Cloud runs are where most PostHog Code token spend happens, but nothing records how many tokens a run actually consumed. The gateway meters spend per team for rate limiting, and per-turn usage flows through ACP notifications to connected clients, but nothing durable lands on the run itself. That blocks per-run spend dashboards and makes rollouts that should reduce token usage (like rtk command-output compression) unmeasurable at run granularity.

## Changes

- **`server/run-usage.ts`** (new): `RunUsageAccumulator` sums per-turn ACP `Usage` into run totals (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `thought_tokens`, `total_tokens`, plus a `turns` counter), defaulting the SDK's nullable fields to 0 so codex turns (no cache writes) and claude turns (no thought tokens) both sum cleanly.
- **`server/agent-server.ts`**: each of the three turn-settlement sites (initial message, resume turn, follow-up user message) now records `result.usage` from the settled `PromptResponse` and PATCHes the cumulative snapshot into `TaskRun.state.token_usage` via the existing `updateTaskRun` endpoint, which merges state keys server-side. Reporting is fire-and-forget: a failed PATCH logs a warning and never affects the turn outcome.