### PR TITLE
feat(models): support gpt-5.6 family

### DIFF
--- a/packages/agent/src/adapters/codex-app-server/models.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/models.test.ts
@@ -24,6 +24,16 @@ describe("getReasoningEffortOptions", () => {
     },
   );
 
+  it.each([
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "openai/gpt-5.6-sol",
+    "GPT-5.6-SOL",
+  ])("offers Extra High for the gpt-5.6 family (%s)", (modelId) => {
+    expect(values(modelId)).toEqual(["low", "medium", "high", "xhigh"]);
+  });
+
   it.each(["gpt-5.3-codex", "gpt-5.1", "o3"])(
     "caps at High for other models (%s)",
     (modelId) => {

--- a/packages/agent/src/adapters/codex-app-server/models.ts
+++ b/packages/agent/src/adapters/codex-app-server/models.ts
@@ -16,9 +16,11 @@ const CODEX_REASONING_EFFORT_OPTIONS: ReasoningEffortOption[] = [
 ];
 
 // OpenAI's `reasoning_effort` exposes an "extra high" tier only on the gpt-5.5
-// family, matching what the Codex app offers. Older models top out at "high".
+// and gpt-5.6 families, matching what the Codex app offers. Older models top
+// out at "high".
 export function supportsXhighEffort(modelId: string): boolean {
-  return modelId.toLowerCase().includes("gpt-5.5");
+  const id = modelId.toLowerCase();
+  return id.includes("gpt-5.5") || id.includes("gpt-5.6");
 }
 
 export function getReasoningEffortOptions(

--- a/packages/agent/src/adapters/reasoning-effort.test.ts
+++ b/packages/agent/src/adapters/reasoning-effort.test.ts
@@ -15,8 +15,20 @@ describe("isSupportedReasoningEffort", () => {
     );
   });
 
+  it("accepts xhigh but not max for the codex gpt-5.6 family", () => {
+    expect(isSupportedReasoningEffort("codex", "gpt-5.6-luna", "xhigh")).toBe(
+      true,
+    );
+    expect(isSupportedReasoningEffort("codex", "gpt-5.6-sol", "max")).toBe(
+      false,
+    );
+  });
+
   it("rejects unknown effort values", () => {
     expect(isSupportedReasoningEffort("codex", "gpt-5.5", "ultra")).toBe(false);
+    expect(isSupportedReasoningEffort("codex", "gpt-5.6-sol", "ultra")).toBe(
+      false,
+    );
   });
 
   it("gates xhigh on Claude models by id", () => {

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -18,8 +18,9 @@ gateway results are identical as well.
 ## Models
 
 The model list is fetched from the gateway's `/{product}/v1/models` at startup, so harness exposes
-whatever models the gateway currently serves — including OpenAI + codex (`gpt-5.5`, `gpt-5.4`,
-`gpt-5.3-codex`, …) and GLM (`@cf/zai-org/glm-5.2`). Each model is routed by owner:
+whatever models the gateway currently serves — including OpenAI + codex (`gpt-5.6-sol`,
+`gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, …) and GLM
+(`@cf/zai-org/glm-5.2`). Each model is routed by owner:
 
 - Anthropic + Cloudflare/GLM models → pi's `anthropic-messages` API on `<gateway>/posthog_code`
 - OpenAI + codex models → pi's `openai-responses` API on `<gateway>/posthog_code/v1`

--- a/packages/harness/src/extensions/posthog-provider/models.ts
+++ b/packages/harness/src/extensions/posthog-provider/models.ts
@@ -124,6 +124,24 @@ const FALLBACK_GATEWAY_MODELS: GatewayModel[] = [
     supports_vision: true,
   },
   {
+    id: "gpt-5.6-sol",
+    owned_by: "openai",
+    context_window: 1050000,
+    supports_vision: true,
+  },
+  {
+    id: "gpt-5.6-terra",
+    owned_by: "openai",
+    context_window: 1050000,
+    supports_vision: true,
+  },
+  {
+    id: "gpt-5.6-luna",
+    owned_by: "openai",
+    context_window: 1050000,
+    supports_vision: true,
+  },
+  {
     id: "gpt-5.5",
     owned_by: "openai",
     context_window: 1050000,


### PR DESCRIPTION
## Problem

OpenAI's GPT-5.6 preview family (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) is rolling out 🚀 
