### PR TITLE
fix(chat): add hover copy buttons to messages in the new thread

### DIFF
--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -303,7 +303,6 @@ function UserBubble({
   );
 
   const containsFileMentions = hasFileMentions(displayContent);
-  const { copied, copy } = useCopy();
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -416,19 +415,43 @@ function UserBubble({
           </ChatMessageFooter>
         )}
       </ChatMessageContent>
-      <Tooltip content={copied ? "Copied!" : "Copy message"}>
-        <IconButton
-          size="1"
-          variant="ghost"
-          color={copied ? "green" : "gray"}
-          onClick={() => copy(displayContent)}
-          className="absolute top-1 right-1 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100"
-          aria-label="Copy message"
-        >
-          {copied ? <Check size={14} /> : <Copy size={14} />}
-        </IconButton>
-      </Tooltip>
+      <MessageCopyButton
+        value={displayContent}
+        revealClassName="group-hover:opacity-100"
+      />
     </ChatMessage>
+  );
+}
+
+/**
+ * Copy icon that floats into a message's right rail on hover. The hover-group qualifier differs by
+ * message type (`group` for user bubbles, `group/msg` for agent prose), so callers pass their own
+ * `revealClassName` (the `group-hover*:opacity-100` utility).
+ */
+function MessageCopyButton({
+  value,
+  revealClassName,
+}: {
+  value: string;
+  revealClassName: string;
+}) {
+  const { copied, copy } = useCopy();
+  return (
+    <Tooltip content={copied ? "Copied!" : "Copy message"}>
+      <IconButton
+        size="1"
+        variant="ghost"
+        color={copied ? "green" : "gray"}
+        onClick={() => copy(value)}
+        className={cn(
+          "absolute top-1 right-1 cursor-pointer opacity-0 transition-opacity",
+          revealClassName,
+        )}
+        aria-label="Copy message"
+      >
+        {copied ? <Check size={14} /> : <Copy size={14} />}
+      </IconButton>
+    </Tooltip>
   );
 }
 
@@ -562,7 +585,6 @@ const AgentProse = memo(function AgentProse({
   isStreaming?: boolean;
 }) {
   const smoothed = useSmoothedText(text);
-  const { copied, copy } = useCopy();
 
   return (
     <ChatMessage align="start" className="group/msg">
@@ -578,18 +600,10 @@ const AgentProse = memo(function AgentProse({
         </ChatBubble>
       </ChatMessageContent>
       {isStreaming ? null : (
-        <Tooltip content={copied ? "Copied!" : "Copy message"}>
-          <IconButton
-            size="1"
-            variant="ghost"
-            color={copied ? "green" : "gray"}
-            onClick={() => copy(text)}
-            className="absolute top-1 right-1 cursor-pointer opacity-0 transition-opacity group-hover/msg:opacity-100"
-            aria-label="Copy message"
-          >
-            {copied ? <Check size={14} /> : <Copy size={14} />}
-          </IconButton>
-        </Tooltip>
+        <MessageCopyButton
+          value={text}
+          revealClassName="group-hover/msg:opacity-100"
+        />
       )}
     </ChatMessage>
   );

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -303,6 +303,7 @@ function UserBubble({
   );
 
   const containsFileMentions = hasFileMentions(displayContent);
+  const { copied, copy } = useCopy();
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -325,7 +326,7 @@ function UserBubble({
 
   return (
     <ChatMessage align="end" className="group">
-      <ChatMessageContent className="gap-1">
+      <ChatMessageContent className="gap-1 pr-9">
         {showHeaderChips && (
           <ChatMessageHeader className="flex-wrap gap-1">
             {showChannelContextTag && channelContext && (
@@ -415,6 +416,18 @@ function UserBubble({
           </ChatMessageFooter>
         )}
       </ChatMessageContent>
+      <Tooltip content={copied ? "Copied!" : "Copy message"}>
+        <IconButton
+          size="1"
+          variant="ghost"
+          color={copied ? "green" : "gray"}
+          onClick={() => copy(displayContent)}
+          className="absolute top-1 right-1 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100"
+          aria-label="Copy message"
+        >
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+        </IconButton>
+      </Tooltip>
     </ChatMessage>
   );
 }
@@ -553,7 +566,7 @@ const AgentProse = memo(function AgentProse({
 
   return (
     <ChatMessage align="start" className="group/msg">
-      <ChatMessageContent className="gap-1">
+      <ChatMessageContent className="gap-1 pr-9">
         <ChatBubble variant="ghost">
           <ChatBubbleContent>
             {isStreaming ? (
@@ -563,23 +576,21 @@ const AgentProse = memo(function AgentProse({
             )}
           </ChatBubbleContent>
         </ChatBubble>
-        {isStreaming ? null : (
-          <ChatMessageFooter className="opacity-0 transition-opacity group-hover/msg:opacity-100">
-            <Tooltip content={copied ? "Copied!" : "Copy message"}>
-              <IconButton
-                size="1"
-                variant="ghost"
-                color={copied ? "green" : "gray"}
-                onClick={() => copy(text)}
-                className="cursor-pointer"
-                aria-label="Copy message"
-              >
-                {copied ? <Check size={14} /> : <Copy size={14} />}
-              </IconButton>
-            </Tooltip>
-          </ChatMessageFooter>
-        )}
       </ChatMessageContent>
+      {isStreaming ? null : (
+        <Tooltip content={copied ? "Copied!" : "Copy message"}>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color={copied ? "green" : "gray"}
+            onClick={() => copy(text)}
+            className="absolute top-1 right-1 cursor-pointer opacity-0 transition-opacity group-hover/msg:opacity-100"
+            aria-label="Copy message"
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+          </IconButton>
+        </Tooltip>
+      )}
     </ChatMessage>
   );
 });


### PR DESCRIPTION
## Problem

In the new (experimental) chat thread:
- The agent copy button sat in a footer, so it rendered on its own line.
- User messages had no copy button at all.

## Changes

https://github.com/user-attachments/assets/51f24752-157f-493b-871a-10a308d955a6




- `AgentProse` and `UserBubble`: reserve a right rail (`pr-9`) on each message and float the copy icon into it on hover, so it sits to the right of the content instead of overlapping the text.

Note: a true outer-gutter float (classic `left-full`) isn't used because the thread caps content at 750px and the scroller/rows use paint containment (`contain: content` / `content-visibility: auto`), which would clip anything pushed outside a row.

## How did you test this?

Biome + `@posthog/ui` typecheck pass. Not yet verified in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*