### PR TITLE
fix(sessions): stop footer status line overlapping diff stats when narrow

### DIFF
--- a/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
+++ b/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
@@ -171,21 +171,22 @@ export function GeneratingIndicator({
     <Flex
       align="center"
       gap="2"
-      className="select-none select-none"
+      className="min-w-0 select-none"
       style={{ WebkitUserSelect: "none" }}
     >
-      <Brain size={12} className="ph-pulse" />
-      <Text className="text-[13px] text-accent-11">{activity}...</Text>
-      <Text color="gray" className="text-[13px]">
+      <Brain size={12} className="ph-pulse shrink-0" />
+      <Text className="truncate text-[13px] text-accent-11">{activity}...</Text>
+      {/* The hint shrinks (and truncates) well before the activity word does. */}
+      <Text color="gray" className="shrink-[8] truncate text-[13px]">
         (Esc to stop
-      </Text>
-      <Circle size={4} weight="fill" className="mx-[2px] my-0 text-gray-9" />
-      <Text
-        color="gray"
-        style={{ fontVariantNumeric: "tabular-nums" }}
-        className="text-[13px]"
-      >
-        {formatDuration(elapsed, 1)})
+        <Circle
+          size={4}
+          weight="fill"
+          className="mx-1 inline-block align-middle text-gray-9"
+        />
+        <span style={{ fontVariantNumeric: "tabular-nums" }}>
+          {formatDuration(elapsed, 1)})
+        </span>
       </Text>
     </Flex>
   );

--- a/packages/ui/src/features/sessions/components/SessionFooter.stories.tsx
+++ b/packages/ui/src/features/sessions/components/SessionFooter.stories.tsx
@@ -1,0 +1,72 @@
+import { SessionFooter } from "@posthog/ui/features/sessions/components/SessionFooter";
+import type { ContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof SessionFooter> = {
+  title: "Sessions/SessionFooter",
+  component: SessionFooter,
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SessionFooter>;
+
+const usage: ContextUsage = {
+  used: 788_000,
+  size: 1_000_000,
+  percentage: 79,
+  cost: null,
+  breakdown: null,
+};
+
+const generatingArgs = {
+  isPromptPending: true,
+  promptStartedAt: Date.now() - 5_400,
+  lastGenerationDuration: null,
+  usage,
+};
+
+/** Wraps the footer in fixed-width boxes so narrow panes are easy to eyeball. */
+function AtWidths({ args }: { args: Parameters<typeof SessionFooter>[0] }) {
+  return (
+    <div className="flex flex-col gap-4">
+      {[720, 480, 400, 340, 280, 220].map((width) => (
+        <div key={width}>
+          <div className="mb-1 text-[11px] text-gray-9">{width}px</div>
+          <div
+            className="rounded border border-gray-6 border-dashed px-2"
+            style={{ width }}
+          >
+            <SessionFooter {...args} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const GeneratingAtNarrowWidths: Story = {
+  args: generatingArgs,
+  render: (args) => <AtWidths args={args} />,
+};
+
+export const GeneratingWithQueueAtNarrowWidths: Story = {
+  args: { ...generatingArgs, queuedCount: 2 },
+  render: (args) => <AtWidths args={args} />,
+};
+
+export const AwaitingPermissionAtNarrowWidths: Story = {
+  args: { ...generatingArgs, hasPendingPermission: true },
+  render: (args) => <AtWidths args={args} />,
+};
+
+export const IdleAtNarrowWidths: Story = {
+  args: {
+    isPromptPending: false,
+    lastGenerationDuration: 331_000,
+    usage,
+  },
+  render: (args) => <AtWidths args={args} />,
+};


### PR DESCRIPTION
## Problem

When the main chat window is narrow (e.g. with panes open), the status line above the prompt input overlaps itself: "(Esc to stop" wraps onto three lines and the elapsed time paints over the diff stats ("22 files").

The left half of the footer row is allowed to shrink (`min-w-0`), but nothing inside `GeneratingIndicator` was constrained to a single line — so wrappable text wrapped, and the non-wrappable elapsed time overflowed into the `shrink-0` right-side stats.

## Fix

Make the indicator a single non-wrapping line that shrinks gracefully:

- Root flex gets `min-w-0` and the brain icon `shrink-0`, so the component shrinks inside the row instead of overflowing into the diff stats.
- "(Esc to stop", the dot separator, and the elapsed time are now one `Text` run (dot rendered inline), so they truncate as a unit with an ellipsis instead of wrapping.
- The hint gets `shrink-[8] truncate` and the activity word `truncate`, so the Esc/timer hint collapses first and the activity word only ellipsizes as a last resort. The context ring and diff stats keep their space.

## After (light mode, from the new Storybook stories)

Wide (720px) — everything on one line:

![Footer at 720px, light mode](https://raw.githubusercontent.com/PostHog/code/72c2a6b7b20af6c96f00dac5650aace78454f8a3/.github/pr-assets/3258/footer-wide-light.png)

Narrow (340px) — the "(Esc to stop · …s)" hint ellipsizes first; the context ring stays intact, nothing overlaps or wraps:

![Footer at 340px, light mode](https://raw.githubusercontent.com/PostHog/code/72c2a6b7b20af6c96f00dac5650aace78454f8a3/.github/pr-assets/3258/footer-narrow-light.png)

(Screenshots live on the [`posthog-code/fix-session-footer-overlap-assets`](https://github.com/PostHog/code/tree/posthog-code/fix-session-footer-overlap-assets) branch so no binaries land in this PR's diff.)

## Testing

- Added `SessionFooter.stories.tsx` rendering the footer at fixed widths from 720px down to 220px (generating, generating + queue, awaiting permission, idle). Verified in Storybook (dark and light) via headless browser screenshots:
  - At 720–400px everything fits on one line.
  - At 340px the "(Esc to stop · …s)" hint ellipsizes; at 280px it's nearly collapsed; only at 220px does the activity word itself truncate.
  - The right-side context ring stays fully legible at every width — no overlap, no wrapping.
  - Note: `DiffStatsChip` doesn't render in Storybook (its diff-stats query never resolves there), but it shares the `shrink-0` right-side group with the context ring, so the overlap scenario is exercised.
- `pnpm exec biome check` on the changed files — clean.
- `pnpm --filter @posthog/ui typecheck` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)