### PR TITLE
feat(command-center): choose folder when opening a terminal

### DIFF
--- a/packages/core/src/command-center/cells.ts
+++ b/packages/core/src/command-center/cells.ts
@@ -1,6 +1,11 @@
 import type { AgentSession, WorkspaceMode } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
-import { getTerminalCellId, isBrainrotCell, isTerminalCell } from "./grid";
+import {
+  getTerminalCellCwd,
+  getTerminalCellId,
+  isBrainrotCell,
+  isTerminalCell,
+} from "./grid";
 import { type CellStatus, deriveStatus, getRepoName } from "./status";
 
 export interface CommandCenterCellData {
@@ -15,6 +20,7 @@ export interface CommandCenterCellData {
   isBrainrot: boolean;
   // Standalone terminal slot, independent of any agent run.
   terminalId: string | null;
+  terminalCwd: string | null;
 }
 
 export interface BuildCellsInput {
@@ -32,6 +38,7 @@ const EMPTY_CELL_DATA = {
   workspaceMode: null,
   isBrainrot: false,
   terminalId: null,
+  terminalCwd: null,
 };
 
 export function buildCommandCenterCells(
@@ -49,6 +56,7 @@ export function buildCommandCenterCells(
         ...EMPTY_CELL_DATA,
         cellIndex,
         terminalId: getTerminalCellId(cellValue),
+        terminalCwd: getTerminalCellCwd(cellValue),
       };
     }
 

--- a/packages/core/src/command-center/grid.test.ts
+++ b/packages/core/src/command-center/grid.test.ts
@@ -5,6 +5,7 @@ import {
   getCellCount,
   getCellSessionId,
   getGridDimensions,
+  getTerminalCellCwd,
   getTerminalCellId,
   isBrainrotCell,
   isTerminalCell,
@@ -71,6 +72,14 @@ describe("terminal cells", () => {
     const value = makeTerminalCellValue("abc123");
     expect(isTerminalCell(value)).toBe(true);
     expect(getTerminalCellId(value)).toBe("abc123");
+    expect(getTerminalCellCwd(value)).toBeNull();
+  });
+
+  it("round-trips a terminal id and cwd through the cell value", () => {
+    const value = makeTerminalCellValue("abc123", "/Users/me/my:repo");
+    expect(isTerminalCell(value)).toBe(true);
+    expect(getTerminalCellId(value)).toBe("abc123");
+    expect(getTerminalCellCwd(value)).toBe("/Users/me/my:repo");
   });
 
   it.each([

--- a/packages/core/src/command-center/grid.ts
+++ b/packages/core/src/command-center/grid.ts
@@ -25,14 +25,28 @@ export function isTerminalCell(value: string | null): value is string {
   return value?.startsWith(TERMINAL_CELL_PREFIX) ?? false;
 }
 
-export function makeTerminalCellValue(terminalId: string): string {
-  return `${TERMINAL_CELL_PREFIX}${terminalId}`;
+// terminalId is a base36 random string (no colon), so an optional cwd can be
+// appended after a colon. cwd is URI-encoded, so it never contains a colon.
+export function makeTerminalCellValue(
+  terminalId: string,
+  cwd?: string,
+): string {
+  const base = `${TERMINAL_CELL_PREFIX}${terminalId}`;
+  return cwd ? `${base}:${encodeURIComponent(cwd)}` : base;
 }
 
 export function getTerminalCellId(value: string | null): string | null {
-  return isTerminalCell(value)
-    ? value.slice(TERMINAL_CELL_PREFIX.length)
-    : null;
+  if (!isTerminalCell(value)) return null;
+  const rest = value.slice(TERMINAL_CELL_PREFIX.length);
+  const colon = rest.indexOf(":");
+  return colon === -1 ? rest : rest.slice(0, colon);
+}
+
+export function getTerminalCellCwd(value: string | null): string | null {
+  if (!isTerminalCell(value)) return null;
+  const rest = value.slice(TERMINAL_CELL_PREFIX.length);
+  const colon = rest.indexOf(":");
+  return colon === -1 ? null : decodeURIComponent(rest.slice(colon + 1));
 }
 
 export function getGridDimensions(preset: LayoutPreset): GridDimensions {

--- a/packages/ui/src/features/command-center/commandCenterStore.ts
+++ b/packages/ui/src/features/command-center/commandCenterStore.ts
@@ -34,7 +34,11 @@ interface CommandCenterStoreActions {
   setActiveCell: (cellIndex: number | null) => void;
   assignTask: (cellIndex: number, taskId: string) => void;
   setBrainrotCell: (cellIndex: number) => void;
-  setTerminalCell: (cellIndex: number, terminalId: string, cwd?: string) => void;
+  setTerminalCell: (
+    cellIndex: number,
+    terminalId: string,
+    cwd?: string,
+  ) => void;
   autofillCells: (taskIds: string[]) => void;
   clearCell: (cellIndex: number) => void;
   removeTaskById: (taskId: string) => void;

--- a/packages/ui/src/features/command-center/commandCenterStore.ts
+++ b/packages/ui/src/features/command-center/commandCenterStore.ts
@@ -34,7 +34,7 @@ interface CommandCenterStoreActions {
   setActiveCell: (cellIndex: number | null) => void;
   assignTask: (cellIndex: number, taskId: string) => void;
   setBrainrotCell: (cellIndex: number) => void;
-  setTerminalCell: (cellIndex: number, terminalId: string) => void;
+  setTerminalCell: (cellIndex: number, terminalId: string, cwd?: string) => void;
   autofillCells: (taskIds: string[]) => void;
   clearCell: (cellIndex: number) => void;
   removeTaskById: (taskId: string) => void;
@@ -118,11 +118,11 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
           };
         }),
 
-      setTerminalCell: (cellIndex, terminalId) =>
+      setTerminalCell: (cellIndex, terminalId, cwd) =>
         set((state) => {
           if (cellIndex < 0 || cellIndex >= state.cells.length) return state;
           const cells = [...state.cells];
-          cells[cellIndex] = makeTerminalCellValue(terminalId);
+          cells[cellIndex] = makeTerminalCellValue(terminalId, cwd);
           return {
             cells,
             activeTaskId: null,

--- a/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
+++ b/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
@@ -133,9 +133,12 @@ function EmptyCell({ cellIndex }: { cellIndex: number }) {
     setBrainrotCell(cellIndex);
   }, [layout, cells, setBrainrotCell, cellIndex]);
 
-  const handleNewTerminal = useCallback(() => {
-    setTerminalCell(cellIndex, secureRandomString(8));
-  }, [setTerminalCell, cellIndex]);
+  const handleNewTerminal = useCallback(
+    (cwd?: string) => {
+      setTerminalCell(cellIndex, secureRandomString(8), cwd);
+    },
+    [setTerminalCell, cellIndex],
+  );
 
   const handleTaskCreated = useCallback(
     (task: Task) => {
@@ -279,13 +282,15 @@ function BrainrotCell({ cellIndex }: { cellIndex: number }) {
 function TerminalCell({
   cellIndex,
   terminalId,
+  terminalCwd,
 }: {
   cellIndex: number;
   terminalId: string;
+  terminalCwd: string | null;
 }) {
   const clearCell = useCommandCenterStore((s) => s.clearCell);
   const { getRecentFolders, getFolderDisplayName } = useFolders();
-  const cwd = getRecentFolders(1)[0]?.path;
+  const cwd = terminalCwd ?? getRecentFolders(1)[0]?.path;
   const folderName = cwd ? getFolderDisplayName(cwd) : null;
   const stateKey = getTerminalCellStateKey(terminalId);
 
@@ -413,7 +418,11 @@ export function CommandCenterPanel({
 
   if (cell.terminalId) {
     return (
-      <TerminalCell cellIndex={cell.cellIndex} terminalId={cell.terminalId} />
+      <TerminalCell
+        cellIndex={cell.cellIndex}
+        terminalId={cell.terminalId}
+        terminalCwd={cell.terminalCwd}
+      />
     );
   }
 

--- a/packages/ui/src/features/command-center/components/TaskSelector.tsx
+++ b/packages/ui/src/features/command-center/components/TaskSelector.tsx
@@ -1,8 +1,15 @@
-import { Lightning, Plus, Terminal } from "@phosphor-icons/react";
+import {
+  ArrowLeft,
+  Folder,
+  Lightning,
+  Plus,
+  Terminal,
+} from "@phosphor-icons/react";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { Popover } from "@radix-ui/themes";
-import { type ReactNode, useCallback } from "react";
+import { type ReactNode, useCallback, useState } from "react";
 import { Combobox } from "../../../primitives/combobox/Combobox";
+import { useFolders } from "../../folders/useFolders";
 import { useCommandCenterStore } from "../commandCenterStore";
 import { useAvailableTasks } from "../hooks/useAvailableTasks";
 
@@ -11,7 +18,7 @@ interface TaskSelectorProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onNewTask?: () => void;
-  onNewTerminal?: () => void;
+  onNewTerminal?: (cwd?: string) => void;
   onBrainrot?: () => void;
   children: ReactNode;
 }
@@ -27,103 +34,161 @@ export function TaskSelector({
 }: TaskSelectorProps) {
   const availableTasks = useAvailableTasks();
   const assignTask = useCommandCenterStore((s) => s.assignTask);
+  const { getRecentFolders } = useFolders();
+  const folders = getRecentFolders();
+  const [step, setStep] = useState<"tasks" | "folder">("tasks");
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) setStep("tasks");
+      onOpenChange(next);
+    },
+    [onOpenChange],
+  );
 
   const handleSelect = useCallback(
-    (taskId: string) => {
-      assignTask(cellIndex, taskId);
-      onOpenChange(false);
+    (value: string) => {
+      if (step === "folder") {
+        onNewTerminal?.(value);
+      } else {
+        assignTask(cellIndex, value);
+      }
+      handleOpenChange(false);
     },
-    [assignTask, cellIndex, onOpenChange],
+    [step, onNewTerminal, assignTask, cellIndex, handleOpenChange],
   );
 
   const handleNewTask = useCallback(() => {
-    onOpenChange(false);
+    handleOpenChange(false);
     if (onNewTask) {
       onNewTask();
     } else {
       openTaskInput();
     }
-  }, [onOpenChange, onNewTask]);
+  }, [handleOpenChange, onNewTask]);
 
   const handleNewTerminal = useCallback(() => {
-    onOpenChange(false);
-    onNewTerminal?.();
-  }, [onOpenChange, onNewTerminal]);
+    if (folders.length > 1) {
+      setStep("folder");
+      return;
+    }
+    handleOpenChange(false);
+    onNewTerminal?.(folders[0]?.path);
+  }, [folders, handleOpenChange, onNewTerminal]);
 
   const handleBrainrot = useCallback(() => {
-    onOpenChange(false);
+    handleOpenChange(false);
     onBrainrot?.();
-  }, [onOpenChange, onBrainrot]);
+  }, [handleOpenChange, onBrainrot]);
 
   return (
     <Combobox.Root
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={handleOpenChange}
       value=""
       onValueChange={handleSelect}
       size="1"
     >
       <Popover.Trigger>{children}</Popover.Trigger>
-      <Combobox.Content
-        items={availableTasks}
-        getValue={(task) => task.title}
-        side="bottom"
-        align="center"
-        sideOffset={4}
-        className="min-w-[240px]"
-      >
-        {({ filtered, hasMore, moreCount }) => (
-          <>
-            <Combobox.Input placeholder="Search tasks..." />
-            <Combobox.Empty>No matching tasks</Combobox.Empty>
-            {filtered.map((task) => (
-              <Combobox.Item
-                key={task.id}
-                value={task.id}
-                textValue={task.title}
-              >
-                {task.title}
-              </Combobox.Item>
-            ))}
-            {hasMore && (
-              <div className="combobox-label">
-                {moreCount} more {moreCount === 1 ? "task" : "tasks"}; type to
-                filter
-              </div>
-            )}
-            <Combobox.Footer>
-              <button
-                type="button"
-                className="combobox-footer-button"
-                onClick={handleNewTask}
-              >
-                <Plus size={11} weight="bold" />
-                New task
-              </button>
-              {onNewTerminal && (
+      {step === "folder" ? (
+        <Combobox.Content
+          items={folders}
+          getValue={(folder) => folder.name}
+          side="bottom"
+          align="center"
+          sideOffset={4}
+          className="min-w-[240px]"
+        >
+          {({ filtered }) => (
+            <>
+              <Combobox.Input placeholder="Search folders..." />
+              <Combobox.Empty>No matching folders</Combobox.Empty>
+              {filtered.map((folder) => (
+                <Combobox.Item
+                  key={folder.id}
+                  value={folder.path}
+                  textValue={folder.name}
+                  icon={<Folder size={12} />}
+                  description={folder.path}
+                >
+                  {folder.name}
+                </Combobox.Item>
+              ))}
+              <Combobox.Footer>
                 <button
                   type="button"
                   className="combobox-footer-button"
-                  onClick={handleNewTerminal}
+                  onClick={() => setStep("tasks")}
                 >
-                  <Terminal size={11} weight="bold" />
-                  Terminal
+                  <ArrowLeft size={11} weight="bold" />
+                  Back
                 </button>
+              </Combobox.Footer>
+            </>
+          )}
+        </Combobox.Content>
+      ) : (
+        <Combobox.Content
+          items={availableTasks}
+          getValue={(task) => task.title}
+          side="bottom"
+          align="center"
+          sideOffset={4}
+          className="min-w-[240px]"
+        >
+          {({ filtered, hasMore, moreCount }) => (
+            <>
+              <Combobox.Input placeholder="Search tasks..." />
+              <Combobox.Empty>No matching tasks</Combobox.Empty>
+              {filtered.map((task) => (
+                <Combobox.Item
+                  key={task.id}
+                  value={task.id}
+                  textValue={task.title}
+                >
+                  {task.title}
+                </Combobox.Item>
+              ))}
+              {hasMore && (
+                <div className="combobox-label">
+                  {moreCount} more {moreCount === 1 ? "task" : "tasks"}; type to
+                  filter
+                </div>
               )}
-              {onBrainrot && (
+              <Combobox.Footer>
                 <button
                   type="button"
                   className="combobox-footer-button"
-                  onClick={handleBrainrot}
+                  onClick={handleNewTask}
                 >
-                  <Lightning size={11} weight="bold" />
-                  Brainrot
+                  <Plus size={11} weight="bold" />
+                  New task
                 </button>
-              )}
-            </Combobox.Footer>
-          </>
-        )}
-      </Combobox.Content>
+                {onNewTerminal && (
+                  <button
+                    type="button"
+                    className="combobox-footer-button"
+                    onClick={handleNewTerminal}
+                  >
+                    <Terminal size={11} weight="bold" />
+                    Terminal
+                  </button>
+                )}
+                {onBrainrot && (
+                  <button
+                    type="button"
+                    className="combobox-footer-button"
+                    onClick={handleBrainrot}
+                  >
+                    <Lightning size={11} weight="bold" />
+                    Brainrot
+                  </button>
+                )}
+              </Combobox.Footer>
+            </>
+          )}
+        </Combobox.Content>
+      )}
     </Combobox.Root>
   );
 }


### PR DESCRIPTION
## Problem

When multiple folders are open, opening a terminal from the command center silently opens it in whichever folder was accessed most recently, with no way to choose.

## Changes

https://github.com/user-attachments/assets/3814c3bd-d3bb-45b9-b812-6108061545af


- Opening a terminal from the command center's "Add task" popover now shows a folder picker **when more than one folder is open**.
- With 0 or 1 folder, behaviour is unchanged (opens in the single / most-recent folder).
- The chosen folder is persisted with the cell (survives reload) and shown in the terminal header badge.

## How did you test this?

- `@posthog/core` command-center unit tests (47 passed), including added round-trip tests for the terminal cell value encoding (id + optional cwd).
- Typecheck clean on all touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*