### PR TITLE
fix(chat): float agent-response copy button instead of new line

### DIFF
--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -563,23 +563,21 @@ const AgentProse = memo(function AgentProse({
             )}
           </ChatBubbleContent>
         </ChatBubble>
-        {isStreaming ? null : (
-          <ChatMessageFooter className="opacity-0 transition-opacity group-hover/msg:opacity-100">
-            <Tooltip content={copied ? "Copied!" : "Copy message"}>
-              <IconButton
-                size="1"
-                variant="ghost"
-                color={copied ? "green" : "gray"}
-                onClick={() => copy(text)}
-                className="cursor-pointer"
-                aria-label="Copy message"
-              >
-                {copied ? <Check size={14} /> : <Copy size={14} />}
-              </IconButton>
-            </Tooltip>
-          </ChatMessageFooter>
-        )}
       </ChatMessageContent>
+      {isStreaming ? null : (
+        <Tooltip content={copied ? "Copied!" : "Copy message"}>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color={copied ? "green" : "gray"}
+            onClick={() => copy(text)}
+            className="absolute top-0 right-0 cursor-pointer opacity-0 transition-opacity group-hover/msg:opacity-100"
+            aria-label="Copy message"
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+          </IconButton>
+        </Tooltip>
+      )}
     </ChatMessage>
   );
 });

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -303,6 +303,7 @@ function UserBubble({
   );
 
   const containsFileMentions = hasFileMentions(displayContent);
+  const { copied, copy } = useCopy();
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -415,6 +416,18 @@ function UserBubble({
           </ChatMessageFooter>
         )}
       </ChatMessageContent>
+      <Tooltip content={copied ? "Copied!" : "Copy message"}>
+        <IconButton
+          size="1"
+          variant="ghost"
+          color={copied ? "green" : "gray"}
+          onClick={() => copy(displayContent)}
+          className="absolute top-1 right-1 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100"
+          aria-label="Copy message"
+        >
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+        </IconButton>
+      </Tooltip>
     </ChatMessage>
   );
 }
@@ -571,7 +584,7 @@ const AgentProse = memo(function AgentProse({
             variant="ghost"
             color={copied ? "green" : "gray"}
             onClick={() => copy(text)}
-            className="absolute top-0 right-0 cursor-pointer opacity-0 transition-opacity group-hover/msg:opacity-100"
+            className="absolute top-1 right-1 cursor-pointer opacity-0 transition-opacity group-hover/msg:opacity-100"
             aria-label="Copy message"
           >
             {copied ? <Check size={14} /> : <Copy size={14} />}


### PR DESCRIPTION
## Problem

The copy button on agent responses in the new chat thread renders on its own line below the message, and reserves that empty line even when hidden.

Root cause: it was placed in a `ChatMessageFooter`, which is a flex-column child of `ChatMessageContent`, so it always stacks below the bubble.

## Changes

- `AgentProse` (`ChatThread`): float the copy button at the message top-right on hover (absolute), matching the classic `AgentMessage`. No longer consumes a row.

## How did you test this?

Biome lint + `@posthog/ui` typecheck pass (pre-existing `defaultEligibleModel` errors are unrelated). Not yet verified in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*