### PR TITLE
feat(channel): quill ThreadItem feed — day separators, smoother scroll

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -10,14 +10,8 @@ import {
   AvatarFallback,
   AvatarGroup,
   Badge,
-  Button,
-  ButtonGroup,
   Card,
   CardContent,
-  ChatMessage,
-  ChatMessageAvatar,
-  ChatMessageContent,
-  ChatMessageHeader,
   ChatMessageScroller,
   ChatMessageScrollerButton,
   ChatMessageScrollerContent,
@@ -26,10 +20,18 @@ import {
   ChatMessageScrollerViewport,
   cn,
   Spinner,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
+  ThreadItem,
+  ThreadItemAction,
+  ThreadItemActions,
+  ThreadItemAuthor,
+  ThreadItemBody,
+  ThreadItemContent,
+  ThreadItemGutter,
+  ThreadItemHeader,
+  ThreadItemReplies,
+  ThreadItemRepliesLabel,
+  ThreadItemRepliesMeta,
+  ThreadItemTimestamp,
 } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
@@ -255,9 +257,9 @@ function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
     <Card
       size="sm"
       className={cn(
-        "mt-1.5 w-full cursor-pointer py-0 transition-colors hover:bg-fill-hover",
+        "mt-1.5 w-full max-w-[820px] cursor-pointer rounded-sm py-0 transition-none hover:bg-fill-hover",
         statusDisplay.isMerged
-          ? "border-transparent bg-(--purple-a1) shadow-[0_0_0_1px_var(--purple-8)]"
+          ? "border-transparent bg-(--purple-a2) shadow-[0_0_0_1px_var(--purple-8)] hover:bg-(--purple-a3) dark:bg-(--purple-a1) dark:hover:bg-(--purple-a2)"
           : "hover:border-border-primary",
       )}
       onClick={onOpen}
@@ -328,11 +330,7 @@ function RepliesRow({
   const last = messages[messages.length - 1];
 
   return (
-    <button
-      type="button"
-      onClick={onOpenThread}
-      className="mt-1 flex w-fit items-center gap-2 rounded-md px-1.5 py-1 hover:bg-fill-secondary"
-    >
+    <ThreadItemReplies onClick={onOpenThread} className="mt-1">
       <AvatarGroup size="xs" stacked>
         {authors.map((author, index) => (
           <Avatar key={author?.uuid ?? index} size="xs">
@@ -340,13 +338,13 @@ function RepliesRow({
           </Avatar>
         ))}
       </AvatarGroup>
-      <Text size="1" weight="medium" className="text-accent-11">
+      <ThreadItemRepliesLabel>
         {messages.length} {messages.length === 1 ? "reply" : "replies"}
-      </Text>
-      <Text size="1" className="text-muted-foreground">
+      </ThreadItemRepliesLabel>
+      <ThreadItemRepliesMeta>
         Last reply {formatRelativeTimeShort(last.created_at)}
-      </Text>
-    </button>
+      </ThreadItemRepliesMeta>
+    </ThreadItemReplies>
   );
 }
 
@@ -363,11 +361,8 @@ function FeedItem({
   const isAgent = !task.created_by || task.origin_product !== "user_created";
 
   return (
-    <ChatMessage className="group relative rounded-md px-3 py-2 hover:bg-fill-secondary/50">
-      {/* Quill's avatar slot bottom-aligns for bubble chats; a Slack feed
-          anchors it beside the name row. The slot draws its own circle, so
-          drop its background and let the inner Avatar render. */}
-      <ChatMessageAvatar className="self-start bg-transparent">
+    <ThreadItem className="py-4 pr-8 hover:bg-fill-hover/10">
+      <ThreadItemGutter>
         <Avatar>
           <AvatarFallback>
             {isAgent && !task.created_by ? (
@@ -377,64 +372,49 @@ function FeedItem({
             )}
           </AvatarFallback>
         </Avatar>
-      </ChatMessageAvatar>
-      <ChatMessageContent className="min-w-0 gap-0.5">
-        <ChatMessageHeader className="items-baseline gap-2 px-0">
-          <Text size="2" weight="bold" className="truncate">
-            {task.created_by ? userDisplayName(task.created_by) : "Agent"}
-          </Text>
-          {isAgent && <Badge variant="info">Agent</Badge>}
-          <Text size="1" className="shrink-0 text-muted-foreground">
-            {formatRelativeTimeShort(task.created_at)}
-          </Text>
-        </ChatMessageHeader>
+      </ThreadItemGutter>
 
-        <Text size="2" className="line-clamp-4 whitespace-pre-wrap break-words">
+      <ThreadItemContent className="min-w-0">
+        <ThreadItemHeader>
+          <ThreadItemAuthor>
+            {task.created_by ? userDisplayName(task.created_by) : "Agent"}
+          </ThreadItemAuthor>
+          {isAgent && <Badge variant="info">Agent</Badge>}
+          <ThreadItemTimestamp
+            dateTime={new Date(task.created_at).toISOString()}
+          >
+            {formatRelativeTimeShort(task.created_at)}
+          </ThreadItemTimestamp>
+        </ThreadItemHeader>
+
+        <ThreadItemBody className="wrap-break-word line-clamp-4 whitespace-pre-wrap">
           {prompt}
-        </Text>
+        </ThreadItemBody>
 
         <TaskCard task={task} onOpen={() => onOpenTask(task)} />
         <RepliesRow taskId={task.id} onOpenThread={() => onOpenThread(task)} />
-      </ChatMessageContent>
+      </ThreadItemContent>
 
-      {/* Hover toolbar, storybook-style: floats top-right of the row. */}
-      <div className="absolute top-1 right-2 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
-        <TooltipProvider delay={400}>
-          <ButtonGroup className="rounded-md border border-border bg-surface shadow-sm">
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="default"
-                    size="icon-sm"
-                    aria-label="Reply in thread"
-                    onClick={() => onOpenThread(task)}
-                  >
-                    <ChatCircleIcon size={15} />
-                  </Button>
-                }
-              />
-              <TooltipContent side="top">Reply in thread</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="default"
-                    size="icon-sm"
-                    aria-label="Open task"
-                    onClick={() => onOpenTask(task)}
-                  >
-                    <ArrowSquareOutIcon size={15} />
-                  </Button>
-                }
-              />
-              <TooltipContent side="top">Open task</TooltipContent>
-            </Tooltip>
-          </ButtonGroup>
-        </TooltipProvider>
-      </div>
-    </ChatMessage>
+      {/* Actions anchor to the row's top-right corner; a top tooltip there
+          overhangs the panel edge and gets clipped by the scroll container, so
+          open tooltips toward the content instead. */}
+      <ThreadItemActions aria-label="Message actions" className="inset-bs-2">
+        <ThreadItemAction
+          label="Reply in thread"
+          tooltipSide="left"
+          onClick={() => onOpenThread(task)}
+        >
+          <ChatCircleIcon size={15} />
+        </ThreadItemAction>
+        <ThreadItemAction
+          label="Open task"
+          tooltipSide="left"
+          onClick={() => onOpenTask(task)}
+        >
+          <ArrowSquareOutIcon size={15} />
+        </ThreadItemAction>
+      </ThreadItemActions>
+    </ThreadItem>
   );
 }
 
@@ -470,9 +450,22 @@ export function ChannelFeedView({
     <ChatMessageScrollerProvider defaultScrollPosition="end">
       <ChatMessageScroller className="min-h-0 flex-1">
         <ChatMessageScrollerViewport>
-          <ChatMessageScrollerContent className="mx-auto w-full max-w-[820px] px-1 py-3">
+          {/* Horizontal padding is load-bearing: ThreadItem's actions float at
+              the row's top-right corner (absolute, past the row edge). Without a
+              gutter they hug the scroll container and get clipped. */}
+          <ChatMessageScrollerContent className="mx-auto w-full gap-0 py-4">
             {tasks.map((task) => (
-              <ChatMessageScrollerItem key={task.id} messageId={task.id}>
+              <ChatMessageScrollerItem
+                key={task.id}
+                messageId={task.id}
+                // Rows already get `content-visibility:auto` from quill, but its
+                // default `contain-intrinsic-size` (10rem) under-reserves a feed
+                // row (message + task card + replies ≈ 13rem), so off-screen
+                // rows collapse too small and the scrollbar jumps as they paint
+                // in. A closer estimate keeps scrolling stable; `auto` still
+                // remembers each row's real height after its first render.
+                className="[contain-intrinsic-size:auto_13rem] hover:bg-fill-hover/50"
+              >
                 <FeedItem
                   task={task}
                   onOpenTask={onOpenTask}

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -24,6 +24,7 @@ import {
   ChatMessageScrollerItem,
   ChatMessageScrollerProvider,
   ChatMessageScrollerViewport,
+  cn,
   Spinner,
   Tooltip,
   TooltipContent,
@@ -41,8 +42,12 @@ import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import { xmlToPlainText } from "@posthog/ui/features/message-editor/content";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { getOriginProductMeta } from "@posthog/ui/features/sidebar/components/items/TaskIcon";
+import {
+  type SidebarPrState,
+  useTaskPrStatus,
+} from "@posthog/ui/features/sidebar/useTaskPrStatus";
 import { Text } from "@radix-ui/themes";
-import { useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 
 // Feed rows poll their reply counts slower than the open thread panel — the
 // shared query key means an open panel naturally speeds the row up too.
@@ -52,9 +57,25 @@ const STATUS_LABELS: Record<TaskRunStatus, string> = {
   not_started: "Not started",
   queued: "Queued",
   in_progress: "In progress",
-  completed: "Completed",
+  // "Ready", not "Completed": the agent has finished its work and the task is
+  // ready to look at, but the change itself isn't necessarily shipped/done.
+  completed: "Ready",
   failed: "Failed",
   cancelled: "Cancelled",
+};
+
+// Once a PR exists its GitHub state is the truest top-line status — more
+// accurate than the run status, which routinely lingers on "in_progress"
+// (or a stale cloud status) after the agent opens the PR. Mirrors the PR
+// states the sidebar's TaskIcon already renders.
+const PR_STATE_LABELS: Record<
+  Exclude<SidebarPrState, null>,
+  { label: string; variant: "success" | "info" | "default" | "destructive" }
+> = {
+  merged: { label: "Merged", variant: "success" },
+  open: { label: "PR ready", variant: "info" },
+  draft: { label: "Draft PR", variant: "default" },
+  closed: { label: "Closed", variant: "destructive" },
 };
 
 function statusBadge(status: TaskRunStatus) {
@@ -74,30 +95,112 @@ function statusBadge(status: TaskRunStatus) {
   );
 }
 
+interface TaskStatusDisplay {
+  // The run/environment badge ("Local", "Completed", "In progress", …).
+  base: ReactNode;
+  // The PR's GitHub state, shown alongside the run badge when a PR exists.
+  prState: Exclude<SidebarPrState, null> | null;
+  // Whether the PR has merged — the card lifts this to a purple border + tint.
+  isMerged: boolean;
+}
+
 // Live status for the card, derived the same way the sidebar's TaskIcon does
 // (via useChannelTaskData: local session + workspace + cloud run). The raw
 // `latest_run.status` alone is wrong for local runs — the backend row often
 // stays "queued" while the agent runs on the creator's machine — so it is
 // only trusted for cloud runs and terminal states (which imply a sync).
-function TaskStatusBadge({ task }: { task: Task }) {
+//
+// Once a PR exists its state ("PR ready", "Merged", …) is the sole top-line
+// status — it replaces the run badge rather than sitting next to it, so a
+// shipped task never reads "Ready + Merged" or a stale "In progress + PR
+// ready". A failed/cancelled run suppresses the PR badge instead — that is a
+// deliberate end state we should not soften with a PR.
+function useTaskStatusDisplay(task: Task): TaskStatusDisplay {
   const data = useChannelTaskData(task);
-  if (data?.needsPermission)
-    return <Badge variant="warning">Needs input</Badge>;
-  if (data?.isGenerating) {
-    return (
+  const { prState } = useTaskPrStatus({
+    id: task.id,
+    cloudPrUrl: data?.cloudPrUrl ?? null,
+    taskRunEnvironment: data?.taskRunEnvironment ?? null,
+  });
+  const status = data?.taskRunStatus ?? task.latest_run?.status;
+  const environment = data?.taskRunEnvironment ?? task.latest_run?.environment;
+  // `prState` is resolved async from git/`gh` and is routinely null for cloud
+  // tasks (the details fetch hasn't landed, or there's no cached row). But the
+  // PR URL itself is a hard signal a PR exists — the card's "PR" link keys off
+  // exactly this. Fall back to it so the badge and the link never disagree; a
+  // known URL with no resolved state is shown as the neutral "open" ("PR
+  // ready"), never something stronger like "merged".
+  const hasPrUrl =
+    typeof (data?.cloudPrUrl ?? task.latest_run?.output?.pr_url) === "string";
+  const effectivePrState: Exclude<SidebarPrState, null> | null =
+    prState ?? (hasPrUrl ? "open" : null);
+  const showPrState =
+    !!effectivePrState && status !== "failed" && status !== "cancelled";
+
+  let base: ReactNode;
+  if (data?.needsPermission) {
+    // Live, actionable states still win over the PR badge — the agent is
+    // waiting on the user right now, which matters more than a PR existing.
+    base = <Badge variant="warning">Needs input</Badge>;
+  } else if (data?.isGenerating) {
+    base = (
       <Badge variant="info">
         <Spinner className="size-2.5" />
         In progress
       </Badge>
     );
+  } else if (showPrState) {
+    // Otherwise the PR badge is the whole story once a PR exists; skip the run
+    // badge so we never show "Ready + Merged" or a stale "In progress".
+    base = null;
+  } else if (!status) {
+    base = <Badge>Draft</Badge>;
+  } else if (environment === "cloud" || isTerminalStatus(status)) {
+    base = statusBadge(status);
+  } else {
+    // Local, non-terminal: the run status is unreliable (the backend row stays
+    // "queued" while the agent runs on the creator's machine), and the
+    // environment already shows in the card's meta row ("· Local"), so we
+    // render no status badge here rather than a redundant "Local" pill.
+    base = null;
   }
-  const status = data?.taskRunStatus ?? task.latest_run?.status;
-  const environment = data?.taskRunEnvironment ?? task.latest_run?.environment;
-  if (!status) return <Badge>Draft</Badge>;
-  if (environment === "cloud" || isTerminalStatus(status)) {
-    return statusBadge(status);
+
+  return {
+    base,
+    prState: showPrState ? effectivePrState : null,
+    isMerged: showPrState && effectivePrState === "merged",
+  };
+}
+
+// The merged badge borrows the purple GitHub-merge accent (matching the
+// sidebar's TaskIcon merge glyph). Quill has no purple variant, so we tint a
+// neutral badge with the Radix purple scale — allowed inline because the
+// values are CSS variables, not hardcoded colors.
+function PrStateBadge({ prState }: { prState: Exclude<SidebarPrState, null> }) {
+  const { label, variant } = PR_STATE_LABELS[prState];
+  if (prState === "merged") {
+    return (
+      <Badge
+        variant="default"
+        style={{
+          backgroundColor: "var(--purple-a3)",
+          color: "var(--purple-11)",
+        }}
+      >
+        {label}
+      </Badge>
+    );
   }
-  return <Badge>Local</Badge>;
+  return <Badge variant={variant}>{label}</Badge>;
+}
+
+function TaskStatusBadge({ display }: { display: TaskStatusDisplay }) {
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      {display.base}
+      {display.prState && <PrStateBadge prState={display.prState} />}
+    </div>
+  );
 }
 
 // The prompt as the user typed it: drop the channel CONTEXT.md block the saga
@@ -130,28 +233,39 @@ function TaskCardOrigin({ task }: { task: Task }) {
 // The task the message kicked off, as a card everyone in the channel sees:
 // origin + status up top, bold title, then run metadata.
 function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
+  const statusDisplay = useTaskStatusDisplay(task);
   const prUrl =
     typeof task.latest_run?.output?.pr_url === "string"
       ? task.latest_run.output.pr_url
       : undefined;
   // The repository renders separately with its icon; `meta` is the plain-text
   // remainder of the row.
+  const environment = task.latest_run?.environment;
   const meta = [
     task.slug || null,
     task.latest_run?.stage ?? null,
-    task.latest_run?.environment === "cloud" ? "Cloud" : null,
+    environment === "cloud"
+      ? "Cloud"
+      : environment === "local"
+        ? "Local"
+        : null,
   ].filter(Boolean) as string[];
 
   return (
     <Card
       size="sm"
-      className="mt-1.5 w-full cursor-pointer transition-colors hover:border-border-primary"
+      className={cn(
+        "mt-1.5 w-full cursor-pointer py-0 transition-colors hover:bg-fill-hover",
+        statusDisplay.isMerged
+          ? "border-transparent bg-(--purple-a1) shadow-[0_0_0_1px_var(--purple-8)]"
+          : "hover:border-border-primary",
+      )}
       onClick={onOpen}
     >
       <CardContent className="flex flex-col gap-1 py-2.5">
         <div className="flex items-center justify-between gap-2">
           <TaskCardOrigin task={task} />
-          <TaskStatusBadge task={task} />
+          <TaskStatusBadge display={statusDisplay} />
         </div>
         <div className="flex min-w-0 items-center gap-1.5">
           {/* Same live status icon as the code side nav, so the card and the

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -12,6 +12,8 @@ import {
   Badge,
   Card,
   CardContent,
+  ChatMarker,
+  ChatMarkerContent,
   ChatMessageScroller,
   ChatMessageScrollerButton,
   ChatMessageScrollerContent,
@@ -48,8 +50,9 @@ import {
   type SidebarPrState,
   useTaskPrStatus,
 } from "@posthog/ui/features/sidebar/useTaskPrStatus";
+import { useInView } from "@posthog/ui/primitives/hooks/useInView";
 import { Text } from "@radix-ui/themes";
-import { type ReactNode, useMemo } from "react";
+import { Fragment, memo, type ReactNode, useMemo } from "react";
 
 // Feed rows poll their reply counts slower than the open thread panel — the
 // shared query key means an open panel naturally speeds the row up too.
@@ -95,6 +98,39 @@ function statusBadge(status: TaskRunStatus) {
       {STATUS_LABELS[status]}
     </Badge>
   );
+}
+
+// Local calendar-day identity, so tasks created on the same day share a heading
+// regardless of time. Uses local getters (not the UTC ISO) so the split lands
+// on the viewer's midnight.
+function dayKey(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+function ordinal(n: number): string {
+  const suffix = ["th", "st", "nd", "rd"];
+  const rem = n % 100;
+  return `${n}${suffix[(rem - 20) % 10] ?? suffix[rem] ?? suffix[0]}`;
+}
+
+// The day-separator label: "Today" / "Yesterday" for the recent days, then a
+// weekday + ordinal ("Monday 5th") within the week, adding the month (and the
+// year when it differs) further back so older separators stay unambiguous.
+function dayLabel(iso: string, now: Date): string {
+  const date = new Date(iso);
+  const startOfDay = (d: Date) =>
+    new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  const days = Math.round((startOfDay(now) - startOfDay(date)) / 86_400_000);
+  if (days <= 0) return "Today";
+  if (days === 1) return "Yesterday";
+  const weekday = date.toLocaleDateString(undefined, { weekday: "long" });
+  const day = ordinal(date.getDate());
+  if (days < 7) return `${weekday} ${day}`;
+  const month = date.toLocaleDateString(undefined, { month: "long" });
+  const year =
+    date.getFullYear() === now.getFullYear() ? "" : `, ${date.getFullYear()}`;
+  return `${weekday}, ${month} ${day}${year}`;
 }
 
 interface TaskStatusDisplay {
@@ -331,7 +367,7 @@ function RepliesRow({
 
   return (
     <ThreadItemReplies onClick={onOpenThread} className="mt-1">
-      <AvatarGroup size="xs" stacked>
+      <AvatarGroup size="xs">
         {authors.map((author, index) => (
           <Avatar key={author?.uuid ?? index} size="xs">
             <AvatarFallback>{getUserInitials(author)}</AvatarFallback>
@@ -348,12 +384,14 @@ function RepliesRow({
   );
 }
 
-function FeedItem({
+const FeedItem = memo(function FeedItem({
   task,
+  inView,
   onOpenTask,
   onOpenThread,
 }: {
   task: Task;
+  inView: boolean;
   onOpenTask: (task: Task) => void;
   onOpenThread: (task: Task) => void;
 }) {
@@ -361,7 +399,7 @@ function FeedItem({
   const isAgent = !task.created_by || task.origin_product !== "user_created";
 
   return (
-    <ThreadItem className="py-4 pr-8 hover:bg-fill-hover/10">
+    <ThreadItem className="rounded-none py-4 pr-8 hover:bg-fill-hover/50">
       <ThreadItemGutter>
         <Avatar>
           <AvatarFallback>
@@ -392,7 +430,15 @@ function FeedItem({
         </ThreadItemBody>
 
         <TaskCard task={task} onOpen={() => onOpenTask(task)} />
-        <RepliesRow taskId={task.id} onOpenThread={() => onOpenThread(task)} />
+        {/* Off-screen rows drop the reply teaser so a long feed isn't running a
+            15s poll timer per row; the wide inView margin mounts it well before
+            the row scrolls into view, so nothing pops in. */}
+        {inView && (
+          <RepliesRow
+            taskId={task.id}
+            onOpenThread={() => onOpenThread(task)}
+          />
+        )}
       </ThreadItemContent>
 
       {/* Actions anchor to the row's top-right corner; a top tooltip there
@@ -415,6 +461,40 @@ function FeedItem({
         </ThreadItemAction>
       </ThreadItemActions>
     </ThreadItem>
+  );
+});
+
+// One feed row: owns the scroller item (the `content-visibility` boundary, so
+// its box is always laid out and safe to observe) and reports whether it is
+// near the viewport, letting `FeedItem` shed off-screen polling.
+function FeedRow({
+  task,
+  onOpenTask,
+  onOpenThread,
+}: {
+  task: Task;
+  onOpenTask: (task: Task) => void;
+  onOpenThread: (task: Task) => void;
+}) {
+  const [ref, inView] = useInView<HTMLDivElement>({ rootMargin: "1200px 0px" });
+  return (
+    <ChatMessageScrollerItem
+      ref={ref}
+      messageId={task.id}
+      // Rows already get `content-visibility:auto` from quill, but its default
+      // `contain-intrinsic-size` (10rem) under-reserves a feed row (message +
+      // task card + replies ≈ 13rem), so off-screen rows collapse too small and
+      // the scrollbar jumps as they paint in. A closer estimate keeps scrolling
+      // stable; `auto` still remembers each row's real height after first paint.
+      className="[contain-intrinsic-size:auto_13rem]"
+    >
+      <FeedItem
+        task={task}
+        inView={inView}
+        onOpenTask={onOpenTask}
+        onOpenThread={onOpenThread}
+      />
+    </ChatMessageScrollerItem>
   );
 }
 
@@ -446,6 +526,8 @@ export function ChannelFeedView({
     return <div className="flex-1 overflow-y-auto">{emptyState}</div>;
   }
 
+  const now = new Date();
+
   return (
     <ChatMessageScrollerProvider defaultScrollPosition="end">
       <ChatMessageScroller className="min-h-0 flex-1">
@@ -454,25 +536,28 @@ export function ChannelFeedView({
               the row's top-right corner (absolute, past the row edge). Without a
               gutter they hug the scroll container and get clipped. */}
           <ChatMessageScrollerContent className="mx-auto w-full gap-0 py-4">
-            {tasks.map((task) => (
-              <ChatMessageScrollerItem
-                key={task.id}
-                messageId={task.id}
-                // Rows already get `content-visibility:auto` from quill, but its
-                // default `contain-intrinsic-size` (10rem) under-reserves a feed
-                // row (message + task card + replies ≈ 13rem), so off-screen
-                // rows collapse too small and the scrollbar jumps as they paint
-                // in. A closer estimate keeps scrolling stable; `auto` still
-                // remembers each row's real height after its first render.
-                className="[contain-intrinsic-size:auto_13rem] hover:bg-fill-hover/50"
-              >
-                <FeedItem
-                  task={task}
-                  onOpenTask={onOpenTask}
-                  onOpenThread={onOpenThread}
-                />
-              </ChatMessageScrollerItem>
-            ))}
+            {tasks.map((task, index) => {
+              const previous = tasks[index - 1];
+              const showDayMarker =
+                !previous ||
+                dayKey(previous.created_at) !== dayKey(task.created_at);
+              return (
+                <Fragment key={task.id}>
+                  {showDayMarker && (
+                    <ChatMarker variant="separator">
+                      <ChatMarkerContent>
+                        {dayLabel(task.created_at, now)}
+                      </ChatMarkerContent>
+                    </ChatMarker>
+                  )}
+                  <FeedRow
+                    task={task}
+                    onOpenTask={onOpenTask}
+                    onOpenThread={onOpenThread}
+                  />
+                </Fragment>
+              );
+            })}
           </ChatMessageScrollerContent>
         </ChatMessageScrollerViewport>
         <ChatMessageScrollerButton />

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -77,7 +77,7 @@ const PR_STATE_LABELS: Record<
   Exclude<SidebarPrState, null>,
   { label: string; variant: "success" | "info" | "default" | "destructive" }
 > = {
-  merged: { label: "Merged" },
+  merged: { label: "Merged", variant: "default" },
   open: { label: "PR ready", variant: "info" },
   draft: { label: "Draft PR", variant: "default" },
   closed: { label: "Closed", variant: "destructive" },

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -447,16 +447,11 @@ const FeedItem = memo(function FeedItem({
       <ThreadItemActions aria-label="Message actions" className="inset-bs-2">
         <ThreadItemAction
           label="Reply in thread"
-          tooltipSide="left"
           onClick={() => onOpenThread(task)}
         >
           <ChatCircleIcon size={15} />
         </ThreadItemAction>
-        <ThreadItemAction
-          label="Open task"
-          tooltipSide="left"
-          onClick={() => onOpenTask(task)}
-        >
+        <ThreadItemAction label="Open task" onClick={() => onOpenTask(task)}>
           <ArrowSquareOutIcon size={15} />
         </ThreadItemAction>
       </ThreadItemActions>

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -77,7 +77,7 @@ const PR_STATE_LABELS: Record<
   Exclude<SidebarPrState, null>,
   { label: string; variant: "success" | "info" | "default" | "destructive" }
 > = {
-  merged: { label: "Merged", variant: "success" },
+  merged: { label: "Merged" },
   open: { label: "PR ready", variant: "info" },
   draft: { label: "Draft PR", variant: "default" },
   closed: { label: "Closed", variant: "destructive" },

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -168,7 +168,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
           onOpenTask={handleOpenTask}
           onOpenThread={handleOpenThread}
         />
-        <div className="mx-auto w-full max-w-[820px] px-4 pb-4">
+        <div className="mx-auto w-full px-4 pb-4">
           <ChannelHomeComposer
             ref={composerRef}
             channelId={channelId}

--- a/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -359,7 +359,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
           <InputGroup
             onClick={handleContainerClick}
             onContextMenu={handleContextMenu}
-            className={`h-auto flex-1 cursor-text bg-card ${isBashMode ? "ring-1 ring-blue-9" : "focus-within:ring-1 focus-within:ring-purple-9"}`}
+            className={`h-auto flex-1 cursor-text bg-card ${isBashMode ? "ring-1 ring-blue-9" : "focus-within:border-ring/50 focus-within:ring-3 focus-within:ring-ring/30"}`}
             {...(tourTarget && {
               "data-tour": `${tourTarget}-editor`,
               "data-tour-ready": !isEmpty ? "true" : undefined,

--- a/packages/ui/src/features/message-editor/components/message-editor.css
+++ b/packages/ui/src/features/message-editor/components/message-editor.css
@@ -1,7 +1,7 @@
 /* Tiptap placeholder - targets empty first paragraph */
 .cli-editor p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
-  color: var(--gray-8);
+  color: var(--muted-foreground);
   pointer-events: none;
   float: left;
   height: 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^2.1.10
       version: 2.1.10
     '@posthog/quill':
-      specifier: 0.3.0-beta.21
-      version: 0.3.0-beta.21
+      specifier: 0.3.0-beta.22
+      version: 0.3.0-beta.22
     '@radix-ui/themes':
       specifier: ^3.2.1
       version: 3.3.0
@@ -189,7 +189,7 @@ importers:
         version: link:../../packages/platform
       '@posthog/quill':
         specifier: 'catalog:'
-        version: 0.3.0-beta.21(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)
+        version: 0.3.0-beta.22(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)
       '@posthog/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -1379,7 +1379,7 @@ importers:
         version: 2.1.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@posthog/quill':
         specifier: 'catalog:'
-        version: 0.3.0-beta.21(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)
+        version: 0.3.0-beta.22(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)
       '@posthog/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/typescript
@@ -5530,8 +5530,8 @@ packages:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
 
-  '@posthog/quill@0.3.0-beta.21':
-    resolution: {integrity: sha512-cA+9aERFpplPXhDn/zMywKR/LXqqI/CnA/IK6MDUZDP/HvebIzzXUvd40TiQN4hCoLrEhXwT5HGzQzHGNWTMdg==}
+  '@posthog/quill@0.3.0-beta.22':
+    resolution: {integrity: sha512-uRqG1XCBE9obCefyqlfcUU6h7xgBGadiWbalja6WBVa4ZpowOf1T2V3VUCuorZyC+I5H/+9ZHUlRXaq5RJPDVg==}
     engines: {node: '>=20'}
     peerDependencies:
       '@base-ui/react': ^1.4.0
@@ -18850,7 +18850,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       simple-statistics: 7.8.9
 
-  '@posthog/quill@0.3.0-beta.21(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)':
+  '@posthog/quill@0.3.0-beta.22(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.2)':
     dependencies:
       '@base-ui/react': 1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
@@ -18862,7 +18862,7 @@ snapshots:
       tailwind-merge: 2.6.1
       tailwindcss: 4.2.2
 
-  '@posthog/quill@0.3.0-beta.21(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)':
+  '@posthog/quill@0.3.0-beta.22(@base-ui/react@1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.1)':
     dependencies:
       '@base-ui/react': 1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
@@ -21406,7 +21406,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.20.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@22.20.0)(typescript@5.9.3))(vite@7.3.5(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@24.12.0)(typescript@5.9.3))(rolldown-vite@7.3.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -29144,6 +29144,36 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.0
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.8)
+      '@vitest/ui': 4.1.8(vitest@4.1.8)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/ui@4.1.8)(jsdom@26.1.0)(msw@2.12.8(@types/node@24.12.0)(typescript@5.9.3))(rolldown-vite@7.3.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@24.12.0)(typescript@5.9.3))(rolldown-vite@7.3.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: rolldown-vite@7.3.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.0)(esbuild@0.27.2)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.12.0
       '@vitest/ui': 4.1.8(vitest@4.1.8)
       jsdom: 26.1.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ catalog:
   '@hono/trpc-server': ^0.3.4
   '@parcel/watcher': ^2.5.6
   '@phosphor-icons/react': ^2.1.10
-  '@posthog/quill': 0.3.0-beta.21
+  '@posthog/quill': 0.3.0-beta.22
   '@radix-ui/themes': ^3.2.1
   '@tanstack/react-query': ^5.100.14
   '@tanstack/react-router': ^1.170.10


### PR DESCRIPTION
Rebuilds the channel feed on quill's ThreadItem primitives, adds day grouping, and cuts scroll jank.

<img width="1702" height="1504" alt="2026-07-08 13 34 51" src="https://github.com/user-attachments/assets/e3046eb4-9180-4604-9f06-9b46b4d78869" />


## Changes
- **ThreadItem feed** — rows now use quill's `ThreadItem` (gutter avatar, header, body, hover action bar) instead of hand-rolled `ChatMessage` markup. Needs the `@posthog/quill` `0.3.0-beta.22` bump (included).
- **Day separators** — a `ChatMarker` between days: "Today" / "Yesterday", then weekday + ordinal ("Monday 5th"), adding month/year further back.
- **Status badges** — once a PR exists its state (Merged / PR ready / Draft / Closed) is the top-line badge; merged shows a purple badge + card tint; run environment moves to the meta row (`· Local` / `· Cloud`), dropping the redundant "Local" pill.
- **Scroll perf** — memoized rows so task-list polls don't re-render the whole feed, off-screen reply-teaser polling gated behind an in-view observer, and `contain-intrinsic-size` tuned to the real ~13rem row height.
- **Minor** — full-width composer, prompt-input focus ring, message-editor placeholder color (`--muted-foreground`).

Supersedes #3254 (same work; that branch was renamed).