### PR TITLE
fix(agent): default missing tool_use input to {} in session hydration

### DIFF
--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
@@ -548,6 +548,30 @@ describe("conversationTurnsToJsonlEntries", () => {
     expect(conv[2].parentUuid).toBe(conv[1].uuid);
   });
 
+  it.each([undefined, null])(
+    "emits input: {} for tool calls whose input is %s",
+    (missingInput) => {
+      const lines = conversationTurnsToJsonlEntries(
+        [
+          {
+            role: "assistant",
+            content: [],
+            toolCalls: [
+              { toolCallId: "tc-1", toolName: "Bash", input: missingInput },
+            ],
+          },
+        ],
+        config,
+      );
+
+      const conv = parseConversationEntries(lines);
+      expect(conv).toHaveLength(1);
+      expect(conv[0].message.content).toEqual([
+        { type: "tool_use", id: "tc-1", name: "Bash", input: {} },
+      ]);
+    },
+  );
+
   it("sets stop_reason only on last block, null on intermediate", () => {
     const lines = conversationTurnsToJsonlEntries(
       [
@@ -1132,6 +1156,29 @@ describe("end-to-end: S3 log entries -> JSONL output", () => {
     expect(msg1.id).toBe(msg2.id);
     expect(msg2.id).toBe(msg3.id);
   });
+
+  it("emits input: {} when the tool input never reached the logs", () => {
+    const s3Logs: StoredEntry[] = [
+      s3Entry("user_message", {
+        content: { type: "text", text: "run the tests" },
+      }),
+      s3Entry("tool_call", {
+        toolCallId: "tc-lost",
+        _meta: { claudeCode: { toolName: "Bash" } },
+      }),
+    ];
+
+    const turns = rebuildConversation(s3Logs);
+    const lines = conversationTurnsToJsonlEntries(turns, config);
+    const conv = filterConv(lines.map((l) => JSON.parse(l)));
+
+    const toolUseLine = conv.find((e) => e.type === "assistant");
+    expect(toolUseLine).toBeDefined();
+    const content = (toolUseLine?.message as { content: unknown[] }).content;
+    expect(content).toEqual([
+      { type: "tool_use", id: "tc-lost", name: "Bash", input: {} },
+    ]);
+  });
 });
 
 describe("sanitizeSessionJsonl", () => {
@@ -1238,6 +1285,32 @@ describe("sanitizeSessionJsonl", () => {
     const lines = await readJsonl(file);
     const assistant = lines[0].message as { content: unknown };
     expect(assistant.content).toEqual([
+      { type: "tool_use", id: "tc-1", name: "Bash", input: {} },
+    ]);
+  });
+
+  it.each([
+    ["a missing", { type: "tool_use", id: "tc-1", name: "Bash" }],
+    ["a null", { type: "tool_use", id: "tc-1", name: "Bash", input: null }],
+  ])("adds input: {} to tool_use blocks with %s input", async (_, block) => {
+    const file = await writeJsonl([
+      {
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: null,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "running" }, block],
+        },
+      },
+    ]);
+
+    expect(await sanitizeSessionJsonl(file)).toBe(true);
+
+    const lines = await readJsonl(file);
+    const assistant = lines[0].message as { content: unknown };
+    expect(assistant.content).toEqual([
+      { type: "text", text: "running" },
       { type: "tool_use", id: "tc-1", name: "Bash", input: {} },
     ]);
   });

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -195,17 +195,14 @@ export function rebuildConversation(
             // Bare streaming updates carry no name; the opening tool_call
             // always does, so the call exists by the time they arrive.
             if (!toolName) break;
-            toolCall = { toolCallId, toolName, input: undefined };
+            toolCall = { toolCallId, toolName, input: {} };
             currentToolCalls.push(toolCall);
           }
 
           const input = update.rawInput ?? meta?.toolInput;
           // The opening tool_call ships rawInput: {} — don't clobber an
           // already-streamed input with it.
-          if (
-            input !== undefined &&
-            !(isEmptyRecord(input) && toolCall.input !== undefined)
-          ) {
+          if (input !== undefined && !isEmptyRecord(input)) {
             toolCall.input = capToolPayload(input);
           }
           const result = update.rawOutput ?? meta?.toolResponse;
@@ -496,7 +493,8 @@ export function conversationTurnsToJsonlEntries(
             type: "tool_use",
             id: tc.toolCallId,
             name: tc.toolName,
-            input: tc.input,
+            // undefined would be dropped on stringify; the API requires input
+            input: tc.input ?? {},
           });
         }
       }
@@ -594,8 +592,9 @@ interface HydrationLog {
   warn: (msg: string, data?: unknown) => void;
 }
 
-// Heals JSONL files written before the empty-block filters existed; without
-// this an already-poisoned transcript keeps 400ing on every resume.
+// Heals JSONL files written before the empty-block and missing-tool_use-input
+// fixes existed; without this an already-poisoned transcript keeps 400ing on
+// every resume.
 export async function sanitizeSessionJsonl(
   jsonlPath: string,
 ): Promise<boolean> {
@@ -619,10 +618,20 @@ export async function sanitizeSessionJsonl(
     }
     const message = parsed.message as { content?: unknown } | undefined;
     if (!message || !Array.isArray(message.content)) return line;
+    let lineChanged = false;
     const kept = message.content.filter((block) => !isEmptyContentBlock(block));
-    if (kept.length === message.content.length) return line;
+    if (kept.length !== message.content.length) {
+      lineChanged = true;
+      message.content = kept.length > 0 ? kept : [{ type: "text", text: " " }];
+    }
+    for (const block of message.content as (Record<string, unknown> | null)[]) {
+      if (block?.type === "tool_use" && block.input == null) {
+        block.input = {};
+        lineChanged = true;
+      }
+    }
+    if (!lineChanged) return line;
     changed = true;
-    message.content = kept.length > 0 ? kept : [{ type: "text", text: " " }];
     return JSON.stringify(parsed);
   });
 


### PR DESCRIPTION
## Problem

on hybernated cloud task resumes, the agent rebuilds the Claude session JSONL from the S3 activity logs. A tool call whose input never reached the logs (e.g. the sandbox died before the input snapshot was flushed) is rebuilt with `input: undefined`, which `JSON.stringify` drops from the emitted `tool_use` block. The Anthropic API requires `tool_use.input`, so replaying the history fails with `400 messages.N.content.M.tool_use.input: Field required` — and since the broken block is baked into the transcript, every subsequent follow-up and resume of that task fails the same way, permanently.

## Changes

- `jsonl-hydration.ts`: emit `input: tc.input ?? {}` so a missing input serializes as an empty object instead of vanishing from the block.
- `sanitizeSessionJsonl`: also heal already-poisoned transcripts by adding `input: {}` to `tool_use` blocks that lack it, so existing stuck tasks recover on their next resume.