### PR TITLE
feat(mobile): auto-publish cloud runs toggle (port #3217)

### DIFF
--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -193,6 +193,12 @@ export default function SettingsScreen() {
   const setDefaultReasoningEffort = usePreferencesStore(
     (s) => s.setDefaultReasoningEffort,
   );
+  const autoPublishCloudRuns = usePreferencesStore(
+    (s) => s.autoPublishCloudRuns,
+  );
+  const setAutoPublishCloudRuns = usePreferencesStore(
+    (s) => s.setAutoPublishCloudRuns,
+  );
   const defaultMessagingMode = useMessagingModeStore((s) => s.defaultMode);
   const setDefaultMessagingMode = useMessagingModeStore(
     (s) => s.setDefaultMode,
@@ -409,7 +415,6 @@ export default function SettingsScreen() {
             label="Messaging mode"
             description="What happens when you send while a turn is running"
             onPress={() => setMessagingModeSheetOpen(true)}
-            showDivider={false}
             rightSlot={
               <>
                 <Text className="text-[14px] text-gray-11">
@@ -417,6 +422,17 @@ export default function SettingsScreen() {
                 </Text>
                 <CaretRight size={14} color={themeColors.gray[10]} />
               </>
+            }
+          />
+          <SettingsRow
+            label="Always create pull requests for cloud runs"
+            description="Cloud runs push their changes and open a draft pull request when they finish, without waiting for you to ask"
+            showDivider={false}
+            rightSlot={
+              <Switch
+                value={autoPublishCloudRuns}
+                onValueChange={setAutoPublishCloudRuns}
+              />
             }
           />
         </SettingsSection>

--- a/apps/mobile/src/app/task/index.tsx
+++ b/apps/mobile/src/app/task/index.tsx
@@ -351,6 +351,7 @@ export default function NewTaskScreen() {
         model,
         reasoningEffort: supportsReasoning ? reasoning : undefined,
         initialPermissionMode: mode,
+        autoPublish: usePreferencesStore.getState().autoPublishCloudRuns,
         ...(signalReport
           ? {
               runSource: "signal_report" as const,

--- a/apps/mobile/src/features/preferences/stores/preferencesStore.ts
+++ b/apps/mobile/src/features/preferences/stores/preferencesStore.ts
@@ -80,6 +80,9 @@ interface PreferencesState {
    *  `defaultReasoningEffort === "last_used"` can pre-fill it next time. */
   lastUsedReasoningEffort: string;
   setLastUsedReasoningEffort: (effort: string) => void;
+
+  autoPublishCloudRuns: boolean;
+  setAutoPublishCloudRuns: (enabled: boolean) => void;
 }
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -120,6 +123,10 @@ export const usePreferencesStore = create<PreferencesState>()(
       lastUsedReasoningEffort: "high",
       setLastUsedReasoningEffort: (effort) =>
         set({ lastUsedReasoningEffort: effort }),
+
+      autoPublishCloudRuns: true,
+      setAutoPublishCloudRuns: (enabled) =>
+        set({ autoPublishCloudRuns: enabled }),
     }),
     {
       name: "posthog-preferences",
@@ -136,6 +143,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         lastNewTaskMode: state.lastNewTaskMode,
         defaultReasoningEffort: state.defaultReasoningEffort,
         lastUsedReasoningEffort: state.lastUsedReasoningEffort,
+        autoPublishCloudRuns: state.autoPublishCloudRuns,
       }),
     },
   ),

--- a/apps/mobile/src/features/tasks/api.test.ts
+++ b/apps/mobile/src/features/tasks/api.test.ts
@@ -39,21 +39,16 @@ describe("runTaskInCloud", () => {
     );
   });
 
-  it("includes auto_publish when enabled", async () => {
-    await runTaskInCloud("task-1", { autoPublish: true });
+  it.each([true, false])(
+    "forwards auto_publish=%s to the payload",
+    async (flag) => {
+      await runTaskInCloud("task-1", { autoPublish: flag });
 
-    expect(bodyOf(mockFetch.mock.calls[0])).toMatchObject({
-      auto_publish: true,
-    });
-  });
-
-  it("sends auto_publish false when disabled", async () => {
-    await runTaskInCloud("task-1", { autoPublish: false });
-
-    expect(bodyOf(mockFetch.mock.calls[0])).toMatchObject({
-      auto_publish: false,
-    });
-  });
+      expect(bodyOf(mockFetch.mock.calls[0])).toMatchObject({
+        auto_publish: flag,
+      });
+    },
+  );
 
   it("omits auto_publish when not provided", async () => {
     await runTaskInCloud("task-1", { model: "claude-opus-4-8" });

--- a/apps/mobile/src/features/tasks/api.test.ts
+++ b/apps/mobile/src/features/tasks/api.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+}));
+
+vi.mock("expo/fetch", () => ({
+  fetch: mockFetch,
+}));
+
+vi.mock("@/lib/api", () => ({
+  getBaseUrl: () => "https://app.posthog.test",
+  getProjectId: () => 42,
+  getAccessToken: () => "token",
+  createTimeoutSignal: () => undefined,
+  authedFetch: (url: string, init?: RequestInit) =>
+    mockFetch(url, {
+      ...init,
+      headers: {
+        Authorization: "Bearer token",
+        "Content-Type": "application/json",
+        ...((init?.headers as Record<string, string> | undefined) ?? {}),
+      },
+    }),
+}));
+
+import { runTaskInCloud } from "./api";
+
+function bodyOf(call: unknown): Record<string, unknown> {
+  const [, init] = call as [string, RequestInit];
+  return JSON.parse(init.body as string);
+}
+
+describe("runTaskInCloud", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ id: "task-1" }), { status: 200 }),
+    );
+  });
+
+  it("includes auto_publish when enabled", async () => {
+    await runTaskInCloud("task-1", { autoPublish: true });
+
+    expect(bodyOf(mockFetch.mock.calls[0])).toMatchObject({
+      auto_publish: true,
+    });
+  });
+
+  it("sends auto_publish false when disabled", async () => {
+    await runTaskInCloud("task-1", { autoPublish: false });
+
+    expect(bodyOf(mockFetch.mock.calls[0])).toMatchObject({
+      auto_publish: false,
+    });
+  });
+
+  it("omits auto_publish when not provided", async () => {
+    await runTaskInCloud("task-1", { model: "claude-opus-4-8" });
+
+    expect(bodyOf(mockFetch.mock.calls[0])).not.toHaveProperty("auto_publish");
+  });
+
+  it("sends no body for the plain initial run", async () => {
+    await runTaskInCloud("task-1");
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(init.body).toBeUndefined();
+  });
+});

--- a/apps/mobile/src/features/tasks/api.ts
+++ b/apps/mobile/src/features/tasks/api.ts
@@ -433,6 +433,9 @@ export interface RunTaskInCloudOptions {
   runSource?: "manual" | "signal_report";
   /** Signal report ID when run_source is "signal_report". */
   signalReportId?: string;
+  /** When true, the cloud run pushes its changes and opens a draft PR on
+   *  completion without waiting for an explicit ask. */
+  autoPublish?: boolean;
 }
 
 export async function runTaskInCloud(
@@ -456,7 +459,8 @@ export async function runTaskInCloud(
       options.reasoningEffort !== undefined ||
       options.initialPermissionMode !== undefined ||
       options.runSource !== undefined ||
-      options.signalReportId !== undefined);
+      options.signalReportId !== undefined ||
+      options.autoPublish !== undefined);
 
   let body: string | undefined;
   if (hasOptions) {
@@ -483,6 +487,9 @@ export async function runTaskInCloud(
     if (options?.runSource) payload.run_source = options.runSource;
     if (options?.signalReportId)
       payload.signal_report_id = options.signalReportId;
+    if (options?.autoPublish !== undefined) {
+      payload.auto_publish = options.autoPublish;
+    }
     body = JSON.stringify(payload);
   }
 


### PR DESCRIPTION
Ports the desktop advanced-settings toggle from #3217 to the mobile app.

## What this adds
A user-facing setting that makes cloud runs push their work and open a draft PR on completion, without waiting for an explicit ask. Manual cloud runs remain review-first by default on the backend; this toggle opts them into auto-publishing.

## Changes (all `apps/mobile`)
- **`preferencesStore.ts`** — persisted `autoPublishCloudRuns` boolean (default `true`, matching desktop) + `setAutoPublishCloudRuns`.
- **`settings/index.tsx`** — a Switch in the Input section labelled "Always create pull requests for cloud runs" with the same description as desktop.
- **`tasks/api.ts`** — `RunTaskInCloudOptions.autoPublish?: boolean`; `runTaskInCloud` sends `auto_publish` in the request body when set.
- **`app/task/index.tsx`** — the new-task composer (initial cloud-run kickoff) threads the setting through, alongside `model`/`reasoningEffort`/`initialPermissionMode`.
- **`tasks/api.test.ts`** — covers that `auto_publish` is included when enabled, sent as `false` when disabled, and omitted when unset.

No desktop or shared-package code changed — the backend already interprets `auto_publish`, so mobile only needs to send it.

## Testing
- `pnpm --filter @posthog/mobile test src/features/tasks/api.test.ts` — 4 passing.
- Biome check clean on all touched files.