### PR TITLE
fix(agent): forward posthog property headers on the codex gateway path

### DIFF
--- a/packages/agent/src/adapters/acp-connection.ts
+++ b/packages/agent/src/adapters/acp-connection.ts
@@ -225,6 +225,7 @@ function createCodexConnection(config: AcpConnectionConfig): AcpConnection {
         apiKey: codexOptions.apiKey,
         codexHome: codexOptions.codexHome,
         developerInstructions: codexOptions.developerInstructions,
+        httpHeaders: codexOptions.httpHeaders,
         configOverrides: codexOptions.configOverrides,
       },
       model: codexOptions.model,

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -50,6 +50,13 @@ export type GatewayEnv = {
   openaiApiKey: string;
   /** Task-specific custom headers forwarded to the gateway (e.g. task_id, run_id). */
   anthropicCustomHeaders?: string;
+  /**
+   * Same task-metadata attribution headers as {@link anthropicCustomHeaders},
+   * in record form for the codex/OpenAI path (which sets provider
+   * `http_headers` rather than `ANTHROPIC_CUSTOM_HEADERS`). Includes `team_id`,
+   * which the Claude path instead appends in {@link buildEnvironment}.
+   */
+  openaiCustomHeaders?: Record<string, string>;
   /** PostHog project ID for per-team attribution headers. */
   posthogProjectId?: string;
 };

--- a/packages/agent/src/adapters/codex-app-server/spawn.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/spawn.test.ts
@@ -39,6 +39,43 @@ describe("buildAppServerArgs", () => {
     );
   });
 
+  it("forwards http headers as a quoted TOML inline table on the posthog provider", () => {
+    const args = buildAppServerArgs({
+      binaryPath: "/bundle/codex",
+      apiBaseUrl: "https://gateway.example/v1",
+      httpHeaders: {
+        "x-posthog-property-ai_stage": "research",
+        "x-posthog-property-team_id": "42",
+      },
+    });
+
+    expect(args).toContain(
+      'model_providers.posthog.http_headers={ "x-posthog-property-ai_stage" = "research", "x-posthog-property-team_id" = "42" }',
+    );
+  });
+
+  it("omits http_headers when none are provided or the provider is unset", () => {
+    const withoutHeaders = buildAppServerArgs({
+      binaryPath: "/bundle/codex",
+      apiBaseUrl: "https://gateway.example/v1",
+    });
+    const withoutProvider = buildAppServerArgs({
+      binaryPath: "/bundle/codex",
+      httpHeaders: { "x-posthog-property-ai_stage": "research" },
+    });
+
+    expect(
+      withoutHeaders.some((arg) =>
+        arg.startsWith("model_providers.posthog.http_headers="),
+      ),
+    ).toBe(false);
+    expect(
+      withoutProvider.some((arg) =>
+        arg.startsWith("model_providers.posthog.http_headers="),
+      ),
+    ).toBe(false);
+  });
+
   it.each([
     ["darwin", 'sandbox_mode="workspace-write"'],
     ["linux", 'sandbox_mode="danger-full-access"'],

--- a/packages/agent/src/adapters/codex-app-server/spawn.ts
+++ b/packages/agent/src/adapters/codex-app-server/spawn.ts
@@ -17,6 +17,13 @@ export interface CodexOptions {
   apiKey?: string;
   model?: string;
   reasoningEffort?: string;
+  /**
+   * Static HTTP headers forwarded on every request to the PostHog gateway
+   * (the codex equivalent of Claude's `ANTHROPIC_CUSTOM_HEADERS`). Carries the
+   * `x-posthog-property-*` attribution headers the gateway lifts onto the
+   * `$ai_generation` event (team_id, ai_stage, task metadata).
+   */
+  httpHeaders?: Record<string, string>;
   /** Guidance appended on top of Codex's base prompt via `developer_instructions`. */
   developerInstructions?: string;
   /**
@@ -50,6 +57,12 @@ export interface CodexAppServerProcessOptions {
   codexHome?: string;
   /** Guidance appended to Codex's base prompt via `developer_instructions`. */
   developerInstructions?: string;
+  /**
+   * Static HTTP headers forwarded on every request to the PostHog gateway, set
+   * as `model_providers.posthog.http_headers`. Codex equivalent of Claude's
+   * `ANTHROPIC_CUSTOM_HEADERS` (see {@link CodexOptions.httpHeaders}).
+   */
+  httpHeaders?: Record<string, string>;
   /** Extra codex `-c key=value` config overrides (e.g. auto_compact_token_limit). */
   configOverrides?: Record<string, string | number>;
   logger?: Logger;
@@ -61,6 +74,19 @@ export interface CodexAppServerProcess {
   stdin: Writable;
   stdout: Readable;
   kill: () => void;
+}
+
+/** Serialize a string map as a TOML basic string (escapes `\` and `"`). */
+function tomlBasicString(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/** Render a `Record<string, string>` as a TOML inline table. */
+function tomlInlineTable(entries: Record<string, string>): string {
+  const pairs = Object.entries(entries).map(
+    ([key, value]) => `${tomlBasicString(key)} = ${tomlBasicString(value)}`,
+  );
+  return `{ ${pairs.join(", ")} }`;
 }
 
 export function buildAppServerArgs(
@@ -116,6 +142,17 @@ export function buildAppServerArgs(
       "-c",
       `model_providers.posthog.env_key="POSTHOG_GATEWAY_API_KEY"`,
     );
+
+    // Attribution + task-metadata headers the gateway lifts onto the captured
+    // $ai_generation event. Passed as a single TOML inline table so hyphenated
+    // header names (`x-posthog-property-*`) stay quoted rather than becoming
+    // bare-key segments of a dotted `-c` path.
+    if (options.httpHeaders && Object.keys(options.httpHeaders).length > 0) {
+      args.push(
+        "-c",
+        `model_providers.posthog.http_headers=${tomlInlineTable(options.httpHeaders)}`,
+      );
+    }
   }
 
   // developer_instructions are set per-thread in thread/start (with the host's

--- a/packages/agent/src/server/agent-server.configure-environment.test.ts
+++ b/packages/agent/src/server/agent-server.configure-environment.test.ts
@@ -161,6 +161,35 @@ describe("AgentServer.configureEnvironment", () => {
     },
   );
 
+  // The codex/OpenAI path sets provider http_headers rather than
+  // ANTHROPIC_CUSTOM_HEADERS, so the same task metadata must be exposed as a
+  // record — including team_id, which the Claude path adds separately in
+  // buildEnvironment.
+  it("forwards task metadata (plus team_id) as openaiCustomHeaders", () => {
+    const env = buildServer("background").configureEnvironment({
+      isInternal: true,
+      originProduct: "signal_report",
+      signalReportId: "report-123",
+      aiStage: "research",
+      taskId: "task-abc",
+      taskRunId: "run-xyz",
+      taskUserId: 42,
+      taskTitle: "Fix the bug",
+    });
+
+    expect(env.openaiCustomHeaders).toEqual({
+      "x-posthog-property-task_origin_product": "signal_report",
+      "x-posthog-property-task_internal": "true",
+      "x-posthog-property-signal_report_id": "report-123",
+      "x-posthog-property-ai_stage": "research",
+      "x-posthog-property-task_id": "task-abc",
+      "x-posthog-property-task_run_id": "run-xyz",
+      "x-posthog-property-task_user_id": "42",
+      "x-posthog-property-task_title": "Fix the bug",
+      "x-posthog-property-team_id": "1",
+    });
+  });
+
   it("forwards task metadata as anthropicCustomHeaders", () => {
     const env = buildServer("background").configureEnvironment({
       isInternal: true,

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -74,6 +74,7 @@ import type {
 import { resourceLink } from "../utils/acp-content";
 import { AsyncMutex } from "../utils/async-mutex";
 import {
+  buildGatewayPropertyHeaderRecord,
   buildGatewayPropertyHeaders,
   resolveGatewayProduct,
   resolveLlmGatewayUrl,
@@ -1254,6 +1255,7 @@ export class AgentServer {
               model: this.config.model ?? DEFAULT_CODEX_MODEL,
               reasoningEffort: this.config.reasoningEffort,
               developerInstructions: codexInstructions,
+              httpHeaders: gatewayEnv.openaiCustomHeaders,
             }
           : undefined,
       onStructuredOutput: async (output) => {
@@ -3060,12 +3062,11 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
       ? gatewayUrl
       : `${gatewayUrl}/v1`;
     // Forward task metadata as `x-posthog-property-*` headers so the gateway
-    // lifts them onto the $ai_generation event. Routes through the Anthropic
-    // SDK's ANTHROPIC_CUSTOM_HEADERS env var; the OpenAI/codex path has no
-    // equivalent today. (The `team_id` attribution header is added downstream
-    // in the Claude session builder from POSTHOG_PROJECT_ID — see
-    // adapters/claude/session/options.ts.)
-    const customHeaders = buildGatewayPropertyHeaders({
+    // lifts them onto the $ai_generation event. The Claude path routes these
+    // through the Anthropic SDK's ANTHROPIC_CUSTOM_HEADERS env var; the codex
+    // path sets them as `model_providers.posthog.http_headers` instead, so we
+    // also expose the record form below.
+    const gatewayProperties = {
       task_origin_product: originProduct,
       task_internal: isInternal,
       signal_report_id: signalReportId,
@@ -3074,6 +3075,14 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
       task_run_id: taskRunId,
       task_user_id: taskUserId,
       task_title: taskTitle,
+    };
+    const customHeaders = buildGatewayPropertyHeaders(gatewayProperties);
+    // The Claude path appends `team_id` in buildEnvironment from
+    // POSTHOG_PROJECT_ID; the codex path has no such hook, so fold it into the
+    // record here to keep team attribution working for both adapters.
+    const openaiCustomHeaders = buildGatewayPropertyHeaderRecord({
+      ...gatewayProperties,
+      team_id: projectId,
     });
 
     // Server-level constants that don't vary per task — safe to keep in
@@ -3096,6 +3105,7 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
       openaiBaseUrl,
       openaiApiKey: apiKey,
       anthropicCustomHeaders: customHeaders,
+      openaiCustomHeaders,
       posthogProjectId: String(projectId),
     };
   }

--- a/packages/agent/src/utils/gateway.ts
+++ b/packages/agent/src/utils/gateway.ts
@@ -31,7 +31,10 @@ export function resolveGatewayProduct({
   return "posthog_code";
 }
 
-export { buildPosthogPropertyHeaderLines as buildGatewayPropertyHeaders } from "@posthog/shared/posthog-property-headers";
+export {
+  buildPosthogPropertyHeaderLines as buildGatewayPropertyHeaders,
+  buildPosthogPropertyHeaderRecord as buildGatewayPropertyHeaderRecord,
+} from "@posthog/shared/posthog-property-headers";
 
 function getGatewayBaseUrl(posthogHost: string): string {
   const url = new URL(posthogHost);


### PR DESCRIPTION
## Problem

For agent runs on the **codex** harness, none of the `x-posthog-property-*` attribution/metadata headers that the LLM gateway lifts onto the captured `$ai_generation` event were being sent. Only the **claude** harness sent them (via the Anthropic SDK's `ANTHROPIC_CUSTOM_HEADERS`). The codex path set up the `posthog` model provider but attached no headers at all.

The visible symptom: signals pipeline work on codex was untagged — `ai_stage` never reached the gateway. While fixing that, the same gap dropped every other property the claude path sends, including `team_id` (used for team spend attribution), `task_origin_product`, `task_internal`, `signal_report_id`, `task_id`, `task_run_id`, `task_user_id`, and `task_title`.

## Changes

- `configureEnvironment` now also builds the property set in record form (`openaiCustomHeaders`) and returns it on `GatewayEnv`. It folds in `team_id` here, since the claude path adds that separately in `buildEnvironment` and the codex path has no equivalent hook.
- The codex adapter accepts `httpHeaders` and emits them as `model_providers.posthog.http_headers` — a single TOML inline table so hyphenated header names (`x-posthog-property-*`) stay quoted rather than being parsed as bare-key segments of a dotted `-c` path.
- Codex forwards a model provider's `http_headers` on every request to that provider's base URL (the gateway), so the gateway lifts them onto the event exactly as it does for claude.
- The Anthropic-only `x-posthog-use-bedrock-fallback` routing header is intentionally left off the OpenAI/codex path.

## How did you test this?

- Added unit coverage: `buildAppServerArgs` emits the quoted inline table (and omits it when no headers or no provider), and `configureEnvironment` returns `openaiCustomHeaders` with the full property set plus `team_id`.
- Ran the codex-adapter and configure-environment suites: 32 passed. (Two failures in `local-tools-mcp.test.ts` are pre-existing and environment-only — they read an ambient GitHub token from the sandbox; they fail identically on a clean checkout.)
- Typecheck clean (`pnpm --filter @posthog/agent typecheck`).
- Validated against the real codex binary with `--strict-config` (which errors on unrecognized fields): the `http_headers` inline table parses and the `posthog` provider is recognized; the only failures reported are the expected runtime auth/reachability checks.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1783588199032839)*