### PR TITLE
fix(ci): don't fail code-tag when team membership can't be verified

### DIFF
--- a/.github/workflows/code-tag.yml
+++ b/.github/workflows/code-tag.yml
@@ -70,7 +70,10 @@ jobs:
             exit 0
           fi
 
-          MEMBERS=$(gh api "orgs/${REPOSITORY%%/*}/teams/${TEAM_SLUG}/members" --paginate --jq '.[].login')
+          if ! MEMBERS=$(gh api "orgs/${REPOSITORY%%/*}/teams/${TEAM_SLUG}/members" --paginate --jq '.[].login'); then
+            skip "Could not verify ${TEAM_SLUG} membership (GitHub API error)."
+            exit 0
+          fi
 
           if echo "$MEMBERS" | grep -qixF "$LABELER"; then
             echo "'Create release' was added by ${LABELER}, a member of ${TEAM_SLUG}."


### PR DESCRIPTION
## Problem

The **Tag PostHog Code Release** workflow failed on PR #3298 with `gh: Not Found (HTTP 404)`. The "Check labeler is a member of team-posthog-code" step looks up team membership with `gh api orgs/<org>/teams/team-posthog-code/members`. That call 404s (the release app token can't read team membership), and because the result was captured in a plain command substitution, `bash -e` aborted the whole job.

Every other branch of that step degrades gracefully via `skip()`