### PR TITLE
chore(ci): gate Create Release label on team membership

### DIFF
--- a/.github/workflows/code-tag.yml
+++ b/.github/workflows/code-tag.yml
@@ -42,6 +42,41 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Check labeler is on Team PostHog Code
+        id: labeler
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          LABELER=$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate \
+            --jq '.[] | select(.event == "labeled" and (.label.name | ascii_downcase) == "create release") | .actor.login' | tail -1)
+
+          if [ -z "$LABELER" ]; then
+            echo "Could not determine who added the 'Create release' label. Skipping auto-release."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if MEMBERSHIP=$(gh api "orgs/PostHog/teams/team-posthog-code/memberships/${LABELER}" 2>&1); then
+            STATE=$(echo "$MEMBERSHIP" | jq -r '.state')
+            if [ "$STATE" = "active" ]; then
+              echo "'Create release' was added by ${LABELER}, an active member of team-posthog-code."
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "'Create release' was added by ${LABELER} with membership state '${STATE}'. Skipping auto-release; the next scheduled release will pick this up."
+              echo "authorized=false" >> "$GITHUB_OUTPUT"
+            fi
+          elif echo "$MEMBERSHIP" | grep -q "HTTP 404"; then
+            echo "'Create release' was added by ${LABELER}, who is not on team-posthog-code. Skipping auto-release; the next scheduled release will pick this up."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Team membership check for ${LABELER} failed unexpectedly:"
+            echo "$MEMBERSHIP"
+            exit 1
+          fi
+
       - name: Check quiet period
         id: quiet
         if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.quiet_retries != '0')
@@ -75,7 +110,7 @@ jobs:
           echo "proceed=false" >> "$GITHUB_OUTPUT"
 
       - name: Compute version and create tag
-        if: steps.quiet.outputs.proceed != 'false'
+        if: steps.quiet.outputs.proceed != 'false' && steps.labeler.outputs.authorized != 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/code-tag.yml
+++ b/.github/workflows/code-tag.yml
@@ -27,6 +27,8 @@ jobs:
     permissions:
       contents: write
       actions: write
+      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Get app token
@@ -42,39 +44,39 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Check labeler is on Team PostHog Code
+      - name: Check labeler is a member of team-posthog-code
         id: labeler
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENT_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          TEAM_SLUG: team-posthog-code
         run: |
+          skip() {
+            echo "$1 Skipping auto-release; the next scheduled release will pick this up."
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            GH_TOKEN="$COMMENT_TOKEN" gh pr comment "$PR_NUMBER" --repo "$REPOSITORY" \
+              --body "$1 Auto-release is limited to Team PostHog Code members, so this will ship with the next scheduled release instead." || true
+          }
+
           LABELER=$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate \
-            --jq '.[] | select(.event == "labeled" and (.label.name | ascii_downcase) == "create release") | .actor.login' | tail -1)
+            --jq '.[] | select(.event == "labeled" and (.label.name | ascii_downcase) == "create release") | "\(.id) \(.actor.login)"' \
+            | sort -n | tail -1 | cut -d" " -f2)
 
           if [ -z "$LABELER" ]; then
-            echo "Could not determine who added the 'Create release' label. Skipping auto-release."
-            echo "authorized=false" >> "$GITHUB_OUTPUT"
+            skip "Could not determine who added the 'Create release' label."
             exit 0
           fi
 
-          if MEMBERSHIP=$(gh api "orgs/PostHog/teams/team-posthog-code/memberships/${LABELER}" 2>&1); then
-            STATE=$(echo "$MEMBERSHIP" | jq -r '.state')
-            if [ "$STATE" = "active" ]; then
-              echo "'Create release' was added by ${LABELER}, an active member of team-posthog-code."
-              echo "authorized=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "'Create release' was added by ${LABELER} with membership state '${STATE}'. Skipping auto-release; the next scheduled release will pick this up."
-              echo "authorized=false" >> "$GITHUB_OUTPUT"
-            fi
-          elif echo "$MEMBERSHIP" | grep -q "HTTP 404"; then
-            echo "'Create release' was added by ${LABELER}, who is not on team-posthog-code. Skipping auto-release; the next scheduled release will pick this up."
-            echo "authorized=false" >> "$GITHUB_OUTPUT"
+          MEMBERS=$(gh api "orgs/${REPOSITORY%%/*}/teams/${TEAM_SLUG}/members" --paginate --jq '.[].login')
+
+          if echo "$MEMBERS" | grep -qixF "$LABELER"; then
+            echo "'Create release' was added by ${LABELER}, a member of ${TEAM_SLUG}."
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Team membership check for ${LABELER} failed unexpectedly:"
-            echo "$MEMBERSHIP"
-            exit 1
+            skip "'Create release' was added by @${LABELER}, who is not on ${TEAM_SLUG}."
           fi
 
       - name: Check quiet period


### PR DESCRIPTION
## Problem

Anyone in the org can add labels, so anyone could put `Create Release` on a PR and trigger a customer-facing desktop release with no oversight from the team.

## Changes

`code-tag.yml` now looks up who last added the `Create Release` label (via the issue events API, sorted by event id so it doesn't depend on API response ordering) and only auto-tags when that person is on `team-posthog-code`. If they are not, the job skips tagging and comments on the PR that the change ships with the next scheduled release instead, so nobody is blocked. If the team lookup itself fails (e.g. the releaser app is missing org Members read permission) the job fails loudly rather than silently skipping releases.

Scheduled and manual dispatch runs are unaffected.

## How did you test this?

Ran the exact labeler lookup and members check against PR #3243 (labeler resolved and authorized) and a non-member (correct skip path). `actionlint` and `shellcheck` are clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?