### PR TITLE
fix(models): never use Fable as the default model for new tasks

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -127,7 +127,7 @@ export {
   mentionsToPlainText,
   splitMentionSegments,
 } from "./mentions";
-export { isModelExcludedFromDefault } from "./models";
+export { defaultEligibleModel } from "./models";
 export {
   getOauthClientIdFromRegion,
   OAUTH_SCOPE_VERSION,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -127,6 +127,7 @@ export {
   mentionsToPlainText,
   splitMentionSegments,
 } from "./mentions";
+export { isModelExcludedFromDefault } from "./models";
 export {
   getOauthClientIdFromRegion,
   OAUTH_SCOPE_VERSION,

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -1,20 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { isModelExcludedFromDefault } from "./models";
+import { defaultEligibleModel } from "./models";
 
-describe("isModelExcludedFromDefault", () => {
+describe("defaultEligibleModel", () => {
   it.each([
-    ["claude-fable-5", true],
-    ["anthropic/claude-fable-5", true],
-    ["CLAUDE-FABLE-5", true],
-    ["claude-fable-5-20260601", true],
-    ["claude-opus-4-8", false],
-    ["claude-sonnet-5", false],
-    ["gpt-5.5", false],
-    ["@cf/zai-org/glm-5.2", false],
-    ["", false],
-    [null, false],
-    [undefined, false],
+    ["claude-fable-5", undefined],
+    ["anthropic/claude-fable-5", undefined],
+    ["CLAUDE-FABLE-5", undefined],
+    ["claude-fable-5-20260601", undefined],
+    ["claude-opus-4-8", "claude-opus-4-8"],
+    ["claude-sonnet-5", "claude-sonnet-5"],
+    ["gpt-5.5", "gpt-5.5"],
+    ["@cf/zai-org/glm-5.2", "@cf/zai-org/glm-5.2"],
+    // Contains "fable" as a substring but is not the Fable family.
+    ["gpt-affable-1", "gpt-affable-1"],
+    ["", undefined],
+    [null, undefined],
+    [undefined, undefined],
   ] as const)("%s -> %s", (modelId, expected) => {
-    expect(isModelExcludedFromDefault(modelId)).toBe(expected);
+    expect(defaultEligibleModel(modelId)).toBe(expected);
   });
 });

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isModelExcludedFromDefault } from "./models";
+
+describe("isModelExcludedFromDefault", () => {
+  it.each([
+    ["claude-fable-5", true],
+    ["anthropic/claude-fable-5", true],
+    ["CLAUDE-FABLE-5", true],
+    ["claude-fable-5-20260601", true],
+    ["claude-opus-4-8", false],
+    ["claude-sonnet-5", false],
+    ["gpt-5.5", false],
+    ["@cf/zai-org/glm-5.2", false],
+    ["", false],
+    [null, false],
+    [undefined, false],
+  ] as const)("%s -> %s", (modelId, expected) => {
+    expect(isModelExcludedFromDefault(modelId)).toBe(expected);
+  });
+});

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1,13 +1,22 @@
 /**
- * Model families that must be picked explicitly for every task: they are never
- * carried over from `lastUsedModel` as the implicit default for a new task or
- * one-click cloud run. Currently the premium Fable tier, which is priced well
- * above the standard models — a user who tried it once shouldn't keep paying
- * for it by default. Explicit selections (composer pick, action-pinned model,
- * deep-link model) are unaffected.
+ * Filter a model id down to one that may serve as an implicit default.
+ *
+ * Premium model families (currently Fable) are never carried over from
+ * `lastUsedModel` as the default for a new task or one-click cloud run — a
+ * user who tried one once shouldn't keep paying its price tier by inertia.
+ * Explicit selections (composer pick, action-pinned model, deep-link model)
+ * are unaffected.
+ *
+ * Returns the id unchanged when it may be used as a default, or undefined
+ * when it must be an explicit per-task pick instead.
  */
-export function isModelExcludedFromDefault(
+export function defaultEligibleModel(
   modelId: string | null | undefined,
-): boolean {
-  return !!modelId && modelId.toLowerCase().includes("fable");
+): string | undefined {
+  if (!modelId) return undefined;
+  // Anchored family check (not a bare substring) so an unrelated id that
+  // merely contains the word can't be excluded; provider prefixes such as
+  // "anthropic/" are ignored.
+  const family = modelId.toLowerCase().split("/").pop() ?? "";
+  return family.startsWith("claude-fable") ? undefined : modelId;
 }

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1,22 +1,11 @@
 /**
- * Filter a model id down to one that may serve as an implicit default.
- *
- * Premium model families (currently Fable) are never carried over from
- * `lastUsedModel` as the default for a new task or one-click cloud run — a
- * user who tried one once shouldn't keep paying its price tier by inertia.
- * Explicit selections (composer pick, action-pinned model, deep-link model)
- * are unaffected.
- *
- * Returns the id unchanged when it may be used as a default, or undefined
- * when it must be an explicit per-task pick instead.
+ * Returns the id unless it's a premium family (currently Fable) that must be
+ * an explicit per-task pick and never the implicit default for a new task.
  */
 export function defaultEligibleModel(
   modelId: string | null | undefined,
 ): string | undefined {
   if (!modelId) return undefined;
-  // Anchored family check (not a bare substring) so an unrelated id that
-  // merely contains the word can't be excluded; provider prefixes such as
-  // "anthropic/" are ignored.
   const family = modelId.toLowerCase().split("/").pop() ?? "";
   return family.startsWith("claude-fable") ? undefined : modelId;
 }

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1,0 +1,13 @@
+/**
+ * Model families that must be picked explicitly for every task: they are never
+ * carried over from `lastUsedModel` as the implicit default for a new task or
+ * one-click cloud run. Currently the premium Fable tier, which is priced well
+ * above the standard models — a user who tried it once shouldn't keep paying
+ * for it by default. Explicit selections (composer pick, action-pinned model,
+ * deep-link model) are unaffected.
+ */
+export function isModelExcludedFromDefault(
+  modelId: string | null | undefined,
+): boolean {
+  return !!modelId && modelId.toLowerCase().includes("fable");
+}

--- a/packages/ui/src/features/home/hooks/useRunWorkstreamAction.ts
+++ b/packages/ui/src/features/home/hooks/useRunWorkstreamAction.ts
@@ -10,6 +10,7 @@ import { useService } from "@posthog/di/react";
 import {
   ANALYTICS_EVENTS,
   getCloudUrlFromRegion,
+  isModelExcludedFromDefault,
   type TaskCreationInput,
 } from "@posthog/shared";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -101,9 +102,15 @@ export function useRunWorkstreamAction(): RunWorkstreamAction {
           // The cloud runtime requires a model: action-pinned, then last-used,
           // then the adapter's server default. The preferred candidate is only
           // honoured if the gateway still offers it (the resolver validates it),
-          // so a stale persisted/pinned id can't reach the run and 403.
+          // so a stale persisted/pinned id can't reach the run and 403. A
+          // premium last-used model (e.g. fable) is skipped — only an explicit
+          // action pin may select it; it is never the implicit default.
           const adapter = action.adapter ?? lastUsedAdapter;
-          const preferredModel = action.model ?? lastUsedModel ?? undefined;
+          const preferredModel =
+            action.model ??
+            (isModelExcludedFromDefault(lastUsedModel)
+              ? undefined
+              : (lastUsedModel ?? undefined));
           let model = preferredModel;
           if (cloudRegion) {
             // The resolver swallows transient failures and returns undefined; fall

--- a/packages/ui/src/features/home/hooks/useRunWorkstreamAction.ts
+++ b/packages/ui/src/features/home/hooks/useRunWorkstreamAction.ts
@@ -9,8 +9,8 @@ import type { TaskService } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
 import {
   ANALYTICS_EVENTS,
+  defaultEligibleModel,
   getCloudUrlFromRegion,
-  isModelExcludedFromDefault,
   type TaskCreationInput,
 } from "@posthog/shared";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -103,14 +103,11 @@ export function useRunWorkstreamAction(): RunWorkstreamAction {
           // then the adapter's server default. The preferred candidate is only
           // honoured if the gateway still offers it (the resolver validates it),
           // so a stale persisted/pinned id can't reach the run and 403. A
-          // premium last-used model (e.g. fable) is skipped — only an explicit
-          // action pin may select it; it is never the implicit default.
+          // premium last-used model is skipped (see defaultEligibleModel);
+          // only an explicit action pin may select it.
           const adapter = action.adapter ?? lastUsedAdapter;
           const preferredModel =
-            action.model ??
-            (isModelExcludedFromDefault(lastUsedModel)
-              ? undefined
-              : (lastUsedModel ?? undefined));
+            action.model ?? defaultEligibleModel(lastUsedModel);
           let model = preferredModel;
           if (cloudRegion) {
             // The resolver swallows transient failures and returns undefined; fall

--- a/packages/ui/src/features/home/hooks/useRunWorkstreamAction.ts
+++ b/packages/ui/src/features/home/hooks/useRunWorkstreamAction.ts
@@ -102,9 +102,7 @@ export function useRunWorkstreamAction(): RunWorkstreamAction {
           // The cloud runtime requires a model: action-pinned, then last-used,
           // then the adapter's server default. The preferred candidate is only
           // honoured if the gateway still offers it (the resolver validates it),
-          // so a stale persisted/pinned id can't reach the run and 403. A
-          // premium last-used model is skipped (see defaultEligibleModel);
-          // only an explicit action pin may select it.
+          // so a stale persisted/pinned id can't reach the run and 403.
           const adapter = action.adapter ?? lastUsedAdapter;
           const preferredModel =
             action.model ?? defaultEligibleModel(lastUsedModel);

--- a/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -11,7 +11,11 @@ import {
 } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
 import { Button } from "@posthog/quill";
-import { ANALYTICS_EVENTS, getCloudUrlFromRegion } from "@posthog/shared";
+import {
+  ANALYTICS_EVENTS,
+  getCloudUrlFromRegion,
+  isModelExcludedFromDefault,
+} from "@posthog/shared";
 import { SELF_DRIVING_SETUP_TASK_FLAG } from "@posthog/shared/constants";
 import { useTrackAgentsViewed } from "@posthog/ui/features/agents/hooks/useTrackAgentsViewed";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -302,17 +306,22 @@ function SetupTaskSection() {
       const settings = useSettingsStore.getState();
       const adapter = settings.lastUsedAdapter ?? "claude";
       const apiHost = getCloudUrlFromRegion(cloudRegion);
+      // A premium last-used model (e.g. fable) is dropped — it must be an
+      // explicit per-task pick, never the implicit default for a setup run.
+      const preferredModel = isModelExcludedFromDefault(settings.lastUsedModel)
+        ? null
+        : settings.lastUsedModel;
       const resolvedModel = await resolveDefaultModel(
         queryClient,
         apiHost,
         adapter,
         modelResolver,
-        settings.lastUsedModel,
+        preferredModel,
       );
       // The resolver returns undefined on a transient failure; fall back to the
       // persisted id so a gateway outage degrades gracefully rather than blocking
       // setup for a user whose persisted model was valid.
-      const model = resolvedModel ?? settings.lastUsedModel;
+      const model = resolvedModel ?? preferredModel;
 
       if (!model) {
         toast.dismiss(toastId);

--- a/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -306,7 +306,6 @@ function SetupTaskSection() {
       const settings = useSettingsStore.getState();
       const adapter = settings.lastUsedAdapter ?? "claude";
       const apiHost = getCloudUrlFromRegion(cloudRegion);
-      // Premium last-used models are dropped (see defaultEligibleModel).
       const preferredModel = defaultEligibleModel(settings.lastUsedModel);
       const resolvedModel = await resolveDefaultModel(
         queryClient,

--- a/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -13,8 +13,8 @@ import { useService } from "@posthog/di/react";
 import { Button } from "@posthog/quill";
 import {
   ANALYTICS_EVENTS,
+  defaultEligibleModel,
   getCloudUrlFromRegion,
-  isModelExcludedFromDefault,
 } from "@posthog/shared";
 import { SELF_DRIVING_SETUP_TASK_FLAG } from "@posthog/shared/constants";
 import { useTrackAgentsViewed } from "@posthog/ui/features/agents/hooks/useTrackAgentsViewed";
@@ -306,11 +306,8 @@ function SetupTaskSection() {
       const settings = useSettingsStore.getState();
       const adapter = settings.lastUsedAdapter ?? "claude";
       const apiHost = getCloudUrlFromRegion(cloudRegion);
-      // A premium last-used model (e.g. fable) is dropped — it must be an
-      // explicit per-task pick, never the implicit default for a setup run.
-      const preferredModel = isModelExcludedFromDefault(settings.lastUsedModel)
-        ? null
-        : settings.lastUsedModel;
+      // Premium last-used models are dropped (see defaultEligibleModel).
+      const preferredModel = defaultEligibleModel(settings.lastUsedModel);
       const resolvedModel = await resolveDefaultModel(
         queryClient,
         apiHost,

--- a/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -13,8 +13,8 @@ import { useService } from "@posthog/di/react";
 import {
   type Adapter,
   ANALYTICS_EVENTS,
+  defaultEligibleModel,
   getCloudUrlFromRegion,
-  isModelExcludedFromDefault,
 } from "@posthog/shared";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { showOfflineToast } from "@posthog/ui/features/connectivity/connectivityToast";
@@ -171,11 +171,8 @@ export function useInboxCloudTaskRunner({
     // resolver keeps it only if the gateway still offers it, otherwise it falls
     // back to the server default. A stale id (e.g. one later de-listed for the
     // org) would otherwise be sent here and fail the run with a gateway 403.
-    // A premium last-used model (e.g. fable) is dropped entirely — it must be
-    // an explicit per-task pick, never the implicit default for a one-click run.
-    const preferredModel = isModelExcludedFromDefault(settings.lastUsedModel)
-      ? null
-      : settings.lastUsedModel;
+    // Premium last-used models are dropped (see defaultEligibleModel).
+    const preferredModel = defaultEligibleModel(settings.lastUsedModel);
     const resolvedModel = await resolveDefaultModel(
       queryClient,
       apiHost,

--- a/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -171,7 +171,6 @@ export function useInboxCloudTaskRunner({
     // resolver keeps it only if the gateway still offers it, otherwise it falls
     // back to the server default. A stale id (e.g. one later de-listed for the
     // org) would otherwise be sent here and fail the run with a gateway 403.
-    // Premium last-used models are dropped (see defaultEligibleModel).
     const preferredModel = defaultEligibleModel(settings.lastUsedModel);
     const resolvedModel = await resolveDefaultModel(
       queryClient,

--- a/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -14,6 +14,7 @@ import {
   type Adapter,
   ANALYTICS_EVENTS,
   getCloudUrlFromRegion,
+  isModelExcludedFromDefault,
 } from "@posthog/shared";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { showOfflineToast } from "@posthog/ui/features/connectivity/connectivityToast";
@@ -170,16 +171,21 @@ export function useInboxCloudTaskRunner({
     // resolver keeps it only if the gateway still offers it, otherwise it falls
     // back to the server default. A stale id (e.g. one later de-listed for the
     // org) would otherwise be sent here and fail the run with a gateway 403.
+    // A premium last-used model (e.g. fable) is dropped entirely — it must be
+    // an explicit per-task pick, never the implicit default for a one-click run.
+    const preferredModel = isModelExcludedFromDefault(settings.lastUsedModel)
+      ? null
+      : settings.lastUsedModel;
     const resolvedModel = await resolveDefaultModel(
       queryClient,
       apiHost,
       adapter,
       modelResolver,
-      settings.lastUsedModel,
+      preferredModel,
     );
     // The resolver returns undefined on a transient failure; fall back to the
     // persisted id so a gateway outage degrades gracefully rather than blocking.
-    const model = resolvedModel ?? settings.lastUsedModel;
+    const model = resolvedModel ?? preferredModel;
 
     if (!model) {
       toast.dismiss(toastId);

--- a/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -8,9 +8,9 @@ import {
 import { useHostTRPCClient } from "@posthog/host-router/react";
 import {
   type Adapter,
+  defaultEligibleModel,
   GLM_MODEL_FLAG,
   getCloudUrlFromRegion,
-  isModelExcludedFromDefault,
 } from "@posthog/shared";
 import { stripGlmModelOption } from "@posthog/ui/features/sessions/modelOptionFilters";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -109,24 +109,23 @@ export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
         // The server always returns its default model as the current value, so
         // without this the user's last pick is lost on every refetch/remount.
         // Restore it through applyConfigChange so the dependent effort options
-        // are recomputed for the restored model. Premium models (e.g. fable)
-        // are deliberately NOT restored: picking one applies to that task only,
-        // and the next composer falls back to the server default so nobody
-        // keeps paying the premium price tier by inertia.
+        // are recomputed for the restored model. Premium picks are not
+        // restored (see defaultEligibleModel) — the composer falls back to
+        // the server default.
         const modelOpt = getOptionByCategory(initial, "model");
+        const restorableModel = defaultEligibleModel(lastUsedModel);
         if (
-          lastUsedModel &&
-          !isModelExcludedFromDefault(lastUsedModel) &&
+          restorableModel &&
           modelOpt?.type === "select" &&
-          modelOpt.currentValue !== lastUsedModel &&
-          flattenConfigValues(modelOpt).includes(lastUsedModel)
+          modelOpt.currentValue !== restorableModel &&
+          flattenConfigValues(modelOpt).includes(restorableModel)
         ) {
           initial = applyConfigChange(initial, {
             adapter,
             configId: modelOpt.id,
-            value: lastUsedModel,
+            value: restorableModel,
             effortOptions:
-              getReasoningEffortOptions(adapter, lastUsedModel) ?? undefined,
+              getReasoningEffortOptions(adapter, restorableModel) ?? undefined,
             settings: {
               defaultInitialTaskMode: "",
               lastUsedInitialTaskMode: undefined,

--- a/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -107,11 +107,9 @@ export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
         );
 
         // The server always returns its default model as the current value, so
-        // without this the user's last pick is lost on every refetch/remount.
-        // Restore it through applyConfigChange so the dependent effort options
-        // are recomputed for the restored model. Premium picks are not
-        // restored (see defaultEligibleModel) — the composer falls back to
-        // the server default.
+        // without this the user's last (default-eligible) pick is lost on every
+        // refetch/remount. Restore it through applyConfigChange so the
+        // dependent effort options are recomputed for the restored model.
         const modelOpt = getOptionByCategory(initial, "model");
         const restorableModel = defaultEligibleModel(lastUsedModel);
         if (

--- a/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -10,6 +10,7 @@ import {
   type Adapter,
   GLM_MODEL_FLAG,
   getCloudUrlFromRegion,
+  isModelExcludedFromDefault,
 } from "@posthog/shared";
 import { stripGlmModelOption } from "@posthog/ui/features/sessions/modelOptionFilters";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -106,12 +107,16 @@ export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
         );
 
         // The server always returns its default model as the current value, so
-        // without this the user's last pick (e.g. fable) is lost on every
-        // refetch/remount. Restore it through applyConfigChange so the dependent
-        // effort options are recomputed for the restored model.
+        // without this the user's last pick is lost on every refetch/remount.
+        // Restore it through applyConfigChange so the dependent effort options
+        // are recomputed for the restored model. Premium models (e.g. fable)
+        // are deliberately NOT restored: picking one applies to that task only,
+        // and the next composer falls back to the server default so nobody
+        // keeps paying the premium price tier by inertia.
         const modelOpt = getOptionByCategory(initial, "model");
         if (
           lastUsedModel &&
+          !isModelExcludedFromDefault(lastUsedModel) &&
           modelOpt?.type === "select" &&
           modelOpt.currentValue !== lastUsedModel &&
           flattenConfigValues(modelOpt).includes(lastUsedModel)


### PR DESCRIPTION
## Problem

let's limit paying premium by inertia

## Changes

Added `isModelExcludedFromDefault()` to `@posthog/shared` (currently matching the Fable family) and applied it everywhere `lastUsedModel` is turned into a default