### PR TITLE
chore(agents): rename the "Applications" tab to "Fleet"

### DIFF
--- a/packages/ui/src/features/agent-applications/components/AgentAnalyticsView.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentAnalyticsView.tsx
@@ -43,7 +43,7 @@ const tileTitle = (label: string): ReactNode => (
  * HogQL and shapes the data; this renders one of loading / error / empty /
  * populated.
  *
- * `scope` "overview" is the fleet board blended into the Applications landing
+ * `scope` "overview" is the fleet board blended into the Fleet landing
  * (KPIs + spend-by-agent + cost-by-model; the agent list below carries the
  * per-agent breakdown). "agent" is the per-agent Observability tab (KPIs +
  * cost-by-model + tool reliability — spend-by-agent is meaningless for one).

--- a/packages/ui/src/features/agent-applications/components/AgentApplicationsListView.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentApplicationsListView.tsx
@@ -32,7 +32,7 @@ type StatusFilter = "all" | "live" | "drafts";
 const PAGE_SIZE = 8;
 
 /**
- * The Applications tab. Renders the deployed-agent fleet as the primary
+ * The Fleet tab. Renders the deployed-agent fleet as the primary
  * surface: a searchable, status-filtered, paged list with the 7-day activity
  * strip pinned at the top and operational / live-now panels below.
  */

--- a/packages/ui/src/features/agent-applications/components/AgentDetailLayout.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentDetailLayout.tsx
@@ -148,7 +148,7 @@ export function AgentDetailLayout({
           className="flex w-fit items-center gap-1.5 text-[12px] text-gray-11 no-underline hover:text-gray-12"
         >
           <ArrowLeftIcon size={13} />
-          Applications
+          Fleet
         </Link>
         <Flex align="center" gap="2" wrap="wrap" className="pr-44">
           <Text className="font-bold text-[22px] text-gray-12 leading-tight tracking-tight">

--- a/packages/ui/src/features/agent-applications/components/AgentFleetApprovalsPane.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentFleetApprovalsPane.tsx
@@ -24,7 +24,7 @@ import { RefreshIndicator } from "./RefreshIndicator";
  * (joined client-side with `useAgentApplications`) and the detail pane reuses
  * `AgentApprovalDetail` once we resolve the application's `idOrSlug`. Owns its
  * own chrome (back link + title) rather than nesting under the Scouts /
- * Applications tab bar, matching how per-agent detail pages render.
+ * Fleet tab bar, matching how per-agent detail pages render.
  */
 export function AgentFleetApprovalsPane({
   selectedId,
@@ -149,7 +149,7 @@ export function AgentFleetApprovalsPane({
           className="flex w-fit items-center gap-1.5 text-[12px] text-gray-11 no-underline hover:text-gray-12"
         >
           <ArrowLeftIcon size={13} />
-          Applications
+          Fleet
         </Link>
         <Flex align="center" gap="2" wrap="wrap">
           <Text className="font-bold text-[22px] text-gray-12 leading-tight tracking-tight">

--- a/packages/ui/src/features/agent-applications/components/AgentFleetLiveSessionsPanel.tsx
+++ b/packages/ui/src/features/agent-applications/components/AgentFleetLiveSessionsPanel.tsx
@@ -15,7 +15,7 @@ import { sessionStateColor } from "../utils/format";
 import { RefreshIndicator } from "./RefreshIndicator";
 
 /**
- * Cross-agent in-flight sessions, surfaced on the Applications landing. Lists
+ * Cross-agent in-flight sessions, surfaced on the Fleet landing. Lists
  * non-terminal sessions across the fleet with state, agent, trigger, turn count
  * and started-ago; clicking a row navigates to the per-agent session detail.
  * Polls aggressively (see {@link useAgentFleetLiveSessions}) so the panel feels

--- a/packages/ui/src/features/agent-applications/featureFlag.ts
+++ b/packages/ui/src/features/agent-applications/featureFlag.ts
@@ -1,5 +1,5 @@
 /**
- * Gates the whole agent-platform surface in PostHog Code: the Applications tab
+ * Gates the whole agent-platform surface in PostHog Code: the Fleet tab
  * content (list + per-agent detail) and the always-on Agent Builder dock. The
  * Scouts tab is unaffected. Mirrors the `agent-platform` flag on the PostHog
  * side (`FEATURE_FLAGS.AGENT_PLATFORM`). Hidden until GA.

--- a/packages/ui/src/features/agents/components/AgentsTabLayout.tsx
+++ b/packages/ui/src/features/agents/components/AgentsTabLayout.tsx
@@ -22,7 +22,7 @@ const TAB_DESCRIPTION: Record<AgentsTab, string> = {
 /**
  * Shared chrome for the two top-level Agents tabs. Each tab view renders its
  * own content inside this layout and declares which tab is active, so the
- * header + tab bar stay identical across Scouts and Applications while detail
+ * header + tab bar stay identical across Scouts and Fleet while detail
  * pages (a scout, an agent, a session) keep their own focused chrome.
  */
 export function AgentsTabLayout({
@@ -50,7 +50,7 @@ export function AgentsTabLayout({
   const pageContext: AgentBuilderPageContext =
     activeTab === "applications" ? { kind: "agent-list" } : { kind: "scouts" };
   useSetAgentBuilderPage(pageContext);
-  // The Applications tab is gated behind the agent-platform flag.
+  // The Fleet tab is gated behind the agent-platform flag.
   const applicationsEnabled = useFeatureFlag(AGENT_PLATFORM_FLAG);
 
   return (
@@ -76,7 +76,7 @@ export function AgentsTabLayout({
           {applicationsEnabled ? (
             <TabLink
               to="/code/agents/applications"
-              label="Applications"
+              label="Fleet"
               active={activeTab === "applications"}
             />
           ) : null}


### PR DESCRIPTION
## Summary

The second Agents tab was labelled **Applications** — vague, and it clashed with **Agent Builder**, which is both mentioned in the page header *and* one of the listed agents. Renames the visible label to **Fleet**, which the app already uses elsewhere for the collection of running agents ("In-flight agent sessions across the fleet") and which parallels the sibling **Scouts** tab tonally.

## What actually changes

Three user-visible strings:
- Tab label in `AgentsTabLayout` (`Applications` → `Fleet`)
- Back-nav link on the agent detail page (`AgentDetailLayout`)
- Back-nav link on the fleet-approvals page (`AgentFleetApprovalsPane`)

Plus six stale JSDoc / inline comments that referred to "the Applications tab" — updated so future readers aren't confused when the visible label no longer matches the code comments.

## What doesn't change

None of the internal names:
- Route: `/code/agents/applications`
- Feature directory: `packages/ui/src/features/agent-applications/`
- Enum value: `AgentsTab = "scouts" | "applications"`
- Feature flag: `AGENT_PLATFORM_FLAG` / `"agent-platform"`
- Hook names: `useAgentApplications`, `agentApplicationsKeys`, etc.
- Query keys, DB schema, tRPC procedures

Renaming those would be scope creep and land in follow-ups if we want to align internal vocabulary. This PR only touches what a user sees on screen.

## Test plan

- [ ] Load the Agents section, confirm the tab reads "Fleet"
- [ ] Click into an agent, confirm the back-nav link reads "← Fleet"
- [ ] Open Fleet approvals, confirm the back-nav link reads "← Fleet"
- [ ] Deep-linking to `/code/agents/applications` still resolves (route unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)