### PR TITLE
feat(mobile): add copy buttons to chat code blocks and messages (port #3238)

### DIFF
--- a/apps/mobile/src/features/chat/components/AgentMessage.tsx
+++ b/apps/mobile/src/features/chat/components/AgentMessage.tsx
@@ -1,12 +1,11 @@
-import * as Clipboard from "expo-clipboard";
-import * as Haptics from "expo-haptics";
 import { Brain } from "phosphor-react-native";
-import { useCallback, useState } from "react";
-import { Alert, Pressable, Text, View } from "react-native";
+import { useState } from "react";
+import { Pressable, Text, View } from "react-native";
 import { formatRelativeTime } from "@/lib/format";
 import { useThemeColors } from "@/lib/theme";
 import { usePeriodicRerender } from "../hooks/usePeriodicRerender";
 import { getRandomThinkingMessage } from "../utils/thinkingMessages";
+import { CopyButton } from "./CopyButton";
 import { MarkdownText } from "./MarkdownText";
 import { ToolMessage } from "./ToolMessage";
 
@@ -85,14 +84,6 @@ export function AgentMessage({
   const hasContent = !!content;
   const isComplete = !isLoading && hasContent;
 
-  const handleLongPress = useCallback(() => {
-    if (!content) return;
-    Clipboard.setStringAsync(content).then(() => {
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-      Alert.alert("Copied", "Message copied to clipboard.");
-    });
-  }, [content]);
-
   return (
     <View className="py-2">
       {toolCalls && toolCalls.length > 0 && (
@@ -124,19 +115,21 @@ export function AgentMessage({
         </View>
       )}
 
-      {/* Show final content — long-press to copy */}
       {content && (
-        <Pressable onLongPress={handleLongPress} delayLongPress={400}>
-          <View className="max-w-[95%] px-4 py-1">
-            <MarkdownText content={content} />
-          </View>
-        </Pressable>
+        <View className="max-w-[95%] px-4 py-1">
+          <MarkdownText content={content} />
+        </View>
       )}
 
-      {timestamp && !isLoading && (
-        <Text className="px-4 pt-1 font-mono text-[10px] text-gray-8">
-          {formatRelativeTime(timestamp)}
-        </Text>
+      {!isLoading && (hasContent || timestamp) && (
+        <View className="flex-row items-center gap-3 px-4 pt-1">
+          {isComplete && <CopyButton text={content} label="Copy message" />}
+          {timestamp && (
+            <Text className="font-mono text-[10px] text-gray-8">
+              {formatRelativeTime(timestamp)}
+            </Text>
+          )}
+        </View>
       )}
     </View>
   );

--- a/apps/mobile/src/features/chat/components/CopyButton.tsx
+++ b/apps/mobile/src/features/chat/components/CopyButton.tsx
@@ -16,8 +16,7 @@ export function CopyButton({ text, size = 14, label }: CopyButtonProps) {
   const { copied, copy } = useCopy();
 
   const handlePress = useCallback(() => {
-    copy(text);
-    Haptics.selectionAsync();
+    copy(text, () => Haptics.selectionAsync());
   }, [copy, text]);
 
   return (

--- a/apps/mobile/src/features/chat/components/CopyButton.tsx
+++ b/apps/mobile/src/features/chat/components/CopyButton.tsx
@@ -1,0 +1,37 @@
+import * as Haptics from "expo-haptics";
+import { Check, Copy } from "phosphor-react-native";
+import { useCallback } from "react";
+import { Pressable } from "react-native";
+import { useThemeColors } from "@/lib/theme";
+import { useCopy } from "../hooks/useCopy";
+
+interface CopyButtonProps {
+  text: string;
+  size?: number;
+  label?: string;
+}
+
+export function CopyButton({ text, size = 14, label }: CopyButtonProps) {
+  const themeColors = useThemeColors();
+  const { copied, copy } = useCopy();
+
+  const handlePress = useCallback(() => {
+    copy(text);
+    Haptics.selectionAsync();
+  }, [copy, text]);
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      hitSlop={8}
+      accessibilityRole="button"
+      accessibilityLabel={label ?? "Copy"}
+    >
+      {copied ? (
+        <Check size={size} color={themeColors.status.success} />
+      ) : (
+        <Copy size={size} color={themeColors.gray[9]} />
+      )}
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/features/chat/components/MarkdownText.tsx
+++ b/apps/mobile/src/features/chat/components/MarkdownText.tsx
@@ -7,6 +7,7 @@ import { openExternalUrl } from "@/lib/openExternalUrl";
 import { type ParsePostHogUrlOptions, parsePostHogUrl } from "@/lib/posthogUrl";
 import { getColorForClass, highlightCode } from "@/lib/syntax-highlight";
 import { useThemeColors } from "@/lib/theme";
+import { CopyButton } from "./CopyButton";
 import { GithubRefChip } from "./GithubRefChip";
 import { MarkdownImage } from "./MarkdownImage";
 import { PostHogRefChip } from "./PostHogRefChip";
@@ -441,13 +442,16 @@ export function MarkdownText({ content }: MarkdownTextProps) {
                 key={key}
                 className="rounded-md border border-gray-6 bg-gray-3"
               >
-                {block.language && (
-                  <View className="border-gray-6 border-b px-3 py-1">
-                    <Text className="font-mono text-[10px] text-gray-9">
-                      {block.language}
-                    </Text>
-                  </View>
-                )}
+                <View className="flex-row items-center justify-between border-gray-6 border-b px-3 py-1">
+                  <Text className="font-mono text-[10px] text-gray-9">
+                    {block.language}
+                  </Text>
+                  <CopyButton
+                    text={block.content}
+                    size={13}
+                    label="Copy code"
+                  />
+                </View>
                 <View className="px-3 py-2">
                   {block.language ? (
                     <HighlightedCode

--- a/apps/mobile/src/features/chat/hooks/useCopy.test.ts
+++ b/apps/mobile/src/features/chat/hooks/useCopy.test.ts
@@ -1,0 +1,62 @@
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const setStringAsync = vi.fn(async (_text: string) => true);
+vi.mock("expo-clipboard", () => ({
+  setStringAsync: (text: string) => setStringAsync(text),
+}));
+
+import { useCopy } from "./useCopy";
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+function renderUseCopy(resetMs?: number) {
+  const state: { current: ReturnType<typeof useCopy> } = {
+    current: { copied: false, copy: () => {} },
+  };
+  function Harness() {
+    state.current = useCopy(resetMs);
+    return null;
+  }
+  act(() => {
+    create(createElement(Harness));
+  });
+  return state;
+}
+
+describe("useCopy", () => {
+  it("writes to the clipboard and flips copied true then false", async () => {
+    vi.useFakeTimers();
+    const state = renderUseCopy(2000);
+
+    expect(state.current.copied).toBe(false);
+
+    await act(async () => {
+      state.current.copy("hello");
+    });
+
+    expect(setStringAsync).toHaveBeenCalledWith("hello");
+    expect(state.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(state.current.copied).toBe(false);
+  });
+
+  it("stays false when the clipboard write rejects", async () => {
+    setStringAsync.mockRejectedValueOnce(new Error("denied"));
+    const state = renderUseCopy();
+
+    await act(async () => {
+      state.current.copy("nope");
+    });
+
+    expect(state.current.copied).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/chat/hooks/useCopy.test.ts
+++ b/apps/mobile/src/features/chat/hooks/useCopy.test.ts
@@ -49,14 +49,23 @@ describe("useCopy", () => {
     expect(state.current.copied).toBe(false);
   });
 
-  it("stays false when the clipboard write rejects", async () => {
+  it("runs onSuccess only after a successful write", async () => {
     setStringAsync.mockRejectedValueOnce(new Error("denied"));
+    const onSuccess = vi.fn();
     const state = renderUseCopy();
 
     await act(async () => {
-      state.current.copy("nope");
+      state.current.copy("nope", onSuccess);
     });
 
     expect(state.current.copied).toBe(false);
+    expect(onSuccess).not.toHaveBeenCalled();
+
+    await act(async () => {
+      state.current.copy("yep", onSuccess);
+    });
+
+    expect(state.current.copied).toBe(true);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/features/chat/hooks/useCopy.ts
+++ b/apps/mobile/src/features/chat/hooks/useCopy.ts
@@ -1,0 +1,26 @@
+import * as Clipboard from "expo-clipboard";
+import { useCallback, useRef, useState } from "react";
+
+export function useCopy(resetMs = 2000): {
+  copied: boolean;
+  copy: (text: string) => void;
+} {
+  const [copied, setCopied] = useState(false);
+  const timeout = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const copy = useCallback(
+    (text: string) => {
+      Clipboard.setStringAsync(text).then(
+        () => {
+          setCopied(true);
+          clearTimeout(timeout.current);
+          timeout.current = setTimeout(() => setCopied(false), resetMs);
+        },
+        () => {},
+      );
+    },
+    [resetMs],
+  );
+
+  return { copied, copy };
+}

--- a/apps/mobile/src/features/chat/hooks/useCopy.ts
+++ b/apps/mobile/src/features/chat/hooks/useCopy.ts
@@ -1,20 +1,23 @@
 import * as Clipboard from "expo-clipboard";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export function useCopy(resetMs = 2000): {
   copied: boolean;
-  copy: (text: string) => void;
+  copy: (text: string, onSuccess?: () => void) => void;
 } {
   const [copied, setCopied] = useState(false);
   const timeout = useRef<ReturnType<typeof setTimeout>>(undefined);
 
+  useEffect(() => () => clearTimeout(timeout.current), []);
+
   const copy = useCallback(
-    (text: string) => {
+    (text: string, onSuccess?: () => void) => {
       Clipboard.setStringAsync(text).then(
         () => {
           setCopied(true);
           clearTimeout(timeout.current);
           timeout.current = setTimeout(() => setCopied(false), resetMs);
+          onSuccess?.();
         },
         () => {},
       );


### PR DESCRIPTION
Ports the desktop copy-to-clipboard buttons from #3238 to the mobile chat thread.

## What changed
- **`useCopy` hook** (`apps/mobile/src/features/chat/hooks/useCopy.ts`) — wraps `expo-clipboard`'s `setStringAsync` and exposes a transient `copied` flag that resets after ~2s. Clipboard rejections are swallowed so the button never shows a false success (mirrors the desktop primitive, but uses the RN clipboard API instead of `navigator.clipboard`).
- **`CopyButton`** (`apps/mobile/src/features/chat/components/CopyButton.tsx`) — a `Pressable` with phosphor `Copy`/`Check` icons and a selection haptic, themed via `useThemeColors`. Shows a check icon for ~2s after a successful copy.
- **Code blocks** (`MarkdownText.tsx`) — each fenced code block header now carries a copy button on the right that copies the block's raw source.
- **Agent messages** (`AgentMessage.tsx`) — the footer gains a "Copy message" button that copies the full message text. It's hidden while the message is still streaming, matching desktop. The old, redundant long-press-to-copy path (which popped a native `Alert`) is removed now that there's a discoverable button with inline feedback.

## Notes
- Mobile-local implementation — no changes to desktop (`apps/code`) or shared `packages/*`.
- `expo-clipboard` / `expo-haptics` were already dependencies.

## Testing
- Added `useCopy.test.ts` covering the copy → `copied` true → reset-to-false flow and the swallowed-rejection case.
- `pnpm --filter @posthog/mobile` typecheck (tsc), `biome check`, and the chat vitest suite all pass.