### PR TITLE
fix(dev): Wait for old Electron to exit on mprocs restart

### DIFF
--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,6 +1,6 @@
 procs:
   1-code:
-    shell: 'node scripts/pnpm-run.mjs --filter code run start'
+    shell: 'node scripts/wait-for-electron-exit.mjs && node scripts/pnpm-run.mjs --filter code run start'
     env:
       DEBUG: "false"
     depends_on:

--- a/scripts/wait-for-electron-exit.mjs
+++ b/scripts/wait-for-electron-exit.mjs
@@ -16,33 +16,40 @@ function runningElectronPids() {
   try {
     const out = execFileSync("pgrep", ["-f", pattern], { encoding: "utf8" });
     return out.split("\n").filter(Boolean);
-  } catch {
-    return [];
+  } catch (error) {
+    if (error.status === 1) return [];
+    throw error;
   }
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 if (process.platform !== "win32") {
-  const initialPids = runningElectronPids();
-  if (initialPids.length > 0) {
-    console.log(
-      `Waiting for previous Electron instance to exit (pids: ${initialPids.join(", ")})`,
-    );
-    const startedAt = Date.now();
-    while (Date.now() - startedAt < WAIT_TIMEOUT_MS) {
-      await sleep(POLL_INTERVAL_MS);
-      if (runningElectronPids().length === 0) break;
-    }
-    const remaining = runningElectronPids();
-    if (remaining.length > 0) {
-      console.warn(
-        `Previous Electron instance still running after ${WAIT_TIMEOUT_MS}ms (pids: ${remaining.join(", ")}), starting anyway`,
-      );
-    } else {
+  try {
+    const initialPids = runningElectronPids();
+    if (initialPids.length > 0) {
       console.log(
-        `Previous Electron instance exited after ${((Date.now() - startedAt) / 1000).toFixed(1)}s`,
+        `Waiting for previous Electron instance to exit (pids: ${initialPids.join(", ")})`,
       );
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < WAIT_TIMEOUT_MS) {
+        await sleep(POLL_INTERVAL_MS);
+        if (runningElectronPids().length === 0) break;
+      }
+      const remaining = runningElectronPids();
+      if (remaining.length > 0) {
+        console.warn(
+          `Previous Electron instance still running after ${WAIT_TIMEOUT_MS}ms (pids: ${remaining.join(", ")}), starting anyway`,
+        );
+      } else {
+        console.log(
+          `Previous Electron instance exited after ${((Date.now() - startedAt) / 1000).toFixed(1)}s`,
+        );
+      }
     }
+  } catch (error) {
+    console.warn(
+      `Skipping wait for previous Electron instance, pgrep failed: ${error.code ?? error.status ?? error.message}`,
+    );
   }
 }

--- a/scripts/wait-for-electron-exit.mjs
+++ b/scripts/wait-for-electron-exit.mjs
@@ -1,0 +1,48 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const WAIT_TIMEOUT_MS = 15_000;
+const POLL_INTERVAL_MS = 200;
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const electronDist = path.join(repoRoot, "node_modules", "electron", "dist");
+const pattern = electronDist.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+function runningElectronPids() {
+  try {
+    const out = execFileSync("pgrep", ["-f", pattern], { encoding: "utf8" });
+    return out.split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+if (process.platform !== "win32") {
+  const initialPids = runningElectronPids();
+  if (initialPids.length > 0) {
+    console.log(
+      `Waiting for previous Electron instance to exit (pids: ${initialPids.join(", ")})`,
+    );
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < WAIT_TIMEOUT_MS) {
+      await sleep(POLL_INTERVAL_MS);
+      if (runningElectronPids().length === 0) break;
+    }
+    const remaining = runningElectronPids();
+    if (remaining.length > 0) {
+      console.warn(
+        `Previous Electron instance still running after ${WAIT_TIMEOUT_MS}ms (pids: ${remaining.join(", ")}), starting anyway`,
+      );
+    } else {
+      console.log(
+        `Previous Electron instance exited after ${((Date.now() - startedAt) / 1000).toFixed(1)}s`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Restarting the `1-code` proc in mprocs/phrocs (pressing `r`) launches a new Electron instance while the old one is still shutting down. The new instance loses the single-instance lock and exits immediately, so the restart leaves nothing running.

## Changes

Adds `scripts/wait-for-electron-exit.mjs`, which polls `pgrep` for processes running from this repo's `node_modules/electron/dist` and waits up to 15s for them to exit. The `1-code` proc now runs it before launching the app. On timeout it starts anyway and the existing single-instance lock still prevents two instances. Applies to phrocs too since it reads the same `mprocs.yaml`.

## How did you test this?

Ran the script with no Electron running (no-op in ~70ms) and against a live Electron instance launched from the repo binary that exited after 3s: the script waited 2.6s for it and its helper processes, then proceeded. Biome check passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
