### PR TITLE
fix(auth): populate project picker for tokens without scoped_organizations

### DIFF
--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -1156,9 +1156,37 @@ describe("AuthService", () => {
       expect(sessionPort.getCurrent()?.selectedProjectId).toBe(84);
     });
 
-    it("does not attempt recovery when the token grants no scoped organizations", async () => {
-      const fetchState = { succeeds: true, orgCalls: 0 };
-      stubOrgFetch(fetchState);
+    it("does not attempt recovery when the user has no organization at all", async () => {
+      // Truly orgless: token has no scoped orgs AND /api/users/@me/ has no
+      // organization. Contrast with team-scoped tokens (empty scoped_organizations
+      // but @me returns a current org id), where we DO fetch that org.
+      let orgCalls = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | Request) => {
+          const url = typeof input === "string" ? input : input.url;
+          if (url.includes("/api/users/@me/")) {
+            return {
+              ok: true,
+              json: vi.fn().mockResolvedValue({
+                uuid: "user-1",
+                organization: null,
+              }),
+            } as unknown as Response;
+          }
+          if (/\/api\/organizations\/[^/]+\/$/.test(url)) {
+            orgCalls++;
+            return {
+              ok: true,
+              json: vi.fn().mockResolvedValue({ name: "Org 1", teams: [] }),
+            } as unknown as Response;
+          }
+          return {
+            ok: true,
+            json: vi.fn().mockResolvedValue({ has_access: true }),
+          } as unknown as Response;
+        }) as unknown as typeof fetch,
+      );
       oauthFlow.startFlow.mockResolvedValue(
         mockTokenResponse({ scopedOrgs: [] }),
       );
@@ -1174,8 +1202,37 @@ describe("AuthService", () => {
       emitStatus(true);
       await new Promise((r) => setTimeout(r, 10));
 
-      expect(fetchState.orgCalls).toBe(0);
+      expect(orgCalls).toBe(0);
       expect(service.getState().currentProjectId).toBeNull();
+    });
+
+    it("falls back to the @me current org when the token has no scoped organizations", async () => {
+      // Team-scoped tokens (required_access_level=project) arrive with empty
+      // scoped_organizations on some backends. Without the fallback, the picker
+      // is stranded on "No projects" even though the user has a current org.
+      const fetchState = { succeeds: true, orgCalls: 0 };
+      stubOrgFetch(fetchState);
+      oauthFlow.startFlow.mockResolvedValue(
+        mockTokenResponse({ scopedOrgs: [] }),
+      );
+
+      await service.login("us");
+
+      expect(fetchState.orgCalls).toBe(1);
+      expect(service.getState()).toMatchObject({
+        status: "authenticated",
+        currentOrgId: "org-1",
+        currentProjectId: 42,
+        orgProjectsMap: {
+          "org-1": {
+            orgName: "Org 1",
+            projects: [
+              { id: 42, name: "Project 42" },
+              { id: 84, name: "Project 84" },
+            ],
+          },
+        },
+      });
     });
   });
 

--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -886,7 +886,10 @@ describe("AuthService", () => {
   });
 
   describe("project-less recovery", () => {
-    function stubOrgFetch(state: { succeeds: boolean; orgCalls: number }) {
+    function stubOrgFetch(
+      state: { succeeds: boolean; orgCalls: number },
+      options: { orgless?: boolean } = {},
+    ) {
       vi.stubGlobal(
         "fetch",
         vi.fn(async (input: string | Request) => {
@@ -897,7 +900,7 @@ describe("AuthService", () => {
               ok: true,
               json: vi.fn().mockResolvedValue({
                 uuid: "user-1",
-                organization: { id: "org-1" },
+                organization: options.orgless ? null : { id: "org-1" },
               }),
             } as unknown as Response;
           }
@@ -1156,84 +1159,63 @@ describe("AuthService", () => {
       expect(sessionPort.getCurrent()?.selectedProjectId).toBe(84);
     });
 
-    it("does not attempt recovery when the user has no organization at all", async () => {
-      // Truly orgless: token has no scoped orgs AND /api/users/@me/ has no
-      // organization. Contrast with team-scoped tokens (empty scoped_organizations
-      // but @me returns a current org id), where we DO fetch that org.
-      let orgCalls = 0;
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async (input: string | Request) => {
-          const url = typeof input === "string" ? input : input.url;
-          if (url.includes("/api/users/@me/")) {
-            return {
-              ok: true,
-              json: vi.fn().mockResolvedValue({
-                uuid: "user-1",
-                organization: null,
-              }),
-            } as unknown as Response;
-          }
-          if (/\/api\/organizations\/[^/]+\/$/.test(url)) {
-            orgCalls++;
-            return {
-              ok: true,
-              json: vi.fn().mockResolvedValue({ name: "Org 1", teams: [] }),
-            } as unknown as Response;
-          }
-          return {
-            ok: true,
-            json: vi.fn().mockResolvedValue({ has_access: true }),
-          } as unknown as Response;
-        }) as unknown as typeof fetch,
-      );
-      oauthFlow.startFlow.mockResolvedValue(
-        mockTokenResponse({ scopedOrgs: [] }),
-      );
-
-      await service.login("us");
-
-      expect(service.getState()).toMatchObject({
-        status: "authenticated",
-        currentProjectId: null,
-        orgProjectsMap: {},
-      });
-
-      emitStatus(true);
-      await new Promise((r) => setTimeout(r, 10));
-
-      expect(orgCalls).toBe(0);
-      expect(service.getState().currentProjectId).toBeNull();
-    });
-
-    it("falls back to the @me current org when the token has no scoped organizations", async () => {
-      // Team-scoped tokens (required_access_level=project) arrive with empty
-      // scoped_organizations on some backends. Without the fallback, the picker
-      // is stranded on "No projects" even though the user has a current org.
-      const fetchState = { succeeds: true, orgCalls: 0 };
-      stubOrgFetch(fetchState);
-      oauthFlow.startFlow.mockResolvedValue(
-        mockTokenResponse({ scopedOrgs: [] }),
-      );
-
-      await service.login("us");
-
-      expect(fetchState.orgCalls).toBe(1);
-      expect(service.getState()).toMatchObject({
-        status: "authenticated",
-        currentOrgId: "org-1",
-        currentProjectId: 42,
-        orgProjectsMap: {
-          "org-1": {
-            orgName: "Org 1",
-            projects: [
-              { id: 42, name: "Project 42" },
-              { id: 84, name: "Project 84" },
-            ],
+    // Team-scoped tokens (required_access_level=project) arrive with empty
+    // scoped_organizations on some backends. When @me carries a current org,
+    // we fetch it so the picker isn't stranded on "No projects". When @me has
+    // no org either (truly orgless user), there's nothing to fetch and the
+    // recovery loop must not spin — that was the concern from #2655.
+    it.each([
+      {
+        when: "the user has no organization at all",
+        orgless: true,
+        expectedOrgCalls: 0,
+        expectedState: {
+          status: "authenticated",
+          currentProjectId: null,
+          orgProjectsMap: {},
+        },
+      },
+      {
+        when: "the @me current org is used as a fallback",
+        orgless: false,
+        expectedOrgCalls: 1,
+        expectedState: {
+          status: "authenticated",
+          currentOrgId: "org-1",
+          currentProjectId: 42,
+          orgProjectsMap: {
+            "org-1": {
+              orgName: "Org 1",
+              projects: [
+                { id: 42, name: "Project 42" },
+                { id: 84, name: "Project 84" },
+              ],
+            },
           },
         },
-      });
-    });
+      },
+    ])(
+      "with empty scoped_organizations: $when",
+      async ({ orgless, expectedOrgCalls, expectedState }) => {
+        const fetchState = { succeeds: true, orgCalls: 0 };
+        stubOrgFetch(fetchState, { orgless });
+        oauthFlow.startFlow.mockResolvedValue(
+          mockTokenResponse({ scopedOrgs: [] }),
+        );
+
+        await service.login("us");
+
+        expect(fetchState.orgCalls).toBe(expectedOrgCalls);
+        expect(service.getState()).toMatchObject(expectedState);
+
+        // Emitting connectivity should not trigger extra work: the map is
+        // complete (or empty by design) and the recovery loop must not spin.
+        emitStatus(true);
+        await new Promise((r) => setTimeout(r, 10));
+        expect(fetchState.orgCalls).toBe(expectedOrgCalls);
+        expect(service.getState()).toMatchObject(expectedState);
+      },
+    );
   });
 
   describe("switchOrg", () => {

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -595,11 +595,21 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       tokenResponse.access_token,
       options.cloudRegion,
     );
+    // Team-scoped tokens (required_access_level=project) can arrive with an
+    // empty scoped_organizations list — the server only populates scoped_teams.
+    // Fall back to the current org from /api/users/@me/ so the picker isn't
+    // empty; without this the user is stranded on "No projects".
+    const orgIdsToFetch =
+      scopedOrgIds.length > 0
+        ? scopedOrgIds
+        : currentOrgId
+          ? [currentOrgId]
+          : [];
     const { map: orgProjectsMap, incomplete: orgProjectsIncomplete } =
       await this.buildOrgProjectsMap(
         tokenResponse.access_token,
         options.cloudRegion,
-        scopedOrgIds,
+        orgIdsToFetch,
         this.session?.orgProjectsMap ?? {},
       );
     const lastPrefs = accountKey


### PR DESCRIPTION
## Problem

Signing in to PostHog Code against a local backend (`localhost:8010`) leaves the project picker stuck on "No projects" even though the user has membership in an org with teams. OAuth completes, the user profile renders (name, avatar, org), but the picker is empty and there's nothing to select.

Confirmed by log diagnostics on a local Hedgehog Inc. account:

```
PICKER-DIAG session build {
  scopedOrgsRaw: [],
  currentOrgId: '019e84db-eb34-0000-d2b6-741b6cc26341',
  orgProjectsMapKeys: [],
  orgProjectsMapSummary: {},
}
```

## Root cause

Local PostHog backends mint project-scoped OAuth tokens (`required_access_level=project` on the authorize URL) with an empty `scoped_organizations` list — only `scoped_teams` gets populated. The old code at `packages/core/src/auth/auth.ts:593` trusted `scoped_organizations` as the sole source of orgs to enumerate:

```ts
const scopedOrgIds = tokenResponse.scoped_organizations ?? [];
// ...
await this.buildOrgProjectsMap(..., scopedOrgIds, ...);
```

Empty array → zero orgs iterated → empty `orgProjectsMap` → "No projects."

## Fix

Fall back to `organization.id` from `/api/users/@me/` when the token doesn't specify orgs. We already fetch `@me` two lines later — we were just throwing the current org id away.

```ts
const orgIdsToFetch =
  scopedOrgIds.length > 0
    ? scopedOrgIds
    : currentOrgId ? [currentOrgId] : [];
```

Confirmed the org endpoint (`/api/organizations/<id>/`) returns 200 under a team-scoped token against a local backend, so this populates the picker without touching the OAuth consent flow, token scoping, or any existing session behavior.

## What this doesn't change

- **OAuth consent scene**: still requests `required_access_level=project`, still mints team-scoped tokens. Security posture unchanged.
- **Recovery loop from #2655**: the "empty scoped_organizations no-retry path" still holds. If `@me` also has no organization (truly orgless user), `orgIdsToFetch` stays empty, `orgProjectsIncomplete` stays false, and the recovery loop never spins.
- **Cloud users**: `scoped_organizations` is populated for hosted PostHog tokens, so the fallback branch is dead code for them. Behavior identical to before.

## Related PRs

- [PostHog/posthog#69102](https://github.com/PostHog/posthog/pull/69102) — server-side sibling that unblocks the same local-dev OAuth flow from the other end (auto-provisioned OIDC RSA key, demo OAuth application ceiling revert so `scope=*` sign-in works). The picker fix here plus the server-side fixes there together give a one-shot working local sign-in for PostHog Code.

## Test updates

- Retitled `does not attempt recovery when the token grants no scoped organizations` → `does not attempt recovery when the user has no organization at all`. The old title/heuristic was too narrow — it equated empty `scoped_organizations` with "no orgs," when the correct discriminator is `@me.organization`. The test now stubs `organization: null` on `@me` and keeps the same 0-fetches / null-project assertions to defend Gustavo's stranded-session concern from #2655.
- Added `falls back to the @me current org when the token has no scoped organizations` to pin the fixed behavior.

## How did you test this?

- Reproduced locally: `hoglet start`, signed in against `localhost:8010` on a Hedgebox Inc. account, watched the picker go from "No projects" to a populated list of 2 projects.
- `pnpm --filter @posthog/core test -- auth` — 43 auth tests pass (2143 core total, +1 new)
- `pnpm --filter @posthog/core typecheck` — clean
- `pnpm exec biome lint packages/core` — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
