### PR TITLE
feat(channels): default-file channel-less tasks into #me

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -831,6 +831,7 @@ export type ChannelsSurface =
   | "sidebar"
   | "command_menu"
   | "new_task"
+  | "task_input"
   | "channel_home"
   | "channel_history"
   | "channel_artifacts"

--- a/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
+++ b/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
@@ -20,7 +20,7 @@ export function normalizeChannelName(name: string): string {
  * folder "channels" stay on the desktop file system for CONTEXT.md and
  * artifacts). Listing also lazily provisions the requester's #me channel.
  */
-export function useTaskChannels(): {
+export function useTaskChannels(options?: { enabled?: boolean }): {
   channels: TaskChannel[];
   personalChannel: TaskChannel | undefined;
   isLoading: boolean;
@@ -28,7 +28,10 @@ export function useTaskChannels(): {
   const query = useAuthenticatedQuery<TaskChannel[]>(
     TASK_CHANNELS_QUERY_KEY,
     (client) => client.getTaskChannels(),
-    { refetchInterval: TASK_CHANNELS_POLL_INTERVAL_MS },
+    {
+      enabled: options?.enabled ?? true,
+      refetchInterval: TASK_CHANNELS_POLL_INTERVAL_MS,
+    },
   );
   const channels = useMemo(() => query.data ?? [], [query.data]);
   const personalChannel = useMemo(

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -13,10 +13,16 @@ import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import {
   type Adapter,
   ANALYTICS_EVENTS,
+  PROJECT_BLUEBIRD_FLAG,
   type TaskCreationInput,
   type WorkspaceMode,
 } from "@posthog/shared";
 import type { ExecutionMode, Task } from "@posthog/shared/domain-types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
+import { PERSONAL_CHANNEL_NAME } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useTaskInputPrefillStore } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { navigateToTaskPending } from "@posthog/ui/router/navigationBridge";
 import { openTask, openTaskInput } from "@posthog/ui/router/useOpenTask";
@@ -201,6 +207,54 @@ export function useTaskCreation({
   // Used to name the task occupying a branch's worktree when reuse is blocked.
   const { data: tasks } = useTasks();
 
+  // Tasks created without a channel default into the private #me channel so
+  // they still surface in the Channels space instead of staying unfiled.
+  const bluebirdEnabled = useFeatureFlag(
+    PROJECT_BLUEBIRD_FLAG,
+    import.meta.env.DEV,
+  );
+  const apiClient = useOptionalAuthenticatedClient();
+  const { createChannel } = useChannelMutations();
+  const { fileTask } = useChannelTaskMutations();
+
+  const fileToPersonalChannel = useCallback(
+    async (task: Task) => {
+      if (!apiClient) return;
+      let meFolderId: string | undefined;
+      try {
+        // List fresh rather than trusting the polled channels cache — a stale
+        // miss here would create a duplicate "me" folder.
+        const rows = await apiClient.getDesktopFileSystemChannels();
+        const existing = rows.find(
+          (fs) =>
+            fs.type === "folder" &&
+            fs.path.replace(/^\/+/, "") === PERSONAL_CHANNEL_NAME,
+        );
+        meFolderId =
+          existing?.id ?? (await createChannel(PERSONAL_CHANNEL_NAME)).id;
+        await fileTask(meFolderId, task.id, task.title);
+        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          action_type: "file_task",
+          surface: "task_input",
+          channel_id: meFolderId,
+          task_id: task.id,
+          success: true,
+        });
+      } catch (error) {
+        // Best-effort: on failure the task just stays unfiled, as before.
+        log.warn("Failed to default-file task to #me", { error });
+        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          action_type: "file_task",
+          surface: "task_input",
+          channel_id: meFolderId,
+          task_id: task.id,
+          success: false,
+        });
+      }
+    },
+    [apiClient, createChannel, fileTask],
+  );
+
   const hasRequiredPath = allowNoRepo
     ? true
     : workspaceMode === "cloud"
@@ -376,6 +430,9 @@ export function useTaskCreation({
             if (!pendingTaskKey && !contentOverride) {
               editor.clear();
             }
+            if (bluebirdEnabled && !channelId && !channelName) {
+              void fileToPersonalChannel(output.task);
+            }
             onTaskCreatedEffect?.(output.task);
             if (onTaskCreated) {
               onTaskCreated(output.task);
@@ -493,6 +550,8 @@ export function useTaskCreation({
       channelName,
       channelId,
       allowNoRepo,
+      bluebirdEnabled,
+      fileToPersonalChannel,
       clearTaskInputReportAssociation,
       invalidateTasks,
       onTaskCreated,

--- a/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -18,10 +18,7 @@ import {
   type WorkspaceMode,
 } from "@posthog/shared";
 import type { ExecutionMode, Task } from "@posthog/shared/domain-types";
-import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
-import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChannels";
-import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
-import { PERSONAL_CHANNEL_NAME } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
+import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useTaskInputPrefillStore } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { navigateToTaskPending } from "@posthog/ui/router/navigationBridge";
@@ -207,53 +204,16 @@ export function useTaskCreation({
   // Used to name the task occupying a branch's worktree when reuse is blocked.
   const { data: tasks } = useTasks();
 
-  // Tasks created without a channel default into the private #me channel so
-  // they still surface in the Channels space instead of staying unfiled.
+  // Tasks created without a channel default into the user's private #me
+  // backend channel so they still surface in the Channels space instead of
+  // staying unfiled. The personal channel is per-user and provisioned lazily
+  // server-side on first list, so this can't collide across teammates. If it
+  // hasn't loaded yet the task is created unfiled, as before.
   const bluebirdEnabled = useFeatureFlag(
     PROJECT_BLUEBIRD_FLAG,
     import.meta.env.DEV,
   );
-  const apiClient = useOptionalAuthenticatedClient();
-  const { createChannel } = useChannelMutations();
-  const { fileTask } = useChannelTaskMutations();
-
-  const fileToPersonalChannel = useCallback(
-    async (task: Task) => {
-      if (!apiClient) return;
-      let meFolderId: string | undefined;
-      try {
-        // List fresh rather than trusting the polled channels cache — a stale
-        // miss here would create a duplicate "me" folder.
-        const rows = await apiClient.getDesktopFileSystemChannels();
-        const existing = rows.find(
-          (fs) =>
-            fs.type === "folder" &&
-            fs.path.replace(/^\/+/, "") === PERSONAL_CHANNEL_NAME,
-        );
-        meFolderId =
-          existing?.id ?? (await createChannel(PERSONAL_CHANNEL_NAME)).id;
-        await fileTask(meFolderId, task.id, task.title);
-        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
-          action_type: "file_task",
-          surface: "task_input",
-          channel_id: meFolderId,
-          task_id: task.id,
-          success: true,
-        });
-      } catch (error) {
-        // Best-effort: on failure the task just stays unfiled, as before.
-        log.warn("Failed to default-file task to #me", { error });
-        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
-          action_type: "file_task",
-          surface: "task_input",
-          channel_id: meFolderId,
-          task_id: task.id,
-          success: false,
-        });
-      }
-    },
-    [apiClient, createChannel, fileTask],
-  );
+  const { personalChannel } = useTaskChannels({ enabled: bluebirdEnabled });
 
   const hasRequiredPath = allowNoRepo
     ? true
@@ -361,6 +321,11 @@ export function useTaskCreation({
         }
 
         const settings = useSettingsStore.getState();
+        const defaultedChannelId =
+          bluebirdEnabled && !channelId && !channelName
+            ? personalChannel?.id
+            : undefined;
+
         const input = prepareTaskInput(serializedContent, filePaths, {
           // In channels chat-box mode no repo is attached up front, even if a
           // directory/repo is lingering in the persisted picker state.
@@ -383,7 +348,7 @@ export function useTaskCreation({
           additionalDirectories,
           channelContext,
           channelName,
-          channelId,
+          channelId: channelId ?? defaultedChannelId,
           customInstructions: getEffectiveCustomInstructions(settings),
           autoPublishCloudRuns: settings.autoPublishCloudRuns,
           rtkEnabledCloud: settings.rtkEnabledCloud,
@@ -430,8 +395,14 @@ export function useTaskCreation({
             if (!pendingTaskKey && !contentOverride) {
               editor.clear();
             }
-            if (bluebirdEnabled && !channelId && !channelName) {
-              void fileToPersonalChannel(output.task);
+            if (defaultedChannelId) {
+              track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                action_type: "file_task",
+                surface: "task_input",
+                channel_id: defaultedChannelId,
+                task_id: output.task.id,
+                success: true,
+              });
             }
             onTaskCreatedEffect?.(output.task);
             if (onTaskCreated) {
@@ -551,7 +522,7 @@ export function useTaskCreation({
       channelId,
       allowNoRepo,
       bluebirdEnabled,
-      fileToPersonalChannel,
+      personalChannel?.id,
       clearTaskInputReportAssociation,
       invalidateTasks,
       onTaskCreated,


### PR DESCRIPTION
## Problem

Tasks created outside a channel (the `/code` composer, `/website/new`, the command center) stay unfiled, so they never show up anywhere in the Channels space and work can get lost.

## Why

Requested so that every task has a channel home by default — anything not explicitly filed to a bluebird channel should land in the private #me channel instead of disappearing into the unfiled pool.

## Changes

- After review feedback: when the `project-bluebird` flag is on and no `channelId`/`channelName` was passed to `useTaskCreation` (the funnel all composers share), the task is created with its `channel` set to the user's **backend personal channel** (`channel_type: "personal"`). That channel is per-user and provisioned lazily + idempotently server-side, so nothing is shared across teammates and there's no create race. If it hasn't loaded yet the task is created unfiled, as before.
- `useTaskChannels` gains an `enabled` option so the channel list is only fetched when the flag is on.
- Instrumented with the existing `Channel action` event (`action_type: "file_task"`, new surface `task_input`); added `task_input` to the `ChannelsSurface` union.

## How did you test this?

- `@posthog/ui` and `@posthog/shared` typecheck clean
- Biome check on touched files
- Full `@posthog/ui` test suite passes (1285 tests / 148 files)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*