### PR TITLE
fix(cloud): keep cloud runs alive across network drops

### DIFF
--- a/apps/code/src/main/di/bindings.ts
+++ b/apps/code/src/main/di/bindings.ts
@@ -10,7 +10,9 @@ import type {
 } from "@posthog/core/auth/identifiers";
 import type {
   CLOUD_TASK_AUTH,
+  CLOUD_TASK_CONNECTIVITY,
   ICloudTaskAuth,
+  ICloudTaskConnectivity,
 } from "@posthog/core/cloud-task/identifiers";
 import type {
   CONTEXT_MENU_EXTERNAL_APPS_SERVICE,
@@ -368,6 +370,7 @@ export interface MainBindings {
   // Lifecycle / cloud task / context menu / deep link
   [MAIN_APP_LIFECYCLE_SERVICE]: AppLifecycleService;
   [CLOUD_TASK_AUTH]: ICloudTaskAuth;
+  [CLOUD_TASK_CONNECTIVITY]: ICloudTaskConnectivity;
   [MAIN_CLOUD_TASK_SERVICE]: unknown;
   [CONTEXT_MENU_EXTERNAL_APPS_SERVICE]: IContextMenuExternalApps;
   [MAIN_CONTEXT_MENU_SERVICE]: unknown;

--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -22,6 +22,7 @@ import { canvasCoreModule } from "@posthog/core/canvas/canvas.module";
 import { cloudTaskModule } from "@posthog/core/cloud-task/cloud-task.module";
 import {
   CLOUD_TASK_AUTH,
+  CLOUD_TASK_CONNECTIVITY,
   CLOUD_TASK_SERVICE,
 } from "@posthog/core/cloud-task/identifiers";
 import { contextMenuCoreModule } from "@posthog/core/context-menu/context-menu.module";
@@ -219,6 +220,7 @@ import { workspaceModule } from "@posthog/workspace-server/services/workspace/wo
 import { workspaceMetadataModule } from "@posthog/workspace-server/services/workspace-metadata/workspace-metadata.module";
 import ExternalAppsStoreImpl from "electron-store";
 import type { FileWatcherBridge } from "../index";
+import { CloudTaskConnectivityPortAdapter } from "../platform-adapters/cloud-task-connectivity";
 import { ElectronAppLifecycle } from "../platform-adapters/electron-app-lifecycle";
 import { ElectronAppMeta } from "../platform-adapters/electron-app-meta";
 import { ElectronAppMetrics } from "../platform-adapters/electron-app-metrics";
@@ -420,6 +422,10 @@ container.bind(CLOUD_TASK_AUTH).toDynamicValue((ctx) => ({
       .get<AuthService>(MAIN_AUTH_SERVICE)
       .authenticatedFetch(fetch, url, init),
 }));
+container
+  .bind(CLOUD_TASK_CONNECTIVITY)
+  .to(CloudTaskConnectivityPortAdapter)
+  .inSingletonScope();
 container.bind(MAIN_CLOUD_TASK_SERVICE).toService(CLOUD_TASK_SERVICE);
 container.load(contextMenuCoreModule);
 container

--- a/apps/code/src/main/platform-adapters/cloud-task-connectivity.ts
+++ b/apps/code/src/main/platform-adapters/cloud-task-connectivity.ts
@@ -1,0 +1,55 @@
+import type { ICloudTaskConnectivity } from "@posthog/core/cloud-task/identifiers";
+import type { WorkspaceClient } from "@posthog/workspace-client/client";
+import { inject, injectable } from "inversify";
+import { WORKSPACE_CLIENT } from "../di/tokens";
+
+/**
+ * Feeds the main-process cloud-run stream watcher real connectivity from the
+ * workspace-server ConnectivityService (the single connectivity source, shared
+ * with auth's ConnectivityPortAdapter). Tracks the offline→online edge so the
+ * watcher can pause while offline and resume the instant the network returns.
+ */
+@injectable()
+export class CloudTaskConnectivityPortAdapter
+  implements ICloudTaskConnectivity
+{
+  private online = true;
+  private readonly onlineHandlers = new Set<() => void>();
+
+  constructor(
+    @inject(WORKSPACE_CLIENT)
+    private readonly workspace: WorkspaceClient,
+  ) {
+    this.workspace.connectivity.onStatusChange.subscribe(undefined, {
+      onData: (status) => this.setOnline(status.isOnline),
+      onError: () => {},
+    });
+    void this.workspace.connectivity.getStatus
+      .query()
+      .then((status) => {
+        this.online = status.isOnline;
+      })
+      .catch(() => {});
+  }
+
+  isOnline(): boolean {
+    return this.online;
+  }
+
+  onOnline(callback: () => void): () => void {
+    this.onlineHandlers.add(callback);
+    return () => {
+      this.onlineHandlers.delete(callback);
+    };
+  }
+
+  private setOnline(next: boolean): void {
+    const cameOnline = !this.online && next;
+    this.online = next;
+    if (!cameOnline) return;
+    // Snapshot: a handler may unsubscribe itself (e.g. a watcher that resumes).
+    for (const handler of [...this.onlineHandlers]) {
+      handler();
+    }
+  }
+}

--- a/packages/core/src/cloud-task/cloud-task-types.ts
+++ b/packages/core/src/cloud-task/cloud-task-types.ts
@@ -40,6 +40,16 @@ export interface CloudTaskErrorUpdate extends CloudTaskUpdateBase {
   retryable: boolean;
 }
 
+/**
+ * Transient posture: the client lost its stream connection but the run is still
+ * executing server-side (typically a local network drop). Distinct from
+ * `error`, which is a genuine terminal failure with a Retry affordance. The
+ * watcher resumes on its own when the network returns.
+ */
+export interface CloudTaskReconnectingUpdate extends CloudTaskUpdateBase {
+  kind: "reconnecting";
+}
+
 export interface CloudPermissionOption {
   kind: string;
   optionId: string;
@@ -66,4 +76,5 @@ export type CloudTaskUpdatePayload =
   | CloudTaskStatusUpdate
   | CloudTaskSnapshotUpdate
   | CloudTaskErrorUpdate
+  | CloudTaskReconnectingUpdate
   | CloudTaskPermissionRequestUpdate;

--- a/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/packages/core/src/cloud-task/cloud-task.test.ts
@@ -28,6 +28,27 @@ const mockAuthService = {
   authenticatedFetch: vi.fn(),
 };
 
+// Controllable connectivity fake: default online, with a way to flip offline and
+// fire the offline→online edge that the watcher listens on.
+function createConnectivityMock() {
+  let online = true;
+  const handlers = new Set<() => void>();
+  return {
+    isOnline: () => online,
+    onOnline: (cb: () => void) => {
+      handlers.add(cb);
+      return () => handlers.delete(cb);
+    },
+    setOnline(next: boolean) {
+      const cameOnline = !online && next;
+      online = next;
+      if (cameOnline) {
+        for (const cb of [...handlers]) cb();
+      }
+    },
+  };
+}
+
 function createJsonResponse(
   data: unknown,
   status = 200,
@@ -68,6 +89,35 @@ function createOpenSseResponse(payload: string, status = 200): Response {
   });
 }
 
+// Open stream that errors its body when the connection's abort signal fires,
+// so the idle watchdog's controller.abort() actually rejects reader.read()
+// (a plain mock stream ignores the signal and would just hang).
+function createAbortableOpenSseResponse(
+  signal: AbortSignal | undefined,
+  initialPayload = "",
+): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (initialPayload) {
+        controller.enqueue(encoder.encode(initialPayload));
+      }
+      const fail = () =>
+        controller.error(new DOMException("Aborted", "AbortError"));
+      if (signal?.aborted) {
+        fail();
+        return;
+      }
+      signal?.addEventListener("abort", fail, { once: true });
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
 async function waitFor(
   predicate: () => boolean,
   timeoutMs = 2_000,
@@ -87,6 +137,7 @@ async function waitFor(
 
 describe("CloudTaskService", () => {
   let service: CloudTaskService;
+  let connectivity: ReturnType<typeof createConnectivityMock>;
 
   beforeEach(() => {
     const scopedLog = {
@@ -97,10 +148,12 @@ describe("CloudTaskService", () => {
     };
     const loggerMock = { ...scopedLog, scope: vi.fn(() => scopedLog) };
     const analyticsMock = { track: vi.fn() };
+    connectivity = createConnectivityMock();
     service = new CloudTaskService(
       mockAuthService as never,
       analyticsMock as never,
       loggerMock,
+      connectivity,
     );
     mockNetFetch.mockReset();
     mockStreamFetch.mockReset();
@@ -1792,6 +1845,180 @@ describe("CloudTaskService", () => {
         "Lost connection to the cloud run stream. Retry to reconnect.",
       retryable: true,
     });
+  });
+
+  it("waits for the network instead of failing while offline, then resumes", async () => {
+    vi.useFakeTimers();
+
+    const updates: { kind?: string }[] = [];
+    service.on(CloudTaskEvent.Update, (payload) =>
+      updates.push(payload as { kind?: string }),
+    );
+
+    const inProgressRun = () =>
+      createJsonResponse({
+        id: "run-1",
+        status: "in_progress",
+        stage: null,
+        output: null,
+        error_message: null,
+        branch: "main",
+        updated_at: "2026-01-01T00:00:00Z",
+      });
+
+    mockNetFetch
+      .mockResolvedValueOnce(inProgressRun()) // bootstrap: fetchTaskRun
+      .mockResolvedValueOnce(
+        createJsonResponse([], 200, { "X-Has-More": "false" }),
+      ) // bootstrap: fetchSessionLogs
+      .mockImplementation(() => Promise.resolve(inProgressRun()));
+
+    mockStreamFetch.mockImplementation(() =>
+      Promise.resolve(
+        createSseResponse('event: error\ndata: {"error":"boom"}\n\n'),
+      ),
+    );
+
+    // Offline before the watch: the stream error must not burn the budget.
+    connectivity.setOnline(false);
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() => mockStreamFetch.mock.calls.length === 1);
+    // Well beyond the ~60s online budget — offline must not fail the watcher.
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    const offlineKinds = updates.map((u) => u.kind);
+    expect(offlineKinds).toContain("reconnecting");
+    expect(offlineKinds).not.toContain("error");
+    // No reconnect attempts fired while offline.
+    expect(mockStreamFetch.mock.calls.length).toBe(1);
+
+    // Network returns: the watcher resumes the stream on its own.
+    connectivity.setOnline(true);
+    await waitFor(() => mockStreamFetch.mock.calls.length >= 2, 10_000);
+    expect(updates.map((u) => u.kind)).not.toContain("error");
+  });
+
+  it("re-fetches terminal status on resume for a run that finished while offline", async () => {
+    vi.useFakeTimers();
+
+    const updates: { kind?: string; status?: string }[] = [];
+    service.on(CloudTaskEvent.Update, (payload) =>
+      updates.push(payload as { kind?: string; status?: string }),
+    );
+
+    const inProgressRun = () =>
+      createJsonResponse({
+        id: "run-1",
+        status: "in_progress",
+        stage: null,
+        output: null,
+        error_message: null,
+        branch: "main",
+        updated_at: "2026-01-01T00:00:00Z",
+      });
+    const completedRun = () =>
+      createJsonResponse({
+        id: "run-1",
+        status: "completed",
+        stage: null,
+        output: null,
+        error_message: null,
+        branch: "main",
+        updated_at: "2026-01-01T00:05:00Z",
+      });
+
+    mockNetFetch
+      .mockResolvedValueOnce(inProgressRun()) // bootstrap: fetchTaskRun
+      .mockResolvedValueOnce(
+        createJsonResponse([], 200, { "X-Has-More": "false" }),
+      ) // bootstrap: fetchSessionLogs
+      .mockImplementation(() => Promise.resolve(inProgressRun()));
+
+    mockStreamFetch.mockImplementation(() =>
+      Promise.resolve(
+        createSseResponse('event: error\ndata: {"error":"boom"}\n\n'),
+      ),
+    );
+
+    connectivity.setOnline(false);
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+    await waitFor(() => mockStreamFetch.mock.calls.length === 1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const streamCallsWhileOffline = mockStreamFetch.mock.calls.length;
+
+    // The run completed during the outage.
+    mockNetFetch.mockImplementation(() => Promise.resolve(completedRun()));
+    connectivity.setOnline(true);
+
+    await waitFor(
+      () =>
+        updates.some((u) => u.kind === "status" && u.status === "completed"),
+      10_000,
+    );
+    // Terminal status finalizes without opening another stream, and never errors.
+    expect(mockStreamFetch.mock.calls.length).toBe(streamCallsWhileOffline);
+    expect(updates.map((u) => u.kind)).not.toContain("error");
+  });
+
+  it("reconnects when the stream goes idle past the keepalive deadline", async () => {
+    vi.useFakeTimers();
+
+    const inProgressRun = () =>
+      createJsonResponse({
+        id: "run-1",
+        status: "in_progress",
+        stage: null,
+        output: null,
+        error_message: null,
+        branch: "main",
+        updated_at: "2026-01-01T00:00:00Z",
+      });
+
+    mockNetFetch
+      .mockResolvedValueOnce(inProgressRun()) // bootstrap: fetchTaskRun
+      .mockResolvedValueOnce(
+        createJsonResponse([], 200, { "X-Has-More": "false" }),
+      ) // bootstrap: fetchSessionLogs
+      .mockImplementation(() => Promise.resolve(inProgressRun()));
+
+    // Stream stays open with only an initial keepalive, then goes silent; the
+    // body errors when the idle watchdog aborts the connection.
+    mockStreamFetch.mockImplementation((_input, init) =>
+      Promise.resolve(
+        createAbortableOpenSseResponse(
+          (init as RequestInit | undefined)?.signal ?? undefined,
+          'event: keepalive\ndata: {"type":"keepalive"}\n\n',
+        ),
+      ),
+    );
+
+    service.watch({
+      taskId: "task-1",
+      runId: "run-1",
+      apiHost: "https://app.example.com",
+      teamId: 2,
+    });
+
+    await waitFor(() => mockStreamFetch.mock.calls.length === 1);
+    // Before the 90s idle deadline: the connection is considered alive.
+    await vi.advanceTimersByTimeAsync(80_000);
+    expect(mockStreamFetch.mock.calls.length).toBe(1);
+
+    // Past the deadline: watchdog aborts the dead socket and reconnects.
+    await vi.advanceTimersByTimeAsync(20_000);
+    await waitFor(() => mockStreamFetch.mock.calls.length >= 2, 10_000);
   });
 
   it("clears the backend-error budget after a healthy long-lived cut", async () => {

--- a/packages/core/src/cloud-task/cloud-task.ts
+++ b/packages/core/src/cloud-task/cloud-task.ts
@@ -12,7 +12,12 @@ import { serializeError, TypedEventEmitter } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { inject, injectable, preDestroy } from "inversify";
 import type { CloudTaskPermissionRequestUpdate } from "./cloud-task-types";
-import { CLOUD_TASK_AUTH, type ICloudTaskAuth } from "./identifiers";
+import {
+  CLOUD_TASK_AUTH,
+  CLOUD_TASK_CONNECTIVITY,
+  type ICloudTaskAuth,
+  type ICloudTaskConnectivity,
+} from "./identifiers";
 import {
   CloudTaskEvent,
   type CloudTaskEvents,
@@ -32,9 +37,17 @@ const SSE_RECONNECT_BASE_DELAY_MS = 500;
 const SSE_RECONNECT_FLAT_ATTEMPTS = 3;
 const SSE_RECONNECT_MAX_DELAY_MS = 30_000;
 const SSE_HEALTHY_CONNECTION_MS = 60_000;
+// No bytes for this long means the socket is dead (e.g. a wifi drop leaving a
+// half-open TCP connection that never errors). The server emits keepalives well
+// under this, so a healthy-but-idle run never trips it. Reset on every read.
+const SSE_IDLE_TIMEOUT_MS = 90_000;
 const EVENT_BATCH_FLUSH_MS = 16;
 const EVENT_BATCH_MAX_SIZE = 50;
 const SESSION_LOG_PAGE_LIMIT = 5_000;
+
+// Abort reason for the idle watchdog, distinguishing a dead-socket abort from an
+// intentional user stop so the read loop reconnects instead of ending cleanly.
+const IDLE_ABORT = Symbol("cloud-task-sse-idle");
 
 // Authoritative end-of-stream sentinel, matched on the SSE event name (event.event, not data.type).
 // The client stops on it without consulting run status.
@@ -142,6 +155,11 @@ interface WatcherState {
   // set; with no re-subscribe it holds the run's emitted entries until the watch ends.
   emittedLogEntries: StoredLogEntry[];
   failed: boolean;
+  // Paused mid-outage: no reconnect timer is armed and the run is left "reconnecting"
+  // (not failed) until connectivity returns. Cleared by clearWaitingForNetwork.
+  waitingForNetwork: boolean;
+  // Unsubscribe for the offline→online listener registered while waitingForNetwork.
+  onlineUnsubscribe: (() => void) | null;
   needsPostBootstrapReconnect: boolean;
   needsStopAfterBootstrap: boolean;
   streamEnded: boolean;
@@ -342,6 +360,8 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     private readonly analytics: IAnalytics,
     @inject(ROOT_LOGGER)
     logger: RootLogger,
+    @inject(CLOUD_TASK_CONNECTIVITY)
+    private readonly connectivity: ICloudTaskConnectivity,
   ) {
     super();
     this.log = logger.scope("cloud-task");
@@ -413,6 +433,11 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
 
   // Resets a watcher to its pre-bootstrap state so bootstrapWatcher can rebuild it from server truth.
   private resetWatcherForRebootstrap(watcher: WatcherState): void {
+    if (watcher.onlineUnsubscribe) {
+      watcher.onlineUnsubscribe();
+      watcher.onlineUnsubscribe = null;
+    }
+    watcher.waitingForNetwork = false;
     watcher.reconnectAttempts = 0;
     watcher.streamErrorAttempts = 0;
     watcher.cumulativeReconnectAttempts = 0;
@@ -564,6 +589,8 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
       bufferedLogBatches: [],
       emittedLogEntries: [],
       failed: false,
+      waitingForNetwork: false,
+      onlineUnsubscribe: null,
       needsPostBootstrapReconnect: false,
       needsStopAfterBootstrap: false,
       streamEnded: false,
@@ -584,6 +611,12 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     if (!watcher) return;
 
     watcher.sseAbortController?.abort();
+
+    if (watcher.onlineUnsubscribe) {
+      watcher.onlineUnsubscribe();
+      watcher.onlineUnsubscribe = null;
+    }
+    watcher.waitingForNetwork = false;
 
     if (watcher.reconnectTimeoutId) {
       clearTimeout(watcher.reconnectTimeoutId);
@@ -914,25 +947,51 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
 
       const reader = response.body.getReader();
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
+      // Reset-on-byte watchdog: a wifi drop can leave the socket half-open so
+      // reader.read() never resolves or rejects. If no bytes arrive within the
+      // idle window, abort with IDLE_ABORT so the read loop unwinds into the
+      // catch below and reconnects (server keepalives keep a live stream well
+      // under the deadline).
+      let idleTimerId: ReturnType<typeof setTimeout> | null = null;
+      const armIdleWatchdog = () => {
+        if (idleTimerId) {
+          clearTimeout(idleTimerId);
         }
+        idleTimerId = setTimeout(() => {
+          controller.abort(IDLE_ABORT);
+        }, SSE_IDLE_TIMEOUT_MS);
+      };
 
-        if (!value) {
-          continue;
-        }
+      try {
+        armIdleWatchdog();
 
-        bytesReceived += value.byteLength;
-        const chunk = decoder.decode(value, { stream: true });
-        const events = parser.parse(chunk);
-        for (const event of events) {
-          eventsReceived += 1;
-          const backendError = this.handleSseEvent(key, event);
-          if (backendError) {
-            throw backendError;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
           }
+
+          armIdleWatchdog();
+
+          if (!value) {
+            continue;
+          }
+
+          bytesReceived += value.byteLength;
+          const chunk = decoder.decode(value, { stream: true });
+          const events = parser.parse(chunk);
+          for (const event of events) {
+            eventsReceived += 1;
+            const backendError = this.handleSseEvent(key, event);
+            if (backendError) {
+              throw backendError;
+            }
+          }
+        }
+      } finally {
+        if (idleTimerId) {
+          clearTimeout(idleTimerId);
+          idleTimerId = null;
         }
       }
 
@@ -946,7 +1005,12 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
 
       this.flushLogBatch(key);
 
-      if (controller.signal.aborted) {
+      // An idle-watchdog abort is a dead socket, not a user stop: fall through
+      // to reconnect. Any other abort (stopWatcher/failWatcher/retry) is terminal.
+      if (
+        controller.signal.aborted &&
+        controller.signal.reason !== IDLE_ABORT
+      ) {
         return;
       }
 
@@ -975,7 +1039,12 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     } catch (error) {
       this.flushLogBatch(key);
 
-      if (controller.signal.aborted) {
+      // A user/terminal abort ends here; an idle-watchdog abort falls through to
+      // reconnect (the socket was dead, the run is still executing server-side).
+      if (
+        controller.signal.aborted &&
+        controller.signal.reason !== IDLE_ABORT
+      ) {
         return;
       }
 
@@ -1350,6 +1419,12 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     watcher.pendingLogEntries = [];
     watcher.bufferedLogBatches = [];
 
+    if (watcher.onlineUnsubscribe) {
+      watcher.onlineUnsubscribe();
+      watcher.onlineUnsubscribe = null;
+    }
+    watcher.waitingForNetwork = false;
+
     if (watcher.reconnectTimeoutId) {
       clearTimeout(watcher.reconnectTimeoutId);
       watcher.reconnectTimeoutId = null;
@@ -1381,6 +1456,13 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
     const watcher = this.watchers.get(key);
     // Status-unaware: the loop only stops on the stream-end sentinel or budget exhaustion below.
     if (!watcher || watcher.failed) {
+      return;
+    }
+
+    // Offline: don't burn the reconnect budget or fail — the run is still
+    // executing server-side. Pause and resume when the network returns.
+    if (!this.connectivity.isOnline()) {
+      this.enterWaitingForNetwork(key);
       return;
     }
 
@@ -1460,6 +1542,106 @@ export class CloudTaskService extends TypedEventEmitter<CloudTaskEvents> {
           currentWatcher.isBootstrapping || currentWatcher.hasEmittedSnapshot,
       });
     }, delay);
+  }
+
+  /**
+   * Pauses reconnection while the machine is offline. The run keeps executing in
+   * the cloud, so instead of exhausting the budget and failing, present a quiet
+   * "reconnecting" posture and resume on the offline→online edge. A slow backstop
+   * timer covers a missed connectivity signal.
+   */
+  private enterWaitingForNetwork(key: string): void {
+    const watcher = this.watchers.get(key);
+    if (!watcher || watcher.failed) return;
+
+    if (watcher.reconnectTimeoutId) {
+      clearTimeout(watcher.reconnectTimeoutId);
+      watcher.reconnectTimeoutId = null;
+    }
+
+    const firstEntry = !watcher.waitingForNetwork;
+    watcher.waitingForNetwork = true;
+
+    if (firstEntry) {
+      this.log.info("Cloud task stream paused, waiting for network", { key });
+      this.emit(CloudTaskEvent.Update, {
+        taskId: watcher.taskId,
+        runId: watcher.runId,
+        kind: "reconnecting",
+      });
+    }
+
+    if (!watcher.onlineUnsubscribe) {
+      watcher.onlineUnsubscribe = this.connectivity.onOnline(() => {
+        this.handleNetworkOnline(key);
+      });
+    }
+
+    // Backstop: if the connectivity signal is missed, re-check at the cap and
+    // either resume (if online) or keep waiting.
+    watcher.reconnectTimeoutId = setTimeout(() => {
+      const current = this.watchers.get(key);
+      if (!current) return;
+      current.reconnectTimeoutId = null;
+      if (this.connectivity.isOnline()) {
+        this.handleNetworkOnline(key);
+      } else {
+        this.enterWaitingForNetwork(key);
+      }
+    }, SSE_RECONNECT_MAX_DELAY_MS);
+  }
+
+  private handleNetworkOnline(key: string): void {
+    const watcher = this.watchers.get(key);
+    if (!watcher || watcher.failed) return;
+    if (!watcher.waitingForNetwork) return;
+
+    this.clearWaitingForNetwork(watcher);
+    // The offline stretch shouldn't count against the transport budget.
+    watcher.reconnectAttempts = 0;
+    watcher.streamErrorAttempts = 0;
+    watcher.cumulativeReconnectAttempts = 0;
+    this.log.info("Network back online, resuming cloud task stream", { key });
+    void this.resumeAfterNetworkReturn(key);
+  }
+
+  private clearWaitingForNetwork(watcher: WatcherState): void {
+    watcher.waitingForNetwork = false;
+    if (watcher.onlineUnsubscribe) {
+      watcher.onlineUnsubscribe();
+      watcher.onlineUnsubscribe = null;
+    }
+    if (watcher.reconnectTimeoutId) {
+      clearTimeout(watcher.reconnectTimeoutId);
+      watcher.reconnectTimeoutId = null;
+    }
+  }
+
+  /**
+   * Re-establishes the stream after a network outage. Re-fetches server truth
+   * first: a run that completed while offline must show terminal, not hang in
+   * the reconnecting posture. Only re-opens SSE for a still-active run.
+   */
+  private async resumeAfterNetworkReturn(key: string): Promise<void> {
+    const watcher = this.watchers.get(key);
+    if (!watcher || watcher.failed) return;
+
+    const run = await this.fetchTaskRun(watcher);
+    const currentWatcher = this.watchers.get(key);
+    if (!currentWatcher || currentWatcher !== watcher || watcher.failed) return;
+
+    if (run) {
+      this.applyTaskRunState(watcher, run);
+      if (isTerminalStatus(watcher.lastStatus)) {
+        await this.finalizeWatcherStop(key);
+        return;
+      }
+      this.emitStatusUpdate(watcher);
+    }
+
+    void this.connectSse(key, {
+      startLatest: watcher.isBootstrapping || watcher.hasEmittedSnapshot,
+    });
   }
 
   private async handleStreamCompletion(

--- a/packages/core/src/cloud-task/identifiers.ts
+++ b/packages/core/src/cloud-task/identifiers.ts
@@ -1,6 +1,24 @@
 export const CLOUD_TASK_SERVICE = Symbol.for("posthog.core.cloudTaskService");
 export const CLOUD_TASK_AUTH = Symbol.for("posthog.core.cloudTaskAuth");
+export const CLOUD_TASK_CONNECTIVITY = Symbol.for(
+  "posthog.core.cloudTaskConnectivity",
+);
 
 export interface ICloudTaskAuth {
   authenticatedFetch(url: string, init?: RequestInit): Promise<Response>;
+}
+
+/**
+ * Reports real network connectivity to the cloud-run stream watcher so a local
+ * outage doesn't burn the reconnect budget and surface a hard error for a run
+ * that is still executing server-side. The host adapter wraps the
+ * workspace-server ConnectivityService (the single connectivity source).
+ */
+export interface ICloudTaskConnectivity {
+  isOnline(): boolean;
+  /**
+   * Invokes `callback` on each offline→online transition. Returns an
+   * unsubscribe function. Multiple subscribers are fanned out independently.
+   */
+  onOnline(callback: () => void): () => void;
 }

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -4606,7 +4606,32 @@ export class SessionService {
    */
   public recoverAfterReconnect(): void {
     this.retryUnhealthyCloudSessions();
+    this.retryReconnectingCloudSessions();
     this.flushQueuedCloudMessagesAfterAuthRestored();
+  }
+
+  /**
+   * Backstop for the main-process watcher's own offline→online self-heal: if a
+   * cloud session is still showing the transient "reconnecting" posture when the
+   * network returns (e.g. its watcher was torn down while offline), kick a
+   * retry. Idempotent — `retryCloudTaskWatch` re-bootstraps from server truth,
+   * so racing the main-process resume just converges.
+   */
+  private retryReconnectingCloudSessions(): void {
+    const sessions = this.d.store.getSessions();
+    for (const session of Object.values(sessions)) {
+      if (!session.isCloud) continue;
+      if (!session.isReconnecting) continue;
+      this.d.log.info("Backstop retry of reconnecting cloud session", {
+        taskId: session.taskId,
+      });
+      this.retryCloudTaskWatch(session.taskId).catch((error) => {
+        this.d.log.warn("Backstop retry of reconnecting cloud session failed", {
+          taskId: session.taskId,
+          error,
+        });
+      });
+    }
   }
 
   public flushQueuedCloudMessagesAfterAuthRestored(): void {
@@ -5082,7 +5107,23 @@ export class SessionService {
           update.errorMessage ??
           "Lost connection to the cloud run. Retry to reconnect.",
         errorRetryable: update.retryable,
+        isReconnecting: false,
         isPromptPending: false,
+      });
+      return;
+    }
+
+    // Transient loss of the stream while the run keeps executing server-side
+    // (typically a local network drop). Present a quiet "reconnecting" posture,
+    // NOT the red error banner — the main-process watcher resumes on its own
+    // when the network returns.
+    if (update.kind === "reconnecting") {
+      this.d.store.updateSession(taskRunId, {
+        status: "disconnected",
+        isReconnecting: true,
+        errorTitle: undefined,
+        errorMessage: undefined,
+        errorRetryable: undefined,
       });
       return;
     }
@@ -5090,6 +5131,13 @@ export class SessionService {
     if (update.kind === "permission_request") {
       this.handleCloudPermissionRequest(taskRunId, update);
       return;
+    }
+
+    // Fresh stream data (logs/status/snapshot) means we've reconnected — drop
+    // the transient reconnecting posture.
+    const reconnectingSession = this.d.store.getSessions()[taskRunId];
+    if (reconnectingSession?.isReconnecting) {
+      this.d.store.updateSession(taskRunId, { isReconnecting: false });
     }
 
     // Append new log entries with dedup guard

--- a/packages/core/src/sessions/sessionViewState.ts
+++ b/packages/core/src/sessions/sessionViewState.ts
@@ -7,6 +7,7 @@ export interface SessionViewState {
   cloudStatus: TaskRunStatus | null;
   isRunning: boolean;
   hasError: boolean;
+  isReconnecting: boolean;
   events: AcpMessage[];
   isPromptPending: boolean;
   promptStartedAt: number | null | undefined;
@@ -30,6 +31,8 @@ export function deriveSessionViewState(
   const isCloudRunTerminal = isCloud && !isCloudRunNotTerminal;
 
   const hasError = session?.status === "error" && !session?.idleKilled;
+  // Cloud only: transient stream loss while the run keeps executing server-side.
+  const isReconnecting = isCloud && (session?.isReconnecting ?? false);
   const handoffInProgress = session?.handoffInProgress ?? false;
 
   let isRunning = false;
@@ -68,6 +71,7 @@ export function deriveSessionViewState(
     cloudStatus,
     isRunning: !!isRunning,
     hasError,
+    isReconnecting,
     events,
     isPromptPending,
     promptStartedAt,

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -223,6 +223,16 @@ export interface CloudTaskErrorUpdate extends CloudTaskUpdateBase {
   retryable: boolean;
 }
 
+/**
+ * Transient posture: the client lost its stream but the run is still executing
+ * server-side (typically a local network drop). Distinct from `error`, which is
+ * a terminal failure with a Retry affordance; the watcher resumes on its own
+ * when the network returns.
+ */
+export interface CloudTaskReconnectingUpdate extends CloudTaskUpdateBase {
+  kind: "reconnecting";
+}
+
 export interface CloudPermissionOption {
   kind: string;
   optionId: string;
@@ -249,6 +259,7 @@ export type CloudTaskUpdatePayload =
   | CloudTaskStatusUpdate
   | CloudTaskSnapshotUpdate
   | CloudTaskErrorUpdate
+  | CloudTaskReconnectingUpdate
   | CloudTaskPermissionRequestUpdate;
 
 // Mention types for editors

--- a/packages/shared/src/sessions.ts
+++ b/packages/shared/src/sessions.ts
@@ -57,6 +57,13 @@ export interface AgentSession {
   errorTitle?: string;
   errorMessage?: string;
   errorRetryable?: boolean;
+  /**
+   * Cloud only: the stream connection dropped transiently (e.g. a local network
+   * drop) but the run is still executing server-side. Drives a quiet
+   * "reconnecting" indicator instead of the red error banner; the watcher
+   * resumes on its own when the network returns. Cleared on fresh stream data.
+   */
+  isReconnecting?: boolean;
   isPromptPending: boolean;
   isCompacting: boolean;
   promptStartedAt: number | null;

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -77,6 +77,8 @@ interface SessionViewProps {
   errorTitle?: string;
   errorMessage?: string;
   errorRetryable?: boolean;
+  /** Cloud only: transient stream loss; show a quiet reconnecting indicator. */
+  isReconnecting?: boolean;
   onRetry?: () => void;
   onNewSession?: () => void;
   isInitializing?: boolean;
@@ -182,6 +184,28 @@ function CloudStreamDisconnectedBanner({
   );
 }
 
+/**
+ * Quiet, non-scary indicator shown when the cloud stream dropped transiently
+ * (e.g. a local network drop) while the run keeps executing server-side. No red,
+ * no Retry — the watcher resumes on its own when the network returns.
+ */
+function CloudReconnectingBanner() {
+  return (
+    <Flex
+      align="center"
+      gap="2"
+      py="2"
+      px="3"
+      className="shrink-0 border-(--gray-4) border-b bg-(--gray-2)"
+    >
+      <Spinner size={14} className="animate-spin text-gray-9" />
+      <Text color="gray" className="truncate text-[13px]">
+        Reconnecting to cloud run…
+      </Text>
+    </Flex>
+  );
+}
+
 export function SessionView({
   events,
   taskId,
@@ -202,6 +226,7 @@ export function SessionView({
   errorTitle,
   errorMessage = DEFAULT_ERROR_MESSAGE,
   errorRetryable = false,
+  isReconnecting = false,
   onRetry,
   onNewSession,
   isInitializing = false,
@@ -562,6 +587,9 @@ export function SessionView({
                     errorMessage={errorMessage}
                     onRetry={onRetry}
                   />
+                )}
+                {isReconnecting && !showInlineBanner && (
+                  <CloudReconnectingBanner />
                 )}
                 <ThreadView
                   events={events}

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -1147,6 +1147,42 @@ describe("SessionService", () => {
       expect(onStatusChange).toHaveBeenCalledTimes(1);
     });
 
+    it("maps a reconnecting update to a quiet disconnected+reconnecting state", () => {
+      const service = getSessionService();
+
+      service.watchCloudTask(
+        "task-123",
+        "run-123",
+        "https://api.anthropic.com",
+        123,
+      );
+
+      const subscribeOptions = mockTrpcCloudTask.onUpdate.subscribe.mock
+        .calls[0][1] as {
+        onData: (update: {
+          kind: string;
+          taskId: string;
+          runId: string;
+        }) => void;
+      };
+      subscribeOptions.onData({
+        kind: "reconnecting",
+        taskId: "task-123",
+        runId: "run-123",
+      });
+
+      expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+        "run-123",
+        {
+          status: "disconnected",
+          isReconnecting: true,
+          errorTitle: undefined,
+          errorMessage: undefined,
+          errorRetryable: undefined,
+        },
+      );
+    });
+
     it("hydrates a fresh cloud session from persisted logs before replay arrives", async () => {
       const service = getSessionService();
       const hydratedSession = createMockSession({

--- a/packages/ui/src/features/task-detail/components/TaskLogsPanel.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskLogsPanel.tsx
@@ -61,6 +61,7 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
     errorTitle,
     errorMessage,
     errorRetryable,
+    isReconnecting,
   } = useSessionViewState(taskId, task);
 
   useSessionConnection({
@@ -176,6 +177,7 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
               errorTitle={errorTitle}
               errorMessage={errorMessage ?? undefined}
               errorRetryable={errorRetryable}
+              isReconnecting={isReconnecting}
               hideInput={hideInput}
               onRetry={handleRetry}
               onNewSession={isCloud ? undefined : handleNewSession}


### PR DESCRIPTION
## Problem

A user runs cloud agents specifically so work continues in the cloud when their local wifi is unstable. When wifi dropped, the cloud agent **appeared to stop** — but the run never actually stopped; it keeps executing server-side. Only the client's stream connection was giving up:

- The main-process SSE watcher burned a fixed ~60s reconnect budget regardless of whether the machine was actually offline, then flipped the session to a red `error` ("Lost connection to the cloud run stream").
- The read loop had no idle timeout, so a silent half-open socket (typical of a wifi drop) could leave the watcher hanging forever, receiving nothing.

## Changes

- **Idle watchdog** on the SSE read loop — a reset-on-byte timer aborts a dead socket (`IDLE_ABORT` sentinel, distinguished from an intentional user stop) so it reconnects instead of hanging.
- **Connectivity-aware reconnect** — a host-agnostic connectivity port is injected into the main-process `CloudTaskService` (wired over the existing workspace-server `ConnectivityService` via a platform adapter). While offline it *pauses* reconnection instead of burning the budget and failing; it resumes on the offline→online edge and **re-fetches true server status first**, so a run that finished during the outage shows completed rather than hanging.
- **Quiet "reconnecting" indicator** (`status: disconnected` + `isReconnecting`) distinct from the terminal error banner + Retry; reconnect recovery broadened to cover it.

## Tests

Idle-watchdog reconnect, offline pause + resume, terminal-status re-fetch on resume, and the reconnecting UI mapping. Typecheck, Biome, and host-boundary checks pass.

## Note

Independent of (and splittable from) the queued-follow-up persistence PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*