### PR TITLE
feat(agent): prefer a detected real node runtime in the PATH shim

### DIFF
--- a/packages/agent/src/utils/spawn-env.test.ts
+++ b/packages/agent/src/utils/spawn-env.test.ts
@@ -11,6 +11,7 @@ function makeDir(
   kind:
     | "symlink-shim"
     | "wrapper-shim"
+    | "real-node-wrapper-shim"
     | "foreign-wrapper"
     | "other-symlink"
     | "real-node"
@@ -21,6 +22,8 @@ function makeDir(
   if (kind === "symlink-shim") symlinkSync(EXEC_PATH, node);
   if (kind === "wrapper-shim")
     writeFileSync(node, buildNodeShimScript(EXEC_PATH));
+  if (kind === "real-node-wrapper-shim")
+    writeFileSync(node, buildNodeShimScript(EXEC_PATH, "/usr/local/bin/node"));
   if (kind === "foreign-wrapper")
     writeFileSync(node, buildNodeShimScript("/some/other/app"));
   if (kind === "other-symlink") symlinkSync("/usr/bin/true", node);
@@ -32,13 +35,20 @@ describe("stripElectronNodeShimFromPath", () => {
   it("removes only dirs whose node aliases the executable", () => {
     const symlinkShim = makeDir("symlink-shim");
     const wrapperShim = makeDir("wrapper-shim");
+    const realNodeWrapperShim = makeDir("real-node-wrapper-shim");
     const foreign = makeDir("foreign-wrapper");
     const other = makeDir("other-symlink");
     const real = makeDir("real-node");
     const empty = makeDir("empty");
-    const input = [symlinkShim, wrapperShim, foreign, other, real, empty].join(
-      delimiter,
-    );
+    const input = [
+      symlinkShim,
+      wrapperShim,
+      realNodeWrapperShim,
+      foreign,
+      other,
+      real,
+      empty,
+    ].join(delimiter);
     expect(stripElectronNodeShimFromPath(input, EXEC_PATH)).toBe(
       [foreign, other, real, empty].join(delimiter),
     );

--- a/packages/agent/src/utils/spawn-env.ts
+++ b/packages/agent/src/utils/spawn-env.ts
@@ -1,11 +1,14 @@
 import { lstatSync, readFileSync, readlinkSync } from "node:fs";
 import { delimiter, join } from "node:path";
-import { buildNodeShimScript } from "@posthog/shared/node-shim";
+import { isNodeShimScript } from "@posthog/shared/node-shim";
 
 // Removes PATH entries that alias `node` to the current executable, whether a
-// legacy symlink or the wrapper script written by ensureNodeShim. Codex
-// children must not resolve `node` to Electron's bundled runtime: native
-// modules they install target the real node ABI.
+// legacy symlink or either wrapper-script variant written by ensureNodeShim.
+// Codex children must not resolve `node` through the shim: with the Electron
+// fallback engaged, native modules they install target the wrong ABI. A
+// real-node-backed shim would be harmless, but stripping it too keeps codex
+// on the user's own PATH resolution (detection only ever picks a node that is
+// independently reachable there).
 export function stripElectronNodeShimFromPath(
   pathValue: string | undefined,
   execPath: string = process.execPath,
@@ -23,7 +26,7 @@ function isElectronNodeShimDir(dir: string, execPath: string): boolean {
     if (lstatSync(shimPath).isSymbolicLink()) {
       return readlinkSync(shimPath) === execPath;
     }
-    return readFileSync(shimPath, "utf-8") === buildNodeShimScript(execPath);
+    return isNodeShimScript(readFileSync(shimPath, "utf-8"), execPath);
   } catch {
     return false;
   }

--- a/packages/shared/src/node-shim.test.ts
+++ b/packages/shared/src/node-shim.test.ts
@@ -1,21 +1,61 @@
 import { describe, expect, it } from "vitest";
-import { buildNodeShimScript } from "./node-shim";
+import { buildNodeShimScript, isNodeShimScript } from "./node-shim";
+
+const EXEC_PATH = "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code";
 
 describe("buildNodeShimScript", () => {
   it("sets ELECTRON_RUN_AS_NODE and execs the binary", () => {
-    const script = buildNodeShimScript(
-      "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code",
-    );
+    const script = buildNodeShimScript(EXEC_PATH);
     expect(script).toContain("#!/bin/sh");
     expect(script).toContain("export ELECTRON_RUN_AS_NODE=1");
-    expect(script).toContain(
-      'exec "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code" "$@"',
-    );
+    expect(script).toContain(`exec "${EXEC_PATH}" "$@"`);
   });
 
-  it("escapes shell-special characters in the binary path", () => {
+  it("prefers the real node when given one, keeping the run-as-node fallback", () => {
+    const script = buildNodeShimScript(EXEC_PATH, "/usr/local/bin/node");
+    const lines = script.split("\n");
+    expect(lines[0]).toBe("#!/bin/sh");
+    expect(lines[1]).toBe('if [ -x "/usr/local/bin/node" ]; then');
+    expect(lines[2]).toBe('  exec "/usr/local/bin/node" "$@"');
+    expect(lines[3]).toBe("fi");
+    expect(script).toContain("export ELECTRON_RUN_AS_NODE=1");
+    expect(script).toContain(`exec "${EXEC_PATH}" "$@"`);
+  });
+
+  it("escapes shell-special characters in both paths", () => {
     expect(buildNodeShimScript('/odd/pa"th/$app`bin\\x')).toContain(
       'exec "/odd/pa\\"th/\\$app\\`bin\\\\x" "$@"',
     );
+    expect(buildNodeShimScript(EXEC_PATH, '/odd/no"de/$v')).toContain(
+      'exec "/odd/no\\"de/\\$v" "$@"',
+    );
+  });
+});
+
+describe("isNodeShimScript", () => {
+  it("recognizes both variants written for the same binary", () => {
+    expect(isNodeShimScript(buildNodeShimScript(EXEC_PATH), EXEC_PATH)).toBe(
+      true,
+    );
+    expect(
+      isNodeShimScript(
+        buildNodeShimScript(EXEC_PATH, "/usr/local/bin/node"),
+        EXEC_PATH,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects shims written for a different binary and non-shim content", () => {
+    expect(
+      isNodeShimScript(buildNodeShimScript("/some/other/app"), EXEC_PATH),
+    ).toBe(false);
+    expect(
+      isNodeShimScript(
+        buildNodeShimScript("/some/other/app", "/usr/local/bin/node"),
+        EXEC_PATH,
+      ),
+    ).toBe(false);
+    expect(isNodeShimScript("not a shim", EXEC_PATH)).toBe(false);
+    expect(isNodeShimScript("", EXEC_PATH)).toBe(false);
   });
 });

--- a/packages/shared/src/node-shim.test.ts
+++ b/packages/shared/src/node-shim.test.ts
@@ -33,29 +33,30 @@ describe("buildNodeShimScript", () => {
 });
 
 describe("isNodeShimScript", () => {
-  it("recognizes both variants written for the same binary", () => {
-    expect(isNodeShimScript(buildNodeShimScript(EXEC_PATH), EXEC_PATH)).toBe(
-      true,
-    );
-    expect(
-      isNodeShimScript(
-        buildNodeShimScript(EXEC_PATH, "/usr/local/bin/node"),
-        EXEC_PATH,
-      ),
-    ).toBe(true);
-  });
-
-  it("rejects shims written for a different binary and non-shim content", () => {
-    expect(
-      isNodeShimScript(buildNodeShimScript("/some/other/app"), EXEC_PATH),
-    ).toBe(false);
-    expect(
-      isNodeShimScript(
-        buildNodeShimScript("/some/other/app", "/usr/local/bin/node"),
-        EXEC_PATH,
-      ),
-    ).toBe(false);
-    expect(isNodeShimScript("not a shim", EXEC_PATH)).toBe(false);
-    expect(isNodeShimScript("", EXEC_PATH)).toBe(false);
+  it.each([
+    {
+      content: "fallback-only shim for the binary",
+      script: buildNodeShimScript(EXEC_PATH),
+      expected: true,
+    },
+    {
+      content: "real-node-preferring shim for the binary",
+      script: buildNodeShimScript(EXEC_PATH, "/usr/local/bin/node"),
+      expected: true,
+    },
+    {
+      content: "fallback-only shim for a different binary",
+      script: buildNodeShimScript("/some/other/app"),
+      expected: false,
+    },
+    {
+      content: "real-node-preferring shim for a different binary",
+      script: buildNodeShimScript("/some/other/app", "/usr/local/bin/node"),
+      expected: false,
+    },
+    { content: "non-shim content", script: "not a shim", expected: false },
+    { content: "empty content", script: "", expected: false },
+  ])("returns $expected for $content", ({ script, expected }) => {
+    expect(isNodeShimScript(script, EXEC_PATH)).toBe(expected);
   });
 });

--- a/packages/shared/src/node-shim.ts
+++ b/packages/shared/src/node-shim.ts
@@ -2,13 +2,44 @@ function escapeForDoubleQuotes(path: string): string {
   return path.replace(/([$`"\\])/g, "\\$1");
 }
 
-// Single source of truth for the PATH `node` shim format: workspace-server
-// writes it and the codex spawn path detects it by exact content.
-export function buildNodeShimScript(execPath: string): string {
+function fallbackBlock(execPath: string): string {
   return [
-    "#!/bin/sh",
     "export ELECTRON_RUN_AS_NODE=1",
     `exec "${escapeForDoubleQuotes(execPath)}" "$@"`,
     "",
   ].join("\n");
+}
+
+// Single source of truth for the PATH `node` shim format: workspace-server
+// writes it and the codex spawn path detects it via isNodeShimScript.
+//
+// With a realNodePath the shim prefers that binary and only falls back to
+// running the app binary as node when it has gone missing — e.g. an nvm
+// prune deleted the version between sessions.
+export function buildNodeShimScript(
+  execPath: string,
+  realNodePath?: string,
+): string {
+  if (!realNodePath) {
+    return `#!/bin/sh\n${fallbackBlock(execPath)}`;
+  }
+  const real = escapeForDoubleQuotes(realNodePath);
+  return [
+    "#!/bin/sh",
+    `if [ -x "${real}" ]; then`,
+    `  exec "${real}" "$@"`,
+    "fi",
+    fallbackBlock(execPath),
+  ].join("\n");
+}
+
+// True for any shim variant written for the given app binary, with or
+// without an embedded preferred real node — detectors (the codex PATH strip,
+// real-node discovery) can't know which real node path a shim embeds, so
+// they match on the fallback block every variant ends with.
+export function isNodeShimScript(content: string, execPath: string): boolean {
+  return (
+    content.startsWith("#!/bin/sh\n") &&
+    content.endsWith(fallbackBlock(execPath))
+  );
 }

--- a/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/packages/workspace-server/src/services/agent/agent.test.ts
@@ -104,6 +104,14 @@ const mockNodeShim = vi.hoisted(() => ({
 
 vi.mock("./node-shim", () => mockNodeShim);
 
+const mockRealNode = vi.hoisted(() => ({
+  findRealNode: vi.fn(
+    async (): Promise<{ path: string; version: string } | null> => null,
+  ),
+}));
+
+vi.mock("./real-node", () => mockRealNode);
+
 // --- Import after mocks ---
 import type { RegisteredFolder } from "../folders/schemas";
 import { AgentService, buildAutoApproveOutcome } from "./agent";
@@ -374,6 +382,21 @@ describe("AgentService", () => {
       });
 
       expect(mockNodeShim.ensureNodeShim).toHaveBeenCalledTimes(2);
+    });
+
+    it("passes the detected real node through to the shim writer", async () => {
+      mockRealNode.findRealNode.mockResolvedValueOnce({
+        path: "/usr/local/bin/node",
+        version: "v22.1.0",
+      });
+
+      await service.startSession({ ...baseSessionParams, adapter: "codex" });
+
+      expect(mockNodeShim.ensureNodeShim).toHaveBeenCalledWith(
+        expect.any(String),
+        process.execPath,
+        { realNodePath: "/usr/local/bin/node" },
+      );
     });
   });
 

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -100,6 +100,7 @@ import type {
   AgentScopedLogger,
   AgentSleepCoordinator,
 } from "./ports";
+import { findRealNode } from "./real-node";
 import {
   AgentServiceEvent,
   type AgentServiceEvents,
@@ -370,6 +371,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
   private sessions = new Map<string, ManagedSession>();
   private pendingPermissions = new Map<string, PendingPermission>();
   private mockNodeReady = false;
+  private nodeShimSetup: Promise<void> | null = null;
   private idleTimeouts = new Map<
     string,
     { handle: ReturnType<typeof setTimeout>; deadline: number }
@@ -761,7 +763,7 @@ If a repository IS genuinely required, attach one in this priority order:
     }
 
     const channel = `agent-event:${taskRunId}`;
-    const mockNodeDir = this.setupMockNodeEnvironment();
+    const mockNodeDir = await this.setupMockNodeEnvironment();
     const proxyUrl = await this.agentAuthAdapter.ensureGatewayProxy(
       credentials.apiHost,
     );
@@ -1596,17 +1598,40 @@ For git operations while detached:
     this.log.info("All agent sessions cleaned up");
   }
 
-  private setupMockNodeEnvironment(): string {
+  private async setupMockNodeEnvironment(): Promise<string> {
     const mockNodeDir = getMockNodeDir();
     if (!this.mockNodeReady) {
-      try {
-        ensureNodeShim(mockNodeDir, process.execPath);
-        this.mockNodeReady = true;
-      } catch (err) {
-        this.log.warn("Failed to setup mock node environment", err);
-      }
+      // Concurrent session starts share one setup; a failed run clears the
+      // memo so the next session retries.
+      this.nodeShimSetup ??= this.runNodeShimSetup(mockNodeDir);
+      await this.nodeShimSetup;
+      this.nodeShimSetup = null;
     }
     return mockNodeDir;
+  }
+
+  private async runNodeShimSetup(mockNodeDir: string): Promise<void> {
+    // findRealNode absorbs its own failures (null → Electron fallback), so
+    // only the shim write can throw, leaving mockNodeReady false to retry.
+    const realNode = await findRealNode({
+      warn: (message, data) => this.log.warn(message, data),
+    });
+    try {
+      ensureNodeShim(mockNodeDir, process.execPath, {
+        realNodePath: realNode?.path,
+      });
+      this.mockNodeReady = true;
+      if (realNode) {
+        this.log.info("node shim prefers detected real node", {
+          path: realNode.path,
+          version: realNode.version,
+        });
+      } else {
+        this.log.info("node shim using Electron run-as-node fallback");
+      }
+    } catch (err) {
+      this.log.warn("Failed to setup mock node environment", err);
+    }
   }
 
   private cancelInFlightMcpToolCalls(session: ManagedSession): void {

--- a/packages/workspace-server/src/services/agent/node-shim.test.ts
+++ b/packages/workspace-server/src/services/agent/node-shim.test.ts
@@ -16,6 +16,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { ensureNodeShim } from "./node-shim";
 
 const EXEC_PATH = "/Applications/PostHog Code.app/Contents/MacOS/PostHog Code";
+const REAL_NODE = "/usr/local/bin/node";
 
 describe("ensureNodeShim", () => {
   const dirs: string[] = [];
@@ -35,7 +36,7 @@ describe("ensureNodeShim", () => {
 
   it("writes an executable wrapper that sets ELECTRON_RUN_AS_NODE itself", () => {
     const dir = makeDir();
-    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    ensureNodeShim(dir, EXEC_PATH, { platform: "darwin" });
 
     const shim = join(dir, "node");
     const content = readFileSync(shim, "utf-8");
@@ -45,14 +46,45 @@ describe("ensureNodeShim", () => {
     expect(statSync(shim).mode & 0o111).not.toBe(0);
   });
 
+  it("writes the real-node-preferring wrapper when a real node was detected", () => {
+    const dir = makeDir();
+    ensureNodeShim(dir, EXEC_PATH, {
+      platform: "darwin",
+      realNodePath: REAL_NODE,
+    });
+
+    const shim = join(dir, "node");
+    expect(readFileSync(shim, "utf-8")).toBe(
+      buildNodeShimScript(EXEC_PATH, REAL_NODE),
+    );
+    expect(statSync(shim).mode & 0o111).not.toBe(0);
+  });
+
+  it("upgrades a fallback-only wrapper once a real node is detected, and back", () => {
+    const dir = makeDir();
+    const shim = join(dir, "node");
+
+    ensureNodeShim(dir, EXEC_PATH, { platform: "darwin" });
+    ensureNodeShim(dir, EXEC_PATH, {
+      platform: "darwin",
+      realNodePath: REAL_NODE,
+    });
+    expect(readFileSync(shim, "utf-8")).toBe(
+      buildNodeShimScript(EXEC_PATH, REAL_NODE),
+    );
+
+    ensureNodeShim(dir, EXEC_PATH, { platform: "darwin" });
+    expect(readFileSync(shim, "utf-8")).toBe(buildNodeShimScript(EXEC_PATH));
+  });
+
   it("replaces a legacy symlink shim with the wrapper script", () => {
     const dir = makeDir();
-    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    ensureNodeShim(dir, EXEC_PATH, { platform: "darwin" });
     const shim = join(dir, "node");
     rmSync(shim);
     symlinkSync(EXEC_PATH, shim);
 
-    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    ensureNodeShim(dir, EXEC_PATH, { platform: "darwin" });
 
     expect(lstatSync(shim).isSymbolicLink()).toBe(false);
     expect(readFileSync(shim, "utf-8")).toBe(buildNodeShimScript(EXEC_PATH));
@@ -60,9 +92,9 @@ describe("ensureNodeShim", () => {
 
   it("rewrites the wrapper when the binary path changes", () => {
     const dir = makeDir();
-    ensureNodeShim(dir, "/old/location/App", "darwin");
+    ensureNodeShim(dir, "/old/location/App", { platform: "darwin" });
 
-    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    ensureNodeShim(dir, EXEC_PATH, { platform: "darwin" });
 
     expect(readFileSync(join(dir, "node"), "utf-8")).toBe(
       buildNodeShimScript(EXEC_PATH),
@@ -71,42 +103,60 @@ describe("ensureNodeShim", () => {
 
   it("leaves an up-to-date wrapper untouched", () => {
     const dir = makeDir();
-    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    ensureNodeShim(dir, EXEC_PATH, {
+      platform: "darwin",
+      realNodePath: REAL_NODE,
+    });
     const shim = join(dir, "node");
     const past = new Date("2020-01-01T00:00:00Z");
     utimesSync(shim, past, past);
 
-    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    ensureNodeShim(dir, EXEC_PATH, {
+      platform: "darwin",
+      realNodePath: REAL_NODE,
+    });
 
     expect(statSync(shim).mtimeMs).toBe(past.getTime());
   });
 
   it("replaces a corrupt shim that is not the expected script", () => {
     const dir = makeDir();
-    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    ensureNodeShim(dir, EXEC_PATH, { platform: "darwin" });
     const shim = join(dir, "node");
     writeFileSync(shim, "not a shim");
 
-    ensureNodeShim(dir, EXEC_PATH, "darwin");
+    ensureNodeShim(dir, EXEC_PATH, { platform: "darwin" });
 
     expect(readFileSync(shim, "utf-8")).toBe(buildNodeShimScript(EXEC_PATH));
   });
 
   it("keeps the symlink behavior on windows and tolerates an existing link", () => {
     const dir = makeDir();
-    ensureNodeShim(dir, EXEC_PATH, "win32");
-    ensureNodeShim(dir, EXEC_PATH, "win32");
+    ensureNodeShim(dir, EXEC_PATH, { platform: "win32" });
+    ensureNodeShim(dir, EXEC_PATH, { platform: "win32" });
 
     const shim = join(dir, "node");
     expect(lstatSync(shim).isSymbolicLink()).toBe(true);
     expect(readlinkSync(shim)).toBe(EXEC_PATH);
   });
 
+  it("points the win32 symlink at a detected real node", () => {
+    const dir = makeDir();
+    ensureNodeShim(dir, EXEC_PATH, {
+      platform: "win32",
+      realNodePath: "C:\\Program Files\\nodejs\\node.exe",
+    });
+
+    expect(readlinkSync(join(dir, "node"))).toBe(
+      "C:\\Program Files\\nodejs\\node.exe",
+    );
+  });
+
   it("retargets the win32 symlink when the binary path changes", () => {
     const dir = makeDir();
-    ensureNodeShim(dir, "/old/location/App.exe", "win32");
+    ensureNodeShim(dir, "/old/location/App.exe", { platform: "win32" });
 
-    ensureNodeShim(dir, EXEC_PATH, "win32");
+    ensureNodeShim(dir, EXEC_PATH, { platform: "win32" });
 
     expect(readlinkSync(join(dir, "node"))).toBe(EXEC_PATH);
   });

--- a/packages/workspace-server/src/services/agent/node-shim.ts
+++ b/packages/workspace-server/src/services/agent/node-shim.ts
@@ -16,33 +16,44 @@ function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && "code" in err;
 }
 
+export interface EnsureNodeShimOptions {
+  platform?: NodeJS.Platform;
+  /** Detected real node the shim prefers over running the app binary as node. */
+  realNodePath?: string;
+}
+
 // Writes the `node` shim agents resolve via PATH. POSIX shims are wrapper
-// scripts that set ELECTRON_RUN_AS_NODE themselves, so a descendant that
+// scripts that prefer a detected real node runtime when one was found and
+// otherwise set ELECTRON_RUN_AS_NODE themselves, so a descendant that
 // strips the var still gets a node runtime instead of a phantom app boot (a
 // bare symlink relied on every layer preserving the env). Self-heals legacy
 // symlinks and shims pointing at a moved binary; no-op when already current.
 export function ensureNodeShim(
   mockNodeDir: string,
   execPath: string,
-  platform: NodeJS.Platform = process.platform,
+  options: EnsureNodeShimOptions = {},
 ): void {
+  const { platform = process.platform, realNodePath } = options;
   mkdirSync(mockNodeDir, { recursive: true });
   const shimPath = join(mockNodeDir, "node");
 
   if (platform === "win32") {
-    // No sh on win32, so the shim stays a symlink; the bootstrap
-    // internal-child guard is the backstop against phantom boots there.
-    if (currentSymlinkTarget(shimPath) === execPath) return;
+    // No sh on win32, so the shim stays a symlink — pointed at a detected
+    // real node.exe when available (resolvable from sh-like shells; PATHEXT
+    // still won't pick it up from cmd). The bootstrap internal-child guard
+    // is the backstop against phantom boots there.
+    const target = realNodePath ?? execPath;
+    if (currentSymlinkTarget(shimPath) === target) return;
     rmSync(shimPath, { force: true });
     try {
-      symlinkSync(execPath, shimPath);
+      symlinkSync(target, shimPath);
     } catch (err) {
       if (!isErrnoException(err) || err.code !== "EEXIST") throw err;
     }
     return;
   }
 
-  const script = buildNodeShimScript(execPath);
+  const script = buildNodeShimScript(execPath, realNodePath);
   if (currentShimContent(shimPath) === script) return;
 
   const tmpPath = `${shimPath}.${process.pid}.tmp`;

--- a/packages/workspace-server/src/services/agent/real-node.test.ts
+++ b/packages/workspace-server/src/services/agent/real-node.test.ts
@@ -1,0 +1,234 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { buildNodeShimScript } from "@posthog/shared/node-shim";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  findRealNode,
+  MAX_PROBED_CANDIDATES,
+  MIN_REAL_NODE_MAJOR,
+  type RealNode,
+} from "./real-node";
+
+const dirs: string[] = [];
+
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "real-node-test-"));
+  dirs.push(dir);
+  return dir;
+}
+
+/** Writes an executable `node` fixture into a fresh dir and returns the dir. */
+function makeBinDir(content: string): string {
+  const dir = makeDir();
+  const node = join(dir, "node");
+  writeFileSync(node, content);
+  chmodSync(node, 0o755);
+  return dir;
+}
+
+function probeFixture(json: string, prelude = ""): string {
+  return `#!/bin/sh\n${prelude}echo '${json}'\n`;
+}
+
+afterEach(() => {
+  while (dirs.length > 0) {
+    const dir = dirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe.skipIf(process.platform === "win32")("findRealNode probing", () => {
+  const EXEC_PATH = "/fake/app/binary";
+
+  function findWithPath(pathDirs: string[], env: NodeJS.ProcessEnv = {}) {
+    return findRealNode({
+      env: { ...env, PATH: pathDirs.join(delimiter) },
+      execPath: EXEC_PATH,
+      platform: "darwin",
+      probeTimeoutMs: 2000,
+    });
+  }
+
+  it("accepts a candidate that identifies as a recent real node", async () => {
+    const dir = makeBinDir(probeFixture('{"node":"v22.1.0","electron":null}'));
+    await expect(findWithPath([dir])).resolves.toEqual({
+      path: join(dir, "node"),
+      version: "v22.1.0",
+    });
+  });
+
+  it("tolerates version-manager noise before the JSON line", async () => {
+    const dir = makeBinDir(
+      probeFixture('{"node":"v24.2.0","electron":null}', "echo 'warn: xyz'\n"),
+    );
+    await expect(findWithPath([dir])).resolves.toEqual({
+      path: join(dir, "node"),
+      version: "v24.2.0",
+    });
+  });
+
+  it("rejects a candidate that identifies as Electron", async () => {
+    const dir = makeBinDir(
+      probeFixture('{"node":"v22.1.0","electron":"37.2.0"}'),
+    );
+    await expect(findWithPath([dir])).resolves.toBeNull();
+  });
+
+  it("rejects a node older than the minimum major", async () => {
+    const dir = makeBinDir(
+      probeFixture(
+        `{"node":"v${MIN_REAL_NODE_MAJOR - 2}.20.0","electron":null}`,
+      ),
+    );
+    await expect(findWithPath([dir])).resolves.toBeNull();
+  });
+
+  it("rejects candidates that emit garbage or fail", async () => {
+    const garbage = makeBinDir("#!/bin/sh\necho 'not json'\n");
+    const failing = makeBinDir("#!/bin/sh\nexit 1\n");
+    await expect(findWithPath([garbage, failing])).resolves.toBeNull();
+  });
+
+  it("kills and rejects a candidate that hangs", async () => {
+    const dir = makeBinDir("#!/bin/sh\nsleep 30\n");
+    await expect(
+      findRealNode({
+        env: { PATH: dir },
+        execPath: EXEC_PATH,
+        platform: "darwin",
+        probeTimeoutMs: 300,
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("findRealNode PATH scanning", () => {
+  function fakeExecPath(): string {
+    const dir = makeDir();
+    const execPath = join(dir, "app-binary");
+    writeFileSync(execPath, "binary");
+    return execPath;
+  }
+
+  function makeCandidateDir(): string {
+    return makeBinDir("#!/bin/sh\nexit 0\n");
+  }
+
+  function scan(
+    pathDirs: string[],
+    probe: (candidatePath: string) => Promise<RealNode | null>,
+    env: NodeJS.ProcessEnv = {},
+    execPath = fakeExecPath(),
+    warn?: (message: string, data?: Record<string, unknown>) => void,
+  ) {
+    return findRealNode({
+      env: { ...env, PATH: pathDirs.join(delimiter) },
+      execPath,
+      platform: "darwin",
+      probe,
+      warn,
+    });
+  }
+
+  it("returns the first candidate the probe accepts, in PATH order", async () => {
+    const first = makeCandidateDir();
+    const second = makeCandidateDir();
+    const probe = vi.fn(async (candidatePath: string) =>
+      candidatePath === join(second, "node")
+        ? { path: candidatePath, version: "v22.0.0" }
+        : null,
+    );
+
+    const result = await scan([first, "/does/not/exist", second], probe);
+
+    expect(result).toEqual({ path: join(second, "node"), version: "v22.0.0" });
+    expect(probe.mock.calls.map(([p]) => p)).toEqual([
+      join(first, "node"),
+      join(second, "node"),
+    ]);
+  });
+
+  it("skips our own shim dirs without probing them", async () => {
+    const execPath = fakeExecPath();
+    const wrapperShim = makeDir();
+    writeFileSync(join(wrapperShim, "node"), buildNodeShimScript(execPath));
+    chmodSync(join(wrapperShim, "node"), 0o755);
+    const realNodeWrapperShim = makeDir();
+    writeFileSync(
+      join(realNodeWrapperShim, "node"),
+      buildNodeShimScript(execPath, "/usr/local/bin/node"),
+    );
+    chmodSync(join(realNodeWrapperShim, "node"), 0o755);
+    const symlinkShim = makeDir();
+    symlinkSync(execPath, join(symlinkShim, "node"));
+    const probe = vi.fn(async () => null);
+
+    await scan(
+      [wrapperShim, realNodeWrapperShim, symlinkShim],
+      probe,
+      {},
+      execPath,
+    );
+
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("prefers a valid POSTHOG_CODE_NODE_PATH override without scanning PATH", async () => {
+    const onPath = makeCandidateDir();
+    const probe = vi.fn(async (candidatePath: string) => ({
+      path: candidatePath,
+      version: "v22.0.0",
+    }));
+
+    const result = await scan([onPath], probe, {
+      POSTHOG_CODE_NODE_PATH: "/custom/node",
+    });
+
+    expect(result).toEqual({ path: "/custom/node", version: "v22.0.0" });
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns and gives up when the override does not validate", async () => {
+    const onPath = makeCandidateDir();
+    const probe = vi.fn(async () => null);
+    const warn = vi.fn();
+
+    const result = await scan(
+      [onPath],
+      probe,
+      { POSTHOG_CODE_NODE_PATH: "/broken/node" },
+      fakeExecPath(),
+      warn,
+    );
+
+    expect(result).toBeNull();
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.any(String), {
+      override: "/broken/node",
+    });
+  });
+
+  it("stops probing after the candidate cap", async () => {
+    const candidates = Array.from(
+      { length: MAX_PROBED_CANDIDATES + 2 },
+      makeCandidateDir,
+    );
+    const probe = vi.fn(async () => null);
+
+    await expect(scan(candidates, probe)).resolves.toBeNull();
+    expect(probe).toHaveBeenCalledTimes(MAX_PROBED_CANDIDATES);
+  });
+
+  it("returns null for an empty PATH", async () => {
+    const probe = vi.fn(async () => null);
+    await expect(scan([], probe)).resolves.toBeNull();
+    expect(probe).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workspace-server/src/services/agent/real-node.test.ts
+++ b/packages/workspace-server/src/services/agent/real-node.test.ts
@@ -74,26 +74,25 @@ describe.skipIf(process.platform === "win32")("findRealNode probing", () => {
     });
   });
 
-  it("rejects a candidate that identifies as Electron", async () => {
-    const dir = makeBinDir(
-      probeFixture('{"node":"v22.1.0","electron":"37.2.0"}'),
-    );
-    await expect(findWithPath([dir])).resolves.toBeNull();
-  });
-
-  it("rejects a node older than the minimum major", async () => {
-    const dir = makeBinDir(
-      probeFixture(
+  it.each([
+    {
+      candidate: "identifies as Electron",
+      script: probeFixture('{"node":"v22.1.0","electron":"37.2.0"}'),
+    },
+    {
+      candidate: "reports a version below the minimum major",
+      script: probeFixture(
         `{"node":"v${MIN_REAL_NODE_MAJOR - 2}.20.0","electron":null}`,
       ),
-    );
+    },
+    {
+      candidate: "emits non-JSON output",
+      script: "#!/bin/sh\necho 'not json'\n",
+    },
+    { candidate: "exits non-zero", script: "#!/bin/sh\nexit 1\n" },
+  ])("rejects a candidate that $candidate", async ({ script }) => {
+    const dir = makeBinDir(script);
     await expect(findWithPath([dir])).resolves.toBeNull();
-  });
-
-  it("rejects candidates that emit garbage or fail", async () => {
-    const garbage = makeBinDir("#!/bin/sh\necho 'not json'\n");
-    const failing = makeBinDir("#!/bin/sh\nexit 1\n");
-    await expect(findWithPath([garbage, failing])).resolves.toBeNull();
   });
 
   it("kills and rejects a candidate that hangs", async () => {

--- a/packages/workspace-server/src/services/agent/real-node.ts
+++ b/packages/workspace-server/src/services/agent/real-node.ts
@@ -1,0 +1,189 @@
+import { execFile } from "node:child_process";
+import {
+  accessSync,
+  constants,
+  lstatSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
+import { delimiter, join } from "node:path";
+import { promisify } from "node:util";
+import { isNodeShimScript } from "@posthog/shared/node-shim";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Oldest node major the shim will prefer over Electron's run-as-node mode.
+ * Anything the agent spawns by name (npx MCP servers, hooks, project
+ * scripts) broadly assumes an active or maintenance LTS; an older real node
+ * is more likely to break those spawns than the Electron fallback is.
+ */
+export const MIN_REAL_NODE_MAJOR = 20;
+
+/**
+ * Bounds a PATH walk full of broken candidates: at most this many probes run
+ * before detection gives up and the shim keeps its Electron fallback.
+ */
+export const MAX_PROBED_CANDIDATES = 5;
+
+const PROBE_TIMEOUT_MS = 2000;
+
+/** Shim scripts are well under this; anything bigger is a real binary. */
+const MAX_SHIM_SCRIPT_BYTES = 4096;
+
+// Prints one JSON line identifying the runtime. process.versions.electron is
+// non-null when the candidate is itself an Electron binary running as node —
+// those are rejected: their addon ABI differs from real node's, which is the
+// main failure the real-node preference exists to avoid.
+const PROBE_EXPRESSION =
+  "JSON.stringify({node:process.version,electron:process.versions.electron??null})";
+
+export interface RealNode {
+  path: string;
+  version: string;
+}
+
+export interface FindRealNodeOptions {
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+  platform?: NodeJS.Platform;
+  probeTimeoutMs?: number;
+  /** Surfaces non-fatal detection problems (e.g. a bad explicit override). */
+  warn?: (message: string, data?: Record<string, unknown>) => void;
+  /** Test seam: replaces the child-process probe. */
+  probe?: (candidatePath: string) => Promise<RealNode | null>;
+}
+
+/**
+ * Finds a real Node.js runtime for the PATH shim to prefer over running the
+ * app binary in run-as-node mode. Resolution order: the
+ * POSTHOG_CODE_NODE_PATH override, then the first PATH entry whose `node`
+ * validates. PATH here is the login-shell-corrected one fixPath() resolved at
+ * boot, so version-manager installs (nvm, mise, volta, brew) are visible.
+ *
+ * Our own shim dirs are skipped, which also guarantees a detected node stays
+ * reachable after codex strips shim dirs from its children's PATH.
+ *
+ * Never throws; any failure just means the Electron fallback stays.
+ */
+export async function findRealNode(
+  options: FindRealNodeOptions = {},
+): Promise<RealNode | null> {
+  const env = options.env ?? process.env;
+  const execPath = options.execPath ?? process.execPath;
+  const platform = options.platform ?? process.platform;
+  const probe =
+    options.probe ??
+    ((candidatePath: string) =>
+      probeCandidate(
+        candidatePath,
+        env,
+        options.probeTimeoutMs ?? PROBE_TIMEOUT_MS,
+      ));
+
+  const override = env.POSTHOG_CODE_NODE_PATH;
+  if (override) {
+    const result = await probe(override);
+    if (!result) {
+      options.warn?.(
+        "POSTHOG_CODE_NODE_PATH did not validate as a usable real node; keeping the Electron fallback",
+        { override },
+      );
+    }
+    return result;
+  }
+
+  const binName = platform === "win32" ? "node.exe" : "node";
+  let probed = 0;
+  for (const dir of (env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, binName);
+    if (!isUsableCandidate(candidate, execPath, platform)) continue;
+    if (probed >= MAX_PROBED_CANDIDATES) return null;
+    probed++;
+    const result = await probe(candidate);
+    if (result) return result;
+  }
+  return null;
+}
+
+function isUsableCandidate(
+  candidatePath: string,
+  execPath: string,
+  platform: NodeJS.Platform,
+): boolean {
+  let isSymlink: boolean;
+  let size: number;
+  try {
+    const stat = lstatSync(candidatePath);
+    isSymlink = stat.isSymbolicLink();
+    size = stat.size;
+  } catch {
+    return false;
+  }
+
+  if (isSymlink) {
+    // Legacy shims were symlinks to the app binary; realpath also catches
+    // indirect chains. A dangling symlink throws and is skipped.
+    try {
+      if (realpathSync(candidatePath) === execPath) return false;
+    } catch {
+      return false;
+    }
+  } else if (size <= MAX_SHIM_SCRIPT_BYTES) {
+    try {
+      if (isNodeShimScript(readFileSync(candidatePath, "utf-8"), execPath)) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  if (platform !== "win32") {
+    try {
+      accessSync(candidatePath, constants.X_OK);
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function probeCandidate(
+  candidatePath: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+): Promise<RealNode | null> {
+  let stdout: string;
+  try {
+    // ELECTRON_RUN_AS_NODE=1 in the probe env keeps a stray Electron binary
+    // from booting its app: it runs as node and identifies itself through
+    // process.versions.electron instead. The timeout + SIGKILL is the
+    // backstop for binaries that ignore the variable entirely.
+    ({ stdout } = await execFileAsync(candidatePath, ["-p", PROBE_EXPRESSION], {
+      env: { ...env, ELECTRON_RUN_AS_NODE: "1" },
+      timeout: timeoutMs,
+      killSignal: "SIGKILL",
+      windowsHide: true,
+      maxBuffer: 64 * 1024,
+    }));
+  } catch {
+    return null;
+  }
+
+  // Version-manager wrappers can print warnings before the JSON line.
+  const lastLine = stdout.trim().split("\n").pop() ?? "";
+  let parsed: { node?: unknown; electron?: unknown };
+  try {
+    parsed = JSON.parse(lastLine);
+  } catch {
+    return null;
+  }
+  if (typeof parsed.node !== "string" || parsed.electron != null) return null;
+
+  const major = Number(/^v(\d+)\./.exec(parsed.node)?.[1]);
+  if (!Number.isFinite(major) || major < MIN_REAL_NODE_MAJOR) return null;
+
+  return { path: candidatePath, version: parsed.node };
+}


### PR DESCRIPTION
## Problem

The `node` shim on the agent's PATH runs the desktop app binary via `ELECTRON_RUN_AS_NODE`. Since #3239 the wrapper script carries the env var itself, so phantom app boots are gone — but everything spawned through the shim still runs on Electron's embedded Node: native addons built for real node fail with ABI mismatches (npx MCP servers, hooks, project scripts), and memory overhead is higher than real node. Most machines running the app already have a perfectly good Node installed.

**Why:** step 2 of the shim hardening discussed after #3239 — prefer the user's real node when one exists, keeping run-as-node only as the zero-setup fallback. One more rung on #3114's resolver ladder (env override → vendored → detected → Electron fallback), independent of the vendored runtime work.

Refs #3114.

## Changes

- New `findRealNode` (`packages/workspace-server/src/services/agent/real-node.ts`): at session start, scan PATH (already login-shell-corrected by `fixPath()`, so nvm/brew/mise installs are visible) for a `node` that probes as real Node >= 20. Candidates reporting `process.versions.electron` are rejected — wrong-ABI runtimes are the problem this solves. Probes run with a 2s SIGKILL timeout, capped at 5 candidates; `POSTHOG_CODE_NODE_PATH` overrides detection.
- The shim script now prefers the detected node and keeps the `ELECTRON_RUN_AS_NODE` fallback only for when it later vanishes (e.g. nvm prune):

  ```sh
  #!/bin/sh
  if [ -x "<detected node>" ]; then
    exec "<detected node>" "$@"
  fi
  export ELECTRON_RUN_AS_NODE=1
  exec "<app binary>" "$@"
  ```
- Detection skips our own shim dirs (legacy symlinks via realpath, wrappers via a new shared `isNodeShimScript` predicate), so it can't pick up a stale shim across restarts. The codex PATH strip uses the same predicate instead of exact-content equality, recognizing both wrapper variants.
- On win32 the symlink targets a detected `node.exe` when available (the PATHEXT gap for cmd remains — that's #3113's `node.cmd` territory).
- `setupMockNodeEnvironment` is async with a memoized setup promise (concurrent session starts share one detection; a failed shim write still retries next session) and logs which mode the shim ended up in.

## How did you test this?

- New suites: `real-node.test.ts` (13 tests — real child-process probes for accept/electron-reject/version-floor/garbage/hang-timeout, injected-probe scans for PATH order, shim skipping, override handling, candidate cap) and expanded `node-shim` tests in shared + workspace-server (upgrade/downgrade between wrapper variants, win32 retargeting).
- Existing suites green: `agent.test.ts` (27, incl. new passthrough assertion), `spawn-env.test.ts` (both wrapper variants stripped), full shared package (518).
- Executed both script branches for real: a shim preferring this machine's node exec'd it directly with no env var; a shim whose embedded node path was deleted fell back through `ELECTRON_RUN_AS_NODE=1` correctly.
- `pnpm typecheck` and biome clean on all changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*