### PR TITLE
feat: declutter task sidebar and simplify worktree repo picker

### DIFF
--- a/packages/ui/src/features/folder-picker/FolderPicker.test.tsx
+++ b/packages/ui/src/features/folder-picker/FolderPicker.test.tsx
@@ -122,6 +122,7 @@ describe("buildFolderRows", () => {
     name: string;
     recents: RegisteredFolder[];
     all: RegisteredFolder[];
+    mainReposOnly?: boolean;
     expected: Array<{ id: string; isWorktree: boolean; indented: boolean }>;
   }>([
     {
@@ -160,9 +161,29 @@ describe("buildFolderRows", () => {
       all: [wtA, main, standalone],
       expected: [{ id: "other", isWorktree: false, indented: false }],
     },
-  ])("$name", ({ recents, all, expected }) => {
+    {
+      name: "mainReposOnly collapses families to their main clone",
+      recents: [wtB, standalone],
+      all: [wtA, main, wtB, standalone],
+      mainReposOnly: true,
+      expected: [
+        { id: "code", isWorktree: false, indented: false },
+        { id: "other", isWorktree: false, indented: false },
+      ],
+    },
+    {
+      name: "mainReposOnly keeps worktrees without a registered main clone",
+      recents: [wtA],
+      all: [wtA, wtB, standalone],
+      mainReposOnly: true,
+      expected: [
+        { id: "code-a", isWorktree: true, indented: false },
+        { id: "code-b", isWorktree: true, indented: false },
+      ],
+    },
+  ])("$name", ({ recents, all, mainReposOnly, expected }) => {
     expect(
-      buildFolderRows(recents, all).map((row) => ({
+      buildFolderRows(recents, all, mainReposOnly).map((row) => ({
         id: row.folder.id,
         isWorktree: row.isWorktree,
         indented: row.indented,

--- a/packages/ui/src/features/folder-picker/FolderPicker.tsx
+++ b/packages/ui/src/features/folder-picker/FolderPicker.tsx
@@ -45,10 +45,15 @@ interface FolderRow {
  * Groups recent folders into repo families: a recent checkout pulls in its
  * main clone and every registered worktree of the same repo, main first,
  * worktrees indented beneath it. Standalone folders stay single rows.
+ *
+ * With `mainReposOnly`, worktrees whose main clone is in the list are dropped
+ * so only one row per repo remains; worktrees without a registered main stay,
+ * as they are the repo's only selectable entry.
  */
 export function buildFolderRows(
   recentFolders: RegisteredFolder[],
   allFolders: RegisteredFolder[],
+  mainReposOnly = false,
 ): FolderRow[] {
   const familyKey = (f: RegisteredFolder) => f.mainRepoPath ?? f.path;
   const emitted = new Set<string>();
@@ -63,6 +68,7 @@ export function buildFolderRows(
       .filter((f) => f.mainRepoPath)
       .sort((a, b) => a.name.localeCompare(b.name));
     if (main) rows.push({ folder: main, isWorktree: false, indented: false });
+    if (main && mainReposOnly) continue;
     for (const wt of worktrees) {
       rows.push({ folder: wt, isWorktree: true, indented: !!main });
     }
@@ -76,6 +82,8 @@ interface FolderPickerProps {
   placeholder?: string;
   variant?: "compact" | "field";
   anchor?: RefObject<HTMLElement | null>;
+  /** Collapse each repo family to its main clone, hiding worktree rows. */
+  mainReposOnly?: boolean;
 }
 
 export function FolderPicker({
@@ -84,6 +92,7 @@ export function FolderPicker({
   placeholder = "Select folder...",
   variant = "compact",
   anchor,
+  mainReposOnly = false,
 }: FolderPickerProps) {
   const trpcClient = useHostTRPCClient();
   const trpc = useHostTRPC();
@@ -106,8 +115,8 @@ export function FolderPicker({
   const [menuOpen, setMenuOpen] = useState(false);
 
   const folderRows = useMemo(
-    () => buildFolderRows(recentFolders, folders),
-    [recentFolders, folders],
+    () => buildFolderRows(recentFolders, folders, mainReposOnly),
+    [recentFolders, folders, mainReposOnly],
   );
 
   // Current branch per visible row, so the picker answers "what is checked

--- a/packages/ui/src/features/folders/resolveMainRepoPath.ts
+++ b/packages/ui/src/features/folders/resolveMainRepoPath.ts
@@ -1,0 +1,19 @@
+import type { RegisteredFolder } from "./types";
+
+/**
+ * Resolve a registered worktree path to its registered main clone. Returns
+ * the input path when it isn't a registered worktree or its main clone isn't
+ * itself registered (then the worktree is the repo's only selectable entry).
+ *
+ * Worktree-mode task creation must target a main repo, so any surface that
+ * feeds a user-selected folder into it should normalize through this.
+ */
+export function resolveMainRepoPath(
+  folders: RegisteredFolder[],
+  path: string,
+): string {
+  const mainRepoPath = folders.find((f) => f.path === path)?.mainRepoPath;
+  return mainRepoPath && folders.some((f) => f.path === mainRepoPath)
+    ? mainRepoPath
+    : path;
+}

--- a/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
+++ b/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
@@ -2,6 +2,7 @@ import {
   ArrowClockwise,
   CaretDown,
   Check,
+  Cloud,
   GitBranch,
   Plus,
   Spinner,
@@ -91,6 +92,13 @@ interface BranchSelectorProps {
    * fail while the working tree is mid-operation. Only applies in local mode.
    */
   busyState?: GitBusyState;
+  /**
+   * Render only the trigger as a muted, non-interactive pill — no dropdown,
+   * no checkout. Used where the branch is informational, e.g. a cloud task's
+   * header, where there is no local checkout to switch. In cloud mode the
+   * pill leads with a cloud icon instead of the branch icon.
+   */
+  readOnly?: boolean;
 }
 
 const BUSY_OPERATION_LABEL: Record<GitBusyOperation, string> = {
@@ -124,6 +132,7 @@ export function BranchSelector({
   taskId,
   anchor,
   busyState,
+  readOnly = false,
 }: BranchSelectorProps) {
   const [open, setOpen] = useState(false);
   const [hovered, setHovered] = useState(false);
@@ -138,7 +147,8 @@ export function BranchSelector({
 
   const isCloudMode = workspaceMode === "cloud";
   const isSelectionOnly = workspaceMode === "worktree" || isCloudMode;
-  const displayedBranch = isSelectionOnly ? selectedBranch : currentBranch;
+  const displayedBranch =
+    isSelectionOnly && !readOnly ? selectedBranch : currentBranch;
 
   useEffect(() => {
     if (isSelectionOnly && defaultBranch && !selectedBranch && onBranchSelect) {
@@ -301,6 +311,38 @@ export function BranchSelector({
         ? [...branches, USE_INPUT_BRANCH_ACTION]
         : branches
     : [...branches, CREATE_BRANCH_ACTION];
+
+  if (readOnly) {
+    return (
+      <Tooltip
+        content={
+          <span className="flex flex-col">
+            <span>{displayText}</span>
+            {isCloudMode ? (
+              <span className="text-gray-10">running in the cloud</span>
+            ) : repoPath ? (
+              <span className="text-gray-10">in {repoPath}</span>
+            ) : null}
+          </span>
+        }
+        side="bottom"
+      >
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label={`Branch ${displayText}`}
+          className="min-w-0 max-w-[250px] shrink cursor-default text-(--gray-10)"
+        >
+          {isCloudMode ? (
+            <Cloud size={14} weight="regular" className="shrink-0" />
+          ) : (
+            <GitBranch size={14} weight="regular" className="shrink-0" />
+          )}
+          <span className="min-w-0 truncate">{displayText}</span>
+        </Button>
+      </Tooltip>
+    );
+  }
 
   return (
     <Combobox

--- a/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
+++ b/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
@@ -147,8 +147,7 @@ export function BranchSelector({
 
   const isCloudMode = workspaceMode === "cloud";
   const isSelectionOnly = workspaceMode === "worktree" || isCloudMode;
-  const displayedBranch =
-    isSelectionOnly && !readOnly ? selectedBranch : currentBranch;
+  const displayedBranch = isSelectionOnly ? selectedBranch : currentBranch;
 
   useEffect(() => {
     if (isSelectionOnly && defaultBranch && !selectedBranch && onBranchSelect) {
@@ -211,6 +210,42 @@ export function BranchSelector({
       });
     },
   });
+
+  // Informational pill: no dropdown, no checkout, and none of the interactive
+  // scaffolding below. Shows `currentBranch` directly — the selection-only
+  // `selectedBranch` has no meaning without a picker.
+  if (readOnly) {
+    const readOnlyBranch = currentBranch ?? "No branch";
+    return (
+      <Tooltip
+        content={
+          <span className="flex flex-col">
+            <span>{readOnlyBranch}</span>
+            {isCloudMode ? (
+              <span className="text-gray-10">running in the cloud</span>
+            ) : repoPath ? (
+              <span className="text-gray-10">in {repoPath}</span>
+            ) : null}
+          </span>
+        }
+        side="bottom"
+      >
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label={`Branch ${readOnlyBranch}`}
+          className="min-w-0 max-w-[250px] shrink cursor-default text-(--gray-10)"
+        >
+          {isCloudMode ? (
+            <Cloud size={14} weight="regular" className="shrink-0" />
+          ) : (
+            <GitBranch size={14} weight="regular" className="shrink-0" />
+          )}
+          <span className="min-w-0 truncate">{readOnlyBranch}</span>
+        </Button>
+      </Tooltip>
+    );
+  }
 
   // In local mode, surface in-progress git operations (rebase/merge/etc.) so the
   // user understands why there's no current branch and why we won't let them
@@ -311,38 +346,6 @@ export function BranchSelector({
         ? [...branches, USE_INPUT_BRANCH_ACTION]
         : branches
     : [...branches, CREATE_BRANCH_ACTION];
-
-  if (readOnly) {
-    return (
-      <Tooltip
-        content={
-          <span className="flex flex-col">
-            <span>{displayText}</span>
-            {isCloudMode ? (
-              <span className="text-gray-10">running in the cloud</span>
-            ) : repoPath ? (
-              <span className="text-gray-10">in {repoPath}</span>
-            ) : null}
-          </span>
-        }
-        side="bottom"
-      >
-        <Button
-          variant="outline"
-          size="sm"
-          aria-label={`Branch ${displayText}`}
-          className="min-w-0 max-w-[250px] shrink cursor-default text-(--gray-10)"
-        >
-          {isCloudMode ? (
-            <Cloud size={14} weight="regular" className="shrink-0" />
-          ) : (
-            <GitBranch size={14} weight="regular" className="shrink-0" />
-          )}
-          <span className="min-w-0 truncate">{displayText}</span>
-        </Button>
-      </Tooltip>
-    );
-  }
 
   return (
     <Combobox

--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -12,7 +12,6 @@ import type {
   TaskGroup,
 } from "@posthog/core/sidebar/sidebarData.types";
 import { MenuLabel } from "@posthog/quill";
-import { getFileName } from "@posthog/shared";
 import { builderHog } from "@posthog/ui/assets/hedgehogs";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
 import { useArchivingTasksStore } from "@posthog/ui/features/sidebar/archivingTasksStore";
@@ -90,32 +89,9 @@ function TaskRow({
   depth?: number;
 }) {
   const workspace = useWorkspace(task.id);
-  const { folders } = useFolders();
   const effectiveMode =
     workspace?.mode ??
     (task.taskRunEnvironment === "cloud" ? "cloud" : undefined);
-
-  // Chip identifying the checkout the task runs in: app-managed worktrees
-  // (worktree mode) and local tasks whose registered folder is itself a
-  // linked worktree of the group's main clone.
-  const worktreeCheckout = useMemo(() => {
-    if (workspace?.worktreePath) {
-      return {
-        name: workspace.worktreeName ?? getFileName(workspace.worktreePath),
-        path: workspace.worktreePath,
-      };
-    }
-    if (workspace?.mode === "local" && workspace.folderPath) {
-      const folder = folders.find((f) => f.path === workspace.folderPath);
-      if (folder?.mainRepoPath) {
-        return {
-          name: getFileName(workspace.folderPath),
-          path: workspace.folderPath,
-        };
-      }
-    }
-    return null;
-  }, [workspace, folders]);
   const { prState, hasDiff } = useTaskPrStatus(task);
   const isArchiving = useArchivingTasksStore((s) =>
     s.archivingTaskIds.has(task.id),
@@ -132,8 +108,6 @@ function TaskRow({
       hideHoverActions={hideHoverActions}
       isEditing={isEditing}
       workspaceMode={effectiveMode}
-      worktreeName={worktreeCheckout?.name}
-      worktreePath={worktreeCheckout?.path}
       isSuspended={task.isSuspended}
       isGenerating={task.isGenerating}
       isUnread={task.isUnread}
@@ -144,7 +118,6 @@ function TaskRow({
       slackThreadUrl={task.slackThreadUrl}
       prState={prState}
       hasDiff={hasDiff}
-      prUrl={task.cloudPrUrl}
       timestamp={timestamp}
       onClick={onClick}
       onDoubleClick={onDoubleClick}

--- a/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -1,49 +1,14 @@
-import {
-  Archive,
-  GitFork,
-  GitPullRequest,
-  PushPin,
-} from "@phosphor-icons/react";
-import { parseGithubUrl } from "@posthog/git/utils";
+import { Archive, PushPin } from "@phosphor-icons/react";
 import type { WorkspaceMode } from "@posthog/shared";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { TaskRunStatus } from "@posthog/shared/domain-types";
-import { navigateToPullRequestView } from "@posthog/ui/router/navigationBridge";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { DotsCircleSpinner } from "../../../../primitives/DotsCircleSpinner";
 import { NestedButton } from "../../../../primitives/NestedButton";
 import { Tooltip } from "../../../../primitives/Tooltip";
 import type { SidebarPrState } from "../../useTaskPrStatus";
 import { SidebarItem } from "../SidebarItem";
 import { ICON_SIZE, TaskIcon } from "./TaskIcon";
-
-function PrBadge({ url, number }: { url: string; number: number }) {
-  return (
-    <Tooltip content="Open pull request" side="top">
-      <NestedButton
-        aria-label={`Open pull request #${number}`}
-        className="flex h-4 shrink-0 cursor-pointer items-center gap-0.5 rounded bg-gray-3 px-1 text-[11px] text-gray-11 transition-colors hover:bg-gray-4 hover:text-gray-12"
-        onActivate={() => {
-          navigateToPullRequestView(url);
-        }}
-      >
-        <GitPullRequest size={10} weight="bold" />
-        {`#${number}`}
-      </NestedButton>
-    </Tooltip>
-  );
-}
-
-function WorktreeChip({ name, path }: { name: string; path?: string }) {
-  return (
-    <Tooltip content={path ?? name} side="top">
-      <span className="flex h-4 max-w-[96px] shrink-0 items-center gap-0.5 rounded bg-gray-3 px-1 text-[11px] text-gray-11">
-        <GitFork size={10} weight="bold" className="shrink-0" />
-        <span className="truncate">{name}</span>
-      </span>
-    </Tooltip>
-  );
-}
 
 interface TaskItemProps {
   depth?: number;
@@ -55,10 +20,6 @@ interface TaskItemProps {
   isArchiving?: boolean;
   hideHoverActions?: boolean;
   workspaceMode?: WorkspaceMode;
-  /** Checkout name shown as a chip when the task runs in a git worktree. */
-  worktreeName?: string;
-  /** Full path of that checkout, surfaced in the chip's tooltip. */
-  worktreePath?: string;
   isGenerating?: boolean;
   isUnread?: boolean;
   isPinned?: boolean;
@@ -69,7 +30,6 @@ interface TaskItemProps {
   slackThreadUrl?: string;
   prState?: SidebarPrState;
   hasDiff?: boolean;
-  prUrl?: string | null;
   timestamp?: number;
   isEditing?: boolean;
   onClick: (e: React.MouseEvent) => void;
@@ -131,8 +91,6 @@ export function TaskItem({
   isArchiving = false,
   hideHoverActions = false,
   workspaceMode,
-  worktreeName,
-  worktreePath,
   isSuspended = false,
   isGenerating,
   isUnread,
@@ -143,7 +101,6 @@ export function TaskItem({
   slackThreadUrl,
   prState,
   hasDiff,
-  prUrl,
   timestamp,
   isEditing = false,
   onClick,
@@ -172,19 +129,11 @@ export function TaskItem({
     />
   );
 
-  const prRef = useMemo(() => (prUrl ? parseGithubUrl(prUrl) : null), [prUrl]);
-  const prBadge =
-    prUrl && prRef?.kind === "pr" ? (
-      <PrBadge url={prUrl} number={prRef.number} />
-    ) : null;
-
-  // The PR badge takes the timestamp's slot, so hide the timestamp when shown.
-  const timestampNode =
-    timestamp && !prBadge ? (
-      <span className="shrink-0 text-[11px] text-gray-11 group-hover:hidden">
-        {formatRelativeTimeShort(timestamp)}
-      </span>
-    ) : null;
+  const timestampNode = timestamp ? (
+    <span className="shrink-0 text-[11px] text-gray-11 group-hover:hidden">
+      {formatRelativeTimeShort(timestamp)}
+    </span>
+  ) : null;
 
   const toolbar =
     !isArchiving && !hideHoverActions && (onArchive || onTogglePin) ? (
@@ -195,15 +144,9 @@ export function TaskItem({
       />
     ) : null;
 
-  const worktreeChip = worktreeName ? (
-    <WorktreeChip name={worktreeName} path={worktreePath} />
-  ) : null;
-
   const endContent =
-    worktreeChip || prBadge || timestampNode || toolbar ? (
+    timestampNode || toolbar ? (
       <>
-        {worktreeChip}
-        {prBadge}
         {timestampNode}
         {toolbar}
       </>

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -41,6 +41,7 @@ import { useFeatureFlagsLoaded } from "../../feature-flags/useFeatureFlagsLoaded
 import { AdditionalDirectoriesButton } from "../../folder-picker/AdditionalDirectoriesButton";
 import { FolderPicker } from "../../folder-picker/FolderPicker";
 import { GitHubRepoPicker } from "../../folder-picker/GitHubRepoPicker";
+import { resolveMainRepoPath } from "../../folders/resolveMainRepoPath";
 import { useFolders } from "../../folders/useFolders";
 import { BranchSelector } from "../../git-interaction/components/BranchSelector";
 import { GitBranchDialog } from "../../git-interaction/components/GitInteractionDialogs";
@@ -387,17 +388,14 @@ export function TaskInput({
   // at a worktree (picked in local mode before switching, or from a past
   // session). Resolve the effective directory to that worktree's registered
   // main clone so task creation doesn't treat a worktree path as the main
-  // repo. Worktrees without a registered main stay as-is: they're the repo's
-  // only selectable entry.
-  const selectedDirectory = useMemo(() => {
-    if (workspaceMode !== "worktree" || !activeRepoPath) return activeRepoPath;
-    const mainRepoPath = folders.find(
-      (f) => f.path === activeRepoPath,
-    )?.mainRepoPath;
-    return mainRepoPath && folders.some((f) => f.path === mainRepoPath)
-      ? mainRepoPath
-      : activeRepoPath;
-  }, [workspaceMode, activeRepoPath, folders]);
+  // repo.
+  const selectedDirectory = useMemo(
+    () =>
+      workspaceMode === "worktree" && activeRepoPath
+        ? resolveMainRepoPath(folders, activeRepoPath)
+        : activeRepoPath,
+    [workspaceMode, activeRepoPath, folders],
+  );
   const {
     repositories: visibleCloudRepositories,
     isPending: cloudRepositoriesLoading,

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -564,6 +564,22 @@ export function TaskInput({
 
   const { folders } = useFolders();
 
+  // Worktree mode creates a fresh checkout from the main clone, and its folder
+  // picker only lists main repos — but the selection can still point at a
+  // worktree (picked in local mode before switching, or persisted from a past
+  // session). Remap it to the worktree's main repo so task creation doesn't
+  // treat a worktree path as the main repo. Only remap when the main clone is
+  // itself registered; otherwise the worktree row is the repo's only entry.
+  useEffect(() => {
+    if (workspaceMode !== "worktree" || !selectedDirectory) return;
+    const mainRepoPath = folders.find(
+      (f) => f.path === selectedDirectory,
+    )?.mainRepoPath;
+    if (mainRepoPath && folders.some((f) => f.path === mainRepoPath)) {
+      setSelectedDirectory(mainRepoPath);
+    }
+  }, [workspaceMode, selectedDirectory, folders, setSelectedDirectory]);
+
   useEffect(() => {
     if (selectedRepository || !lastUsedCloudRepository) {
       return;

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -168,14 +168,14 @@ export function TaskInput({
   const setSelectedReportIds = useInboxReportSelectionStore(
     (s) => s.setSelectedReportIds,
   );
-  const selectedDirectory = useActiveRepoStore((s) => s.path);
+  const activeRepoPath = useActiveRepoStore((s) => s.path);
   const setSelectedDirectory = useActiveRepoStore((s) => s.setPath);
   // Inline file preview opened from the command palette's file search.
   const previewFile = useFileSearchStore((s) => s.previewFile);
   const closePreviewFile = useFileSearchStore((s) => s.closePreview);
   // Clear the open file on repo change + unmount.
   // biome-ignore lint/correctness/useExhaustiveDependencies: clear on repo change + unmount only
-  useEffect(() => closePreviewFile, [selectedDirectory, closePreviewFile]);
+  useEffect(() => closePreviewFile, [activeRepoPath, closePreviewFile]);
   const { data: mostRecentRepo } = useQuery(
     trpc.folders.getMostRecentlyAccessedRepository.queryOptions(),
   );
@@ -202,8 +202,8 @@ export function TaskInput({
   const editorRef = useRef<EditorHandle>(null);
   const handleAddSelectionToPrompt = useCallback(
     (startLine: number, endLine: number, text: string) => {
-      if (!selectedDirectory || !previewFile) return;
-      const absolutePath = `${selectedDirectory.replace(/\/+$/, "")}/${previewFile}`;
+      if (!activeRepoPath || !previewFile) return;
+      const absolutePath = `${activeRepoPath.replace(/\/+$/, "")}/${previewFile}`;
       const prompt = buildFileLineReferencePrompt(
         absolutePath,
         startLine,
@@ -213,7 +213,7 @@ export function TaskInput({
       editorRef.current?.insertEditorContent(xmlToContent(prompt));
       editorRef.current?.focus();
     },
-    [selectedDirectory, previewFile],
+    [activeRepoPath, previewFile],
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const buttonGroupRef = useRef<HTMLDivElement>(null);
@@ -299,10 +299,10 @@ export function TaskInput({
   }, [activeReportAssociation, setSelectedReportIds]);
 
   useEffect(() => {
-    if (!selectedDirectory && mostRecentRepo?.path) {
+    if (!activeRepoPath && mostRecentRepo?.path) {
       setSelectedDirectory(mostRecentRepo.path);
     }
-  }, [mostRecentRepo?.path, selectedDirectory, setSelectedDirectory]);
+  }, [mostRecentRepo?.path, activeRepoPath, setSelectedDirectory]);
 
   const setAdapter = (newAdapter: AgentAdapter) =>
     setLastUsedAdapter(newAdapter);
@@ -379,6 +379,25 @@ export function TaskInput({
       setLastUsedLocalWorkspaceMode(mode);
     }
   };
+
+  const { folders } = useFolders();
+
+  // Worktree mode creates a fresh checkout from the main clone, and its folder
+  // picker only lists main repos — but the persisted selection can still point
+  // at a worktree (picked in local mode before switching, or from a past
+  // session). Resolve the effective directory to that worktree's registered
+  // main clone so task creation doesn't treat a worktree path as the main
+  // repo. Worktrees without a registered main stay as-is: they're the repo's
+  // only selectable entry.
+  const selectedDirectory = useMemo(() => {
+    if (workspaceMode !== "worktree" || !activeRepoPath) return activeRepoPath;
+    const mainRepoPath = folders.find(
+      (f) => f.path === activeRepoPath,
+    )?.mainRepoPath;
+    return mainRepoPath && folders.some((f) => f.path === mainRepoPath)
+      ? mainRepoPath
+      : activeRepoPath;
+  }, [workspaceMode, activeRepoPath, folders]);
   const {
     repositories: visibleCloudRepositories,
     isPending: cloudRepositoriesLoading,
@@ -561,24 +580,6 @@ export function TaskInput({
     modeOption,
     setConfigOption,
   ]);
-
-  const { folders } = useFolders();
-
-  // Worktree mode creates a fresh checkout from the main clone, and its folder
-  // picker only lists main repos — but the selection can still point at a
-  // worktree (picked in local mode before switching, or persisted from a past
-  // session). Remap it to the worktree's main repo so task creation doesn't
-  // treat a worktree path as the main repo. Only remap when the main clone is
-  // itself registered; otherwise the worktree row is the repo's only entry.
-  useEffect(() => {
-    if (workspaceMode !== "worktree" || !selectedDirectory) return;
-    const mainRepoPath = folders.find(
-      (f) => f.path === selectedDirectory,
-    )?.mainRepoPath;
-    if (mainRepoPath && folders.some((f) => f.path === mainRepoPath)) {
-      setSelectedDirectory(mainRepoPath);
-    }
-  }, [workspaceMode, selectedDirectory, folders, setSelectedDirectory]);
 
   useEffect(() => {
     if (selectedRepository || !lastUsedCloudRepository) {
@@ -1043,10 +1044,10 @@ export function TaskInput({
     >
       <DropZoneOverlay isVisible={isDraggingFile} />
       <Flex height="100%" width="100%">
-        {previewFile && selectedDirectory && (
+        {previewFile && activeRepoPath && (
           <Box className="h-full min-w-0 flex-1 border-gray-4 border-r">
             <NewTaskFilePreview
-              repoPath={selectedDirectory}
+              repoPath={activeRepoPath}
               filePath={previewFile}
               onAddSelection={handleAddSelectionToPrompt}
             />

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -1123,6 +1123,7 @@ export function TaskInput({
                         onChange={setSelectedDirectory}
                         placeholder="Select repository..."
                         anchor={buttonGroupRef}
+                        mainReposOnly={workspaceMode === "worktree"}
                       />
                     )}
                     <BranchSelector

--- a/packages/ui/src/router/navigationBridge.ts
+++ b/packages/ui/src/router/navigationBridge.ts
@@ -26,13 +26,6 @@ export function navigateToTaskDetail(taskId: string): void {
   });
 }
 
-export function navigateToPullRequestView(prUrl: string): void {
-  void getRouterOrNull()?.navigate({
-    to: "/code/pr",
-    search: { prUrl },
-  });
-}
-
 export function navigateToTaskPending(key: string): void {
   void getRouterOrNull()?.navigate({
     to: "/code/tasks/pending/$key",

--- a/packages/ui/src/shell/ContentHeader.tsx
+++ b/packages/ui/src/shell/ContentHeader.tsx
@@ -1,5 +1,6 @@
 import { Cloud, Spinner } from "@phosphor-icons/react";
 import { Button as QuillButton } from "@posthog/quill";
+import type { Workspace } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { AutoresearchHeaderButton } from "@posthog/ui/features/autoresearch/AutoresearchHeaderButton";
@@ -107,20 +108,53 @@ function LocalHandoffButton({ taskId, task }: { taskId: string; task: Task }) {
   );
 }
 
-// Cloud tasks have no local checkout to switch branches in, so they get the
-// BranchSelector in read-only mode: a muted pill with a cloud icon and the
-// branch the cloud run works on. Hidden until the run has reported a branch.
-function CloudBranchBadge({ taskId, task }: { taskId: string; task: Task }) {
-  const session = useSessionForTask(taskId);
-  const branch = task.latest_run?.branch ?? session?.cloudBranch ?? null;
-  if (!branch) return null;
+// The header's single branch slot. Cloud tasks get the BranchSelector in
+// read-only mode (cloud icon + the branch the run works on, hidden until the
+// run reports one); repo-backed local/worktree tasks get the interactive
+// selector, shown even on a detached HEAD — the linked branch is where the
+// task's commits land, and hiding the control entirely makes a local task
+// look like a cloud one. Scratch (repo-less) tasks show nothing.
+function TaskBranchControl({
+  task,
+  workspace,
+}: {
+  task: Task;
+  workspace: Workspace | null;
+}) {
+  const session = useSessionForTask(task.id);
+  if (!workspace || workspace.isScratch) return null;
+
+  let selector: React.ReactNode;
+  if (workspace.mode === "cloud") {
+    const branch = task.latest_run?.branch ?? session?.cloudBranch ?? null;
+    if (!branch) return null;
+    selector = (
+      <BranchSelector
+        repoPath={null}
+        currentBranch={branch}
+        workspaceMode="cloud"
+        readOnly
+      />
+    );
+  } else {
+    const repoPath = workspace.worktreePath ?? workspace.folderPath ?? null;
+    const currentBranch =
+      workspace.branchName ??
+      workspace.linkedBranch ??
+      workspace.baseBranch ??
+      null;
+    if (!repoPath && !currentBranch) return null;
+    selector = (
+      <BranchSelector
+        repoPath={repoPath}
+        currentBranch={currentBranch}
+        taskId={task.id}
+      />
+    );
+  }
+
   return (
-    <BranchSelector
-      repoPath={null}
-      currentBranch={branch}
-      workspaceMode="cloud"
-      readOnly
-    />
+    <div className="no-drag flex h-full min-w-0 items-center">{selector}</div>
   );
 }
 
@@ -193,39 +227,7 @@ export function ContentHeader() {
           <div className="no-drag">
             <AutoresearchHeaderButton taskId={activeTask.id} />
           </div>
-          {/* Show the branch control whenever the task has a repo checkout,
-              even if HEAD is detached (the default for worktree tasks) — the
-              linked branch is where the task's commits land, and hiding the
-              control entirely makes a local task look like a cloud one. */}
-          {isCloudTask && (
-            <div className="no-drag flex h-full min-w-0 items-center">
-              <CloudBranchBadge taskId={activeTask.id} task={activeTask} />
-            </div>
-          )}
-          {activeWorkspace &&
-            !isCloudTask &&
-            !activeWorkspace.isScratch &&
-            (activeWorkspace.worktreePath ||
-              activeWorkspace.folderPath ||
-              activeWorkspace.branchName ||
-              activeWorkspace.baseBranch) && (
-              <div className="no-drag flex h-full min-w-0 items-center">
-                <BranchSelector
-                  repoPath={
-                    activeWorkspace.worktreePath ??
-                    activeWorkspace.folderPath ??
-                    null
-                  }
-                  currentBranch={
-                    activeWorkspace.branchName ??
-                    activeWorkspace.linkedBranch ??
-                    activeWorkspace.baseBranch ??
-                    null
-                  }
-                  taskId={activeTask.id}
-                />
-              </div>
-            )}
+          <TaskBranchControl task={activeTask} workspace={activeWorkspace} />
           <TaskDiffStatsBadge task={activeTask} />
 
           {isCloudTask ? (

--- a/packages/ui/src/shell/ContentHeader.tsx
+++ b/packages/ui/src/shell/ContentHeader.tsx
@@ -107,34 +107,20 @@ function LocalHandoffButton({ taskId, task }: { taskId: string; task: Task }) {
   );
 }
 
-// Cloud tasks have no local checkout to switch branches in, so instead of the
-// interactive BranchSelector they get a muted, read-only pill in the same
-// slot: cloud icon + the branch the cloud run works on. Hidden until the run
-// has reported a branch.
+// Cloud tasks have no local checkout to switch branches in, so they get the
+// BranchSelector in read-only mode: a muted pill with a cloud icon and the
+// branch the cloud run works on. Hidden until the run has reported a branch.
 function CloudBranchBadge({ taskId, task }: { taskId: string; task: Task }) {
   const session = useSessionForTask(taskId);
   const branch = task.latest_run?.branch ?? session?.cloudBranch ?? null;
   if (!branch) return null;
   return (
-    <Tooltip
-      content={
-        <span className="flex flex-col">
-          <span>{branch}</span>
-          <span className="text-gray-10">running in the cloud</span>
-        </span>
-      }
-      side="bottom"
-    >
-      <QuillButton
-        variant="outline"
-        size="sm"
-        aria-label={`Cloud branch ${branch}`}
-        className="min-w-0 max-w-[250px] shrink cursor-default text-(--gray-10)"
-      >
-        <Cloud size={14} weight="regular" className="shrink-0" />
-        <span className="min-w-0 truncate">{branch}</span>
-      </QuillButton>
-    </Tooltip>
+    <BranchSelector
+      repoPath={null}
+      currentBranch={branch}
+      workspaceMode="cloud"
+      readOnly
+    />
   );
 }
 

--- a/packages/ui/src/shell/ContentHeader.tsx
+++ b/packages/ui/src/shell/ContentHeader.tsx
@@ -176,8 +176,16 @@ export function ContentHeader() {
           <div className="no-drag">
             <AutoresearchHeaderButton taskId={activeTask.id} />
           </div>
+          {/* Show the branch control whenever the task has a repo checkout,
+              even if HEAD is detached (the default for worktree tasks) — the
+              linked branch is where the task's commits land, and hiding the
+              control entirely makes a local task look like a cloud one. */}
           {activeWorkspace &&
-            (activeWorkspace.branchName || activeWorkspace.baseBranch) && (
+            !activeWorkspace.isScratch &&
+            (activeWorkspace.worktreePath ||
+              activeWorkspace.folderPath ||
+              activeWorkspace.branchName ||
+              activeWorkspace.baseBranch) && (
               <div className="no-drag flex h-full min-w-0 items-center">
                 <BranchSelector
                   repoPath={
@@ -187,6 +195,7 @@ export function ContentHeader() {
                   }
                   currentBranch={
                     activeWorkspace.branchName ??
+                    activeWorkspace.linkedBranch ??
                     activeWorkspace.baseBranch ??
                     null
                   }

--- a/packages/ui/src/shell/ContentHeader.tsx
+++ b/packages/ui/src/shell/ContentHeader.tsx
@@ -107,6 +107,37 @@ function LocalHandoffButton({ taskId, task }: { taskId: string; task: Task }) {
   );
 }
 
+// Cloud tasks have no local checkout to switch branches in, so instead of the
+// interactive BranchSelector they get a muted, read-only pill in the same
+// slot: cloud icon + the branch the cloud run works on. Hidden until the run
+// has reported a branch.
+function CloudBranchBadge({ taskId, task }: { taskId: string; task: Task }) {
+  const session = useSessionForTask(taskId);
+  const branch = task.latest_run?.branch ?? session?.cloudBranch ?? null;
+  if (!branch) return null;
+  return (
+    <Tooltip
+      content={
+        <span className="flex flex-col">
+          <span>{branch}</span>
+          <span className="text-gray-10">running in the cloud</span>
+        </span>
+      }
+      side="bottom"
+    >
+      <QuillButton
+        variant="outline"
+        size="sm"
+        aria-label={`Cloud branch ${branch}`}
+        className="min-w-0 max-w-[250px] shrink cursor-default text-(--gray-10)"
+      >
+        <Cloud size={14} weight="regular" className="shrink-0" />
+        <span className="min-w-0 truncate">{branch}</span>
+      </QuillButton>
+    </Tooltip>
+  );
+}
+
 function TaskDiffStatsBadge({ task }: { task: Task }) {
   const { filesChanged, linesAdded, linesRemoved, isOpen, toggle } =
     useDiffStatsToggle(task, "split");
@@ -180,7 +211,13 @@ export function ContentHeader() {
               even if HEAD is detached (the default for worktree tasks) — the
               linked branch is where the task's commits land, and hiding the
               control entirely makes a local task look like a cloud one. */}
+          {isCloudTask && (
+            <div className="no-drag flex h-full min-w-0 items-center">
+              <CloudBranchBadge taskId={activeTask.id} task={activeTask} />
+            </div>
+          )}
           {activeWorkspace &&
+            !isCloudTask &&
             !activeWorkspace.isScratch &&
             (activeWorkspace.worktreePath ||
               activeWorkspace.folderPath ||

--- a/packages/ui/src/shell/ContentHeader.tsx
+++ b/packages/ui/src/shell/ContentHeader.tsx
@@ -17,7 +17,10 @@ import { TaskActionsMenu } from "@posthog/ui/features/git-interaction/components
 import { HandoffConfirmDialog } from "@posthog/ui/features/sessions/components/HandoffConfirmDialog";
 import { useHandoffDialogStore } from "@posthog/ui/features/sessions/handoffDialogStore";
 import { useSessionCallbacks } from "@posthog/ui/features/sessions/hooks/useSessionCallbacks";
-import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
+import {
+  useSessionForTask,
+  useSessionSelector,
+} from "@posthog/ui/features/sessions/useSession";
 import { SkillButtonsMenu } from "@posthog/ui/features/skill-buttons/components/SkillButtonsMenu";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useWorkspace } from "@posthog/ui/features/workspace/useWorkspace";
@@ -121,12 +124,19 @@ function TaskBranchControl({
   task: Task;
   workspace: Workspace | null;
 }) {
-  const session = useSessionForTask(task.id);
+  // Selector, not useSessionForTask: the header is always visible and the full
+  // session object changes identity on every streamed event.
+  const sessionCloudBranch = useSessionSelector(
+    task.id,
+    (s) => s?.cloudBranch ?? null,
+  );
   if (!workspace || workspace.isScratch) return null;
 
   let selector: React.ReactNode;
   if (workspace.mode === "cloud") {
-    const branch = task.latest_run?.branch ?? session?.cloudBranch ?? null;
+    // Same run-then-session precedence as deriveCloudRunState's
+    // effectiveBranch (core/task-detail/cloudRunState.ts).
+    const branch = task.latest_run?.branch ?? sessionCloudBranch;
     if (!branch) return null;
     selector = (
       <BranchSelector


### PR DESCRIPTION
## Problem

The task sidebar is noisy: every task row can carry a worktree chip and a PR chip on top of its status icon, timestamp, and hover actions. In the new-task view, worktree mode also listed every registered checkout (main clones *and* their worktrees), even though the app creates its own worktree from the selected repo — picking a specific worktree folder there is confusing.

## Changes

- Removed the worktree (directory) chip and the PR chip from sidebar task items — rows now show just the title, status icon, timestamp, and hover actions. PR status is still visible via the task's status icon, and the PR remains reachable from the task view.
- In the new-task composer, the folder picker collapses each repo family to its main clone when worktree mode is selected (worktrees without a registered main clone stay listed, as they're the repo's only entry). Local mode still lists worktrees, where selecting one is meaningful.

- The top-bar branch dropdown now renders whenever the task has a repo checkout, instead of only when a branch name resolved. Worktree tasks start on a detached HEAD, so tasks with a real checkout (and even an open PR) showed no branch at all and looked like cloud tasks; the control now falls back to the task's linked branch, then "No branch". Scratch and cloud tasks are unchanged.

- Switching the composer to worktree mode now remaps a previously selected worktree path to its registered main clone, so task creation can't treat a worktree checkout as the main repo.

- Cloud tasks now show a muted, read-only branch pill (cloud icon + the run's branch) in the header where local tasks show the branch selector, so a cloud task is recognizable at a glance.

## How did you test this?

- Added `buildFolderRows` test cases for the new `mainReposOnly` behavior; ran the folder-picker and sidebar unit tests (all passing).
- `pnpm --filter @posthog/ui typecheck` and Biome check on the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

**Why:** The sidebar chips duplicated information and made the task list hard to scan, and the worktree-mode folder dropdown exposed on-disk checkout details users shouldn't have to think about.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


