### PR TITLE
fix(git): keep task PR state in sync when the primary PR changes

### DIFF
--- a/packages/host-router/src/ports/git-pr-status.ts
+++ b/packages/host-router/src/ports/git-pr-status.ts
@@ -13,5 +13,5 @@ export interface IGitPrStatus {
     cloudPrUrl: string | null,
   ): Promise<TaskPrStatus>;
   getCachedPrUrl(taskId: string): CachedPrUrlOutput;
-  setPrimaryPrUrl(taskId: string, prUrl: string): void;
+  setPrimaryPrUrl(taskId: string, prUrl: string): Promise<void>;
 }

--- a/packages/workspace-server/src/services/git/task-pr-status.test.ts
+++ b/packages/workspace-server/src/services/git/task-pr-status.test.ts
@@ -234,47 +234,43 @@ describe("TaskPrStatusService.setPrimaryPrUrl", () => {
     return { service, workspaceService, workspaceRepo };
   }
 
-  it("recomputes and emits the promoted PR's live state, not the stale cache", async () => {
-    const getPrDetailsByUrl = vi
-      .fn()
-      .mockResolvedValue({ state: "open", merged: false, draft: false });
-    const { service, workspaceService, workspaceRepo } =
-      makeService(getPrDetailsByUrl);
+  it.each([
+    {
+      name: "recomputes and emits the promoted PR's live state, not the stale cache",
+      details: vi.fn().mockResolvedValue({
+        state: "open",
+        merged: false,
+        draft: false,
+      }),
+      expectedPrState: "open",
+    },
+    {
+      name: "emits a null state when the promoted PR's details are unavailable",
+      details: vi.fn().mockResolvedValue(null),
+      expectedPrState: null,
+    },
+    {
+      name: "falls back to a null state when the details fetch rejects",
+      details: vi.fn().mockRejectedValue(new Error("network down")),
+      expectedPrState: null,
+    },
+  ])("$name", async ({ details, expectedPrState }) => {
+    const { service, workspaceService, workspaceRepo } = makeService(details);
 
     await service.setPrimaryPrUrl("task-1", PR_NEW);
 
     expect(workspaceRepo.promotePrUrl).toHaveBeenCalledWith("task-1", PR_NEW);
-    expect(getPrDetailsByUrl).toHaveBeenCalledWith(PR_NEW);
+    expect(details).toHaveBeenCalledWith(PR_NEW);
     expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-1", {
       prUrl: PR_NEW,
-      prState: "open",
+      prState: expectedPrState,
       accumulate: false,
     });
     expect(workspaceService.emit).toHaveBeenCalledWith("taskPrInfoChanged", {
       taskId: "task-1",
       prUrl: PR_NEW,
       prUrls: [PR_NEW, PR_OLD],
-      prState: "open",
-    });
-  });
-
-  it("emits a null state when the promoted PR's details are unavailable", async () => {
-    const getPrDetailsByUrl = vi.fn().mockResolvedValue(null);
-    const { service, workspaceService, workspaceRepo } =
-      makeService(getPrDetailsByUrl);
-
-    await service.setPrimaryPrUrl("task-1", PR_NEW);
-
-    expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-1", {
-      prUrl: PR_NEW,
-      prState: null,
-      accumulate: false,
-    });
-    expect(workspaceService.emit).toHaveBeenCalledWith("taskPrInfoChanged", {
-      taskId: "task-1",
-      prUrl: PR_NEW,
-      prUrls: [PR_NEW, PR_OLD],
-      prState: null,
+      prState: expectedPrState,
     });
   });
 });

--- a/packages/workspace-server/src/services/git/task-pr-status.test.ts
+++ b/packages/workspace-server/src/services/git/task-pr-status.test.ts
@@ -215,14 +215,15 @@ describe("TaskPrStatusService revalidation PR detection", () => {
 });
 
 describe("TaskPrStatusService.setPrimaryPrUrl", () => {
-  it("emits the promoted url as prUrl even though the row column is stale", () => {
-    const PR_OLD = "https://github.com/acme/repo/pull/1";
-    const PR_NEW = "https://github.com/acme/repo/pull/2";
-    const gitService = {} as unknown as GitService;
+  const PR_OLD = "https://github.com/acme/repo/pull/1";
+  const PR_NEW = "https://github.com/acme/repo/pull/2";
+
+  function makeService(getPrDetailsByUrl: ReturnType<typeof vi.fn>) {
+    const gitService = { getPrDetailsByUrl } as unknown as GitService;
     const workspaceService = { emit: vi.fn() };
     const workspaceRepo = {
       promotePrUrl: vi.fn(),
-      findByTaskId: vi.fn().mockReturnValue({ prUrl: PR_OLD, prState: "open" }),
+      updatePrCache: vi.fn(),
       getPrUrls: vi.fn().mockReturnValue([PR_NEW, PR_OLD]),
     };
     const service = new TaskPrStatusService(
@@ -230,15 +231,50 @@ describe("TaskPrStatusService.setPrimaryPrUrl", () => {
       workspaceRepo as unknown as IWorkspaceRepository,
       workspaceService as unknown as WorkspaceService,
     );
+    return { service, workspaceService, workspaceRepo };
+  }
 
-    service.setPrimaryPrUrl("task-1", PR_NEW);
+  it("recomputes and emits the promoted PR's live state, not the stale cache", async () => {
+    const getPrDetailsByUrl = vi
+      .fn()
+      .mockResolvedValue({ state: "open", merged: false, draft: false });
+    const { service, workspaceService, workspaceRepo } =
+      makeService(getPrDetailsByUrl);
+
+    await service.setPrimaryPrUrl("task-1", PR_NEW);
 
     expect(workspaceRepo.promotePrUrl).toHaveBeenCalledWith("task-1", PR_NEW);
+    expect(getPrDetailsByUrl).toHaveBeenCalledWith(PR_NEW);
+    expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-1", {
+      prUrl: PR_NEW,
+      prState: "open",
+      accumulate: false,
+    });
     expect(workspaceService.emit).toHaveBeenCalledWith("taskPrInfoChanged", {
       taskId: "task-1",
       prUrl: PR_NEW,
       prUrls: [PR_NEW, PR_OLD],
       prState: "open",
+    });
+  });
+
+  it("emits a null state when the promoted PR's details are unavailable", async () => {
+    const getPrDetailsByUrl = vi.fn().mockResolvedValue(null);
+    const { service, workspaceService, workspaceRepo } =
+      makeService(getPrDetailsByUrl);
+
+    await service.setPrimaryPrUrl("task-1", PR_NEW);
+
+    expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-1", {
+      prUrl: PR_NEW,
+      prState: null,
+      accumulate: false,
+    });
+    expect(workspaceService.emit).toHaveBeenCalledWith("taskPrInfoChanged", {
+      taskId: "task-1",
+      prUrl: PR_NEW,
+      prUrls: [PR_NEW, PR_OLD],
+      prState: null,
     });
   });
 });

--- a/packages/workspace-server/src/services/git/task-pr-status.ts
+++ b/packages/workspace-server/src/services/git/task-pr-status.ts
@@ -50,7 +50,9 @@ export class TaskPrStatusService {
 
   async setPrimaryPrUrl(taskId: string, prUrl: string): Promise<void> {
     this.workspaceRepo.promotePrUrl(taskId, prUrl);
-    const details = await this.gitService.getPrDetailsByUrl(prUrl);
+    const details = await this.gitService
+      .getPrDetailsByUrl(prUrl)
+      .catch(() => null);
     const prState: SidebarPrState = details
       ? mapPrState(details.state, details.merged, details.draft)
       : null;

--- a/packages/workspace-server/src/services/git/task-pr-status.ts
+++ b/packages/workspace-server/src/services/git/task-pr-status.ts
@@ -48,14 +48,22 @@ export class TaskPrStatusService {
     };
   }
 
-  setPrimaryPrUrl(taskId: string, prUrl: string): void {
+  async setPrimaryPrUrl(taskId: string, prUrl: string): Promise<void> {
     this.workspaceRepo.promotePrUrl(taskId, prUrl);
-    const row = this.workspaceRepo.findByTaskId(taskId);
+    const details = await this.gitService.getPrDetailsByUrl(prUrl);
+    const prState: SidebarPrState = details
+      ? mapPrState(details.state, details.merged, details.draft)
+      : null;
+    this.workspaceRepo.updatePrCache(taskId, {
+      prUrl,
+      prState,
+      accumulate: false,
+    });
     this.workspaceService.emit("taskPrInfoChanged", {
       taskId,
       prUrl,
       prUrls: this.workspaceRepo.getPrUrls(taskId),
-      prState: row?.prState ?? null,
+      prState,
     });
   }
 


### PR DESCRIPTION
## Problem

The #3227 feature let a task carry multiple PRs, with the "primary" PR being whichever URL sits at index 0 of an ordered list. A task's displayed state (`merged` / `open` / `draft` / `closed`) is a denormalized cache derived from that primary PR.

When a user promotes a different PR to primary (via the "Other PRs" submenu), `TaskPrStatusService.setPrimaryPrUrl` reordered the URL list but broadcast the **old** primary's cached `prState` alongside the **new** primary's URL. If the old primary was merged and the new primary was still open, every consumer of the `taskPrInfoChanged` event (sidebar badge, inbox, home, code-review) showed the task as "merged" while its primary PR was actually open. The drift only self-healed up to ~60s later when the next background revalidation poll overwrote the cache.

Root cause: `promotePrUrl` only rewrites the `prUrls` JSON column; the `prUrl`/`prState` columns are maintained by a separate `updatePrCache` path driven by revalidation, so the two disagreed until the next poll.

## Fix

`setPrimaryPrUrl` now fetches the promoted PR's live state via `gitService.getPrDetailsByUrl` + `mapPrState` (the same primitives `computeTaskPrStatus` already uses), persists it through `updatePrCache`, then emits the fresh state. The cache columns and `prUrls[0]` can no longer disagree, and every `taskPrInfoChanged` consumer updates immediately rather than on the next poll.

The port signature changed from `void` to `Promise<void>`; the tRPC router forward already awaits it transparently.

## Non-goals

The reverse scenario (a *non-primary* PR merging) intentionally leaves task state unchanged, since state is derived only from the primary PR.

## Testing

- Replaced the `setPrimaryPrUrl` test that codified the buggy stale-emit with two tests: one asserting the promoted PR's live state is recomputed and emitted, one covering `getPrDetailsByUrl` → null yielding `prState: null`.
- `pnpm --filter @posthog/workspace-server test task-pr-status` — 7 tests pass.
- `@posthog/workspace-server` and `@posthog/host-router` typecheck clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*