### PR TITLE
feat(power): opt-in keep-display-awake tier for the keep-awake setting

### DIFF
--- a/apps/code/src/main/platform-adapters/electron-power-manager.ts
+++ b/apps/code/src/main/platform-adapters/electron-power-manager.ts
@@ -1,7 +1,10 @@
 import { execFile } from "node:child_process";
 import { readdir } from "node:fs/promises";
 import { promisify } from "node:util";
-import type { IPowerManager } from "@posthog/platform/power-manager";
+import type {
+  IPowerManager,
+  PowerSaveBlockerType,
+} from "@posthog/platform/power-manager";
 import { powerMonitor, powerSaveBlocker } from "electron";
 import { injectable } from "inversify";
 
@@ -14,8 +17,8 @@ export class ElectronPowerManager implements IPowerManager {
     return () => powerMonitor.off("resume", handler);
   }
 
-  public preventSleep(_reason: string): () => void {
-    const id = powerSaveBlocker.start("prevent-app-suspension");
+  public preventSleep(type: PowerSaveBlockerType): () => void {
+    const id = powerSaveBlocker.start(type);
     return () => {
       if (powerSaveBlocker.isStarted(id)) {
         powerSaveBlocker.stop(id);

--- a/apps/code/src/main/platform-adapters/electron-workspace-settings.ts
+++ b/apps/code/src/main/platform-adapters/electron-workspace-settings.ts
@@ -4,11 +4,13 @@ import {
   getAllWorktreeLocations,
   getAutoSuspendAfterDays,
   getAutoSuspendEnabled,
+  getKeepDisplayAwakeWhileRunning,
   getMaxActiveWorktrees,
   getPreventSleepWhileRunning,
   getWorktreeLocation,
   setAutoSuspendAfterDays,
   setAutoSuspendEnabled,
+  setKeepDisplayAwakeWhileRunning,
   setMaxActiveWorktrees,
   setPreventSleepWhileRunning,
   setWorktreeLocation,
@@ -58,5 +60,13 @@ export class ElectronWorkspaceSettings implements IWorkspaceSettings {
 
   setPreventSleepWhileRunning(value: boolean): void {
     setPreventSleepWhileRunning(value);
+  }
+
+  getKeepDisplayAwakeWhileRunning(): boolean {
+    return getKeepDisplayAwakeWhileRunning();
+  }
+
+  setKeepDisplayAwakeWhileRunning(value: boolean): void {
+    setKeepDisplayAwakeWhileRunning(value);
   }
 }

--- a/apps/code/src/main/services/settingsStore.ts
+++ b/apps/code/src/main/services/settingsStore.ts
@@ -8,6 +8,7 @@ import { getUserDataDir, isDevBuild } from "../utils/env";
 interface SettingsSchema {
   worktreeLocation: string;
   preventSleepWhileRunning: boolean;
+  keepDisplayAwakeWhileRunning: boolean;
   autoSuspendEnabled: boolean;
   maxActiveWorktrees: number;
   autoSuspendAfterDays: number;
@@ -71,6 +72,10 @@ const schema = {
     type: "boolean" as const,
     default: false,
   },
+  keepDisplayAwakeWhileRunning: {
+    type: "boolean" as const,
+    default: false,
+  },
   autoSuspendEnabled: {
     type: "boolean" as const,
     default: true,
@@ -108,6 +113,7 @@ export const settingsStore = new Store<SettingsSchema>({
   defaults: {
     worktreeLocation: getDefaultWorktreeLocation(),
     preventSleepWhileRunning: false,
+    keepDisplayAwakeWhileRunning: false,
     autoSuspendEnabled: true,
     maxActiveWorktrees: 5,
     autoSuspendAfterDays: 7,
@@ -191,4 +197,12 @@ export function getPreventSleepWhileRunning(): boolean {
 
 export function setPreventSleepWhileRunning(value: boolean): void {
   settingsStore.set("preventSleepWhileRunning", value);
+}
+
+export function getKeepDisplayAwakeWhileRunning(): boolean {
+  return settingsStore.get("keepDisplayAwakeWhileRunning", false);
+}
+
+export function setKeepDisplayAwakeWhileRunning(value: boolean): void {
+  settingsStore.set("keepDisplayAwakeWhileRunning", value);
 }

--- a/packages/core/src/sleep/sleep.test.ts
+++ b/packages/core/src/sleep/sleep.test.ts
@@ -13,7 +13,10 @@ function makeLogger() {
   return { ...scoped, scope: vi.fn(() => scoped) };
 }
 
-function createDeps(preventSleepInitially = true) {
+function createDeps(
+  preventSleepInitially = true,
+  keepDisplayAwakeInitially = false,
+) {
   const release = vi.fn();
   const powerManager: IPowerManager = {
     onResume: vi.fn(() => () => {}),
@@ -22,10 +25,15 @@ function createDeps(preventSleepInitially = true) {
   };
 
   let stored = preventSleepInitially;
+  let storedDisplayAwake = keepDisplayAwakeInitially;
   const settings: IWorkspaceSettings = {
     getPreventSleepWhileRunning: vi.fn(() => stored),
     setPreventSleepWhileRunning: vi.fn((value: boolean) => {
       stored = value;
+    }),
+    getKeepDisplayAwakeWhileRunning: vi.fn(() => storedDisplayAwake),
+    setKeepDisplayAwakeWhileRunning: vi.fn((value: boolean) => {
+      storedDisplayAwake = value;
     }),
   } as unknown as IWorkspaceSettings;
 
@@ -107,6 +115,48 @@ describe("SleepService", () => {
       true,
     );
     expect(disabled.powerManager.preventSleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks app suspension only when display awake is off", () => {
+    ctx.service.acquire("turn-1");
+    expect(ctx.powerManager.preventSleep).toHaveBeenCalledWith(
+      "prevent-app-suspension",
+    );
+  });
+
+  it("blocks display sleep when display awake is on", () => {
+    const displayAwake = createDeps(true, true);
+    displayAwake.service.acquire("turn-1");
+    expect(displayAwake.powerManager.preventSleep).toHaveBeenCalledWith(
+      "prevent-display-sleep",
+    );
+  });
+
+  it("restarts the blocker with the new type when display awake changes mid-activity", () => {
+    ctx.service.acquire("turn-1");
+    expect(ctx.powerManager.preventSleep).toHaveBeenLastCalledWith(
+      "prevent-app-suspension",
+    );
+
+    ctx.service.setKeepDisplayAwake(true);
+
+    expect(ctx.release).toHaveBeenCalledTimes(1);
+    expect(ctx.powerManager.preventSleep).toHaveBeenLastCalledWith(
+      "prevent-display-sleep",
+    );
+    expect(ctx.settings.setKeepDisplayAwakeWhileRunning).toHaveBeenCalledWith(
+      true,
+    );
+  });
+
+  it("does not restart the blocker when display awake changes with no activity", () => {
+    ctx.service.setKeepDisplayAwake(true);
+    expect(ctx.powerManager.preventSleep).not.toHaveBeenCalled();
+  });
+
+  it("seeds display awake from persisted settings", () => {
+    expect(ctx.service.getKeepDisplayAwake()).toBe(false);
+    expect(createDeps(true, true).service.getKeepDisplayAwake()).toBe(true);
   });
 
   it("releases the blocker on cleanup", () => {

--- a/packages/core/src/sleep/sleep.ts
+++ b/packages/core/src/sleep/sleep.ts
@@ -6,6 +6,7 @@ import {
 import {
   type IPowerManager,
   POWER_MANAGER_SERVICE,
+  type PowerSaveBlockerType,
 } from "@posthog/platform/power-manager";
 import {
   type IWorkspaceSettings,
@@ -16,7 +17,9 @@ import { inject, injectable, preDestroy } from "inversify";
 @injectable()
 export class SleepService {
   private enabled: boolean;
+  private keepDisplayAwake: boolean;
   private releaseBlocker: (() => void) | null = null;
+  private activeBlockerType: PowerSaveBlockerType | null = null;
   private activeActivities = new Set<string>();
   private readonly log: ScopedLogger;
 
@@ -30,6 +33,7 @@ export class SleepService {
   ) {
     this.log = rootLogger.scope("sleep");
     this.enabled = this.settings.getPreventSleepWhileRunning();
+    this.keepDisplayAwake = this.settings.getKeepDisplayAwakeWhileRunning();
   }
 
   setEnabled(enabled: boolean): void {
@@ -41,6 +45,17 @@ export class SleepService {
 
   getEnabled(): boolean {
     return this.enabled;
+  }
+
+  setKeepDisplayAwake(enabled: boolean): void {
+    this.log.info("setKeepDisplayAwake", { enabled });
+    this.keepDisplayAwake = enabled;
+    this.settings.setKeepDisplayAwakeWhileRunning(enabled);
+    this.updateBlocker();
+  }
+
+  getKeepDisplayAwake(): boolean {
+    return this.keepDisplayAwake;
   }
 
   hasBuiltInBattery(): Promise<boolean> {
@@ -63,25 +78,34 @@ export class SleepService {
   }
 
   private updateBlocker(): void {
-    if (this.enabled && this.activeActivities.size > 0) {
-      this.startBlocker();
-    } else {
-      this.stopBlocker();
+    const desiredType = this.desiredBlockerType();
+    if (desiredType === this.activeBlockerType) return;
+    this.stopBlocker();
+    if (desiredType) {
+      this.startBlocker(desiredType);
     }
   }
 
-  private startBlocker(): void {
-    if (this.releaseBlocker) return;
-    this.releaseBlocker = this.powerManager.preventSleep(
-      "prevent-app-suspension",
-    );
-    this.log.info("Started power save blocker");
+  private desiredBlockerType(): PowerSaveBlockerType | null {
+    if (!this.enabled || this.activeActivities.size === 0) return null;
+    return this.keepDisplayAwake
+      ? "prevent-display-sleep"
+      : "prevent-app-suspension";
+  }
+
+  private startBlocker(type: PowerSaveBlockerType): void {
+    this.releaseBlocker = this.powerManager.preventSleep(type);
+    this.activeBlockerType = type;
+    this.log.info("Started power save blocker", { type });
   }
 
   private stopBlocker(): void {
     if (!this.releaseBlocker) return;
-    this.log.info("Stopping power save blocker");
+    this.log.info("Stopping power save blocker", {
+      type: this.activeBlockerType,
+    });
     this.releaseBlocker();
     this.releaseBlocker = null;
+    this.activeBlockerType = null;
   }
 }

--- a/packages/host-router/src/routers/sleep.router.ts
+++ b/packages/host-router/src/routers/sleep.router.ts
@@ -16,6 +16,20 @@ export const sleepRouter = router({
       ctx.container.get<SleepService>(SLEEP_SERVICE).setEnabled(input.enabled);
     }),
 
+  getKeepDisplayAwake: publicProcedure
+    .output(z.boolean())
+    .query(({ ctx }) =>
+      ctx.container.get<SleepService>(SLEEP_SERVICE).getKeepDisplayAwake(),
+    ),
+
+  setKeepDisplayAwake: publicProcedure
+    .input(z.object({ enabled: z.boolean() }))
+    .mutation(({ ctx, input }) => {
+      ctx.container
+        .get<SleepService>(SLEEP_SERVICE)
+        .setKeepDisplayAwake(input.enabled);
+    }),
+
   hasBuiltInBattery: publicProcedure
     .output(z.boolean())
     .query(({ ctx }) =>

--- a/packages/platform/src/power-manager.ts
+++ b/packages/platform/src/power-manager.ts
@@ -1,6 +1,10 @@
+export type PowerSaveBlockerType =
+  | "prevent-app-suspension"
+  | "prevent-display-sleep";
+
 export interface IPowerManager {
   onResume(handler: () => void): () => void;
-  preventSleep(reason: string): () => void;
+  preventSleep(type: PowerSaveBlockerType): () => void;
   hasBuiltInBattery(): Promise<boolean>;
 }
 

--- a/packages/platform/src/workspace-settings.ts
+++ b/packages/platform/src/workspace-settings.ts
@@ -10,6 +10,8 @@ export interface IWorkspaceSettings {
   setAutoSuspendAfterDays(value: number): void;
   getPreventSleepWhileRunning(): boolean;
   setPreventSleepWhileRunning(value: boolean): void;
+  getKeepDisplayAwakeWhileRunning(): boolean;
+  setKeepDisplayAwakeWhileRunning(value: boolean): void;
 }
 
 export const WORKSPACE_SETTINGS_SERVICE = Symbol.for(

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -35,10 +35,17 @@ export function GeneralSettings() {
   const theme = useThemeStore((state) => state.theme);
   const setTheme = useThemeStore((state) => state.setTheme);
   // Power state
-  const { preventSleepWhileRunning, setPreventSleepWhileRunning } =
-    useSettingsStore();
+  const {
+    preventSleepWhileRunning,
+    setPreventSleepWhileRunning,
+    keepDisplayAwakeWhileRunning,
+    setKeepDisplayAwakeWhileRunning,
+  } = useSettingsStore();
   const { data: serverPreventSleep } = useQuery(
     hostTRPC.sleep.getEnabled.queryOptions(),
+  );
+  const { data: serverKeepDisplayAwake } = useQuery(
+    hostTRPC.sleep.getKeepDisplayAwake.queryOptions(),
   );
   const { data: hasBuiltInBattery } = useQuery(
     hostTRPC.sleep.hasBuiltInBattery.queryOptions(),
@@ -46,12 +53,21 @@ export function GeneralSettings() {
   const preventSleepMutation = useMutation(
     hostTRPC.sleep.setEnabled.mutationOptions(),
   );
+  const keepDisplayAwakeMutation = useMutation(
+    hostTRPC.sleep.setKeepDisplayAwake.mutationOptions(),
+  );
 
   useEffect(() => {
     if (serverPreventSleep !== undefined) {
       setPreventSleepWhileRunning(serverPreventSleep);
     }
   }, [serverPreventSleep, setPreventSleepWhileRunning]);
+
+  useEffect(() => {
+    if (serverKeepDisplayAwake !== undefined) {
+      setKeepDisplayAwakeWhileRunning(serverKeepDisplayAwake);
+    }
+  }, [serverKeepDisplayAwake, setKeepDisplayAwakeWhileRunning]);
 
   const handlePreventSleepChange = useCallback(
     (checked: boolean) => {
@@ -64,6 +80,19 @@ export function GeneralSettings() {
       preventSleepMutation.mutate({ enabled: checked });
     },
     [setPreventSleepWhileRunning, preventSleepMutation],
+  );
+
+  const handleKeepDisplayAwakeChange = useCallback(
+    (checked: boolean) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "keep_display_awake_while_running",
+        new_value: checked,
+        old_value: !checked,
+      });
+      setKeepDisplayAwakeWhileRunning(checked);
+      keepDisplayAwakeMutation.mutate({ enabled: checked });
+    },
+    [setKeepDisplayAwakeWhileRunning, keepDisplayAwakeMutation],
   );
 
   // Chat state
@@ -442,11 +471,23 @@ export function GeneralSettings() {
             ? "Prevent your computer from going to sleep on its own while the agent is running a task. Closing the lid will still put it to sleep."
             : "Prevent your computer from going to sleep on its own while the agent is running a task"
         }
-        noBorder
       >
         <Switch
           checked={preventSleepWhileRunning}
           onCheckedChange={handlePreventSleepChange}
+          size="1"
+        />
+      </SettingRow>
+
+      <SettingRow
+        label="Also keep display awake"
+        description="Keep the display on so your computer doesn't lock while the agent works. Useful if commits are signed with a key that needs an unlocked machine (e.g. Secretive). Your screen stays unlocked, so only use this somewhere you trust."
+        noBorder
+      >
+        <Switch
+          checked={preventSleepWhileRunning && keepDisplayAwakeWhileRunning}
+          disabled={!preventSleepWhileRunning}
+          onCheckedChange={handleKeepDisplayAwakeChange}
           size="1"
         />
       </SettingRow>

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -151,12 +151,14 @@ interface SettingsStore {
   // System / power / permissions
   allowBypassPermissions: boolean;
   preventSleepWhileRunning: boolean;
+  keepDisplayAwakeWhileRunning: boolean;
   debugLogsCloudRuns: boolean;
   // When on, cloud runs push their work and open a draft PR on completion
   // without waiting for an explicit ask.
   autoPublishCloudRuns: boolean;
   setAllowBypassPermissions: (enabled: boolean) => void;
   setPreventSleepWhileRunning: (enabled: boolean) => void;
+  setKeepDisplayAwakeWhileRunning: (enabled: boolean) => void;
   setDebugLogsCloudRuns: (enabled: boolean) => void;
   setAutoPublishCloudRuns: (enabled: boolean) => void;
 
@@ -324,12 +326,15 @@ export const useSettingsStore = create<SettingsStore>()(
       // System / power / permissions
       allowBypassPermissions: false,
       preventSleepWhileRunning: false,
+      keepDisplayAwakeWhileRunning: false,
       debugLogsCloudRuns: false,
       autoPublishCloudRuns: true,
       setAllowBypassPermissions: (enabled) =>
         set({ allowBypassPermissions: enabled }),
       setPreventSleepWhileRunning: (enabled) =>
         set({ preventSleepWhileRunning: enabled }),
+      setKeepDisplayAwakeWhileRunning: (enabled) =>
+        set({ keepDisplayAwakeWhileRunning: enabled }),
       setDebugLogsCloudRuns: (enabled) => set({ debugLogsCloudRuns: enabled }),
       setAutoPublishCloudRuns: (enabled) =>
         set({ autoPublishCloudRuns: enabled }),
@@ -444,6 +449,7 @@ export const useSettingsStore = create<SettingsStore>()(
         // System / power / permissions
         allowBypassPermissions: state.allowBypassPermissions,
         preventSleepWhileRunning: state.preventSleepWhileRunning,
+        keepDisplayAwakeWhileRunning: state.keepDisplayAwakeWhileRunning,
         debugLogsCloudRuns: state.debugLogsCloudRuns,
         autoPublishCloudRuns: state.autoPublishCloudRuns,
 


### PR DESCRIPTION
## Problem

The "Keep awake while agents work" setting starts a `prevent-app-suspension` power save blocker, which deliberately lets the display sleep — and display sleep triggers the screen lock. When the Mac locks, Secure Enclave-backed SSH signing agents (e.g. Secretive) can't serve signing requests, so any `git commit` the agent runs fails with `agent refused operation` mid-task and the run dies.

## Change

Adds an opt-in second toggle, **"Also keep display awake"**, nested under the existing keep-awake setting. When both are on, the blocker acquired while a task is running is upgraded from `prevent-app-suspension` to `prevent-display-sleep`, so the display never sleeps and the machine never auto-locks while agents work.

- `IPowerManager.preventSleep` now takes the blocker type (`PowerSaveBlockerType`); the Electron adapter passes it through to `powerSaveBlocker.start`.
- `SleepService` tracks the new `keepDisplayAwakeWhileRunning` setting and picks the blocker type; if the setting flips while a blocker is active, the blocker is restarted with the new type.
- New `sleep.getKeepDisplayAwake` / `sleep.setKeepDisplayAwake` host tRPC procedures, persisted via electron-store like the existing flag.
- Settings UI: the new switch is disabled unless the parent keep-awake toggle is on, with a description calling out the security tradeoff (the machine stays unlocked).
- Off by default.

## Notes

This is the blunt fix for the Secretive-lock problem. A follow-up could interpose an SSH agent proxy on `SSH_AUTH_SOCK` to park signing requests while locked and resume on unlock, which would cover the case without keeping the machine unlocked.

## Testing

- `pnpm typecheck` (23 packages) and Biome lint clean.
- New `SleepService` unit tests: blocker type selection, mid-activity restart on toggle, persistence seeding, no-op when idle.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*