### PR TITLE
feat(task-detail): default new task execution to cloud

### DIFF
--- a/packages/core/src/integrations/connectErrors.ts
+++ b/packages/core/src/integrations/connectErrors.ts
@@ -3,6 +3,9 @@ export interface GithubConnectError {
   code: string | null;
 }
 
+export const GITHUB_CONNECT_TIMEOUT_MESSAGE =
+  "We didn't hear back from GitHub. If your organization requires approval to install the PostHog app, ask a GitHub org owner to approve it, then connect again.";
+
 export const GITHUB_CONNECT_ERROR_MESSAGES: Record<string, string> = {
   access_denied:
     "You declined access on GitHub. Try again to grant the permissions PostHog Code needs.",

--- a/packages/core/src/onboarding/githubConnectPanel.test.ts
+++ b/packages/core/src/onboarding/githubConnectPanel.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { GITHUB_CONNECT_TIMEOUT_MESSAGE } from "../integrations/connectErrors";
 import {
   buildConnectFailedProps,
   buildConnectFailureFingerprint,
@@ -29,7 +30,7 @@ describe("getGithubPanelMessage", () => {
     };
     expect(
       getGithubPanelMessage({ ...base, timedOut: true, isConnecting: false }),
-    ).toMatch(/didn't hear back/);
+    ).toBe(GITHUB_CONNECT_TIMEOUT_MESSAGE);
     expect(
       getGithubPanelMessage({ ...base, timedOut: false, isConnecting: true }),
     ).toBe("Waiting for GitHub...");

--- a/packages/core/src/onboarding/githubConnectPanel.ts
+++ b/packages/core/src/onboarding/githubConnectPanel.ts
@@ -1,3 +1,4 @@
+import { GITHUB_CONNECT_TIMEOUT_MESSAGE } from "../integrations/connectErrors";
 import { POSTHOG_GITHUB_APP_URL } from "../integrations/githubApp";
 
 export interface GithubPanelMessageOptions {
@@ -12,7 +13,7 @@ export function getGithubPanelMessage(
 ): string {
   if (options.hasConnectError) return options.connectErrorMessage;
   if (options.timedOut) {
-    return "We didn't hear back from GitHub. If the browser tab was closed, click Connect again.";
+    return GITHUB_CONNECT_TIMEOUT_MESSAGE;
   }
   if (options.isConnecting) return "Waiting for GitHub...";
   return "Unlocks cloud runs, branch pushes, and PR review on this account.";

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import { useConnectivity } from "../../../hooks/useConnectivity";
+import { useUserRepositoryIntegration } from "../../integrations/useIntegrations";
 import { PromptInput } from "../../message-editor/components/PromptInput";
 import { useDraftStore } from "../../message-editor/draftStore";
 import type { EditorHandle } from "../../message-editor/types";
@@ -22,8 +23,10 @@ import {
   type WorkspaceMode,
   WorkspaceModeSelect,
 } from "../../task-detail/components/WorkspaceModeSelect";
+import { useCloudModeEnabled } from "../../task-detail/hooks/useCloudModeEnabled";
 import { usePreviewConfig } from "../../task-detail/hooks/usePreviewConfig";
 import { useTaskCreation } from "../../task-detail/hooks/useTaskCreation";
+import { resolveWorkspaceModePreference } from "../../task-detail/hooks/workspaceModePreference";
 
 export interface ChannelHomeComposerHandle {
   /** Drop a starter prompt into the editor and apply its mode, if any. */
@@ -77,10 +80,18 @@ export const ChannelHomeComposer = forwardRef<
     [setLastUsedAdapter],
   );
 
+  const cloudModeEnabled = useCloudModeEnabled();
+  const { hasGithubIntegration } = useUserRepositoryIntegration();
+
   // Repo-less channel tasks only run local or cloud (worktree needs a repo), so
   // collapse any lingering worktree preference down to local for the initial pick.
-  const [workspaceMode, setWorkspaceModeState] = useState<WorkspaceMode>(
-    lastUsedWorkspaceMode === "cloud" ? "cloud" : "local",
+  const [workspaceMode, setWorkspaceModeState] = useState<WorkspaceMode>(() =>
+    resolveWorkspaceModePreference({
+      preferredMode: lastUsedWorkspaceMode === "cloud" ? "cloud" : "local",
+      cloudModeEnabled,
+      hasGithubIntegration,
+      lastUsedLocalWorkspaceMode: "local",
+    }),
   );
   const [selectedCloudEnvId, setSelectedCloudEnvId] = useState<string | null>(
     null,

--- a/packages/ui/src/features/feature-flags/useFeatureFlagsLoaded.ts
+++ b/packages/ui/src/features/feature-flags/useFeatureFlagsLoaded.ts
@@ -1,0 +1,12 @@
+import { useService } from "@posthog/di/react";
+import { useEffect, useState } from "react";
+import { FEATURE_FLAGS, type FeatureFlags } from "./identifiers";
+
+export function useFeatureFlagsLoaded(): boolean {
+  const flags = useService<FeatureFlags>(FEATURE_FLAGS);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => flags.onFlagsLoaded(() => setLoaded(true)), [flags]);
+
+  return loaded;
+}

--- a/packages/ui/src/features/settings/sections/GitHubIntegrationSection.tsx
+++ b/packages/ui/src/features/settings/sections/GitHubIntegrationSection.tsx
@@ -4,6 +4,7 @@ import {
   GitBranchIcon,
   InfoIcon,
 } from "@phosphor-icons/react";
+import { GITHUB_CONNECT_TIMEOUT_MESSAGE } from "@posthog/core/integrations/connectErrors";
 import { summarizeReposByOwner } from "@posthog/core/settings/githubRepoSummary";
 import { Button } from "@posthog/quill";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -129,7 +130,7 @@ export function GitHubIntegrationSection({
                 : hasConnectError
                   ? describeGithubConnectError(connectError)
                   : timedOut
-                    ? "We didn't hear back from GitHub. Try again."
+                    ? GITHUB_CONNECT_TIMEOUT_MESSAGE
                     : "Required for the Inbox pipeline to work"}
             </Text>
           )}

--- a/packages/ui/src/features/settings/sections/GitHubIntegrationSection.tsx
+++ b/packages/ui/src/features/settings/sections/GitHubIntegrationSection.tsx
@@ -4,14 +4,14 @@ import {
   GitBranchIcon,
   InfoIcon,
 } from "@phosphor-icons/react";
-import { GITHUB_CONNECT_TIMEOUT_MESSAGE } from "@posthog/core/integrations/connectErrors";
+import {
+  describeGithubConnectError,
+  GITHUB_CONNECT_TIMEOUT_MESSAGE,
+} from "@posthog/core/integrations/connectErrors";
 import { summarizeReposByOwner } from "@posthog/core/settings/githubRepoSummary";
 import { Button } from "@posthog/quill";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
-import {
-  describeGithubConnectError,
-  useGithubConnect,
-} from "@posthog/ui/features/integrations/useGithubUserConnect";
+import { useGithubConnect } from "@posthog/ui/features/integrations/useGithubUserConnect";
 import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { Box, Flex, Spinner, Text, Tooltip } from "@radix-ui/themes";
 import { useMemo } from "react";

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -1,12 +1,28 @@
 import { registerRendererStateStorage } from "@posthog/ui/shell/rendererStorage";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { type CompletionSound, useSettingsStore } from "./settingsStore";
+import {
+  type CompletionSound,
+  DEFAULT_WORKSPACE_MODE,
+  useSettingsStore,
+} from "./settingsStore";
 
 const getItem = vi.fn();
 const setItem = vi.fn();
 const removeItem = vi.fn();
 
 registerRendererStateStorage({ getItem, setItem, removeItem });
+
+// Runs before any test mutates the store singleton, so getState() still
+// reflects the initial values.
+describe("feature settingsStore defaults", () => {
+  it("defaults the workspace mode to cloud with a local fallback", () => {
+    expect(DEFAULT_WORKSPACE_MODE).toBe("cloud");
+    expect(useSettingsStore.getState().lastUsedWorkspaceMode).toBe("cloud");
+    expect(useSettingsStore.getState().lastUsedLocalWorkspaceMode).toBe(
+      "local",
+    );
+  });
+});
 
 describe("feature settingsStore cloud selections", () => {
   beforeEach(() => {

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -221,7 +221,7 @@ export const useSettingsStore = create<SettingsStore>()(
       defaultRunMode: "last_used",
       lastUsedRunMode: "local",
       lastUsedLocalWorkspaceMode: "local",
-      lastUsedWorkspaceMode: "local",
+      lastUsedWorkspaceMode: "cloud",
       lastUsedAdapter: "claude",
       lastUsedModel: null,
       lastUsedReasoningEffort: null,

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -12,6 +12,8 @@ import { persist } from "zustand/middleware";
 
 export type DefaultRunMode = "local" | "cloud" | "last_used";
 export type LocalWorkspaceMode = "worktree" | "local";
+
+export const DEFAULT_WORKSPACE_MODE: WorkspaceMode = "cloud";
 export type AgentAdapter = Adapter;
 export type DefaultInitialTaskMode = "plan" | "last_used";
 export type DefaultMessagingMode = "queue" | "steer";
@@ -221,7 +223,7 @@ export const useSettingsStore = create<SettingsStore>()(
       defaultRunMode: "last_used",
       lastUsedRunMode: "local",
       lastUsedLocalWorkspaceMode: "local",
-      lastUsedWorkspaceMode: "cloud",
+      lastUsedWorkspaceMode: DEFAULT_WORKSPACE_MODE,
       lastUsedAdapter: "claude",
       lastUsedModel: null,
       lastUsedReasoningEffort: null,

--- a/packages/ui/src/features/task-detail/components/CloudGithubMissingNotice.tsx
+++ b/packages/ui/src/features/task-detail/components/CloudGithubMissingNotice.tsx
@@ -1,4 +1,5 @@
 import { ArrowSquareOutIcon, InfoIcon } from "@phosphor-icons/react";
+import { GITHUB_CONNECT_TIMEOUT_MESSAGE } from "@posthog/core/integrations/connectErrors";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import {
   describeGithubConnectError,
@@ -12,10 +13,11 @@ export function CloudGithubMissingNotice() {
   const cloudRegion = useAuthStateValue((s) => s.cloudRegion);
   const { hasGithubIntegration: hasTeamGithubIntegration } =
     useRepositoryIntegration();
-  const { error, isConnecting, hasError, connect, reset } = useGithubConnect({
-    projectId,
-    projectHasTeamIntegration: hasTeamGithubIntegration,
-  });
+  const { error, isConnecting, isTimedOut, hasError, connect, reset } =
+    useGithubConnect({
+      projectId,
+      projectHasTeamIntegration: hasTeamGithubIntegration,
+    });
   const canConnect = projectId != null && cloudRegion != null;
 
   return (
@@ -29,7 +31,9 @@ export function CloudGithubMissingNotice() {
             <Text size="1">
               {hasError
                 ? describeGithubConnectError(error)
-                : "Connect GitHub to your PostHog account for cloud tasks."}
+                : isTimedOut
+                  ? GITHUB_CONNECT_TIMEOUT_MESSAGE
+                  : "Connect GitHub to your PostHog account for cloud tasks."}
             </Text>
           </Callout.Text>
         </Flex>
@@ -49,7 +53,11 @@ export function CloudGithubMissingNotice() {
           ) : (
             <ArrowSquareOutIcon size={12} />
           )}
-          {isConnecting ? "Waiting…" : "Connect GitHub"}
+          {isConnecting
+            ? "Waiting…"
+            : hasError || isTimedOut
+              ? "Try again"
+              : "Connect GitHub"}
         </Button>
       </Flex>
     </Callout.Root>

--- a/packages/ui/src/features/task-detail/components/CloudGithubMissingNotice.tsx
+++ b/packages/ui/src/features/task-detail/components/CloudGithubMissingNotice.tsx
@@ -1,10 +1,10 @@
 import { ArrowSquareOutIcon, InfoIcon } from "@phosphor-icons/react";
-import { GITHUB_CONNECT_TIMEOUT_MESSAGE } from "@posthog/core/integrations/connectErrors";
-import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import {
   describeGithubConnectError,
-  useGithubConnect,
-} from "@posthog/ui/features/integrations/useGithubUserConnect";
+  GITHUB_CONNECT_TIMEOUT_MESSAGE,
+} from "@posthog/core/integrations/connectErrors";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { useGithubConnect } from "@posthog/ui/features/integrations/useGithubUserConnect";
 import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { Button, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
 

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -75,6 +75,7 @@ import {
   useSettingsStore,
 } from "../../settings/settingsStore";
 import { useSkills } from "../../skills/useSkills";
+import { useCloudModeEnabled } from "../hooks/useCloudModeEnabled";
 import {
   areReposReady,
   useInitialRepoSelectionFromFolderId,
@@ -313,19 +314,45 @@ export function TaskInput({
     hasGithubIntegration,
   } = useUserRepositoryIntegration();
 
+  const cloudModeEnabled = useCloudModeEnabled();
+  const reposReady = areReposReady({
+    isLoadingRepos,
+    repositoriesCount: repositories.length,
+    hasGithubIntegration,
+  });
+
+  // Cloud is the default, but only when it works out of the box: with the flag
+  // off or GitHub not connected, fall back to the last local mode instead of
+  // stranding the user behind a connect-GitHub prompt.
+  const resolveWorkspaceModePreference = useCallback(
+    (mode: WorkspaceMode): WorkspaceMode =>
+      mode === "cloud" && (!cloudModeEnabled || !hasGithubIntegration)
+        ? lastUsedLocalWorkspaceMode
+        : mode,
+    [cloudModeEnabled, hasGithubIntegration, lastUsedLocalWorkspaceMode],
+  );
+
   const [workspaceMode, setWorkspaceModeState] = useState<WorkspaceMode>(() => {
     if (initialCloudRepository) return "cloud";
-    return lastUsedWorkspaceMode || "local";
+    return resolveWorkspaceModePreference(lastUsedWorkspaceMode || "cloud");
   });
 
   const didResolveWorkspaceModeRef = useRef(false);
   useEffect(() => {
     if (didResolveWorkspaceModeRef.current) return;
-    if (!settingsHydrated) return;
+    if (!settingsHydrated || !reposReady) return;
     didResolveWorkspaceModeRef.current = true;
     if (initialCloudRepository) return;
-    setWorkspaceModeState(lastUsedWorkspaceMode || "local");
-  }, [settingsHydrated, lastUsedWorkspaceMode, initialCloudRepository]);
+    setWorkspaceModeState(
+      resolveWorkspaceModePreference(lastUsedWorkspaceMode || "cloud"),
+    );
+  }, [
+    settingsHydrated,
+    reposReady,
+    lastUsedWorkspaceMode,
+    initialCloudRepository,
+    resolveWorkspaceModePreference,
+  ]);
 
   const setWorkspaceMode = (mode: WorkspaceMode) => {
     didResolveWorkspaceModeRef.current = true;
@@ -570,11 +597,7 @@ export function TaskInput({
     requestId: view.taskInputRequestId,
     folders,
     repositories,
-    reposLoaded: areReposReady({
-      isLoadingRepos,
-      repositoriesCount: repositories.length,
-      hasGithubIntegration,
-    }),
+    reposLoaded: reposReady,
     currentMode: workspaceMode,
     lastUsedLocalMode: lastUsedLocalWorkspaceMode,
     mostRecentEnvironment: view.folderRunEnvironment,

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -37,6 +37,7 @@ import { useAutoresearchEnabled } from "../../autoresearch/useAutoresearchEnable
 import { useFileSearchStore } from "../../command/fileSearchStore";
 import { NewTaskFilePreview } from "../../command/NewTaskFilePreview";
 import { EnvironmentSelector } from "../../environments/EnvironmentSelector";
+import { useFeatureFlagsLoaded } from "../../feature-flags/useFeatureFlagsLoaded";
 import { AdditionalDirectoriesButton } from "../../folder-picker/AdditionalDirectoriesButton";
 import { FolderPicker } from "../../folder-picker/FolderPicker";
 import { GitHubRepoPicker } from "../../folder-picker/GitHubRepoPicker";
@@ -72,6 +73,7 @@ import { UnifiedModelSelector } from "../../sessions/components/UnifiedModelSele
 import { getCurrentModeFromConfigOptions } from "../../sessions/sessionStore";
 import {
   type AgentAdapter,
+  DEFAULT_WORKSPACE_MODE,
   useSettingsStore,
 } from "../../settings/settingsStore";
 import { useSkills } from "../../skills/useSkills";
@@ -83,6 +85,7 @@ import {
 import { usePreviewConfig } from "../hooks/usePreviewConfig";
 import { useTaskCreation } from "../hooks/useTaskCreation";
 import { useWarmTask } from "../hooks/useWarmTask";
+import { resolveWorkspaceModePreference } from "../hooks/workspaceModePreference";
 import { CloudGithubMissingNotice } from "./CloudGithubMissingNotice";
 import { NewTaskSuggestions } from "./ContinueCliSessions";
 import {
@@ -315,43 +318,57 @@ export function TaskInput({
   } = useUserRepositoryIntegration();
 
   const cloudModeEnabled = useCloudModeEnabled();
+  const flagsLoaded = useFeatureFlagsLoaded();
   const reposReady = areReposReady({
     isLoadingRepos,
     repositoriesCount: repositories.length,
     hasGithubIntegration,
   });
 
-  // Cloud is the default, but only when it works out of the box: with the flag
-  // off or GitHub not connected, fall back to the last local mode instead of
-  // stranding the user behind a connect-GitHub prompt.
-  const resolveWorkspaceModePreference = useCallback(
-    (mode: WorkspaceMode): WorkspaceMode =>
-      mode === "cloud" && (!cloudModeEnabled || !hasGithubIntegration)
-        ? lastUsedLocalWorkspaceMode
-        : mode,
-    [cloudModeEnabled, hasGithubIntegration, lastUsedLocalWorkspaceMode],
-  );
-
   const [workspaceMode, setWorkspaceModeState] = useState<WorkspaceMode>(() => {
     if (initialCloudRepository) return "cloud";
-    return resolveWorkspaceModePreference(lastUsedWorkspaceMode || "cloud");
+    return resolveWorkspaceModePreference({
+      preferredMode: lastUsedWorkspaceMode || DEFAULT_WORKSPACE_MODE,
+      cloudModeEnabled,
+      hasGithubIntegration,
+      lastUsedLocalWorkspaceMode,
+    });
   });
+
+  // A positive flag or integration signal is final, but a negative one may
+  // just mean the async flag fetch or integrations query hasn't landed yet, so
+  // a cloud preference only resolves once each negative signal is settled.
+  const cloudSignalsSettled =
+    (cloudModeEnabled || flagsLoaded) &&
+    (hasGithubIntegration || !isLoadingRepos);
 
   const didResolveWorkspaceModeRef = useRef(false);
   useEffect(() => {
     if (didResolveWorkspaceModeRef.current) return;
-    if (!settingsHydrated || !reposReady) return;
+    if (!settingsHydrated) return;
+    if (initialCloudRepository) {
+      didResolveWorkspaceModeRef.current = true;
+      return;
+    }
+    const preferredMode = lastUsedWorkspaceMode || DEFAULT_WORKSPACE_MODE;
+    if (preferredMode === "cloud" && !cloudSignalsSettled) return;
     didResolveWorkspaceModeRef.current = true;
-    if (initialCloudRepository) return;
     setWorkspaceModeState(
-      resolveWorkspaceModePreference(lastUsedWorkspaceMode || "cloud"),
+      resolveWorkspaceModePreference({
+        preferredMode,
+        cloudModeEnabled,
+        hasGithubIntegration,
+        lastUsedLocalWorkspaceMode,
+      }),
     );
   }, [
     settingsHydrated,
-    reposReady,
     lastUsedWorkspaceMode,
     initialCloudRepository,
-    resolveWorkspaceModePreference,
+    cloudSignalsSettled,
+    cloudModeEnabled,
+    hasGithubIntegration,
+    lastUsedLocalWorkspaceMode,
   ]);
 
   const setWorkspaceMode = (mode: WorkspaceMode) => {

--- a/packages/ui/src/features/task-detail/components/WorkspaceModeSelect.tsx
+++ b/packages/ui/src/features/task-detail/components/WorkspaceModeSelect.tsx
@@ -24,9 +24,9 @@ import {
 import type { WorkspaceMode } from "@posthog/shared";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { useCallback, useMemo, useState } from "react";
-import { useFeatureFlag } from "../../feature-flags/useFeatureFlag";
 import { useSandboxCustomImages } from "../../settings/sections/environments/useSandboxCustomImages";
 import { useSandboxEnvironments } from "../../settings/sections/environments/useSandboxEnvironments";
+import { useCloudModeEnabled } from "../hooks/useCloudModeEnabled";
 
 export type { WorkspaceMode };
 
@@ -74,8 +74,7 @@ export function WorkspaceModeSelect({
   selectedCustomImageId,
   onCustomImageChange,
 }: WorkspaceModeSelectProps) {
-  const cloudModeEnabled =
-    useFeatureFlag("twig-cloud-mode-toggle") || import.meta.env.DEV;
+  const cloudModeEnabled = useCloudModeEnabled();
 
   const { environments } = useSandboxEnvironments();
   const { images, customImagesEnabled } = useSandboxCustomImages();

--- a/packages/ui/src/features/task-detail/hooks/useCloudModeEnabled.ts
+++ b/packages/ui/src/features/task-detail/hooks/useCloudModeEnabled.ts
@@ -1,0 +1,5 @@
+import { useFeatureFlag } from "../../feature-flags/useFeatureFlag";
+
+export function useCloudModeEnabled(): boolean {
+  return useFeatureFlag("twig-cloud-mode-toggle") || import.meta.env.DEV;
+}

--- a/packages/ui/src/features/task-detail/hooks/workspaceModePreference.test.ts
+++ b/packages/ui/src/features/task-detail/hooks/workspaceModePreference.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveWorkspaceModePreference } from "./workspaceModePreference";
+
+describe("resolveWorkspaceModePreference", () => {
+  it.each([
+    ["cloud", true, true, "local", "cloud"],
+    ["cloud", false, true, "local", "local"],
+    ["cloud", true, false, "local", "local"],
+    ["cloud", false, false, "local", "local"],
+    ["cloud", false, true, "worktree", "worktree"],
+    ["cloud", true, false, "worktree", "worktree"],
+  ] as const)(
+    "resolves %s (flag %s, integration %s, local fallback %s) to %s",
+    (
+      preferredMode,
+      cloudModeEnabled,
+      hasGithubIntegration,
+      lastUsedLocalWorkspaceMode,
+      expected,
+    ) => {
+      expect(
+        resolveWorkspaceModePreference({
+          preferredMode,
+          cloudModeEnabled,
+          hasGithubIntegration,
+          lastUsedLocalWorkspaceMode,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it.each([
+    ["local", true, true],
+    ["local", false, false],
+    ["worktree", true, false],
+    ["worktree", false, true],
+  ] as const)(
+    "passes %s through untouched (flag %s, integration %s)",
+    (preferredMode, cloudModeEnabled, hasGithubIntegration) => {
+      expect(
+        resolveWorkspaceModePreference({
+          preferredMode,
+          cloudModeEnabled,
+          hasGithubIntegration,
+          lastUsedLocalWorkspaceMode: "worktree",
+        }),
+      ).toBe(preferredMode);
+    },
+  );
+});

--- a/packages/ui/src/features/task-detail/hooks/workspaceModePreference.ts
+++ b/packages/ui/src/features/task-detail/hooks/workspaceModePreference.ts
@@ -1,0 +1,25 @@
+import type { WorkspaceMode } from "@posthog/shared";
+import type { LocalWorkspaceMode } from "../../settings/settingsStore";
+
+export interface WorkspaceModePreferenceInput {
+  preferredMode: WorkspaceMode;
+  cloudModeEnabled: boolean;
+  hasGithubIntegration: boolean;
+  lastUsedLocalWorkspaceMode: LocalWorkspaceMode;
+}
+
+// Cloud is only honoured when it works out of the box (flag on + GitHub
+// connected); otherwise the preference falls back to the last local mode so
+// users never start behind a connect-GitHub prompt.
+export function resolveWorkspaceModePreference({
+  preferredMode,
+  cloudModeEnabled,
+  hasGithubIntegration,
+  lastUsedLocalWorkspaceMode,
+}: WorkspaceModePreferenceInput): WorkspaceMode {
+  if (preferredMode !== "cloud") return preferredMode;
+  if (!cloudModeEnabled || !hasGithubIntegration) {
+    return lastUsedLocalWorkspaceMode;
+  }
+  return "cloud";
+}


### PR DESCRIPTION
## Problem

Cloud should be the default execution mode for new tasks, but only when the Github integration is setup. Users without the GitHub integration (including people who lack permission to install the GitHub App on their org) should default to local still.

## Changes

- The new task composer now defaults to Cloud when the cloud-mode flag is on and a GitHub integration is connected. Otherwise it falls back to the last used local mode. Explicit picks still persist and always win.

## How did you test this?

- `pnpm typecheck` (all 23 packages)
- Full `@posthog/ui` (1405 tests) and `@posthog/core` (2160 tests) vitest suites
- `biome check` on the changed files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?