### PR TITLE
fix(message-editor): stop github ref chips getting stuck on "Loading..."

### DIFF
--- a/packages/core/src/message-editor/content.test.ts
+++ b/packages/core/src/message-editor/content.test.ts
@@ -97,6 +97,24 @@ describe("xmlToContent", () => {
     );
   });
 
+  it("drops the 'Loading...' placeholder title when a ref is submitted before it resolves", () => {
+    const content: EditorContent = {
+      segments: [
+        {
+          type: "chip",
+          chip: {
+            type: "github_pr",
+            id: "https://github.com/org/repo/pull/42",
+            label: "#42 - Loading...",
+          },
+        },
+      ],
+    };
+    expect(contentToXml(content)).toBe(
+      '<github_pr number="42" title="" url="https://github.com/org/repo/pull/42" />',
+    );
+  });
+
   it("round-trips a github_pr chip", () => {
     const content: EditorContent = {
       segments: [

--- a/packages/core/src/message-editor/content.ts
+++ b/packages/core/src/message-editor/content.ts
@@ -1,4 +1,5 @@
 import { escapeXmlAttr, type UploadableSkillSource } from "@posthog/shared";
+import { GITHUB_REF_PLACEHOLDER_TITLE } from "./githubIssueChip";
 import { isUploadableSkillSource, parseXmlAttrs } from "./skillTags";
 
 export interface MentionChip {
@@ -83,7 +84,12 @@ export function contentToXml(content: EditorContent): string {
       case "github_pr": {
         const labelMatch = chip.label.match(/^#(\d+)(?:\s*-\s*(.*))?$/);
         const number = labelMatch?.[1] ?? "";
-        const title = labelMatch?.[2] ?? "";
+        const rawTitle = labelMatch?.[2] ?? "";
+        // Drop the transient "Loading..." placeholder so a ref submitted before
+        // its title resolves serializes as a clean number + url rather than
+        // freezing the placeholder into the sent message.
+        const title =
+          rawTitle === GITHUB_REF_PLACEHOLDER_TITLE ? "" : rawTitle;
         return `<${chip.type} number="${escapeXmlAttr(number)}" title="${escapeXmlAttr(title)}" url="${escapedId}" />`;
       }
       default:

--- a/packages/core/src/message-editor/content.ts
+++ b/packages/core/src/message-editor/content.ts
@@ -88,8 +88,7 @@ export function contentToXml(content: EditorContent): string {
         // Drop the transient "Loading..." placeholder so a ref submitted before
         // its title resolves serializes as a clean number + url rather than
         // freezing the placeholder into the sent message.
-        const title =
-          rawTitle === GITHUB_REF_PLACEHOLDER_TITLE ? "" : rawTitle;
+        const title = rawTitle === GITHUB_REF_PLACEHOLDER_TITLE ? "" : rawTitle;
         return `<${chip.type} number="${escapeXmlAttr(number)}" title="${escapeXmlAttr(title)}" url="${escapedId}" />`;
       }
       default:

--- a/packages/core/src/message-editor/githubIssueChip.test.ts
+++ b/packages/core/src/message-editor/githubIssueChip.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildGithubRefPlaceholderChip,
   GITHUB_ISSUE_STATE_COLORS,
   githubIssueStateColor,
   githubIssueToMentionChip,
+  isGithubRefPlaceholderLabel,
 } from "./githubIssueChip";
 
 describe("githubIssueToMentionChip", () => {
@@ -18,6 +20,24 @@ describe("githubIssueToMentionChip", () => {
       id: "https://github.com/PostHog/code/issues/1819",
       label: "#1819 - Let me mention GH issues",
     });
+  });
+});
+
+describe("isGithubRefPlaceholderLabel", () => {
+  it("matches the placeholder built for an unresolved ref", () => {
+    const chip = buildGithubRefPlaceholderChip({
+      kind: "issue",
+      owner: "PostHog",
+      repo: "code",
+      number: 1819,
+      normalizedUrl: "https://github.com/PostHog/code/issues/1819",
+    });
+    expect(isGithubRefPlaceholderLabel(chip.label)).toBe(true);
+  });
+
+  it("does not match resolved or fallback labels", () => {
+    expect(isGithubRefPlaceholderLabel("#1819 - Real title")).toBe(false);
+    expect(isGithubRefPlaceholderLabel("#1819")).toBe(false);
   });
 });
 

--- a/packages/core/src/message-editor/githubIssueChip.ts
+++ b/packages/core/src/message-editor/githubIssueChip.ts
@@ -38,12 +38,25 @@ export function githubIssueStateColor(state: GithubRefState): string {
   return GITHUB_ISSUE_STATE_COLORS[state];
 }
 
+// Transient title shown on a github chip while its real title is being fetched.
+// Kept as a shared constant so serialization and reconciliation can recognize
+// (and never persist) the placeholder.
+export const GITHUB_REF_PLACEHOLDER_TITLE = "Loading...";
+
+const GITHUB_REF_PLACEHOLDER_LABEL_PATTERN = /^#\d+\s*-\s*Loading\.\.\.$/;
+
+// True for a chip label still showing the "Loading..." placeholder, e.g. a ref
+// pasted then submitted or persisted before its title finished loading.
+export function isGithubRefPlaceholderLabel(label: string): boolean {
+  return GITHUB_REF_PLACEHOLDER_LABEL_PATTERN.test(label);
+}
+
 export function buildGithubRefPlaceholderChip(
   parsed: ParsedGithubIssueUrl,
 ): MentionChip {
   const source = {
     number: parsed.number,
-    title: "Loading...",
+    title: GITHUB_REF_PLACEHOLDER_TITLE,
     url: parsed.normalizedUrl,
   };
   return parsed.kind === "pr"

--- a/packages/ui/src/features/message-editor/tiptap/useDraftSync.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useDraftSync.ts
@@ -113,8 +113,11 @@ export function useDraftSync(
   editor: Editor | null,
   sessionId: string,
   context?: DraftContext,
+  onRestore?: (editor: Editor) => void,
 ) {
   const hasRestoredRef = useRef(false);
+  const onRestoreRef = useRef(onRestore);
+  onRestoreRef.current = onRestore;
   const lastSessionIdRef = useRef(sessionId);
   const lastEditorRef = useRef(editor);
   const editorRef = useRef(editor);
@@ -165,6 +168,8 @@ export function useDraftSync(
     } else {
       editor.commands.setContent(editorContentToTiptapJson(draft));
     }
+
+    onRestoreRef.current?.(editor);
   }, [hasHydrated, draft, editor]);
 
   // Handle pending content (e.g., restoring queued messages after cancel)

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -5,7 +5,10 @@ import {
   isContentEmpty,
   type MentionChip,
 } from "@posthog/core/message-editor/content";
-import { buildGithubRefPlaceholderChip } from "@posthog/core/message-editor/githubIssueChip";
+import {
+  buildGithubRefPlaceholderChip,
+  isGithubRefPlaceholderLabel,
+} from "@posthog/core/message-editor/githubIssueChip";
 import {
   type ParsedGithubIssueUrl,
   parseGithubIssueUrl,
@@ -137,7 +140,6 @@ async function resolveGithubRefChip(
   parsed: ParsedGithubIssueUrl,
 ): Promise<void> {
   const chipType = parsed.kind === "pr" ? "github_pr" : "github_issue";
-  const placeholderLabel = `#${parsed.number} - Loading...`;
   const title = await fetchGithubRefTitle(parsed);
   const resolvedLabel =
     title !== null ? `#${parsed.number} - ${title}` : `#${parsed.number}`;
@@ -147,11 +149,14 @@ async function resolveGithubRefChip(
   const { doc, tr } = view.state;
   let updated = false;
   doc.descendants((node, pos) => {
+    // Match by url + placeholder state rather than an exact label so the update
+    // still lands after the doc mutated (e.g. the chip was restored from a
+    // persisted draft) while the fetch was in flight.
     if (
       node.type.name !== "mentionChip" ||
       node.attrs.type !== chipType ||
       node.attrs.id !== parsed.normalizedUrl ||
-      node.attrs.label !== placeholderLabel
+      !isGithubRefPlaceholderLabel(node.attrs.label)
     ) {
       return true;
     }
@@ -164,6 +169,45 @@ async function resolveGithubRefChip(
   });
 
   if (updated) view.dispatch(tr);
+}
+
+// Resolve a chip's title at most once per url; concurrent paste + restore
+// reconciliation share one in-flight set so they don't double-fetch.
+function resolveGithubRefChipOnce(
+  view: EditorView,
+  parsed: ParsedGithubIssueUrl,
+  inFlight: Set<string>,
+): void {
+  if (inFlight.has(parsed.normalizedUrl)) return;
+  inFlight.add(parsed.normalizedUrl);
+  void resolveGithubRefChip(view, parsed).finally(() => {
+    inFlight.delete(parsed.normalizedUrl);
+  });
+}
+
+// Re-resolve any github chips still showing "Loading..." — e.g. a draft
+// persisted before its title loaded and restored after a refresh, which would
+// otherwise stay "Loading..." forever since the original fetch never rewrote it.
+function reconcileGithubRefChips(
+  view: EditorView,
+  inFlight: Set<string>,
+): void {
+  const pending: ParsedGithubIssueUrl[] = [];
+  view.state.doc.descendants((node) => {
+    if (
+      node.type.name !== "mentionChip" ||
+      (node.attrs.type !== "github_issue" && node.attrs.type !== "github_pr") ||
+      !isGithubRefPlaceholderLabel(node.attrs.label)
+    ) {
+      return true;
+    }
+    const parsed = parseGithubIssueUrl(node.attrs.id);
+    if (parsed) pending.push(parsed);
+    return true;
+  });
+  for (const parsed of pending) {
+    resolveGithubRefChipOnce(view, parsed, inFlight);
+  }
 }
 
 function showPasteHint(message: string, description: string): void {
@@ -234,6 +278,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
   const draftRef = useRef<ReturnType<typeof useDraftSync> | null>(null);
 
   const pasteCountRef = useRef(0);
+  const githubResolveInFlightRef = useRef<Set<string>>(new Set());
   const historyActions = usePromptHistoryStore.getState();
   const [isEmptyState, setIsEmptyState] = useState(true);
   const [isReady, setIsReady] = useState(false);
@@ -404,7 +449,11 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
             if (parsedRef) {
               event.preventDefault();
               insertGithubRefPlaceholder(view, parsedRef);
-              void resolveGithubRefChip(view, parsedRef);
+              resolveGithubRefChipOnce(
+                view,
+                parsedRef,
+                githubResolveInFlightRef.current,
+              );
               return true;
             }
           }
@@ -529,7 +578,14 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
     [sessionId, disabled, fileMentions, commands, placeholder],
   );
 
-  const draft = useDraftSync(editor, sessionId, context);
+  const draft = useDraftSync(editor, sessionId, context, (restoredEditor) => {
+    // A draft persisted while a github title was still loading restores with the
+    // "Loading..." placeholder; re-resolve it so it doesn't stay stuck forever.
+    reconcileGithubRefChips(
+      restoredEditor.view,
+      githubResolveInFlightRef.current,
+    );
+  });
   draftRef.current = draft;
 
   // Keep attachmentsRef in sync with state (synchronous, no effect needed)


### PR DESCRIPTION
## Problem

Pasting a GitHub URL into the composer inserts a chip that shows `#123 - Loading...` while it fetches the issue/PR title. If you press Enter (or the draft got persisted) before the title finished loading, the chip stayed **stuck on "Loading..." forever — even after a refresh.**

Two root causes:
- On submit, the `"Loading..."` placeholder was baked into the serialized message, so the sent message kept it permanently.
- The title fetch only ran once from the paste handler and was never re-run for a chip restored from a persisted draft, so a refresh never rewrote it.

## Changes

- `contentToXml` now drops the `"Loading..."` placeholder title, so a ref submitted before it resolves serializes as a clean `number + url` instead of freezing the placeholder into the sent message.
- Draft restore now reconciles any GitHub chip still showing the placeholder and re-resolves its title, sharing one in-flight set with the paste path so nothing double-fetches.
- The resolver now matches on the ref url + placeholder state rather than an exact label string, so the update still lands after the doc mutates while the fetch is in flight.

## How did you test this?

- `pnpm --filter @posthog/core test message-editor` (64 passed), including new cases: `contentToXml` drops the `"Loading..."` placeholder, and `isGithubRefPlaceholderLabel` matches the placeholder but not resolved/fallback labels.
- `pnpm --filter @posthog/ui test useDraftSync` (passed).
- `pnpm --filter @posthog/core typecheck` and `pnpm --filter @posthog/ui typecheck` clean; Biome lint clean on touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783515225592409?thread_ts=1783515225.592409&cid=C09G8Q32R6F)*
