### PR TITLE
fix(code-review): refresh branch/PR review diff on code updates

### DIFF
--- a/packages/ui/src/features/code-review/components/ReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewPage.tsx
@@ -428,13 +428,23 @@ function RemoteReviewPage({
   const taskId = task.id;
   const isBranch = effectiveSource === "branch";
 
-  const { data: branchFiles = EMPTY_CHANGED_FILES, isLoading: branchLoading } =
-    useLocalBranchChangedFiles(
-      isBranch && isReviewOpen ? repoPath : null,
-      isBranch && isReviewOpen ? branch : null,
-    );
-  const { data: prFiles = EMPTY_CHANGED_FILES, isLoading: prLoading } =
-    usePrChangedFiles(!isBranch && isReviewOpen ? prUrl : null);
+  const {
+    data: branchFiles = EMPTY_CHANGED_FILES,
+    isLoading: branchLoading,
+    refetch: refetchBranch,
+  } = useLocalBranchChangedFiles(
+    isBranch && isReviewOpen ? repoPath : null,
+    isBranch && isReviewOpen ? branch : null,
+  );
+  const {
+    data: prFiles = EMPTY_CHANGED_FILES,
+    isLoading: prLoading,
+    refetch: refetchPr,
+  } = usePrChangedFiles(!isBranch && isReviewOpen ? prUrl : null);
+
+  const onRefresh = useCallback(() => {
+    void (isBranch ? refetchBranch() : refetchPr());
+  }, [isBranch, refetchBranch, refetchPr]);
 
   const files = isBranch ? branchFiles : prFiles;
   const isLoading = isBranch
@@ -479,6 +489,7 @@ function RemoteReviewPage({
       onExpandAll={reviewState.expandAll}
       onCollapseAll={reviewState.collapseAll}
       onUncollapseFile={reviewState.uncollapseFile}
+      onRefresh={onRefresh}
       effectiveSource={effectiveSource}
       branchSourceAvailable={branchSourceAvailable}
       prSourceAvailable={prSourceAvailable}

--- a/packages/ui/src/features/git-interaction/gitCacheKeys.ts
+++ b/packages/ui/src/features/git-interaction/gitCacheKeys.ts
@@ -52,6 +52,10 @@ export function invalidateGitBranchQueries(repoPath: string) {
   queryClient.invalidateQueries(
     provider.gitPathFilter("getLocalBranchChangedFiles"),
   );
+  queryClient.invalidateQueries(provider.gitPathFilter("getPrChangedFiles"));
+  queryClient.invalidateQueries(
+    provider.gitPathFilter("getBranchChangedFiles"),
+  );
 }
 
 export function clearGitReviewQueries() {


### PR DESCRIPTION
## Problem

When reviewing a branch/PR diff, updating code left the review view showing a stale diff. Two gaps caused it:

1. `invalidateGitBranchQueries` (fired on `git-state-changed`, e.g. commit/checkout) refreshed the local-branch changed files but **not** the remote `getPrChangedFiles` / `getBranchChangedFiles`, so the PR diff sat stale for up to its 5-min `staleTime` with no auto-refetch.
2. `RemoteReviewPage` never passed `onRefresh` to `ReviewShell`, so branch/PR reviews had no manual refresh button (local review did).

## Changes

- `gitCacheKeys.ts`: `invalidateGitBranchQueries` now also invalidates `getPrChangedFiles` and `getBranchChangedFiles`, so a commit/checkout auto-refreshes the remote review diff.
- `ReviewPage.tsx`: added an `onRefresh` that refetches the active branch/PR query and wired it into `ReviewShell`, restoring the manual refresh button.

> [!NOTE]
> Auto-refresh depends on a local `git-state-changed` watcher event. A push from outside the app won't fire it, so the restored manual refresh button is the fallback until the stale window elapses.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` passes.
- Biome lint on both touched files passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*