### PR TITLE
fix(ci): correct "damaged" guidance for PR installer builds

### DIFF
--- a/.github/workflows/pr-build-installer.yml
+++ b/.github/workflows/pr-build-installer.yml
@@ -6,8 +6,10 @@ name: PR Build Installer
 # download the artifact and run the app locally.
 #
 # This deliberately does NOT publish a GitHub release or notarize the build. It
-# signs (so the app launches after a right-click → Open) but skips notarization,
-# which lives in the real release pipeline (code-release.yml, on v* tags).
+# signs but skips notarization (which lives in the real release pipeline,
+# code-release.yml, on v* tags). Because the build is unnotarized, macOS
+# quarantines the downloaded app and Gatekeeper reports it as "damaged"; the PR
+# comment tells testers to clear the flag with `xattr -dr com.apple.quarantine`.
 #
 # Gating: only same-repo PRs run — fork PRs never receive the signing/AWS
 # secrets, so building them would red spuriously.
@@ -48,9 +50,11 @@ jobs:
       CSC_LINK: ${{ secrets.APPLE_CODESIGN_CERT_BASE64 }}
       CSC_KEY_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      # Sign but do not notarize: a signed-but-unnotarized app launches for a
-      # tester after a right-click → Open. Notarization runs only in the tag
-      # release (code-release.yml).
+      # Sign but do not notarize: keeps the build fast. macOS quarantines the
+      # downloaded app, and Gatekeeper blocks a quarantined, unnotarized build as
+      # "damaged", so testers clear the flag with `xattr -dr com.apple.quarantine`
+      # (see the PR comment). Notarization runs only in the tag release
+      # (code-release.yml).
       SKIP_NOTARIZE: "1"
     steps:
       - name: Checkout
@@ -144,10 +148,15 @@ jobs:
               echo ""
               echo "**[⬇️ Open this run and download the \`code-macos-arm64\` artifact](${RUN_URL}#artifacts)** (Apple Silicon / M-series)."
               echo ""
-              echo "Unzip it, then open the \`.dmg\` (or the \`.app\` inside the \`-mac.zip\`)."
+              echo "Unzip it to get the \`.dmg\`, open it, and drag **PostHog Code** into **Applications**."
               echo ""
-              echo "> ℹ️ The build is **signed but not notarized**, so macOS may warn on first launch."
-              echo "> Right-click the app → **Open**, or run \`xattr -dr com.apple.quarantine \"PostHog Code.app\"\`."
+              echo "This build is **signed but not notarized**, so macOS quarantines it on download and Gatekeeper reports *\"PostHog Code is damaged and can't be opened\"*. That is the missing notarization, not a corrupt file — clear the quarantine flag once and it launches:"
+              echo ""
+              echo "\`\`\`sh"
+              echo "xattr -dr com.apple.quarantine \"/Applications/PostHog Code.app\""
+              echo "\`\`\`"
+              echo ""
+              echo "Then open **PostHog Code** normally. (Fully notarized, double-click-to-run builds ship only from the tagged release pipeline.)"
               echo ""
               echo "<sub>Built from ${GITHUB_SHA} · rebuilds on each push while the \`build-installer\` label is present. Downloading requires being signed in to GitHub with repo access.</sub>"
             } > comment-body.md


### PR DESCRIPTION
## Problem

We added a CI job that builds a macOS installer when the `build-installer` label is added to a PR. But pulling down one of those images and opening it fails with **"PostHog Code" is damaged and can't be opened. You should eject the disk image.**

The build is code-signed but deliberately **not notarized** (to stay fast). When the artifact is downloaded through a browser, macOS stamps it with the `com.apple.quarantine` attribute, and on current macOS Gatekeeper rejects a quarantined, unnotarized app as *"damaged"* — the older "right-click → **Open**" bypass the sticky comment promised no longer works. So the file isn't corrupt; the guidance was just wrong.

## Changes

Keep the build unnotarized (fast) but fix the misleading docs in `pr-build-installer.yml`:

- Rewrite the sticky PR comment: explain that "damaged" is the expected missing-notarization state, not a corrupt download, and give the one command that fixes it — `xattr -dr com.apple.quarantine "/Applications/PostHog Code.app"`.
- Drop the stale "right-click → Open" instruction.
- Update the two source-level comments (file header + `SKIP_NOTARIZE`) to match.

## How did you test this?

- Rendered the updated success-comment bash locally and confirmed the Markdown (escaped quotes, fenced code block) comes out correctly.
- Confirmed the edits are limited to comment text / `echo` strings within the existing `run: |` block — no structural or indentation changes to the workflow.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
