### PR TITLE
perf(ui): coalesce persisted-store writes before they hit host storage

### DIFF
--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -15,6 +15,28 @@ const removeItem = vi.fn();
 
 registerRendererStateStorage({ getItem, setItem, removeItem });
 
+// Lands any coalesced write from the previous test on the old mocks (so a
+// pending value cannot leak into this test's reads or assertions), then
+// resets them.
+async function resetPersistenceMocks() {
+  await flushRendererStateWrites();
+  getItem.mockReset();
+  setItem.mockReset();
+  removeItem.mockReset();
+  getItem.mockResolvedValue(null);
+  setItem.mockResolvedValue(undefined);
+  removeItem.mockResolvedValue(undefined);
+}
+
+// Persisted writes are debounced; flush while polling so the assertion sees
+// the coalesced write as soon as the store has queued it.
+async function waitForPersistedWrite() {
+  await vi.waitFor(async () => {
+    await flushRendererStateWrites();
+    expect(setItem).toHaveBeenCalled();
+  });
+}
+
 // Runs before any test mutates the store singleton, so getState() still
 // reflects the initial values.
 describe("feature settingsStore defaults", () => {
@@ -28,16 +50,8 @@ describe("feature settingsStore defaults", () => {
 });
 
 describe("feature settingsStore cloud selections", () => {
-  beforeEach(() => {
-    // Land any coalesced write from the previous test on the old mocks so a
-    // pending value cannot leak into this test's reads or assertions.
-    flushRendererStateWrites();
-    getItem.mockReset();
-    setItem.mockReset();
-    removeItem.mockReset();
-    getItem.mockResolvedValue(null);
-    setItem.mockResolvedValue(undefined);
-    removeItem.mockResolvedValue(undefined);
+  beforeEach(async () => {
+    await resetPersistenceMocks();
 
     useSettingsStore.setState({
       allowBypassPermissions: false,
@@ -49,10 +63,7 @@ describe("feature settingsStore cloud selections", () => {
   it("persists the last used cloud repository", async () => {
     useSettingsStore.getState().setLastUsedCloudRepository("posthog/posthog");
 
-    await vi.waitFor(() => {
-      flushRendererStateWrites();
-      expect(setItem).toHaveBeenCalled();
-    });
+    await waitForPersistedWrite();
 
     const lastCall = setItem.mock.calls[setItem.mock.calls.length - 1];
     const persisted = JSON.parse(lastCall[1]);
@@ -89,10 +100,7 @@ describe("feature settingsStore cloud selections", () => {
       },
     });
 
-    await vi.waitFor(() => {
-      flushRendererStateWrites();
-      expect(setItem).toHaveBeenCalled();
-    });
+    await waitForPersistedWrite();
 
     const lastCall = setItem.mock.calls[setItem.mock.calls.length - 1];
     const persisted = JSON.parse(lastCall[1]);
@@ -178,16 +186,8 @@ describe("feature settingsStore cloud selections", () => {
 });
 
 describe("feature settingsStore custom sounds", () => {
-  beforeEach(() => {
-    // Land any coalesced write from the previous test on the old mocks so a
-    // pending value cannot leak into this test's reads or assertions.
-    flushRendererStateWrites();
-    getItem.mockReset();
-    setItem.mockReset();
-    removeItem.mockReset();
-    getItem.mockResolvedValue(null);
-    setItem.mockResolvedValue(undefined);
-    removeItem.mockResolvedValue(undefined);
+  beforeEach(async () => {
+    await resetPersistenceMocks();
 
     useSettingsStore.setState({ customSounds: [], completionSound: "none" });
   });
@@ -250,10 +250,7 @@ describe("feature settingsStore custom sounds", () => {
   it("persists custom sounds", async () => {
     useSettingsStore.getState().addCustomSound(sound);
 
-    await vi.waitFor(() => {
-      flushRendererStateWrites();
-      expect(setItem).toHaveBeenCalled();
-    });
+    await waitForPersistedWrite();
 
     const lastCall = setItem.mock.calls[setItem.mock.calls.length - 1];
     const persisted = JSON.parse(lastCall[1]);
@@ -296,16 +293,8 @@ describe("feature settingsStore custom sounds", () => {
 });
 
 describe("feature settingsStore terminal font", () => {
-  beforeEach(() => {
-    // Land any coalesced write from the previous test on the old mocks so a
-    // pending value cannot leak into this test's reads or assertions.
-    flushRendererStateWrites();
-    getItem.mockReset();
-    setItem.mockReset();
-    removeItem.mockReset();
-    getItem.mockResolvedValue(null);
-    setItem.mockResolvedValue(undefined);
-    removeItem.mockResolvedValue(undefined);
+  beforeEach(async () => {
+    await resetPersistenceMocks();
 
     useSettingsStore.setState({
       terminalFont: "berkeley-mono",
@@ -322,10 +311,7 @@ describe("feature settingsStore terminal font", () => {
     useSettingsStore.getState().setTerminalFont("custom");
     useSettingsStore.getState().setTerminalCustomFontFamily("Fira Code");
 
-    await vi.waitFor(() => {
-      flushRendererStateWrites();
-      expect(setItem).toHaveBeenCalled();
-    });
+    await waitForPersistedWrite();
 
     const lastCall = setItem.mock.calls[setItem.mock.calls.length - 1];
     const persisted = JSON.parse(lastCall[1]);

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -1,4 +1,7 @@
-import { registerRendererStateStorage } from "@posthog/ui/shell/rendererStorage";
+import {
+  flushRendererStateWrites,
+  registerRendererStateStorage,
+} from "@posthog/ui/shell/rendererStorage";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type CompletionSound,
@@ -26,6 +29,9 @@ describe("feature settingsStore defaults", () => {
 
 describe("feature settingsStore cloud selections", () => {
   beforeEach(() => {
+    // Land any coalesced write from the previous test on the old mocks so a
+    // pending value cannot leak into this test's reads or assertions.
+    flushRendererStateWrites();
     getItem.mockReset();
     setItem.mockReset();
     removeItem.mockReset();
@@ -44,6 +50,7 @@ describe("feature settingsStore cloud selections", () => {
     useSettingsStore.getState().setLastUsedCloudRepository("posthog/posthog");
 
     await vi.waitFor(() => {
+      flushRendererStateWrites();
       expect(setItem).toHaveBeenCalled();
     });
 
@@ -83,6 +90,7 @@ describe("feature settingsStore cloud selections", () => {
     });
 
     await vi.waitFor(() => {
+      flushRendererStateWrites();
       expect(setItem).toHaveBeenCalled();
     });
 
@@ -171,6 +179,9 @@ describe("feature settingsStore cloud selections", () => {
 
 describe("feature settingsStore custom sounds", () => {
   beforeEach(() => {
+    // Land any coalesced write from the previous test on the old mocks so a
+    // pending value cannot leak into this test's reads or assertions.
+    flushRendererStateWrites();
     getItem.mockReset();
     setItem.mockReset();
     removeItem.mockReset();
@@ -240,6 +251,7 @@ describe("feature settingsStore custom sounds", () => {
     useSettingsStore.getState().addCustomSound(sound);
 
     await vi.waitFor(() => {
+      flushRendererStateWrites();
       expect(setItem).toHaveBeenCalled();
     });
 
@@ -285,6 +297,9 @@ describe("feature settingsStore custom sounds", () => {
 
 describe("feature settingsStore terminal font", () => {
   beforeEach(() => {
+    // Land any coalesced write from the previous test on the old mocks so a
+    // pending value cannot leak into this test's reads or assertions.
+    flushRendererStateWrites();
     getItem.mockReset();
     setItem.mockReset();
     removeItem.mockReset();
@@ -308,6 +323,7 @@ describe("feature settingsStore terminal font", () => {
     useSettingsStore.getState().setTerminalCustomFontFamily("Fira Code");
 
     await vi.waitFor(() => {
+      flushRendererStateWrites();
       expect(setItem).toHaveBeenCalled();
     });
 

--- a/packages/ui/src/shell/rendererStorage.test.ts
+++ b/packages/ui/src/shell/rendererStorage.test.ts
@@ -1,15 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-
-// Debounce constants mirrored from rendererStorage.ts.
-const WRITE_DEBOUNCE_MS = 1_000;
+import { WRITE_DEBOUNCE_MS } from "./rendererStorage";
 
 type RendererStorageModule = typeof import("./rendererStorage");
 
 async function importFreshRendererStorage(): Promise<RendererStorageModule> {
   vi.resetModules();
   return await import("./rendererStorage");
+}
+
+/** Fresh module with fake timers and a backend already registered. */
+async function setupRegisteredBackend(data: Record<string, string> = {}) {
+  vi.useFakeTimers();
+  const module = await importFreshRendererStorage();
+  const backend = fakeBackend(data);
+  module.registerRendererStateStorage(backend);
+  return { module, storage: jsonStorageOf(module), backend };
 }
 
 function fakeBackend(data: Record<string, string>) {
@@ -211,8 +218,8 @@ describe("rendererStorage", () => {
     });
 
     useStore.setState({ defaultInitialTaskMode: "plan" });
-    await vi.waitFor(() => {
-      module.flushRendererStateWrites();
+    await vi.waitFor(async () => {
+      await module.flushRendererStateWrites();
       expect(backend.setItem).toHaveBeenCalled();
     });
     const persisted = JSON.parse(
@@ -222,11 +229,7 @@ describe("rendererStorage", () => {
   });
 
   it("coalesces a burst of writes into one backend write with the latest value", async () => {
-    vi.useFakeTimers();
-    const module = await importFreshRendererStorage();
-    const storage = jsonStorageOf(module);
-    const backend = fakeBackend({});
-    module.registerRendererStateStorage(backend);
+    const { storage, backend } = await setupRegisteredBackend();
 
     await storage.setItem("drafts", { state: { value: 1 }, version: 0 });
     await storage.setItem("drafts", { state: { value: 2 }, version: 0 });
@@ -240,11 +243,7 @@ describe("rendererStorage", () => {
   });
 
   it("flushes at the max-wait bound during sustained writes", async () => {
-    vi.useFakeTimers();
-    const module = await importFreshRendererStorage();
-    const storage = jsonStorageOf(module);
-    const backend = fakeBackend({});
-    module.registerRendererStateStorage(backend);
+    const { storage, backend } = await setupRegisteredBackend();
 
     // Write every 500ms for 6s: a plain trailing debounce would never fire,
     // the max-wait bound forces a flush mid-burst.
@@ -260,13 +259,9 @@ describe("rendererStorage", () => {
   });
 
   it("lands the pending coalesced write before serving a read", async () => {
-    vi.useFakeTimers();
-    const module = await importFreshRendererStorage();
-    const storage = jsonStorageOf(module);
-    const backend = fakeBackend({
+    const { storage, backend } = await setupRegisteredBackend({
       drafts: JSON.stringify({ state: { value: "stale" }, version: 0 }),
     });
-    module.registerRendererStateStorage(backend);
 
     await storage.setItem("drafts", { state: { value: "fresh" }, version: 0 });
 
@@ -282,11 +277,7 @@ describe("rendererStorage", () => {
   });
 
   it("cancels a pending write when the key is removed", async () => {
-    vi.useFakeTimers();
-    const module = await importFreshRendererStorage();
-    const storage = jsonStorageOf(module);
-    const backend = fakeBackend({});
-    module.registerRendererStateStorage(backend);
+    const { storage, backend } = await setupRegisteredBackend();
 
     await storage.setItem("drafts", { state: { value: 1 }, version: 0 });
     await storage.removeItem("drafts");
@@ -297,15 +288,10 @@ describe("rendererStorage", () => {
   });
 
   it("flushRendererStateWrites persists pending state immediately", async () => {
-    vi.useFakeTimers();
-    const module = await importFreshRendererStorage();
-    const storage = jsonStorageOf(module);
-    const backend = fakeBackend({});
-    module.registerRendererStateStorage(backend);
+    const { module, storage, backend } = await setupRegisteredBackend();
 
     await storage.setItem("drafts", { state: { value: 1 }, version: 0 });
-    module.flushRendererStateWrites();
-    await vi.advanceTimersByTimeAsync(0);
+    await module.flushRendererStateWrites();
     expect(backend.setItem).toHaveBeenCalledTimes(1);
 
     // The debounce timer was cancelled by the flush; no duplicate write.

--- a/packages/ui/src/shell/rendererStorage.test.ts
+++ b/packages/ui/src/shell/rendererStorage.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+
+// Debounce constants mirrored from rendererStorage.ts.
+const WRITE_DEBOUNCE_MS = 1_000;
 
 type RendererStorageModule = typeof import("./rendererStorage");
 
@@ -30,6 +33,10 @@ function jsonStorageOf(module: RendererStorageModule) {
 }
 
 describe("rendererStorage", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("serves reads issued before the host registers its storage", async () => {
     const module = await importFreshRendererStorage();
     const storage = jsonStorageOf(module);
@@ -51,6 +58,7 @@ describe("rendererStorage", () => {
   });
 
   it("drops writes racing the initial read, then writes through", async () => {
+    vi.useFakeTimers();
     const module = await importFreshRendererStorage();
     const storage = jsonStorageOf(module);
     const backend = fakeBackend({
@@ -65,31 +73,35 @@ describe("rendererStorage", () => {
 
     module.registerRendererStateStorage(backend);
     await Promise.all([read, racingWrite]);
+    await vi.advanceTimersByTimeAsync(WRITE_DEBOUNCE_MS);
     expect(backend.setItem).not.toHaveBeenCalled();
 
     await storage.setItem("settings-storage", {
       state: { mode: "changed" },
       version: 0,
     });
+    await vi.advanceTimersByTimeAsync(WRITE_DEBOUNCE_MS);
     expect(backend.setItem).toHaveBeenCalledTimes(1);
   });
 
   it("passes writes through for keys that were never read", async () => {
+    vi.useFakeTimers();
     const module = await importFreshRendererStorage();
     const storage = jsonStorageOf(module);
     const backend = fakeBackend({});
 
-    const write = storage.setItem("write-only", {
+    await storage.setItem("write-only", {
       state: { value: 1 },
       version: 0,
     });
     module.registerRendererStateStorage(backend);
-    await write;
+    await vi.advanceTimersByTimeAsync(WRITE_DEBOUNCE_MS);
 
     expect(backend.setItem).toHaveBeenCalledTimes(1);
   });
 
   it("settles concurrent initial reads of the same key once", async () => {
+    vi.useFakeTimers();
     const module = await importFreshRendererStorage();
     const storage = jsonStorageOf(module);
     const backend = fakeBackend({
@@ -110,10 +122,12 @@ describe("rendererStorage", () => {
       state: { mode: "changed" },
       version: 0,
     });
+    await vi.advanceTimersByTimeAsync(WRITE_DEBOUNCE_MS);
     expect(backend.setItem).toHaveBeenCalledTimes(1);
   });
 
   it("marks a key settled when the initial read rejects so later writes pass", async () => {
+    vi.useFakeTimers();
     const module = await importFreshRendererStorage();
     const storage = jsonStorageOf(module);
     const backend = fakeBackend({});
@@ -127,6 +141,7 @@ describe("rendererStorage", () => {
       state: { mode: "changed" },
       version: 0,
     });
+    await vi.advanceTimersByTimeAsync(WRITE_DEBOUNCE_MS);
     expect(backend.setItem).toHaveBeenCalledTimes(1);
   });
 
@@ -197,11 +212,104 @@ describe("rendererStorage", () => {
 
     useStore.setState({ defaultInitialTaskMode: "plan" });
     await vi.waitFor(() => {
+      module.flushRendererStateWrites();
       expect(backend.setItem).toHaveBeenCalled();
     });
     const persisted = JSON.parse(
       backend.setItem.mock.calls[backend.setItem.mock.calls.length - 1][1],
     );
     expect(persisted.state.defaultInitialTaskMode).toBe("plan");
+  });
+
+  it("coalesces a burst of writes into one backend write with the latest value", async () => {
+    vi.useFakeTimers();
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const backend = fakeBackend({});
+    module.registerRendererStateStorage(backend);
+
+    await storage.setItem("drafts", { state: { value: 1 }, version: 0 });
+    await storage.setItem("drafts", { state: { value: 2 }, version: 0 });
+    await storage.setItem("drafts", { state: { value: 3 }, version: 0 });
+
+    expect(backend.setItem).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(WRITE_DEBOUNCE_MS);
+    expect(backend.setItem).toHaveBeenCalledTimes(1);
+    const persisted = JSON.parse(backend.setItem.mock.calls[0][1]);
+    expect(persisted.state.value).toBe(3);
+  });
+
+  it("flushes at the max-wait bound during sustained writes", async () => {
+    vi.useFakeTimers();
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const backend = fakeBackend({});
+    module.registerRendererStateStorage(backend);
+
+    // Write every 500ms for 6s: a plain trailing debounce would never fire,
+    // the max-wait bound forces a flush mid-burst.
+    for (let i = 0; i < 12; i++) {
+      await storage.setItem("drafts", { state: { value: i }, version: 0 });
+      await vi.advanceTimersByTimeAsync(500);
+    }
+    expect(backend.setItem.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+    await vi.advanceTimersByTimeAsync(WRITE_DEBOUNCE_MS);
+    const last = backend.setItem.mock.calls.at(-1);
+    expect(JSON.parse(last?.[1] ?? "{}").state.value).toBe(11);
+  });
+
+  it("lands the pending coalesced write before serving a read", async () => {
+    vi.useFakeTimers();
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const backend = fakeBackend({
+      drafts: JSON.stringify({ state: { value: "stale" }, version: 0 }),
+    });
+    module.registerRendererStateStorage(backend);
+
+    await storage.setItem("drafts", { state: { value: "fresh" }, version: 0 });
+
+    await expect(storage.getItem("drafts")).resolves.toMatchObject({
+      state: { value: "fresh" },
+    });
+    expect(backend.setItem).toHaveBeenCalledTimes(1);
+
+    // The read consumed the pending write; the debounce timer must not fire
+    // a duplicate.
+    await vi.advanceTimersByTimeAsync(WRITE_DEBOUNCE_MS);
+    expect(backend.setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a pending write when the key is removed", async () => {
+    vi.useFakeTimers();
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const backend = fakeBackend({});
+    module.registerRendererStateStorage(backend);
+
+    await storage.setItem("drafts", { state: { value: 1 }, version: 0 });
+    await storage.removeItem("drafts");
+    await vi.advanceTimersByTimeAsync(WRITE_DEBOUNCE_MS);
+
+    expect(backend.setItem).not.toHaveBeenCalled();
+    expect(backend.removeItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushRendererStateWrites persists pending state immediately", async () => {
+    vi.useFakeTimers();
+    const module = await importFreshRendererStorage();
+    const storage = jsonStorageOf(module);
+    const backend = fakeBackend({});
+    module.registerRendererStateStorage(backend);
+
+    await storage.setItem("drafts", { state: { value: 1 }, version: 0 });
+    module.flushRendererStateWrites();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(backend.setItem).toHaveBeenCalledTimes(1);
+
+    // The debounce timer was cancelled by the flush; no duplicate write.
+    await vi.advanceTimersByTimeAsync(WRITE_DEBOUNCE_MS);
+    expect(backend.setItem).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/shell/rendererStorage.ts
+++ b/packages/ui/src/shell/rendererStorage.ts
@@ -16,6 +16,10 @@ function deferred<T>() {
 let hostStorage: RendererStateStorage | null = null;
 const hostStorageReady = deferred<RendererStateStorage>();
 
+// Re-registration replaces `hostStorage` for new calls, while the promise
+// keeps settling waiters against the first registration.
+const resolveHostStorage = () => hostStorage ?? hostStorageReady.promise;
+
 const pendingFirstReads = new Set<string>();
 const settledFirstReads = new Set<string>();
 
@@ -25,8 +29,8 @@ const settledFirstReads = new Set<string>();
 // the main process. Only the latest value per key matters, so bursts fold
 // into one write after WRITE_DEBOUNCE_MS of quiet, with WRITE_MAX_WAIT_MS
 // bounding how stale the persisted copy can get during sustained typing.
-const WRITE_DEBOUNCE_MS = 1_000;
-const WRITE_MAX_WAIT_MS = 5_000;
+export const WRITE_DEBOUNCE_MS = 1_000;
+export const WRITE_MAX_WAIT_MS = 5_000;
 
 interface PendingWrite {
   value: string;
@@ -36,17 +40,25 @@ interface PendingWrite {
 
 const pendingWrites = new Map<string, PendingWrite>();
 
-async function flushPendingWrite(key: string): Promise<void> {
+/** Detach and return the pending write for a key, cancelling its timer. */
+function takePendingWrite(key: string): PendingWrite | undefined {
   const pending = pendingWrites.get(key);
+  if (pending) {
+    clearTimeout(pending.timer);
+    pendingWrites.delete(key);
+  }
+  return pending;
+}
+
+async function flushPendingWrite(key: string): Promise<void> {
+  // Detach before awaiting so a write landing mid-flush queues a fresh entry
+  // instead of mutating one that is already on its way out.
+  const pending = takePendingWrite(key);
   if (!pending) {
     return;
   }
-  clearTimeout(pending.timer);
-  // Delete before awaiting so a write landing mid-flush queues a fresh entry
-  // instead of mutating one that is already on its way out.
-  pendingWrites.delete(key);
   try {
-    const storage = hostStorage ?? (await hostStorageReady.promise);
+    const storage = await resolveHostStorage();
     await storage.setItem(key, pending.value);
   } catch (error) {
     // zustand persist fires writes without awaiting them; a rejection here
@@ -57,37 +69,35 @@ async function flushPendingWrite(key: string): Promise<void> {
 
 function queuePendingWrite(key: string, value: string): void {
   const existing = pendingWrites.get(key);
-  if (!existing) {
-    pendingWrites.set(key, {
-      value,
-      firstQueuedAt: Date.now(),
-      timer: setTimeout(() => void flushPendingWrite(key), WRITE_DEBOUNCE_MS),
-    });
-    return;
+  if (existing) {
+    clearTimeout(existing.timer);
   }
-  existing.value = value;
-  clearTimeout(existing.timer);
-  const elapsed = Date.now() - existing.firstQueuedAt;
+  const firstQueuedAt = existing?.firstQueuedAt ?? Date.now();
   const delay = Math.max(
     0,
-    Math.min(WRITE_DEBOUNCE_MS, WRITE_MAX_WAIT_MS - elapsed),
+    Math.min(WRITE_DEBOUNCE_MS, firstQueuedAt + WRITE_MAX_WAIT_MS - Date.now()),
   );
-  existing.timer = setTimeout(() => void flushPendingWrite(key), delay);
+  pendingWrites.set(key, {
+    value,
+    firstQueuedAt,
+    timer: setTimeout(() => void flushPendingWrite(key), delay),
+  });
 }
 
 /**
- * Push every coalesced write to the host immediately. Wired to `pagehide` so
- * pending state (e.g. a draft mid-keystroke) lands before the window goes
- * away; hosts with an explicit shutdown seam can call it too.
+ * Push every coalesced write to the host immediately. Wired to `pagehide` as
+ * a best-effort flush so pending state (e.g. a draft mid-keystroke) lands
+ * before the window goes away; hosts with an explicit shutdown seam can
+ * await it for a guaranteed flush.
  */
-export function flushRendererStateWrites(): void {
-  for (const key of [...pendingWrites.keys()]) {
-    void flushPendingWrite(key);
-  }
+export async function flushRendererStateWrites(): Promise<void> {
+  await Promise.all(
+    Array.from(pendingWrites.keys(), (key) => flushPendingWrite(key)),
+  );
 }
 
 if (typeof window !== "undefined") {
-  window.addEventListener("pagehide", flushRendererStateWrites);
+  window.addEventListener("pagehide", () => void flushRendererStateWrites());
 }
 
 /**
@@ -115,18 +125,19 @@ const deferredHostStorage: StateStorage = {
     // write also means the key is past hydration, so the first-read
     // bookkeeping below (which must run synchronously to catch racing
     // writes) does not apply.
-    if (pendingWrites.has(key)) {
+    const hadPendingWrite = pendingWrites.has(key);
+    if (hadPendingWrite) {
       await flushPendingWrite(key);
-      const storage = hostStorage ?? (await hostStorageReady.promise);
-      return await storage.getItem(key);
     }
     const isFirstRead =
-      !settledFirstReads.has(key) && !pendingFirstReads.has(key);
+      !hadPendingWrite &&
+      !settledFirstReads.has(key) &&
+      !pendingFirstReads.has(key);
     if (isFirstRead) {
       pendingFirstReads.add(key);
     }
     try {
-      const storage = hostStorage ?? (await hostStorageReady.promise);
+      const storage = await resolveHostStorage();
       return await storage.getItem(key);
     } finally {
       if (isFirstRead) {
@@ -149,13 +160,9 @@ const deferredHostStorage: StateStorage = {
     // Removal is explicit intent rather than a stale state snapshot, so it is
     // not dropped while the initial read is in flight. A coalesced write for
     // the key is cancelled so it cannot resurrect the state afterwards.
-    const pending = pendingWrites.get(key);
-    if (pending) {
-      clearTimeout(pending.timer);
-      pendingWrites.delete(key);
-    }
+    takePendingWrite(key);
     try {
-      const storage = hostStorage ?? (await hostStorageReady.promise);
+      const storage = await resolveHostStorage();
       await storage.removeItem(key);
     } catch (error) {
       log.error("Failed to remove persisted state", { key, error });

--- a/packages/ui/src/shell/rendererStorage.ts
+++ b/packages/ui/src/shell/rendererStorage.ts
@@ -19,6 +19,77 @@ const hostStorageReady = deferred<RendererStateStorage>();
 const pendingFirstReads = new Set<string>();
 const settledFirstReads = new Set<string>();
 
+// Writes are coalesced per key before they reach the host: persisted stores
+// (drafts in particular) can update on every keystroke, and on desktop each
+// write is an IPC hop plus an encrypt-and-rewrite of the whole store file on
+// the main process. Only the latest value per key matters, so bursts fold
+// into one write after WRITE_DEBOUNCE_MS of quiet, with WRITE_MAX_WAIT_MS
+// bounding how stale the persisted copy can get during sustained typing.
+const WRITE_DEBOUNCE_MS = 1_000;
+const WRITE_MAX_WAIT_MS = 5_000;
+
+interface PendingWrite {
+  value: string;
+  firstQueuedAt: number;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pendingWrites = new Map<string, PendingWrite>();
+
+async function flushPendingWrite(key: string): Promise<void> {
+  const pending = pendingWrites.get(key);
+  if (!pending) {
+    return;
+  }
+  clearTimeout(pending.timer);
+  // Delete before awaiting so a write landing mid-flush queues a fresh entry
+  // instead of mutating one that is already on its way out.
+  pendingWrites.delete(key);
+  try {
+    const storage = hostStorage ?? (await hostStorageReady.promise);
+    await storage.setItem(key, pending.value);
+  } catch (error) {
+    // zustand persist fires writes without awaiting them; a rejection here
+    // would only surface as an unhandled rejection.
+    log.error("Failed to persist state", { key, error });
+  }
+}
+
+function queuePendingWrite(key: string, value: string): void {
+  const existing = pendingWrites.get(key);
+  if (!existing) {
+    pendingWrites.set(key, {
+      value,
+      firstQueuedAt: Date.now(),
+      timer: setTimeout(() => void flushPendingWrite(key), WRITE_DEBOUNCE_MS),
+    });
+    return;
+  }
+  existing.value = value;
+  clearTimeout(existing.timer);
+  const elapsed = Date.now() - existing.firstQueuedAt;
+  const delay = Math.max(
+    0,
+    Math.min(WRITE_DEBOUNCE_MS, WRITE_MAX_WAIT_MS - elapsed),
+  );
+  existing.timer = setTimeout(() => void flushPendingWrite(key), delay);
+}
+
+/**
+ * Push every coalesced write to the host immediately. Wired to `pagehide` so
+ * pending state (e.g. a draft mid-keystroke) lands before the window goes
+ * away; hosts with an explicit shutdown seam can call it too.
+ */
+export function flushRendererStateWrites(): void {
+  for (const key of [...pendingWrites.keys()]) {
+    void flushPendingWrite(key);
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("pagehide", flushRendererStateWrites);
+}
+
 /**
  * Hosts call this during boot with their persistence backend. Persisted UI
  * stores are created at module-evaluation time, which can run before the host
@@ -39,6 +110,16 @@ export function registerRendererStateStorage(
 
 const deferredHostStorage: StateStorage = {
   getItem: async (key) => {
+    // A coalesced write that has not flushed yet is newer than the backend
+    // copy; land it first so the read never observes older state. A queued
+    // write also means the key is past hydration, so the first-read
+    // bookkeeping below (which must run synchronously to catch racing
+    // writes) does not apply.
+    if (pendingWrites.has(key)) {
+      await flushPendingWrite(key);
+      const storage = hostStorage ?? (await hostStorageReady.promise);
+      return await storage.getItem(key);
+    }
     const isFirstRead =
       !settledFirstReads.has(key) && !pendingFirstReads.has(key);
     if (isFirstRead) {
@@ -62,18 +143,17 @@ const deferredHostStorage: StateStorage = {
     if (pendingFirstReads.has(key)) {
       return;
     }
-    try {
-      const storage = hostStorage ?? (await hostStorageReady.promise);
-      await storage.setItem(key, value);
-    } catch (error) {
-      // zustand persist fires writes without awaiting them; a rejection here
-      // would only surface as an unhandled rejection.
-      log.error("Failed to persist state", { key, error });
-    }
+    queuePendingWrite(key, value);
   },
   removeItem: async (key) => {
     // Removal is explicit intent rather than a stale state snapshot, so it is
-    // not dropped while the initial read is in flight.
+    // not dropped while the initial read is in flight. A coalesced write for
+    // the key is cancelled so it cannot resurrect the state afterwards.
+    const pending = pendingWrites.get(key);
+    if (pending) {
+      clearTimeout(pending.timer);
+      pendingWrites.delete(key);
+    }
     try {
       const storage = hostStorage ?? (await hostStorageReady.promise);
       await storage.removeItem(key);


### PR DESCRIPTION
## Problem

Every persisted zustand UI store writes through `rendererStorage` to the host on each state change. 

ERach write is a renderer→main IPC hop plus an encrypt-and-rewrite of the entire electron-store JSON file, synchronously, on the main process. The message-editor draft store persists per keystroke, so typing produces a steady write storm that shows up prominently in the IPC traffic panel and contributes to main-process event-loop congestion (other IPC calls queue behind the file writes).

| Typed into composer | Host writes on `main` | Host writes on this branch | Reduction |
| --- | --- | --- | --- |
| 9-char word | 9 | 1 | 89% |
| 51-char message | 51 | 2 | 96% |
| 116-char message (~8s sustained) | 116 | 2 | 98% |

cuts host storage writes by ~90 to 98 percent 🚀 

## Changes

- coalesce renderer storage writes per key, batching bursts into a single write after 1s of inactivity with a 5s maximum delay during continuous updates. Only the latest value is retained.

- flush pending writes on `pagehide`, before reads of the same key, or via `flushRendererStateWrites()`. Cancel pending writes on `removeItem` to prevent deleted values from being restored.

- preserve the existing protection against writes racing a key's initial read.