### PR TITLE
feat(data-warehouse): add Jira as a self-driving inbox source

### DIFF
--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -250,6 +250,7 @@ export interface SignalSourceConfig {
     | "llm_analytics"
     | "github"
     | "linear"
+    | "jira"
     | "zendesk"
     | "conversations"
     | "error_tracking"
@@ -400,6 +401,86 @@ export interface ExternalDataSource {
   // The generated `ExternalDataSourceSerializers` types this as `string`,
   // but the actual API returns an array of schema objects
   schemas?: ExternalDataSourceSchema[] | string;
+}
+
+/**
+ * Field-config variants for an external data source's connect form, as served
+ * by the `external_data_sources/wizard/` endpoint. Mirrors PostHog Cloud's
+ * `SourceFieldConfig` union (`posthog/schema.py`). The backend is the single
+ * source of truth for which credential fields a source needs, so forms can be
+ * rendered generically instead of hardcoded per source.
+ */
+export interface SourceFieldInputConfig {
+  type:
+    | "text"
+    | "email"
+    | "search"
+    | "url"
+    | "password"
+    | "time"
+    | "number"
+    | "textarea";
+  name: string;
+  label: string;
+  required: boolean;
+  placeholder?: string;
+  caption?: string | null;
+  /** Redacted from API responses; render as a password field. */
+  secret?: boolean;
+}
+
+export interface SourceFieldOauthConfig {
+  type: "oauth";
+  name: string;
+  label: string;
+  kind: string;
+  required: boolean;
+  requiredScopes?: string;
+}
+
+export interface SourceFieldSelectConfigOption {
+  label: string;
+  value: string;
+  fields?: SourceFieldConfig[];
+}
+
+export interface SourceFieldSelectConfig {
+  type: "select";
+  name: string;
+  label: string;
+  required: boolean;
+  defaultValue?: string;
+  options: SourceFieldSelectConfigOption[];
+}
+
+export interface SourceFieldSwitchGroupConfig {
+  type: "switch-group";
+  name: string;
+  label: string;
+  caption?: string;
+  default?: boolean;
+  fields: SourceFieldConfig[];
+}
+
+/** Field types the generic renderer does not (yet) handle inline. */
+export interface SourceFieldUnsupportedConfig {
+  type: "ssh-tunnel" | "file-upload";
+  name: string;
+  label: string;
+}
+
+export type SourceFieldConfig =
+  | SourceFieldInputConfig
+  | SourceFieldOauthConfig
+  | SourceFieldSelectConfig
+  | SourceFieldSwitchGroupConfig
+  | SourceFieldUnsupportedConfig;
+
+export interface SourceConfig {
+  name: string;
+  label?: string;
+  caption?: string;
+  fields: SourceFieldConfig[];
 }
 
 export interface FolderInstructionsUser {
@@ -2106,6 +2187,30 @@ export class PostHogAPIClient {
       );
     }
     return response.data as unknown as ExternalDataSource;
+  }
+
+  /**
+   * Fetch the connect-form field schema for external data source types from the
+   * warehouse wizard endpoint. Pass `sourceType` (e.g. `"Jira"`) to scope to one
+   * source; omit to fetch every source's config. Returns a map keyed by the
+   * capitalized source type string.
+   */
+  async getExternalDataSourceConfigs(
+    projectId: number,
+    sourceType?: string,
+  ): Promise<Record<string, SourceConfig>> {
+    const url = new URL(
+      `${this.api.baseUrl}/api/environments/${projectId}/external_data_sources/wizard/`,
+    );
+    if (sourceType) {
+      url.searchParams.set("source_type", sourceType);
+    }
+    const path = `/api/environments/${projectId}/external_data_sources/wizard/`;
+    const response = await this.api.fetcher.fetch({ method: "get", url, path });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch source configs: ${response.statusText}`);
+    }
+    return (await response.json()) as Record<string, SourceConfig>;
   }
 
   async updateExternalDataSchema(

--- a/packages/core/src/inbox/dataSourceService.ts
+++ b/packages/core/src/inbox/dataSourceService.ts
@@ -2,11 +2,17 @@ import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
 import { inject, injectable } from "inversify";
 import { LINEAR_OAUTH_FLOW, type LinearOAuthFlow } from "./identifiers";
 
-export type DataSourceType = "github" | "linear" | "zendesk" | "pganalyze";
+export type DataSourceType =
+  | "github"
+  | "linear"
+  | "jira"
+  | "zendesk"
+  | "pganalyze";
 
 const REQUIRED_SCHEMAS: Record<DataSourceType, string[]> = {
   github: ["issues"],
   linear: ["issues"],
+  jira: ["issues"],
   zendesk: ["tickets"],
   pganalyze: ["issues", "servers"],
 };
@@ -31,6 +37,12 @@ function delay(ms: number): Promise<void> {
 export interface GithubDataSourceParams {
   repository: string;
   githubIntegrationId: number;
+}
+
+export interface JiraDataSourceParams {
+  subdomain: string;
+  email: string;
+  apiToken: string;
 }
 
 export interface ZendeskDataSourceParams {
@@ -79,6 +91,22 @@ export class DataSourceService {
       payload: {
         linear_integration_id: linearIntegrationId,
         schemas: schemasPayload("linear"),
+      },
+    });
+  }
+
+  async createJiraDataSource(
+    client: PostHogAPIClient,
+    projectId: number,
+    params: JiraDataSourceParams,
+  ): Promise<void> {
+    await client.createExternalDataSource(projectId, {
+      source_type: "Jira",
+      payload: {
+        subdomain: params.subdomain,
+        email: params.email,
+        api_token: params.apiToken,
+        schemas: schemasPayload("jira"),
       },
     });
   }

--- a/packages/core/src/inbox/dataSourceService.ts
+++ b/packages/core/src/inbox/dataSourceService.ts
@@ -39,12 +39,6 @@ export interface GithubDataSourceParams {
   githubIntegrationId: number;
 }
 
-export interface JiraDataSourceParams {
-  subdomain: string;
-  email: string;
-  apiToken: string;
-}
-
 export interface ZendeskDataSourceParams {
   subdomain: string;
   apiKey: string;
@@ -91,22 +85,6 @@ export class DataSourceService {
       payload: {
         linear_integration_id: linearIntegrationId,
         schemas: schemasPayload("linear"),
-      },
-    });
-  }
-
-  async createJiraDataSource(
-    client: PostHogAPIClient,
-    projectId: number,
-    params: JiraDataSourceParams,
-  ): Promise<void> {
-    await client.createExternalDataSource(projectId, {
-      source_type: "Jira",
-      payload: {
-        subdomain: params.subdomain,
-        email: params.email,
-        api_token: params.apiToken,
-        schemas: schemasPayload("jira"),
       },
     });
   }

--- a/packages/core/src/inbox/signalSourceService.ts
+++ b/packages/core/src/inbox/signalSourceService.ts
@@ -12,6 +12,7 @@ export interface SignalSourceValues {
   error_tracking: boolean;
   github: boolean;
   linear: boolean;
+  jira: boolean;
   zendesk: boolean;
   conversations: boolean;
   pganalyze: boolean;
@@ -22,6 +23,7 @@ export type SignalSourceProduct = keyof SignalSourceValues;
 export type WarehouseSourceProduct =
   | "github"
   | "linear"
+  | "jira"
   | "zendesk"
   | "pganalyze";
 
@@ -45,6 +47,7 @@ const SOURCE_TYPE_MAP: Record<
   session_replay: "session_analysis_cluster",
   github: "issue",
   linear: "issue",
+  jira: "issue",
   zendesk: "ticket",
   conversations: "ticket",
   pganalyze: "issue",
@@ -62,6 +65,7 @@ const DATA_WAREHOUSE_SOURCES: Record<
 > = {
   github: { dwSourceType: "Github", requiredTable: "issues" },
   linear: { dwSourceType: "Linear", requiredTable: "issues" },
+  jira: { dwSourceType: "Jira", requiredTable: "issues" },
   zendesk: { dwSourceType: "Zendesk", requiredTable: "tickets" },
   pganalyze: { dwSourceType: "PgAnalyze", requiredTable: "issues" },
 };
@@ -71,6 +75,7 @@ const ALL_SOURCE_PRODUCTS: SignalSourceProduct[] = [
   "error_tracking",
   "github",
   "linear",
+  "jira",
   "zendesk",
   "conversations",
   "pganalyze",
@@ -106,6 +111,7 @@ export function computeSourceValues(
     error_tracking: false,
     github: false,
     linear: false,
+    jira: false,
     zendesk: false,
     conversations: false,
     pganalyze: false,
@@ -194,7 +200,7 @@ export class SignalSourceService {
     }
 
     const issuesFullReplication =
-      (product === "github" || product === "linear") &&
+      (product === "github" || product === "linear" || product === "jira") &&
       dwConfig.requiredTable === "issues";
 
     if (issuesFullReplication) {

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -785,6 +785,7 @@ export interface SignalSourceConnectedProperties {
     | "signals_scout"
     | "github"
     | "linear"
+    | "jira"
     | "zendesk"
     | "conversations"
     | "pganalyze"

--- a/packages/shared/src/inbox-types.ts
+++ b/packages/shared/src/inbox-types.ts
@@ -11,6 +11,7 @@ export type SourceProduct =
   | "llm_analytics"
   | "github"
   | "linear"
+  | "jira"
   | "zendesk"
   | "conversations"
   | "pganalyze"

--- a/packages/ui/src/features/inbox/components/DataSourceSetup.tsx
+++ b/packages/ui/src/features/inbox/components/DataSourceSetup.tsx
@@ -3,6 +3,7 @@ import { Button } from "@posthog/quill";
 import { useAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
+import { DynamicSourceSetup } from "@posthog/ui/features/inbox/components/DynamicSourceSetup";
 import {
   describeGithubConnectError,
   useGithubConnect,
@@ -16,11 +17,12 @@ import { Box, Flex, Text, TextField } from "@radix-ui/themes";
 import { useMutation } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-type DataSourceType = "github" | "linear" | "zendesk" | "pganalyze";
+type DataSourceType = "github" | "linear" | "jira" | "zendesk" | "pganalyze";
 
 const REQUIRED_SCHEMAS: Record<DataSourceType, string[]> = {
   github: ["issues"],
   linear: ["issues"],
+  jira: ["issues"],
   zendesk: ["tickets"],
   pganalyze: ["issues", "servers"],
 };
@@ -52,6 +54,16 @@ export function DataSourceSetup({
       return <GitHubSetup onComplete={onComplete} onCancel={onCancel} />;
     case "linear":
       return <LinearSetup onComplete={onComplete} onCancel={onCancel} />;
+    case "jira":
+      return (
+        <DynamicSourceSetup
+          sourceType="Jira"
+          title="Connect Jira"
+          schemas={schemasPayload("jira")}
+          onComplete={onComplete}
+          onCancel={onCancel}
+        />
+      );
     case "zendesk":
       return <ZendeskSetup onComplete={onComplete} onCancel={onCancel} />;
     case "pganalyze":

--- a/packages/ui/src/features/inbox/components/DynamicSourceSetup.tsx
+++ b/packages/ui/src/features/inbox/components/DynamicSourceSetup.tsx
@@ -8,7 +8,15 @@ import { useAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { useSourceConfig } from "@posthog/ui/features/inbox/hooks/useSourceConfig";
 import { toast } from "@posthog/ui/primitives/toast";
-import { Box, Flex, Select, Switch, Text, TextField } from "@radix-ui/themes";
+import {
+  Box,
+  Flex,
+  Select,
+  Switch,
+  Text,
+  TextArea,
+  TextField,
+} from "@radix-ui/themes";
 import { useCallback, useMemo, useState } from "react";
 
 interface SchemaPayload {
@@ -60,29 +68,38 @@ function isUnsupportedField(field: SourceFieldConfig): boolean {
 }
 
 /**
- * Collect the required text-input field names that are currently active, so we
- * can gate the submit button and validate before posting.
+ * Walk the currently active fields and collect the names of required inputs and
+ * selects that are not yet satisfied, so we can gate the submit button and
+ * validate before posting. A select with a `defaultValue` is always satisfied,
+ * because the control renders that value pre-selected.
  */
-function requiredInputNames(
+function missingRequiredFields(
   config: SourceConfig,
   values: FieldValues,
 ): string[] {
-  const names: string[] = [];
+  const missing: string[] = [];
   const walk = (fields: SourceFieldConfig[]) => {
     for (const field of fields) {
       if (field.type === "switch-group") {
         if (values[field.name]) walk(field.fields);
       } else if (field.type === "select") {
-        const selected = values[field.name];
+        const selected =
+          (values[field.name] as string) ?? field.defaultValue ?? "";
+        if (field.required && selected.trim().length === 0) {
+          missing.push(field.name);
+        }
         const option = field.options.find((o) => o.value === selected);
         if (option?.fields) walk(option.fields);
       } else if (isInputField(field) && field.required) {
-        names.push(field.name);
+        const value = values[field.name];
+        if (typeof value !== "string" || value.trim().length === 0) {
+          missing.push(field.name);
+        }
       }
     }
   };
   walk(config.fields);
-  return names;
+  return missing;
 }
 
 /**
@@ -140,10 +157,7 @@ export function DynamicSourceSetup({
 
   const canSubmit = useMemo(() => {
     if (!config || hasUnsupportedField) return false;
-    return requiredInputNames(config, values).every((name) => {
-      const value = values[name];
-      return typeof value === "string" && value.trim().length > 0;
-    });
+    return missingRequiredFields(config, values).length === 0;
   }, [config, values, hasUnsupportedField]);
 
   const handleSubmit = useCallback(async () => {
@@ -295,15 +309,24 @@ function SourceField({
 
   if (isInputField(field)) {
     const isSecret = field.type === "password" || field.secret === true;
-    const inputType = field.type === "textarea" ? "text" : field.type;
     return (
       <Flex direction="column" gap="1">
-        <TextField.Root
-          type={isSecret ? "password" : inputType}
-          placeholder={field.placeholder || field.label}
-          value={(values[field.name] as string) ?? ""}
-          onChange={(e) => setValue(field.name, e.target.value)}
-        />
+        <Text className="text-gray-12 text-sm">{field.label}</Text>
+        {field.type === "textarea" ? (
+          <TextArea
+            rows={4}
+            placeholder={field.placeholder || field.label}
+            value={(values[field.name] as string) ?? ""}
+            onChange={(e) => setValue(field.name, e.target.value)}
+          />
+        ) : (
+          <TextField.Root
+            type={isSecret ? "password" : field.type}
+            placeholder={field.placeholder || field.label}
+            value={(values[field.name] as string) ?? ""}
+            onChange={(e) => setValue(field.name, e.target.value)}
+          />
+        )}
         {field.caption && (
           <Text className="text-[13px] text-gray-11">{field.caption}</Text>
         )}

--- a/packages/ui/src/features/inbox/components/DynamicSourceSetup.tsx
+++ b/packages/ui/src/features/inbox/components/DynamicSourceSetup.tsx
@@ -1,0 +1,337 @@
+import type {
+  SourceConfig,
+  SourceFieldConfig,
+  SourceFieldInputConfig,
+} from "@posthog/api-client/posthog-client";
+import { Button } from "@posthog/quill";
+import { useAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { useSourceConfig } from "@posthog/ui/features/inbox/hooks/useSourceConfig";
+import { toast } from "@posthog/ui/primitives/toast";
+import { Box, Flex, Select, Switch, Text, TextField } from "@radix-ui/themes";
+import { useCallback, useMemo, useState } from "react";
+
+interface SchemaPayload {
+  name: string;
+  should_sync: boolean;
+  sync_type: string;
+}
+
+interface DynamicSourceSetupProps {
+  /** Capitalized DWH source type string, e.g. `"Jira"`. */
+  sourceType: string;
+  title: string;
+  /** The warehouse tables to sync for this source (forced on at create time). */
+  schemas: SchemaPayload[];
+  onComplete: () => void;
+  onCancel: () => void;
+}
+
+type FieldValues = Record<string, string | boolean>;
+
+const INPUT_TYPES = new Set([
+  "text",
+  "email",
+  "search",
+  "url",
+  "password",
+  "time",
+  "number",
+  "textarea",
+]);
+
+/** Whether a field is a plain text-like input the generic renderer handles. */
+function isInputField(
+  field: SourceFieldConfig,
+): field is SourceFieldInputConfig {
+  return INPUT_TYPES.has(field.type);
+}
+
+/**
+ * A field type the generic renderer cannot handle inline (OAuth grants, SSH
+ * tunnels, file uploads). Sources requiring these still need a bespoke form.
+ */
+function isUnsupportedField(field: SourceFieldConfig): boolean {
+  return (
+    field.type === "oauth" ||
+    field.type === "ssh-tunnel" ||
+    field.type === "file-upload"
+  );
+}
+
+/**
+ * Collect the required text-input field names that are currently active, so we
+ * can gate the submit button and validate before posting.
+ */
+function requiredInputNames(
+  config: SourceConfig,
+  values: FieldValues,
+): string[] {
+  const names: string[] = [];
+  const walk = (fields: SourceFieldConfig[]) => {
+    for (const field of fields) {
+      if (field.type === "switch-group") {
+        if (values[field.name]) walk(field.fields);
+      } else if (field.type === "select") {
+        const selected = values[field.name];
+        const option = field.options.find((o) => o.value === selected);
+        if (option?.fields) walk(option.fields);
+      } else if (isInputField(field) && field.required) {
+        names.push(field.name);
+      }
+    }
+  };
+  walk(config.fields);
+  return names;
+}
+
+/**
+ * Build the `createExternalDataSource` payload from the collected field values,
+ * mirroring how PostHog Cloud nests switch-group and select fields.
+ */
+function buildPayload(
+  config: SourceConfig,
+  values: FieldValues,
+): Record<string, unknown> {
+  const collect = (fields: SourceFieldConfig[]): Record<string, unknown> => {
+    const out: Record<string, unknown> = {};
+    for (const field of fields) {
+      if (field.type === "switch-group") {
+        const enabled = !!values[field.name];
+        out[field.name] = { enabled, ...collect(field.fields) };
+      } else if (field.type === "select") {
+        const selected = (values[field.name] as string) ?? field.defaultValue;
+        const option = field.options.find((o) => o.value === selected);
+        out[field.name] = {
+          selection: selected,
+          ...(option?.fields ? collect(option.fields) : {}),
+        };
+      } else if (isInputField(field)) {
+        const value = values[field.name];
+        if (typeof value === "string") out[field.name] = value.trim();
+      }
+    }
+    return out;
+  };
+  return collect(config.fields);
+}
+
+export function DynamicSourceSetup({
+  sourceType,
+  title,
+  schemas,
+  onComplete,
+  onCancel,
+}: DynamicSourceSetupProps) {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  const client = useAuthenticatedClient();
+  const { data: config, isLoading, error } = useSourceConfig(sourceType);
+  const [values, setValues] = useState<FieldValues>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const setValue = useCallback((name: string, value: string | boolean) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+  }, []);
+
+  const hasUnsupportedField = useMemo(
+    () => (config ? config.fields.some(isUnsupportedField) : false),
+    [config],
+  );
+
+  const canSubmit = useMemo(() => {
+    if (!config || hasUnsupportedField) return false;
+    return requiredInputNames(config, values).every((name) => {
+      const value = values[name];
+      return typeof value === "string" && value.trim().length > 0;
+    });
+  }, [config, values, hasUnsupportedField]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!projectId || !client || !config) return;
+    setSubmitting(true);
+    try {
+      await client.createExternalDataSource(projectId, {
+        source_type: sourceType,
+        payload: { ...buildPayload(config, values), schemas },
+      });
+      toast.success(`${title} data source created`);
+      onComplete();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create data source",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    projectId,
+    client,
+    config,
+    values,
+    schemas,
+    sourceType,
+    title,
+    onComplete,
+  ]);
+
+  return (
+    <SetupFormContainer title={title}>
+      {isLoading ? (
+        <Text className="text-gray-11 text-sm">Loading connection form…</Text>
+      ) : error || !config ? (
+        <Text className="text-(--red-11) text-sm">
+          Couldn't load the {title} connection form. Please try again.
+        </Text>
+      ) : (
+        <Flex direction="column" gap="3">
+          {config.caption && (
+            <Text className="text-[13px] text-gray-11">{config.caption}</Text>
+          )}
+          {config.fields.map((field) => (
+            <SourceField
+              key={field.name}
+              field={field}
+              values={values}
+              setValue={setValue}
+            />
+          ))}
+          {hasUnsupportedField && (
+            <Text className="text-(--amber-11) text-[13px]">
+              This source needs a connection step that isn't supported here yet.
+            </Text>
+          )}
+          <Flex gap="2" justify="end">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onCancel}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              onClick={handleSubmit}
+              disabled={!canSubmit || submitting}
+            >
+              {submitting ? "Creating..." : "Create source"}
+            </Button>
+          </Flex>
+        </Flex>
+      )}
+    </SetupFormContainer>
+  );
+}
+
+function SourceField({
+  field,
+  values,
+  setValue,
+}: {
+  field: SourceFieldConfig;
+  values: FieldValues;
+  setValue: (name: string, value: string | boolean) => void;
+}) {
+  if (field.type === "switch-group") {
+    const enabled = !!values[field.name];
+    return (
+      <Flex direction="column" gap="2">
+        <Flex align="center" gap="2">
+          <Switch
+            checked={enabled}
+            onCheckedChange={(checked) => setValue(field.name, checked)}
+          />
+          <Text className="text-gray-12 text-sm">{field.label}</Text>
+        </Flex>
+        {field.caption && (
+          <Text className="text-[13px] text-gray-11">{field.caption}</Text>
+        )}
+        {enabled &&
+          field.fields.map((nested) => (
+            <SourceField
+              key={nested.name}
+              field={nested}
+              values={values}
+              setValue={setValue}
+            />
+          ))}
+      </Flex>
+    );
+  }
+
+  if (field.type === "select") {
+    const selected = (values[field.name] as string) ?? field.defaultValue ?? "";
+    const option = field.options.find((o) => o.value === selected);
+    return (
+      <Flex direction="column" gap="2">
+        <Text className="text-gray-12 text-sm">{field.label}</Text>
+        <Select.Root
+          value={selected}
+          onValueChange={(value) => setValue(field.name, value)}
+        >
+          <Select.Trigger placeholder={field.label} />
+          <Select.Content>
+            {field.options.map((o) => (
+              <Select.Item key={o.value} value={o.value}>
+                {o.label}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+        {option?.fields?.map((nested) => (
+          <SourceField
+            key={nested.name}
+            field={nested}
+            values={values}
+            setValue={setValue}
+          />
+        ))}
+      </Flex>
+    );
+  }
+
+  if (isInputField(field)) {
+    const isSecret = field.type === "password" || field.secret === true;
+    const inputType = field.type === "textarea" ? "text" : field.type;
+    return (
+      <Flex direction="column" gap="1">
+        <TextField.Root
+          type={isSecret ? "password" : inputType}
+          placeholder={field.placeholder || field.label}
+          value={(values[field.name] as string) ?? ""}
+          onChange={(e) => setValue(field.name, e.target.value)}
+        />
+        {field.caption && (
+          <Text className="text-[13px] text-gray-11">{field.caption}</Text>
+        )}
+      </Flex>
+    );
+  }
+
+  return null;
+}
+
+function SetupFormContainer({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box
+      p="4"
+      className="rounded-(--radius-2) border border-border bg-(--color-panel-solid)"
+    >
+      <Flex direction="column" gap="3">
+        <Flex align="center" justify="between">
+          <Text className="font-medium text-gray-12 text-sm">{title}</Text>
+        </Flex>
+        {children}
+      </Flex>
+    </Box>
+  );
+}

--- a/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
+++ b/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
@@ -11,6 +11,7 @@ import {
 } from "@phosphor-icons/react";
 import type { SignalSourceConfig } from "@posthog/api-client/posthog-client";
 import { Button } from "@posthog/quill";
+import { JiraIcon } from "@posthog/ui/features/inbox/components/utils/JiraIcon";
 import { PgAnalyzeIcon } from "@posthog/ui/features/inbox/components/utils/PgAnalyzeIcon";
 import { Badge } from "@posthog/ui/primitives/Badge";
 import { Box, Flex, Spinner, Switch, Text, Tooltip } from "@radix-ui/themes";
@@ -21,6 +22,7 @@ export interface SignalSourceValues {
   error_tracking: boolean;
   github: boolean;
   linear: boolean;
+  jira: boolean;
   zendesk: boolean;
   conversations: boolean;
   pganalyze: boolean;
@@ -290,6 +292,10 @@ export function SignalSourceToggles({
     (checked: boolean) => onToggle("linear", checked),
     [onToggle],
   );
+  const toggleJira = useCallback(
+    (checked: boolean) => onToggle("jira", checked),
+    [onToggle],
+  );
   const toggleZendesk = useCallback(
     (checked: boolean) => onToggle("zendesk", checked),
     [onToggle],
@@ -304,6 +310,7 @@ export function SignalSourceToggles({
   );
   const setupGithub = useCallback(() => onSetup?.("github"), [onSetup]);
   const setupLinear = useCallback(() => onSetup?.("linear"), [onSetup]);
+  const setupJira = useCallback(() => onSetup?.("jira"), [onSetup]);
   const setupZendesk = useCallback(() => onSetup?.("zendesk"), [onSetup]);
   const setupPgAnalyze = useCallback(() => onSetup?.("pganalyze"), [onSetup]);
 
@@ -390,6 +397,18 @@ export function SignalSourceToggles({
             onSetup={setupLinear}
             loading={sourceStates?.linear?.loading}
             syncStatus={sourceStates?.linear?.syncStatus}
+          />
+          <SignalSourceToggleCard
+            icon={<JiraIcon size={20} />}
+            label="Jira"
+            description="Monitor new issues and updates"
+            checked={value.jira}
+            onCheckedChange={toggleJira}
+            disabled={disabled}
+            requiresSetup={sourceStates?.jira?.requiresSetup}
+            onSetup={setupJira}
+            loading={sourceStates?.jira?.loading}
+            syncStatus={sourceStates?.jira?.syncStatus}
           />
           <SignalSourceToggleCard
             icon={<TicketIcon size={20} />}

--- a/packages/ui/src/features/inbox/components/utils/JiraIcon.tsx
+++ b/packages/ui/src/features/inbox/components/utils/JiraIcon.tsx
@@ -1,0 +1,24 @@
+import type { IconProps } from "@phosphor-icons/react";
+
+// Inlined single-path Jira mark so the SVG inherits `currentColor` from the
+// parent text color and adapts to light/dark mode the same way as the Phosphor
+// icons used elsewhere.
+//
+// Accepts the Phosphor `IconProps` shape so it can be substituted for one in
+// the SOURCE_PRODUCT_META table without a type cast. Only `size` and
+// `className` are honored – `weight`, `mirrored`, etc. are ignored.
+export function JiraIcon({ size = 20, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path d="M11.571 11.513H0a5.218 5.218 0 0 0 5.232 5.215h2.13v2.057A5.215 5.215 0 0 0 12.575 24V12.518a1.005 1.005 0 0 0-1.005-1.005zm5.723-5.756H5.736a5.215 5.215 0 0 0 5.215 5.214h2.129v2.058a5.218 5.218 0 0 0 5.215 5.214V6.762a1.005 1.005 0 0 0-1.006-1.005zM23.013 0H11.455a5.215 5.215 0 0 0 5.215 5.215h2.129v2.057A5.215 5.215 0 0 0 24 12.483V1.005A1.005 1.005 0 0 0 23.013 0z" />
+    </svg>
+  );
+}

--- a/packages/ui/src/features/inbox/components/utils/source-product-icons.tsx
+++ b/packages/ui/src/features/inbox/components/utils/source-product-icons.tsx
@@ -9,6 +9,7 @@ import {
   TicketIcon,
   VideoIcon,
 } from "@phosphor-icons/react";
+import { JiraIcon } from "@posthog/ui/features/inbox/components/utils/JiraIcon";
 import { PgAnalyzeIcon } from "@posthog/ui/features/inbox/components/utils/PgAnalyzeIcon";
 import type { SourceProduct } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
 import type { ComponentType } from "react";
@@ -74,6 +75,11 @@ export const SOURCE_PRODUCT_META: Partial<
     Icon: KanbanIcon,
     color: "var(--blue-9)",
     label: "Linear",
+  },
+  jira: {
+    Icon: JiraIcon,
+    color: "var(--blue-11)",
+    label: "Jira",
   },
   zendesk: {
     Icon: TicketIcon,

--- a/packages/ui/src/features/inbox/filterOptions.tsx
+++ b/packages/ui/src/features/inbox/filterOptions.tsx
@@ -18,6 +18,7 @@ import type {
   SignalReportPriority,
   SourceProduct,
 } from "@posthog/shared/types";
+import { JiraIcon } from "@posthog/ui/features/inbox/components/utils/JiraIcon";
 import { PgAnalyzeIcon } from "@posthog/ui/features/inbox/components/utils/PgAnalyzeIcon";
 import type { ReactNode } from "react";
 
@@ -93,6 +94,7 @@ export const INBOX_SOURCE_OPTIONS: {
   },
   { value: "github", label: "GitHub", icon: <GithubLogoIcon size={14} /> },
   { value: "linear", label: "Linear", icon: <KanbanIcon size={14} /> },
+  { value: "jira", label: "Jira", icon: <JiraIcon size={14} /> },
   { value: "zendesk", label: "Zendesk", icon: <TicketIcon size={14} /> },
   {
     value: "conversations",

--- a/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
+++ b/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
@@ -12,7 +12,12 @@ import { useCallback, useMemo, useRef, useState } from "react";
 
 type SourceProduct = SignalSourceConfig["source_product"];
 type SourceType = SignalSourceConfig["source_type"];
-type SetupSourceProduct = "github" | "linear" | "zendesk" | "pganalyze";
+type SetupSourceProduct =
+  | "github"
+  | "linear"
+  | "jira"
+  | "zendesk"
+  | "pganalyze";
 
 const SOURCE_TYPE_MAP: Record<
   Exclude<SourceProduct, "error_tracking" | "llm_analytics" | "signals_scout">,
@@ -21,6 +26,7 @@ const SOURCE_TYPE_MAP: Record<
   session_replay: "session_analysis_cluster",
   github: "issue",
   linear: "issue",
+  jira: "issue",
   zendesk: "ticket",
   conversations: "ticket",
   pganalyze: "issue",
@@ -37,6 +43,7 @@ const SOURCE_LABELS: Record<keyof SignalSourceValues, string> = {
   error_tracking: "Error tracking",
   github: "GitHub Issues",
   linear: "Linear Issues",
+  jira: "Jira Issues",
   zendesk: "Zendesk Tickets",
   conversations: "PostHog Support",
   pganalyze: "pganalyze",
@@ -48,6 +55,7 @@ const DATA_WAREHOUSE_SOURCES: Record<
 > = {
   github: { dwSourceType: "Github", requiredTable: "issues" },
   linear: { dwSourceType: "Linear", requiredTable: "issues" },
+  jira: { dwSourceType: "Jira", requiredTable: "issues" },
   zendesk: { dwSourceType: "Zendesk", requiredTable: "tickets" },
   pganalyze: { dwSourceType: "PgAnalyze", requiredTable: "issues" },
 };
@@ -57,6 +65,7 @@ const ALL_SOURCE_PRODUCTS: (keyof SignalSourceValues)[] = [
   "error_tracking",
   "github",
   "linear",
+  "jira",
   "zendesk",
   "conversations",
   "pganalyze",
@@ -76,6 +85,7 @@ function computeValues(
     error_tracking: false,
     github: false,
     linear: false,
+    jira: false,
     zendesk: false,
     conversations: false,
     pganalyze: false,
@@ -203,7 +213,7 @@ export function useSignalSourceToggles() {
       if (!requiredSchema) return;
 
       const issuesFullReplication =
-        (product === "github" || product === "linear") &&
+        (product === "github" || product === "linear" || product === "jira") &&
         dwConfig.requiredTable === "issues";
 
       if (issuesFullReplication) {

--- a/packages/ui/src/features/inbox/hooks/useSourceConfig.ts
+++ b/packages/ui/src/features/inbox/hooks/useSourceConfig.ts
@@ -1,0 +1,24 @@
+import type { SourceConfig } from "@posthog/api-client/posthog-client";
+import { useAuthenticatedQuery } from "../../../hooks/useAuthenticatedQuery";
+import { useAuthStateValue } from "../../auth/store";
+
+/**
+ * Fetch the connect-form field schema for a single external data source type
+ * (e.g. `"Jira"`) from the warehouse wizard endpoint, so setup forms can be
+ * rendered from the backend's field definitions instead of being hardcoded.
+ */
+export function useSourceConfig(sourceType: string | null) {
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  return useAuthenticatedQuery<SourceConfig | null>(
+    ["external-data-source-config", projectId, sourceType],
+    async (client) => {
+      if (!projectId || !sourceType) return null;
+      const configs = await client.getExternalDataSourceConfigs(
+        projectId,
+        sourceType,
+      );
+      return configs[sourceType] ?? null;
+    },
+    { enabled: !!projectId && !!sourceType, staleTime: 300_000 },
+  );
+}


### PR DESCRIPTION
## Problem

The self-driving inbox lets users connect issue/ticket sources (GitHub, Linear, Zendesk) so the scout can surface findings. Jira — a very common issue tracker — isn't available. Separately, each source's connect form was hand-coded, which drifts from the backend's actual field requirements.

## Changes

- Wire Jira into the source-toggle grid (`source_product: "jira"`, `issues` table) across `@posthog/shared`, `@posthog/api-client`, `@posthog/core`, and `@posthog/ui`.
- Add a generic `DynamicSourceSetup` that renders the connect form from the warehouse wizard endpoint (`external_data_sources/wizard/?source_type=Jira`) instead of hardcoding fields — field names/labels/required/secret come from the backend and can't drift. Jira uses it; GitHub (repo picker) and Linear (OAuth) keep their bespoke flows. `ZendeskSetup`/`PgAnalyzeSetup` can migrate to it opportunistically.

Depends on **PostHog/posthog#69680** (Jira signals-scout support), which must land first: the inbox toggle creates a `SignalSourceConfig` with `source_product: "jira"`, which the backend rejects until that ships.

## How did you test this?

- `pnpm --filter @posthog/ui --filter @posthog/core typecheck` — clean for the changed files.
- `vitest run` on `signalSourceService` + `reportMembership` — pass.
- Biome lint/format clean on the changed files.
- Not verified in the running app: the live wizard fetch + Jira source creation against a real Jira account.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
