### PR TITLE
feat(sessions): use Tooltip for execute command title

### DIFF
--- a/packages/ui/src/features/sessions/components/session-update/ExecuteToolView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/ExecuteToolView.tsx
@@ -1,5 +1,6 @@
 import { Terminal } from "@phosphor-icons/react";
 import { compactHomePath } from "@posthog/shared";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { useChatThreadChrome } from "../chat-thread/chatThreadChrome";
 import { ToolRow } from "./ToolRow";
 import {
@@ -51,6 +52,12 @@ export function ExecuteToolView({
   );
   const hasOutput = output.trim().length > 0;
 
+  const commandTooltip = (
+    <span className="block max-w-md whitespace-pre-wrap break-all font-mono text-xs">
+      {command}
+    </span>
+  );
+
   return (
     <ToolRow
       icon={Terminal}
@@ -64,18 +71,19 @@ export function ExecuteToolView({
       {command &&
         (chatChrome ? (
           <ToolTitle className="min-w-0 shrink truncate font-mono">
-            <span className="block truncate" title={command}>
-              {truncateText(compactHomePath(command), MAX_COMMAND_LENGTH)}
-            </span>
+            <Tooltip content={commandTooltip}>
+              <span className="block truncate">
+                {truncateText(compactHomePath(command), MAX_COMMAND_LENGTH)}
+              </span>
+            </Tooltip>
           </ToolTitle>
         ) : (
           <ToolTitle className="min-w-0 shrink truncate">
-            <span
-              className="block truncate border border-border bg-gray-5 font-mono"
-              title={command}
-            >
-              {truncateText(compactHomePath(command), MAX_COMMAND_LENGTH)}
-            </span>
+            <Tooltip content={commandTooltip}>
+              <span className="block truncate border border-border bg-gray-5 font-mono">
+                {truncateText(compactHomePath(command), MAX_COMMAND_LENGTH)}
+              </span>
+            </Tooltip>
           </ToolTitle>
         ))}
     </ToolRow>

--- a/packages/ui/src/features/sessions/components/session-update/ExecuteToolView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/ExecuteToolView.tsx
@@ -54,7 +54,7 @@ export function ExecuteToolView({
 
   const commandTooltip = (
     <span className="block max-w-md whitespace-pre-wrap break-all font-mono text-xs">
-      {command}
+      {compactHomePath(command)}
     </span>
   );
 


### PR DESCRIPTION
## Problem

The execute tool row showed the full command via the native `title` attribute, which relies on the OS tooltip: slow to appear, unstyled, and truncated inconsistently.

## Changes

Before:
<img width="2312" height="956" alt="CleanShot 2026-07-08 at 11 55 20@2x" src="https://github.com/user-attachments/assets/d3734647-0ba1-4d89-bba9-716a981d109e" />

After:
<img width="1724" height="1154" alt="CleanShot 2026-07-08 at 11 53 44@2x" src="https://github.com/user-attachments/assets/ed8305dc-b303-4f0c-b3c7-8179e28570ac" />


- Replace the native `title={command}` with the `Tooltip` primitive in both chat-thread and legacy chromes.
- Extract a shared `commandTooltip` node rendering the full command as wrapping mono text.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` -- no errors in the changed file (pre-existing failures live in `@posthog/agent`/`workspace-server` and are unrelated).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*