### PR TITLE
docs: pin pnpm version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If an issue does not yet exist for your change, please create one first so we ca
 ## Development setup
 
 ```bash
-# Prerequisites: Node.js 22+, pnpm 10.23+
+# Prerequisites: Node.js 22+, pnpm 10.23.0
 pnpm install
 cp .env.example .env
 pnpm dev


### PR DESCRIPTION
## Summary
- Aligns the pnpm prerequisite in `CONTRIBUTING.md` with the exact version already pinned in `package.json`'s `packageManager` field and stated in `README.md`.

## Why
`CONTRIBUTING.md` said "pnpm 10.23+" while `README.md` and `package.json` pin exactly `10.23.0` — tightening this avoids drift between the docs and the pinned version.

## Test plan
- [x] Visual diff review (one-line doc change, no code/build impact)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*