### PR TITLE
feat(settings): add rtk compression toggle, on by default

### DIFF
--- a/packages/agent/src/adapters/claude/session/rtk.test.ts
+++ b/packages/agent/src/adapters/claude/session/rtk.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import type { Logger } from "../../../utils/logger";
 import {
   createRtkRewriteHook,
+  detectRtkBinary,
   resolveRtkPrefix,
   rewriteBashForRtk,
 } from "./rtk";
@@ -129,6 +130,50 @@ describe("resolveRtkPrefix", () => {
   test("is disabled for an explicit path that does not exist", () => {
     expect(
       resolveRtkPrefix({ POSTHOG_RTK: path.join(dir, "missing") }),
+    ).toBeUndefined();
+  });
+});
+
+describe("detectRtkBinary", () => {
+  let dir: string;
+  let binary: string;
+
+  beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "rtk-detect-"));
+    binary = path.join(dir, "rtk");
+    fs.writeFileSync(binary, "#!/bin/sh\n");
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  // The per-session toggle must not hide an installed binary from the
+  // status probe — a prior session leaving POSTHOG_RTK=0 in the process
+  // env would otherwise flap the settings hint.
+  test.each([
+    ["unset", undefined],
+    ["0", "0"],
+    ["false", "false"],
+    ["1", "1"],
+    ["true", "true"],
+  ])("finds the PATH binary when POSTHOG_RTK is %s", (_label, value) => {
+    expect(detectRtkBinary({ POSTHOG_RTK: value, PATH: dir })).toBe(binary);
+  });
+
+  test("reports no binary when rtk is not on PATH", () => {
+    expect(detectRtkBinary({ PATH: "/nonexistent" })).toBeUndefined();
+  });
+
+  test("honors an explicit path override that exists", () => {
+    expect(detectRtkBinary({ POSTHOG_RTK: binary, PATH: "/nonexistent" })).toBe(
+      binary,
+    );
+  });
+
+  test("reports no binary for a broken explicit path, matching the resolver", () => {
+    expect(
+      detectRtkBinary({ POSTHOG_RTK: path.join(dir, "missing"), PATH: dir }),
     ).toBeUndefined();
   });
 });

--- a/packages/agent/src/adapters/claude/session/rtk.ts
+++ b/packages/agent/src/adapters/claude/session/rtk.ts
@@ -129,6 +129,29 @@ export function resolveRtkPrefix(env: NodeJS.ProcessEnv): string | undefined {
   return findOnPath("rtk", env);
 }
 
+/**
+ * Detects the rtk binary a session on this host could use. The on/off flag
+ * values of POSTHOG_RTK ("0"/"false"/"1"/"true"/unset) all mean auto-detect
+ * here, so the answer reflects installation, not the per-session toggle a
+ * previous session may have left in the environment. An explicit binary-path
+ * override mirrors the resolver: honored when it exists, otherwise no binary.
+ */
+export function detectRtkBinary(env: NodeJS.ProcessEnv): string | undefined {
+  const raw = env.POSTHOG_RTK?.trim();
+  const lowered = raw?.toLowerCase();
+  const isFlagValue =
+    !raw || ["0", "false", "1", "true"].includes(lowered ?? "");
+  if (!isFlagValue && raw) {
+    try {
+      if (fs.statSync(raw).isFile()) return raw;
+    } catch {
+      // Explicit path doesn't exist — sessions would get no rtk either.
+    }
+    return undefined;
+  }
+  return findOnPath("rtk", env);
+}
+
 export const createRtkRewriteHook =
   (rtkPrefix: string, logger: Logger): HookCallback =>
   async (input: HookInput, _toolUseID: string | undefined) => {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4,4 +4,5 @@ export {
   isMcpToolReadOnly,
   type McpToolMetadata,
 } from "./adapters/claude/mcp/tool-metadata";
+export { detectRtkBinary } from "./adapters/claude/session/rtk";
 export type { PostHogProductId } from "./posthog-products";

--- a/packages/api-client/src/posthog-client.test.ts
+++ b/packages/api-client/src/posthog-client.test.ts
@@ -277,6 +277,41 @@ describe("PostHogAPIClient", () => {
     expect(body.initial_permission_mode).toBe("plan");
   });
 
+  it("serializes an rtk opt-out as rtk_enabled false on run creation", async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "run-123", environment: "cloud" }),
+    });
+    const client = new PostHogAPIClient(
+      "http://localhost:8000",
+      async () => "token",
+      async () => "token",
+      123,
+    );
+
+    (
+      client as unknown as {
+        api: { baseUrl: string; fetcher: { fetch: typeof fetch } };
+      }
+    ).api = {
+      baseUrl: "http://localhost:8000",
+      fetcher: { fetch },
+    };
+
+    await client.createTaskRun("task-123", {
+      environment: "cloud",
+      mode: "interactive",
+      rtkEnabled: false,
+    });
+
+    const request = fetch.mock.calls[0][0] as {
+      overrides: { body: string };
+    };
+    expect(JSON.parse(request.overrides.body)).toMatchObject({
+      rtk_enabled: false,
+    });
+  });
+
   it("omits the permission mode from created task runs without an adapter", async () => {
     const fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -497,6 +497,8 @@ interface CloudRunOptions {
   customImageId?: string;
   prAuthorshipMode?: PrAuthorshipMode;
   autoPublish?: boolean;
+  /** Only false is sent: opts the run out of rtk command-output compression. */
+  rtkEnabled?: boolean;
   runSource?: CloudRunSource;
   signalReportId?: string;
   initialPermissionMode?: ExecutionMode;
@@ -582,6 +584,9 @@ function buildCloudRunRequestBody(
   }
   if (options?.autoPublish) {
     body.auto_publish = options.autoPublish;
+  }
+  if (options?.rtkEnabled === false) {
+    body.rtk_enabled = false;
   }
   if (options?.runSource) {
     body.run_source = options.runSource;

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -299,7 +299,11 @@ export interface SessionServiceDeps {
     setAdapter(taskRunId: string, adapter: Adapter): void;
     removeAdapter(taskRunId: string): void;
   };
-  readonly settings: { customInstructions?: string | null };
+  readonly settings: {
+    customInstructions?: string | null;
+    rtkEnabledLocal?: boolean;
+    rtkEnabledCloud?: boolean;
+  };
   usageLimit: { show: (...args: any[]) => any };
   readonly addDirectoryDialog: { open: boolean };
   taskViewedApi: { markActivity(taskId: string): void };
@@ -1027,11 +1031,12 @@ export class SessionService {
           this.d.log.warn("Failed to verify workspace", { taskId, err });
         });
 
-      const { customInstructions } = this.d.settings;
+      const { customInstructions, rtkEnabledLocal } = this.d.settings;
       const result = await this.d.trpc.agent.reconnect.mutate({
         taskId,
         taskRunId,
         repoPath,
+        rtkEnabled: rtkEnabledLocal,
         apiHost: auth.apiHost,
         projectId: auth.projectId,
         logUrl,
@@ -1362,6 +1367,7 @@ export class SessionService {
       permissionMode: executionMode,
       adapter,
       customInstructions: startCustomInstructions || undefined,
+      rtkEnabled: this.d.settings.rtkEnabledLocal,
       effort: effortLevelSchema.safeParse(reasoningLevel).success
         ? (reasoningLevel as EffortLevel)
         : undefined,
@@ -3087,6 +3093,7 @@ export class SessionService {
             artifactIds.length > 0 ? artifactIds : undefined,
           prAuthorshipMode,
           autoPublish: previousState.auto_publish === true || undefined,
+          rtkEnabled: this.d.settings.rtkEnabledCloud,
           runSource: getCloudRunSource(previousState),
           signalReportId:
             typeof previousState.signal_report_id === "string"

--- a/packages/core/src/task-detail/taskCreationApiClient.ts
+++ b/packages/core/src/task-detail/taskCreationApiClient.ts
@@ -16,6 +16,7 @@ export interface CreateTaskRunClientOptions {
   customImageId?: string;
   prAuthorshipMode?: PrAuthorshipMode;
   autoPublish?: boolean;
+  rtkEnabled?: boolean;
   runSource?: CloudRunSource;
   signalReportId?: string;
   initialPermissionMode?: string;

--- a/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -153,6 +153,7 @@ describe("TaskCreationSaga", () => {
       model: "gpt-5.4",
       reasoningLevel: "high",
       cloudAutoPublish: true,
+      cloudRtkEnabled: false,
     });
 
     expect(result.success).toBe(true);
@@ -170,6 +171,7 @@ describe("TaskCreationSaga", () => {
       sandboxEnvironmentId: undefined,
       prAuthorshipMode: "user",
       autoPublish: true,
+      rtkEnabled: false,
       runSource: "manual",
       signalReportId: undefined,
       initialPermissionMode: "auto",

--- a/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/packages/core/src/task-detail/taskCreationSaga.ts
@@ -403,6 +403,7 @@ export class TaskCreationSaga extends Saga<
             customImageId: input.customImageId,
             prAuthorshipMode,
             autoPublish: input.cloudAutoPublish,
+            rtkEnabled: input.cloudRtkEnabled,
             runSource: input.cloudRunSource ?? "manual",
             signalReportId: input.signalReportId,
             homeQuickAction: input.homeQuickActionLabel,

--- a/packages/core/src/task-detail/taskInput.ts
+++ b/packages/core/src/task-detail/taskInput.ts
@@ -29,6 +29,7 @@ export interface PrepareTaskInputOptions {
   channelId?: string;
   customInstructions?: string;
   autoPublishCloudRuns?: boolean;
+  rtkEnabledCloud?: boolean;
   allowNoRepo?: boolean;
 }
 
@@ -64,6 +65,7 @@ export function prepareTaskInput(
     cloudRunSource:
       options.signalReportId && isCloud ? "signal_report" : undefined,
     cloudAutoPublish: isCloud ? options.autoPublishCloudRuns : undefined,
+    cloudRtkEnabled: isCloud ? options.rtkEnabledCloud : undefined,
     signalReportId: options.signalReportId,
     additionalDirectories: isCloud ? undefined : options.additionalDirectories,
     channelContext: options.channelContext,

--- a/packages/host-router/src/routers/agent.router.ts
+++ b/packages/host-router/src/routers/agent.router.ts
@@ -21,6 +21,7 @@ import {
   reconnectSessionInput,
   recordActivityInput,
   respondToPermissionInput,
+  rtkStatusOutput,
   sessionResponseSchema,
   setConfigOptionInput,
   startSessionInput,
@@ -64,6 +65,12 @@ export const agentRouter = router({
       ctx.container
         .get<AgentService>(AGENT_SERVICE)
         .cancelPrompt(input.sessionId, input.reason),
+    ),
+
+  rtkStatus: publicProcedure
+    .output(rtkStatusOutput)
+    .query(({ ctx }) =>
+      ctx.container.get<AgentService>(AGENT_SERVICE).getRtkStatus(),
     ),
 
   reconnect: publicProcedure

--- a/packages/shared/src/task-creation-domain.ts
+++ b/packages/shared/src/task-creation-domain.ts
@@ -43,6 +43,11 @@ export interface TaskCreationInput {
    * completion without waiting for an explicit ask (Settings → Advanced).
    */
   cloudAutoPublish?: boolean;
+  /**
+   * rtk command-output compression for the cloud run. Only false is
+   * meaningful: it opts the run out of the server-side default (enabled).
+   */
+  cloudRtkEnabled?: boolean;
   signalReportId?: string;
   additionalDirectories?: string[];
   /**

--- a/packages/ui/src/features/settings/sections/AdvancedSettings.tsx
+++ b/packages/ui/src/features/settings/sections/AdvancedSettings.tsx
@@ -1,4 +1,5 @@
 import { useServiceOptional } from "@posthog/di/react";
+import { useHostTRPC } from "@posthog/host-router/react";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useOnboardingStore } from "@posthog/ui/features/onboarding/onboardingStore";
 import {
@@ -11,7 +12,8 @@ import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { useSetupStore } from "@posthog/ui/features/setup/setupStore";
 import { useTourStore } from "@posthog/ui/features/tour/tourStore";
 import { clearApplicationStorage } from "@posthog/ui/utils/clearStorage";
-import { Button, Flex, Switch } from "@radix-ui/themes";
+import { Button, Checkbox, Flex, Switch, Text } from "@radix-ui/themes";
+import { useQuery } from "@tanstack/react-query";
 import { useSyncExternalStore } from "react";
 
 export function AdvancedSettings() {
@@ -27,6 +29,12 @@ export function AdvancedSettings() {
   const setAutoPublishCloudRuns = useSettingsStore(
     (s) => s.setAutoPublishCloudRuns,
   );
+  const rtkEnabledLocal = useSettingsStore((s) => s.rtkEnabledLocal);
+  const setRtkEnabledLocal = useSettingsStore((s) => s.setRtkEnabledLocal);
+  const rtkEnabledCloud = useSettingsStore((s) => s.rtkEnabledCloud);
+  const setRtkEnabledCloud = useSettingsStore((s) => s.setRtkEnabledCloud);
+  const hostTRPC = useHostTRPC();
+  const { data: rtkStatus } = useQuery(hostTRPC.agent.rtkStatus.queryOptions());
   const devModeClient = useServiceOptional<DevModeClient>(DEV_MODE_CLIENT);
 
   return (
@@ -40,6 +48,45 @@ export function AdvancedSettings() {
           onCheckedChange={setAutoPublishCloudRuns}
           size="1"
         />
+      </SettingRow>
+      <SettingRow
+        label="Compress command output"
+        description="Route eligible shell commands through rtk so their verbose output is compressed before it reaches the model, reducing token usage. Local covers local and worktree sessions"
+      >
+        <Flex direction="column" gap="1" align="end">
+          <Flex gap="4" align="center">
+            <Text as="label" size="1">
+              <Flex gap="1" align="center">
+                <Checkbox
+                  checked={rtkEnabledLocal}
+                  onCheckedChange={(checked) =>
+                    setRtkEnabledLocal(checked === true)
+                  }
+                  size="1"
+                />
+                Local
+              </Flex>
+            </Text>
+            <Text as="label" size="1">
+              <Flex gap="1" align="center">
+                <Checkbox
+                  checked={rtkEnabledCloud}
+                  onCheckedChange={(checked) =>
+                    setRtkEnabledCloud(checked === true)
+                  }
+                  size="1"
+                />
+                Cloud
+              </Flex>
+            </Text>
+          </Flex>
+          {rtkEnabledLocal && rtkStatus?.available === false && (
+            <Text size="1" color="orange">
+              rtk binary not found — local sessions run uncompressed until it is
+              installed
+            </Text>
+          )}
+        </Flex>
       </SettingRow>
       <SettingRow
         label="Reset onboarding and tours"

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -155,10 +155,17 @@ interface SettingsStore {
   // When on, cloud runs push their work and open a draft PR on completion
   // without waiting for an explicit ask.
   autoPublishCloudRuns: boolean;
+  // When on, agent runs compress eligible command output through rtk before it
+  // reaches the model. Split by modality: local covers local and worktree
+  // sessions, cloud covers cloud runs.
+  rtkEnabledLocal: boolean;
+  rtkEnabledCloud: boolean;
   setAllowBypassPermissions: (enabled: boolean) => void;
   setPreventSleepWhileRunning: (enabled: boolean) => void;
   setDebugLogsCloudRuns: (enabled: boolean) => void;
   setAutoPublishCloudRuns: (enabled: boolean) => void;
+  setRtkEnabledLocal: (enabled: boolean) => void;
+  setRtkEnabledCloud: (enabled: boolean) => void;
 
   // Terminal
   terminalFont: TerminalFont;
@@ -326,6 +333,8 @@ export const useSettingsStore = create<SettingsStore>()(
       preventSleepWhileRunning: false,
       debugLogsCloudRuns: false,
       autoPublishCloudRuns: true,
+      rtkEnabledLocal: true,
+      rtkEnabledCloud: true,
       setAllowBypassPermissions: (enabled) =>
         set({ allowBypassPermissions: enabled }),
       setPreventSleepWhileRunning: (enabled) =>
@@ -333,6 +342,8 @@ export const useSettingsStore = create<SettingsStore>()(
       setDebugLogsCloudRuns: (enabled) => set({ debugLogsCloudRuns: enabled }),
       setAutoPublishCloudRuns: (enabled) =>
         set({ autoPublishCloudRuns: enabled }),
+      setRtkEnabledLocal: (enabled) => set({ rtkEnabledLocal: enabled }),
+      setRtkEnabledCloud: (enabled) => set({ rtkEnabledCloud: enabled }),
 
       // Terminal
       terminalFont: "berkeley-mono",
@@ -446,6 +457,8 @@ export const useSettingsStore = create<SettingsStore>()(
         preventSleepWhileRunning: state.preventSleepWhileRunning,
         debugLogsCloudRuns: state.debugLogsCloudRuns,
         autoPublishCloudRuns: state.autoPublishCloudRuns,
+        rtkEnabledLocal: state.rtkEnabledLocal,
+        rtkEnabledCloud: state.rtkEnabledCloud,
 
         // Terminal
         terminalFont: state.terminalFont,

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -329,6 +329,7 @@ export function useTaskCreation({
           channelId,
           customInstructions: settings.customInstructions,
           autoPublishCloudRuns: settings.autoPublishCloudRuns,
+          rtkEnabledCloud: settings.rtkEnabledCloud,
           allowNoRepo,
         });
 

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -13,6 +13,7 @@ import {
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import {
+  detectRtkBinary,
   isMcpToolReadOnly,
   isNotification,
   POSTHOG_NOTIFICATIONS,
@@ -107,6 +108,7 @@ import {
   type InterruptReason,
   type PromptOutput,
   type ReconnectSessionInput,
+  type RtkStatus,
   type SessionResponse,
   type StartSessionInput,
 } from "./schemas";
@@ -280,6 +282,8 @@ interface SessionConfig {
    * replayed to the client. Claude adapter only.
    */
   importedSessionId?: string;
+  /** rtk command-output compression for this session; false opts out. */
+  rtkEnabled?: boolean;
 }
 
 /** Pull the adapter's `agentCapabilities._meta.posthog.steering` from initialize. */
@@ -422,6 +426,15 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     // (copyClaudeExecutable plugin).
     const binary = process.platform === "win32" ? "claude.exe" : "claude";
     return this.bundledResources.resolve(`.vite/build/claude-cli/${binary}`);
+  }
+
+  /** Whether an rtk binary is installed on this host, independent of the toggle. */
+  getRtkStatus(): RtkStatus {
+    const binaryPath = detectRtkBinary(process.env);
+    return {
+      available: binaryPath !== undefined,
+      binaryPath: binaryPath ?? null,
+    };
   }
 
   private getCodexBinaryPath(): string {
@@ -759,6 +772,7 @@ If a repository IS genuinely required, attach one in this priority order:
       credentials,
       proxyUrl,
       claudeCliPath: this.getClaudeCliPath(),
+      rtkEnabled: config.rtkEnabled,
     });
 
     const isPreview = taskId === "__preview__";
@@ -1963,6 +1977,7 @@ For git operations while detached:
       jsonSchema: "jsonSchema" in params ? params.jsonSchema : undefined,
       importedSessionId:
         "importedSessionId" in params ? params.importedSessionId : undefined,
+      rtkEnabled: "rtkEnabled" in params ? params.rtkEnabled : undefined,
     };
   }
 

--- a/packages/workspace-server/src/services/agent/auth-adapter.test.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.test.ts
@@ -245,4 +245,26 @@ describe("AgentAuthAdapter", () => {
     // The node-shim era prepended a shim dir here; PATH must stay untouched.
     expect(process.env.PATH).toBe(pathBefore);
   });
+
+  it.each([
+    { rtkEnabled: false, expected: "0" },
+    { rtkEnabled: true, expected: undefined },
+    { rtkEnabled: undefined, expected: undefined },
+  ])(
+    "pins POSTHOG_RTK for rtkEnabled=$rtkEnabled",
+    async ({ rtkEnabled, expected }) => {
+      // A stale value from a previous session must not leak into an
+      // enabled/default session — the enabled path deletes, not skips.
+      process.env.POSTHOG_RTK = "0";
+
+      await adapter.configureProcessEnv({
+        credentials: baseCredentials,
+        proxyUrl: "http://127.0.0.1:9999",
+        claudeCliPath: "/mock/claude-cli.js",
+        rtkEnabled,
+      });
+
+      expect(process.env.POSTHOG_RTK).toBe(expected);
+    },
+  );
 });

--- a/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -49,6 +49,8 @@ interface ConfigureProcessEnvInput {
   credentials: Credentials;
   proxyUrl: string;
   claudeCliPath: string;
+  /** rtk command-output compression for the session; false opts out. */
+  rtkEnabled?: boolean;
 }
 
 @injectable()
@@ -140,6 +142,7 @@ export class AgentAuthAdapter {
     credentials,
     proxyUrl,
     claudeCliPath,
+    rtkEnabled,
   }: ConfigureProcessEnvInput): Promise<void> {
     await this.getValidToken();
 
@@ -147,6 +150,14 @@ export class AgentAuthAdapter {
     process.env.CLAUDE_CODE_EXECUTABLE = claudeCliPath;
     process.env.POSTHOG_API_URL = credentials.apiHost;
     process.env.POSTHOG_PROJECT_ID = String(credentials.projectId);
+    // The agent auto-detects rtk on PATH; an explicit opt-out from settings
+    // pins it off for sessions this process spawns. Deleting on the enabled
+    // path restores auto-detection after a re-enable without a restart.
+    if (rtkEnabled === false) {
+      process.env.POSTHOG_RTK = "0";
+    } else {
+      delete process.env.POSTHOG_RTK;
+    }
   }
 
   private syncTokenEnvironment(token: string): void {

--- a/packages/workspace-server/src/services/agent/schemas.ts
+++ b/packages/workspace-server/src/services/agent/schemas.ts
@@ -75,6 +75,11 @@ export const startSessionInput = z.object({
    * history is replayed to the client. Claude adapter only.
    */
   importedSessionId: z.string().optional(),
+  /**
+   * Whether rtk command-output compression is enabled for this session.
+   * Defaults to enabled; false sets POSTHOG_RTK=0 on the agent environment.
+   */
+  rtkEnabled: z.boolean().optional(),
 });
 
 export type StartSessionInput = z.infer<typeof startSessionInput>;
@@ -206,9 +211,19 @@ export const reconnectSessionInput = z.object({
   customInstructions: z.string().max(2000).optional(),
   effort: effortLevelSchema.optional(),
   jsonSchema: z.record(z.string(), z.unknown()).nullish(),
+  /** See startSessionInput.rtkEnabled. */
+  rtkEnabled: z.boolean().optional(),
 });
 
 export type ReconnectSessionInput = z.infer<typeof reconnectSessionInput>;
+
+/** Whether an rtk binary is installed on this host, independent of the toggle. */
+export const rtkStatusOutput = z.object({
+  available: z.boolean(),
+  binaryPath: z.string().nullable(),
+});
+
+export type RtkStatus = z.infer<typeof rtkStatusOutput>;
 
 // Set config option input (for Codex reasoning level, etc.)
 export const setConfigOptionInput = z.object({


### PR DESCRIPTION
## Problem

rtk command-output compression is rolling out on by default: the runtime auto-detects the binary on PATH (#3096), and cloud sandboxes ship it in the image with `POSTHOG_RTK` set from the run's state (PostHog/posthog#69176). What's missing is the user-facing opt-out, one place in PostHog Code settings that turns it off across local, worktree, and cloud runs.

## Changes

- add a "Compress command output" setting under Advanced, enabled by default. The preference is persisted and available across desktop, web, and mobile.

- apply the setting to local and worktree sessions by passing it through session creation and reconnect, setting `POSTHOG_RTK=0` when disabled and restoring automatic detection when enabled.

- apply the setting to cloud runs by sending `rtk_enabled: false` only when users opt out. When enabled, no value is sent so the server-side default continues to control rollout.