### PR TITLE
feat(command): add Usage command to command menu

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -55,6 +55,7 @@ export type CommandMenuAction =
   | "open-channel"
   | "open-command-center"
   | "open-inbox"
+  | "open-usage"
   | "search-files"
   | "open-file"
   | "reload-window"

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -1,6 +1,7 @@
 import {
   CaretLeftIcon,
   CaretRightIcon,
+  ChartLine,
   EnvelopeSimple,
   HashIcon,
 } from "@phosphor-icons/react";
@@ -54,6 +55,7 @@ import {
   navigateToChannel,
   navigateToCommandCenter,
   navigateToInbox,
+  navigateToUsage,
 } from "@posthog/ui/router/navigationBridge";
 import { useAppView } from "@posthog/ui/router/useAppView";
 import { openTask, openTaskInput } from "@posthog/ui/router/useOpenTask";
@@ -266,6 +268,17 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         onRun: () => {
           closeSettingsDialog();
           navigateToCommandCenter();
+        },
+      },
+      {
+        id: "usage",
+        label: "Usage",
+        keywords: "billing spend cost credits",
+        icon: <ChartLine size={12} className="text-gray-11" />,
+        action: "open-usage",
+        onRun: () => {
+          closeSettingsDialog();
+          navigateToUsage();
         },
       },
       {


### PR DESCRIPTION
## Problem

No way to jump to the Usage page from the command menu / search box.

## Changes
<img width="1564" height="1052" alt="CleanShot 2026-07-09 at 09 56 43@2x" src="https://github.com/user-attachments/assets/fb6df1cd-159a-4689-8e62-909dbf690ace" />


- Added a **Usage** command to the command menu navigation section
- Wires to the existing `/usage` route via `navigateToUsage()`
- Added `open-usage` to the `CommandMenuAction` analytics union

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` passes for touched files (pre-existing unrelated errors in sandbox/worktree modules remain)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*