### PR TITLE
feat(mcp-store): personal/shared MCP installation scope

### DIFF
--- a/packages/api-client/src/generated.ts
+++ b/packages/api-client/src/generated.ts
@@ -9722,6 +9722,7 @@ export namespace Schemas {
     auth_type?: MCPAuthTypeEnum | undefined;
     is_enabled?: boolean | undefined;
     scope: MCPServerInstallationScopeEnum;
+    is_owner?: boolean | undefined;
     needs_reauth: boolean;
     pending_oauth: boolean;
     proxy_url: string;

--- a/packages/api-client/src/generated.ts
+++ b/packages/api-client/src/generated.ts
@@ -9350,6 +9350,7 @@ export namespace Schemas {
   export type InsightsToolCall = { query: string; insight_type: InsightTypeEnum };
   export type InstallCustomAuthTypeEnum = "api_key" | "oauth";
   export type InstallSourceEnum = "posthog" | "posthog-code";
+  export type MCPInstallationScopeEnum = "personal" | "shared";
   export type InstallCustom = {
     name: string;
     url: string;
@@ -9360,12 +9361,14 @@ export namespace Schemas {
     client_secret?: string | undefined;
     install_source?: (InstallSourceEnum & unknown) | undefined;
     posthog_code_callback_url?: string | undefined;
+    scope?: (MCPInstallationScopeEnum & unknown) | undefined;
   };
   export type InstallTemplate = {
     template_id: string;
     api_key?: string | undefined;
     install_source?: (InstallSourceEnum & unknown) | undefined;
     posthog_code_callback_url?: string | undefined;
+    scope?: (MCPInstallationScopeEnum & unknown) | undefined;
   };
   export type IntegrationKindEnum =
     | "azure-blob"
@@ -9707,6 +9710,7 @@ export namespace Schemas {
     updated_at: string | null;
   };
   export type MCPAuthTypeEnum = "api_key" | "oauth";
+  export type MCPServerInstallationScopeEnum = "personal" | "shared";
   export type MCPServerInstallation = {
     id: string;
     template_id: string | null;
@@ -9717,6 +9721,7 @@ export namespace Schemas {
     description?: string | undefined;
     auth_type?: MCPAuthTypeEnum | undefined;
     is_enabled?: boolean | undefined;
+    scope: MCPServerInstallationScopeEnum;
     needs_reauth: boolean;
     pending_oauth: boolean;
     proxy_url: string;

--- a/packages/api-client/src/generated.ts
+++ b/packages/api-client/src/generated.ts
@@ -9721,7 +9721,7 @@ export namespace Schemas {
     description?: string | undefined;
     auth_type?: MCPAuthTypeEnum | undefined;
     is_enabled?: boolean | undefined;
-    scope: MCPServerInstallationScopeEnum;
+    scope?: MCPServerInstallationScopeEnum | undefined;
     is_owner?: boolean | undefined;
     needs_reauth: boolean;
     pending_oauth: boolean;

--- a/packages/api-client/src/posthog-client.test.ts
+++ b/packages/api-client/src/posthog-client.test.ts
@@ -361,6 +361,75 @@ describe("PostHogAPIClient", () => {
     });
   });
 
+  describe("share/unshare MCP installation", () => {
+    function makeClient(fetch: ReturnType<typeof vi.fn>) {
+      const client = new PostHogAPIClient(
+        "http://localhost:8000",
+        async () => "token",
+        async () => "token",
+        123,
+      );
+      (
+        client as unknown as {
+          api: { baseUrl: string; fetcher: { fetch: typeof fetch } };
+        }
+      ).api = { baseUrl: "http://localhost:8000", fetcher: { fetch } };
+      return client;
+    }
+
+    it.each([
+      ["shareMcpInstallation", "share"],
+      ["unshareMcpInstallation", "unshare"],
+    ] as const)(
+      "%s POSTs to the %s action and returns the installation",
+      async (method, action) => {
+        const installation = { id: "inst-1", scope: "shared" };
+        const fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => installation,
+        });
+        const client = makeClient(fetch);
+
+        await expect(client[method]("inst-1")).resolves.toEqual(installation);
+
+        expect(fetch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: "post",
+            path: `/api/environments/123/mcp_server_installations/inst-1/${action}/`,
+          }),
+        );
+      },
+    );
+
+    it("surfaces the backend detail message on failure", async () => {
+      const fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        statusText: "Forbidden",
+        json: async () => ({ detail: "Only admins can share installations." }),
+      });
+      const client = makeClient(fetch);
+
+      await expect(client.shareMcpInstallation("inst-1")).rejects.toThrow(
+        "Only admins can share installations.",
+      );
+    });
+
+    it("falls back to statusText when the error body is not JSON", async () => {
+      const fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        statusText: "Bad Gateway",
+        json: async () => {
+          throw new Error("not json");
+        },
+      });
+      const client = makeClient(fetch);
+
+      await expect(client.unshareMcpInstallation("inst-1")).rejects.toThrow(
+        "Failed to unshare MCP server: Bad Gateway",
+      );
+    });
+  });
+
   describe("getSignalReport", () => {
     function makeClient(fetch: ReturnType<typeof vi.fn>) {
       const client = new PostHogAPIClient(

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -169,6 +169,7 @@ import type {
   McpApprovalState,
   McpAuthType,
   McpCategory,
+  McpInstallationScope,
   McpInstallationTool,
   McpRecommendedServer,
   McpServerInstallation,
@@ -177,6 +178,7 @@ export type {
   McpApprovalState,
   McpAuthType,
   McpCategory,
+  McpInstallationScope,
   McpInstallationTool,
   McpRecommendedServer,
   McpServerInstallation,
@@ -3959,6 +3961,7 @@ export class PostHogAPIClient {
     client_secret?: string;
     install_source?: "posthog" | "posthog-code";
     posthog_code_callback_url?: string;
+    scope?: "personal" | "shared";
   }): Promise<McpServerInstallation | Schemas.OAuthRedirectResponse> {
     const teamId = await this.getTeamId();
     const apiUrl = new URL(
@@ -4039,6 +4042,7 @@ export class PostHogAPIClient {
     api_key?: string;
     install_source?: "posthog" | "posthog-code";
     posthog_code_callback_url?: string;
+    scope?: "personal" | "shared";
   }): Promise<McpServerInstallation | Schemas.OAuthRedirectResponse> {
     const teamId = await this.getTeamId();
     const path = `/api/environments/${teamId}/mcp_server_installations/install_template/`;

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -4066,6 +4066,43 @@ export class PostHogAPIClient {
       | Schemas.OAuthRedirectResponse;
   }
 
+  /** Escalate a personal installation to team-wide shared (owner + admin only). */
+  async shareMcpInstallation(
+    installationId: string,
+  ): Promise<McpServerInstallation> {
+    return this.postMcpInstallationScopeAction(installationId, "share");
+  }
+
+  /** Revert a shared installation to personal (owner or admin). */
+  async unshareMcpInstallation(
+    installationId: string,
+  ): Promise<McpServerInstallation> {
+    return this.postMcpInstallationScopeAction(installationId, "unshare");
+  }
+
+  private async postMcpInstallationScopeAction(
+    installationId: string,
+    action: "share" | "unshare",
+  ): Promise<McpServerInstallation> {
+    const teamId = await this.getTeamId();
+    const path = `/api/environments/${teamId}/mcp_server_installations/${installationId}/${action}/`;
+    const response = await this.api.fetcher.fetch({
+      method: "post",
+      url: new URL(`${this.api.baseUrl}${path}`),
+      path,
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(
+        (errorData as { detail?: string }).detail ??
+          `Failed to ${action} MCP server: ${response.statusText}`,
+      );
+    }
+
+    return (await response.json()) as McpServerInstallation;
+  }
+
   async authorizeMcpInstallation(options: {
     installation_id: string;
     install_source?: "posthog" | "posthog-code";

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -5,6 +5,7 @@ export type McpCategory = Schemas.CategoryEnum;
 export type McpApprovalState =
   Schemas.MCPServerInstallationToolApprovalStateEnum;
 export type McpAuthType = Schemas.MCPAuthTypeEnum;
+export type McpInstallationScope = Schemas.MCPServerInstallationScopeEnum;
 export type McpRecommendedServer = Schemas.MCPServerTemplate;
 export type McpServerInstallation = Schemas.MCPServerInstallation;
 export type McpInstallationTool = Schemas.MCPServerInstallationTool;

--- a/packages/core/src/mcp-servers/customServerForm.test.ts
+++ b/packages/core/src/mcp-servers/customServerForm.test.ts
@@ -17,6 +17,7 @@ function values(
     apiKey: "",
     clientId: "",
     clientSecret: "",
+    scope: "personal",
     ...overrides,
   };
 }
@@ -73,6 +74,10 @@ describe("buildCustomServerRequest", () => {
       buildCustomServerRequest(values({ authType: "api_key", apiKey: "" }))
         .api_key,
     ).toBeUndefined();
+  });
+
+  it.each(["personal", "shared"] as const)("forwards the %s scope", (scope) => {
+    expect(buildCustomServerRequest(values({ scope })).scope).toBe(scope);
   });
 
   it("includes client_id/client_secret only for oauth when non-empty", () => {

--- a/packages/core/src/mcp-servers/customServerForm.ts
+++ b/packages/core/src/mcp-servers/customServerForm.ts
@@ -1,4 +1,7 @@
-import type { McpAuthType } from "@posthog/api-client/types";
+import type {
+  McpAuthType,
+  McpInstallationScope,
+} from "@posthog/api-client/types";
 
 export interface CustomServerFormValues {
   name: string;
@@ -8,6 +11,7 @@ export interface CustomServerFormValues {
   apiKey: string;
   clientId: string;
   clientSecret: string;
+  scope: McpInstallationScope;
 }
 
 export interface CustomServerRequest {
@@ -18,6 +22,7 @@ export interface CustomServerRequest {
   api_key?: string;
   client_id?: string;
   client_secret?: string;
+  scope: McpInstallationScope;
 }
 
 export function isValidMcpUrl(url: string): boolean {
@@ -38,6 +43,7 @@ export function buildCustomServerRequest(
     url: values.url.trim(),
     description: values.description.trim(),
     auth_type: values.authType,
+    scope: values.scope,
     ...(values.authType === "api_key" && values.apiKey
       ? { api_key: values.apiKey }
       : {}),

--- a/packages/core/src/mcp-servers/installFlow.test.ts
+++ b/packages/core/src/mcp-servers/installFlow.test.ts
@@ -33,11 +33,13 @@ describe("installTemplateWithOAuth", () => {
     const result = await installTemplateWithOAuth(client, oauth, {
       template_id: "tpl-1",
       api_key: "k",
+      scope: "shared",
     });
 
     expect(client.installMcpTemplate).toHaveBeenCalledWith({
       template_id: "tpl-1",
       api_key: "k",
+      scope: "shared",
       install_source: "posthog-code",
       posthog_code_callback_url: "cb://here",
     });
@@ -82,6 +84,7 @@ describe("installCustomWithOAuth", () => {
       url: "https://x",
       description: "d",
       auth_type: "oauth",
+      scope: "shared",
     });
 
     expect(client.installCustomMcpServer).toHaveBeenCalledWith({
@@ -89,6 +92,7 @@ describe("installCustomWithOAuth", () => {
       url: "https://x",
       description: "d",
       auth_type: "oauth",
+      scope: "shared",
       install_source: "posthog-code",
       posthog_code_callback_url: "cb://here",
     });

--- a/packages/core/src/mcp-servers/installFlow.ts
+++ b/packages/core/src/mcp-servers/installFlow.ts
@@ -1,5 +1,6 @@
 import type {
   McpAuthType,
+  McpInstallationScope,
   McpServerInstallation,
 } from "@posthog/api-client/types";
 
@@ -15,6 +16,7 @@ export interface InstallFlowClient {
     api_key?: string;
     install_source?: "posthog" | "posthog-code";
     posthog_code_callback_url?: string;
+    scope?: McpInstallationScope;
   }): Promise<InstallResult>;
   installCustomMcpServer(options: {
     name: string;
@@ -26,6 +28,7 @@ export interface InstallFlowClient {
     client_secret?: string;
     install_source?: "posthog" | "posthog-code";
     posthog_code_callback_url?: string;
+    scope?: McpInstallationScope;
   }): Promise<InstallResult>;
   authorizeMcpInstallation(options: {
     installation_id: string;
@@ -55,7 +58,11 @@ function hasRedirect(data: InstallResult): data is OAuthRedirect {
 export async function installTemplateWithOAuth(
   client: InstallFlowClient,
   oauth: IOAuthCallback,
-  vars: { template_id: string; api_key?: string },
+  vars: {
+    template_id: string;
+    api_key?: string;
+    scope?: McpInstallationScope;
+  },
 ): Promise<OAuthCallbackResult> {
   const { callbackUrl } = await oauth.getCallbackUrl();
   const data = await client.installMcpTemplate({
@@ -80,6 +87,7 @@ export async function installCustomWithOAuth(
     api_key?: string;
     client_id?: string;
     client_secret?: string;
+    scope?: McpInstallationScope;
   },
 ): Promise<OAuthCallbackResult> {
   const { callbackUrl } = await oauth.getCallbackUrl();

--- a/packages/core/src/mcp-servers/status.test.ts
+++ b/packages/core/src/mcp-servers/status.test.ts
@@ -16,6 +16,7 @@ function makeInstallation(
     updated_at: "2026-01-01T00:00:00Z",
     needs_reauth: false,
     pending_oauth: false,
+    scope: "personal",
     ...overrides,
   };
 }

--- a/packages/ui/src/features/mcp-server-manager/AddCustomServerForm.tsx
+++ b/packages/ui/src/features/mcp-server-manager/AddCustomServerForm.tsx
@@ -1,9 +1,13 @@
 import { ArrowLeft, CaretDown, CaretRight, Plus } from "@phosphor-icons/react";
-import type { McpAuthType } from "@posthog/api-client/posthog-client";
+import type {
+  McpAuthType,
+  McpInstallationScope,
+} from "@posthog/api-client/posthog-client";
 import {
   buildCustomServerRequest,
   canSubmitCustomServer,
 } from "@posthog/core/mcp-servers/customServerForm";
+import { useIsOrgAdmin } from "@posthog/ui/features/auth/useOrgRole";
 import {
   Button,
   Flex,
@@ -25,6 +29,7 @@ interface AddCustomServerFormProps {
     api_key?: string;
     client_id?: string;
     client_secret?: string;
+    scope: McpInstallationScope;
   }) => void;
   /** Prefill the form (e.g. the agent builder's connect_mcp punch-out supplies a
    *  suggested name/url). The user can still edit every field before connecting. */
@@ -57,7 +62,14 @@ export function AddCustomServerForm({
   const [apiKey, setApiKey] = useState("");
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
+  const [scope, setScope] = useState<McpInstallationScope>("personal");
   const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // Shared servers expose the installer's credential to every project member
+  // and all autonomous agents, so creating one is admin-only (enforced again
+  // on the backend). Non-admins still see shared servers in the installed list.
+  const { isAdmin } = useIsOrgAdmin();
+  const canAddShared = isAdmin === true;
 
   const canSubmit = canSubmitCustomServer({ name, url }) && !pending;
 
@@ -74,6 +86,7 @@ export function AddCustomServerForm({
           apiKey,
           clientId,
           clientSecret,
+          scope,
         }),
       );
     },
@@ -86,6 +99,7 @@ export function AddCustomServerForm({
       apiKey,
       clientId,
       clientSecret,
+      scope,
       onSubmit,
     ],
   );
@@ -152,6 +166,27 @@ export function AddCustomServerForm({
               onChange={(e) => setDescription(e.target.value)}
               placeholder="What does this server do?"
             />
+          </Flex>
+
+          <Flex direction="column" gap="1">
+            <Text className="font-medium text-sm">Visibility</Text>
+            <Text color="gray" className="text-[13px]">
+              {canAddShared
+                ? "Shared servers are available to all project members and autonomous agents."
+                : "Only project admins can add shared servers."}
+            </Text>
+            <Select.Root
+              value={scope}
+              onValueChange={(val) => setScope(val as McpInstallationScope)}
+            >
+              <Select.Trigger />
+              <Select.Content>
+                <Select.Item value="personal">Personal (only you)</Select.Item>
+                <Select.Item value="shared" disabled={!canAddShared}>
+                  Shared (everyone in project)
+                </Select.Item>
+              </Select.Content>
+            </Select.Root>
           </Flex>
 
           <Flex direction="column" gap="1">

--- a/packages/ui/src/features/mcp-server-manager/AddCustomServerForm.tsx
+++ b/packages/ui/src/features/mcp-server-manager/AddCustomServerForm.tsx
@@ -171,9 +171,9 @@ export function AddCustomServerForm({
           <Flex direction="column" gap="1">
             <Text className="font-medium text-sm">Visibility</Text>
             <Text color="gray" className="text-[13px]">
-              {canAddShared
-                ? "Shared servers are available to all project members and autonomous agents."
-                : "Only project admins can add shared servers."}
+              {isAdmin === false
+                ? "Only project admins can add shared servers."
+                : "Shared servers are available to all project members and autonomous agents."}
             </Text>
             <Select.Root
               value={scope}

--- a/packages/ui/src/features/mcp-server-manager/useMcpConnect.ts
+++ b/packages/ui/src/features/mcp-server-manager/useMcpConnect.ts
@@ -1,5 +1,6 @@
 import type {
   McpAuthType,
+  McpInstallationScope,
   McpServerInstallation,
 } from "@posthog/api-client/posthog-client";
 import {
@@ -44,6 +45,7 @@ export interface CustomServerInput {
   api_key?: string;
   client_id?: string;
   client_secret?: string;
+  scope?: McpInstallationScope;
 }
 
 /**

--- a/packages/ui/src/features/mcp-servers/components/McpServersView.tsx
+++ b/packages/ui/src/features/mcp-servers/components/McpServersView.tsx
@@ -74,6 +74,10 @@ export function McpServersView() {
     installCustomPending,
     reauthorize,
     reauthorizePending,
+    share,
+    sharePending,
+    unshare,
+    unsharePending,
   } = useMcpServers();
 
   useEffect(() => {
@@ -208,6 +212,19 @@ export function McpServersView() {
         view.kind === "detail-installation" ? selectedInstallation : null;
       const template = selectedTemplate;
 
+      // Whether the user already holds their own (personal) installation of
+      // the server shown — matched by URL or template, since a teammate's
+      // shared install and the user's personal one are distinct rows.
+      const hasPersonalInstall =
+        !!install &&
+        installationList.some(
+          (i) =>
+            i.id !== install.id &&
+            i.scope !== "shared" &&
+            ((!!install.url && i.url === install.url) ||
+              (!!install.template_id && i.template_id === install.template_id)),
+        );
+
       if (!install && !template) {
         return (
           <Flex align="center" justify="center" py="6">
@@ -227,14 +244,26 @@ export function McpServersView() {
           installation={install}
           template={template}
           isEnabled={install?.is_enabled !== false}
-          isInstalling={!!template && installingId === template.id && !install}
+          isInstalling={!!template && installingId === template.id}
           isReauthorizing={reauthorizePending}
+          isSharing={sharePending}
+          isUnsharing={unsharePending}
+          hasPersonalInstall={hasPersonalInstall}
           onBack={() => setView({ kind: "marketplace" })}
           onConnect={() => {
-            if (template) {
+            if (!template) return;
+            if (install) {
+              // "Connect personally" from a teammate's shared install. The
+              // template-id watcher would immediately match the existing
+              // shared row, so identify the new personal row by id snapshot
+              // instead (same mechanism as custom installs).
+              setPendingCustomKnownIds(
+                new Set(installationList.map((i) => i.id)),
+              );
+            } else {
               setPendingTemplateId(template.id);
-              installTemplate(template);
             }
+            installTemplate(template);
           }}
           onReauthorize={() => {
             if (install) reauthorize(install.id);
@@ -244,6 +273,12 @@ export function McpServersView() {
           }}
           onUninstall={() => {
             if (install) setUninstallTarget(install);
+          }}
+          onShare={() => {
+            if (install) share(install.id);
+          }}
+          onUnshare={() => {
+            if (install) unshare(install.id);
           }}
         />
       );

--- a/packages/ui/src/features/mcp-servers/components/McpServersView.tsx
+++ b/packages/ui/src/features/mcp-servers/components/McpServersView.tsx
@@ -256,14 +256,20 @@ export function McpServersView() {
               // "Connect personally" from a teammate's shared install. The
               // template-id watcher would immediately match the existing
               // shared row, so identify the new personal row by id snapshot
-              // instead (same mechanism as custom installs).
+              // instead (same mechanism as custom installs). Clear the
+              // snapshot on failure, or a row appearing later for any other
+              // reason (e.g. a teammate sharing a server) would hijack the
+              // view.
               setPendingCustomKnownIds(
                 new Set(installationList.map((i) => i.id)),
               );
+              installTemplate(template, {
+                onError: () => setPendingCustomKnownIds(null),
+              });
             } else {
               setPendingTemplateId(template.id);
+              installTemplate(template);
             }
-            installTemplate(template);
           }}
           onReauthorize={() => {
             if (install) reauthorize(install.id);

--- a/packages/ui/src/features/mcp-servers/components/parts/MarketplaceView.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/MarketplaceView.tsx
@@ -53,7 +53,14 @@ export function MarketplaceView({
   const installationByTemplateId = useMemo(() => {
     const map = new Map<string, string>();
     for (const installation of installations) {
-      if (installation.template_id) {
+      if (!installation.template_id) continue;
+      // A template can have both the user's personal row and a teammate's
+      // shared one; prefer the personal row so the card opens the same
+      // detail regardless of API ordering.
+      if (
+        !map.has(installation.template_id) ||
+        installation.scope !== "shared"
+      ) {
         map.set(installation.template_id, installation.id);
       }
     }

--- a/packages/ui/src/features/mcp-servers/components/parts/McpInstalledRail.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/McpInstalledRail.tsx
@@ -164,6 +164,7 @@ export function McpInstalledRail({
                       className="text-[10px] leading-none"
                     >
                       {installation.tool_count ?? 0} tools
+                      {installation.scope === "shared" ? " · Shared" : ""}
                     </Text>
                   </Flex>
                   <span

--- a/packages/ui/src/features/mcp-servers/components/parts/ServerDetailView.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/ServerDetailView.tsx
@@ -119,6 +119,13 @@ export function ServerDetailView({
             <Text truncate className="font-bold text-xl">
               {name}
             </Text>
+            {installation?.scope === "shared" && (
+              <Tooltip content="Available to all project members and autonomous agents">
+                <Badge color="blue" variant="soft">
+                  Shared
+                </Badge>
+              </Tooltip>
+            )}
             {installation && (
               <Badge color={statusColor} variant="soft">
                 {statusLabel}

--- a/packages/ui/src/features/mcp-servers/components/parts/ServerDetailView.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/ServerDetailView.tsx
@@ -8,6 +8,7 @@ import {
   Prohibit,
   Shield,
   Trash,
+  UsersThree,
   X,
 } from "@phosphor-icons/react";
 import type {
@@ -23,6 +24,7 @@ import {
   filterToolsByName,
   sortToolsForDisplay,
 } from "@posthog/core/mcp-servers/toolDerivation";
+import { useIsOrgAdmin } from "@posthog/ui/features/auth/useOrgRole";
 import { ServerIcon } from "@posthog/ui/features/mcp-servers/components/parts/icons";
 import {
   STATUS_COLORS,
@@ -31,6 +33,7 @@ import {
 import { ToolRow } from "@posthog/ui/features/mcp-servers/components/parts/ToolRow";
 import { useMcpInstallationTools } from "@posthog/ui/features/mcp-servers/hooks/useMcpInstallationTools";
 import {
+  AlertDialog,
   Badge,
   Button,
   Flex,
@@ -50,11 +53,18 @@ interface ServerDetailViewProps {
   isEnabled: boolean;
   isInstalling: boolean;
   isReauthorizing: boolean;
+  isSharing: boolean;
+  isUnsharing: boolean;
+  /** Whether the current user already has their own personal installation for
+   *  this server — hides "Connect personally" on a teammate's shared server. */
+  hasPersonalInstall: boolean;
   onBack: () => void;
   onConnect: () => void;
   onReauthorize: () => void;
   onToggleEnabled: (enabled: boolean) => void;
   onUninstall: () => void;
+  onShare: () => void;
+  onUnshare: () => void;
 }
 
 export function ServerDetailView({
@@ -63,14 +73,34 @@ export function ServerDetailView({
   isEnabled,
   isInstalling,
   isReauthorizing,
+  isSharing,
+  isUnsharing,
+  hasPersonalInstall,
   onBack,
   onConnect,
   onReauthorize,
   onToggleEnabled,
   onUninstall,
+  onShare,
+  onUnshare,
 }: ServerDetailViewProps) {
   const [showRemoved, setShowRemoved] = useState(false);
   const [toolSearch, setToolSearch] = useState("");
+  const [shareConfirmOpen, setShareConfirmOpen] = useState(false);
+
+  // Shared-scope gating. `is_owner` is absent on older backends; treat unknown
+  // as owner so controls stay usable — the backend is the enforcement point.
+  const { isAdmin } = useIsOrgAdmin();
+  const isShared = installation?.scope === "shared";
+  const isOwner = !!installation && installation.is_owner !== false;
+  const canShare = !!installation && !isShared && isOwner && isAdmin === true;
+  const canUnshare =
+    !!installation && isShared && (isOwner || isAdmin === true);
+  const canRemove =
+    !!installation && (!isShared || isOwner || isAdmin === true);
+  const canManage = !!installation && (!isShared || isOwner);
+  const canConnectPersonally =
+    isShared && !isOwner && !!template && !hasPersonalInstall;
 
   const { name, description, docsUrl, iconKey, authType } =
     resolveServerDetails(installation, template);
@@ -185,7 +215,47 @@ export function ServerDetailView({
                 Connect
               </Button>
             )}
-            {installation && (
+            {canConnectPersonally && (
+              <Tooltip content="Connect your own account instead of using the shared connection">
+                <Button
+                  variant="outline"
+                  size="2"
+                  onClick={onConnect}
+                  disabled={isInstalling}
+                >
+                  {isInstalling ? (
+                    <Spinner size="1" />
+                  ) : (
+                    <DownloadSimple size={12} />
+                  )}
+                  Connect personally
+                </Button>
+              </Tooltip>
+            )}
+            {canShare && (
+              <Button
+                variant="outline"
+                size="2"
+                onClick={() => setShareConfirmOpen(true)}
+                disabled={isSharing}
+              >
+                {isSharing ? <Spinner size="1" /> : <UsersThree size={12} />}
+                Share with project
+              </Button>
+            )}
+            {canUnshare && (
+              <Button
+                variant="outline"
+                color="gray"
+                size="2"
+                onClick={onUnshare}
+                disabled={isUnsharing}
+              >
+                {isUnsharing ? <Spinner size="1" /> : null}
+                Unshare
+              </Button>
+            )}
+            {installation && canRemove && (
               <Tooltip content="Remove server">
                 <IconButton
                   variant="ghost"
@@ -198,7 +268,7 @@ export function ServerDetailView({
               </Tooltip>
             )}
           </Flex>
-          {installation && status === "connected" && (
+          {installation && status === "connected" && canManage && (
             <Flex align="center" gap="2">
               <Switch
                 size="1"
@@ -209,6 +279,13 @@ export function ServerDetailView({
           )}
         </Flex>
       </Flex>
+
+      <ShareConfirmDialog
+        open={shareConfirmOpen}
+        serverName={name}
+        onOpenChange={setShareConfirmOpen}
+        onConfirm={onShare}
+      />
 
       {installation && status === "connected" && (
         <>
@@ -237,83 +314,89 @@ export function ServerDetailView({
                 ) : null}
               </Flex>
             </Flex>
-            <Flex gap="2" align="center">
+            {canManage ? (
+              <Flex gap="2" align="center">
+                <Text color="gray" className="text-[13px]">
+                  Set all:
+                </Text>
+                <Tooltip
+                  content={toolSearch ? "Approve filtered" : "Approve all"}
+                >
+                  <IconButton
+                    variant="soft"
+                    color="green"
+                    size="1"
+                    disabled={bulkPending || filteredTools.length === 0}
+                    onClick={() =>
+                      setBulkApproval(
+                        "approved",
+                        toolSearch ? filteredTools : undefined,
+                      )
+                    }
+                  >
+                    <Check size={12} weight="bold" />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip
+                  content={
+                    toolSearch
+                      ? "Require approval for filtered"
+                      : "Require approval for all"
+                  }
+                >
+                  <IconButton
+                    variant="soft"
+                    color="amber"
+                    size="1"
+                    disabled={bulkPending || filteredTools.length === 0}
+                    onClick={() =>
+                      setBulkApproval(
+                        "needs_approval",
+                        toolSearch ? filteredTools : undefined,
+                      )
+                    }
+                  >
+                    <Shield size={12} weight="bold" />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip content={toolSearch ? "Block filtered" : "Block all"}>
+                  <IconButton
+                    variant="soft"
+                    color="red"
+                    size="1"
+                    disabled={bulkPending || filteredTools.length === 0}
+                    onClick={() =>
+                      setBulkApproval(
+                        "do_not_use",
+                        toolSearch ? filteredTools : undefined,
+                      )
+                    }
+                  >
+                    <Prohibit size={12} weight="bold" />
+                  </IconButton>
+                </Tooltip>
+                <Separator orientation="vertical" />
+                <Tooltip content="Refresh tools from server">
+                  <IconButton
+                    variant="soft"
+                    color="gray"
+                    size="1"
+                    disabled={refreshPending}
+                    onClick={refresh}
+                  >
+                    {refreshPending ? (
+                      <Spinner size="1" />
+                    ) : (
+                      <ArrowClockwise size={12} weight="bold" />
+                    )}
+                  </IconButton>
+                </Tooltip>
+              </Flex>
+            ) : (
               <Text color="gray" className="text-[13px]">
-                Set all:
+                Tool permissions are managed by the sharer.
               </Text>
-              <Tooltip
-                content={toolSearch ? "Approve filtered" : "Approve all"}
-              >
-                <IconButton
-                  variant="soft"
-                  color="green"
-                  size="1"
-                  disabled={bulkPending || filteredTools.length === 0}
-                  onClick={() =>
-                    setBulkApproval(
-                      "approved",
-                      toolSearch ? filteredTools : undefined,
-                    )
-                  }
-                >
-                  <Check size={12} weight="bold" />
-                </IconButton>
-              </Tooltip>
-              <Tooltip
-                content={
-                  toolSearch
-                    ? "Require approval for filtered"
-                    : "Require approval for all"
-                }
-              >
-                <IconButton
-                  variant="soft"
-                  color="amber"
-                  size="1"
-                  disabled={bulkPending || filteredTools.length === 0}
-                  onClick={() =>
-                    setBulkApproval(
-                      "needs_approval",
-                      toolSearch ? filteredTools : undefined,
-                    )
-                  }
-                >
-                  <Shield size={12} weight="bold" />
-                </IconButton>
-              </Tooltip>
-              <Tooltip content={toolSearch ? "Block filtered" : "Block all"}>
-                <IconButton
-                  variant="soft"
-                  color="red"
-                  size="1"
-                  disabled={bulkPending || filteredTools.length === 0}
-                  onClick={() =>
-                    setBulkApproval(
-                      "do_not_use",
-                      toolSearch ? filteredTools : undefined,
-                    )
-                  }
-                >
-                  <Prohibit size={12} weight="bold" />
-                </IconButton>
-              </Tooltip>
-              <Separator orientation="vertical" />
-              <Tooltip content="Refresh tools from server">
-                <IconButton
-                  variant="soft"
-                  color="gray"
-                  size="1"
-                  disabled={refreshPending}
-                  onClick={refresh}
-                >
-                  {refreshPending ? (
-                    <Spinner size="1" />
-                  ) : (
-                    <ArrowClockwise size={12} weight="bold" />
-                  )}
-                </IconButton>
-              </Tooltip>
-            </Flex>
+            )}
           </Flex>
 
           {isLoading ? (
@@ -378,6 +461,7 @@ export function ServerDetailView({
                   <ToolRow
                     key={tool.tool_name}
                     tool={tool}
+                    disabled={!canManage}
                     onChange={(approval_state) =>
                       setToolApproval({
                         toolName: tool.tool_name,
@@ -425,5 +509,45 @@ export function ServerDetailView({
         </Flex>
       )}
     </Flex>
+  );
+}
+
+function ShareConfirmDialog({
+  open,
+  serverName,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  serverName: string;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog.Root open={open} onOpenChange={onOpenChange}>
+      <AlertDialog.Content maxWidth="480px">
+        <AlertDialog.Title>Share with project?</AlertDialog.Title>
+        <AlertDialog.Description className="text-sm">
+          Everyone in this project — including autonomous agents — will be able
+          to use <Text className="font-bold">{serverName}</Text> through your
+          connection. Actions they take are attributed to your account on the
+          connected service. Consider connecting a service account rather than a
+          personal one. You can unshare at any time.
+        </AlertDialog.Description>
+        <Flex gap="3" mt="4" justify="end">
+          <AlertDialog.Cancel>
+            <Button variant="soft" color="gray">
+              Cancel
+            </Button>
+          </AlertDialog.Cancel>
+          <AlertDialog.Action>
+            <Button variant="solid" onClick={onConfirm}>
+              <UsersThree size={12} />
+              Share with project
+            </Button>
+          </AlertDialog.Action>
+        </Flex>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
   );
 }

--- a/packages/ui/src/features/mcp-servers/components/parts/ServerDetailView.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/ServerDetailView.tsx
@@ -528,11 +528,10 @@ function ShareConfirmDialog({
       <AlertDialog.Content maxWidth="480px">
         <AlertDialog.Title>Share with project?</AlertDialog.Title>
         <AlertDialog.Description className="text-sm">
-          Everyone in this project — including autonomous agents — will be able
-          to use <Text className="font-bold">{serverName}</Text> through your
-          connection. Actions they take are attributed to your account on the
-          connected service. Consider connecting a service account rather than a
-          personal one. You can unshare at any time.
+          Everyone in this project, including the PostHog agent, can use{" "}
+          <Text className="font-bold">{serverName}</Text> via your connection.
+          Their actions will be attributed to your account. For better security,
+          connect a service account. You can unshare anytime.
         </AlertDialog.Description>
         <Flex gap="3" mt="4" justify="end">
           <AlertDialog.Cancel>

--- a/packages/ui/src/features/mcp-servers/components/parts/ServerDetailView.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/ServerDetailView.tsx
@@ -99,6 +99,9 @@ export function ServerDetailView({
   const canRemove =
     !!installation && (!isShared || isOwner || isAdmin === true);
   const canManage = !!installation && (!isShared || isOwner);
+  // Template-backed servers only for phase 1: "Connect personally" re-runs
+  // the template install. A shared custom server has no template to install
+  // from — members recreate it via "Add custom" instead.
   const canConnectPersonally =
     isShared && !isOwner && !!template && !hasPersonalInstall;
 
@@ -255,7 +258,7 @@ export function ServerDetailView({
                 Unshare
               </Button>
             )}
-            {installation && canRemove && (
+            {canRemove && (
               <Tooltip content="Remove server">
                 <IconButton
                   variant="ghost"

--- a/packages/ui/src/features/mcp-servers/components/parts/ToolRow.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/ToolRow.tsx
@@ -10,9 +10,10 @@ import { ToolPolicyToggle } from "./ToolPolicyToggle";
 interface ToolRowProps {
   tool: McpInstallationTool;
   onChange: (approval_state: McpApprovalState) => void;
+  disabled?: boolean;
 }
 
-export function ToolRow({ tool, onChange }: ToolRowProps) {
+export function ToolRow({ tool, onChange, disabled }: ToolRowProps) {
   const [open, setOpen] = useState(false);
   const hasDescription = !!tool.description?.trim();
   const removed = !!tool.removed_at;
@@ -69,7 +70,7 @@ export function ToolRow({ tool, onChange }: ToolRowProps) {
           <ToolPolicyToggle
             value={tool.approval_state ?? "needs_approval"}
             onChange={onChange}
-            disabled={removed}
+            disabled={removed || disabled}
           />
         </div>
       </div>

--- a/packages/ui/src/features/mcp-servers/hooks/useMcpServers.ts
+++ b/packages/ui/src/features/mcp-servers/hooks/useMcpServers.ts
@@ -171,6 +171,34 @@ export function useMcpServers() {
     },
   );
 
+  const shareMutation = useAuthenticatedMutation(
+    (client, installationId: string) =>
+      client.shareMcpInstallation(installationId),
+    {
+      onSuccess: () => {
+        toast.success("Server shared with project");
+        invalidateInstallations();
+      },
+      onError: (error: Error) => {
+        toast.error(error.message || "Failed to share server");
+      },
+    },
+  );
+
+  const unshareMutation = useAuthenticatedMutation(
+    (client, installationId: string) =>
+      client.unshareMcpInstallation(installationId),
+    {
+      onSuccess: () => {
+        toast.success("Server is personal again");
+        invalidateInstallations();
+      },
+      onError: (error: Error) => {
+        toast.error(error.message || "Failed to unshare server");
+      },
+    },
+  );
+
   const reauthorizeMutation = useAuthenticatedMutation(
     (client, installationId: string) =>
       reauthorizeWithOAuth(client, oauth, installationId),
@@ -214,6 +242,10 @@ export function useMcpServers() {
     installCustomPending: installCustomMutation.isPending,
     reauthorize: reauthorizeMutation.mutate,
     reauthorizePending: reauthorizeMutation.isPending,
+    share: shareMutation.mutate,
+    sharePending: shareMutation.isPending,
+    unshare: unshareMutation.mutate,
+    unsharePending: unshareMutation.isPending,
     invalidateInstallations,
   };
 }

--- a/packages/ui/src/features/mcp-servers/hooks/useMcpServers.ts
+++ b/packages/ui/src/features/mcp-servers/hooks/useMcpServers.ts
@@ -130,14 +130,23 @@ export function useMcpServers() {
   const installTemplate = useCallback(
     (
       template: McpRecommendedServer,
-      opts?: { api_key?: string; scope?: McpInstallationScope },
+      opts?: {
+        api_key?: string;
+        scope?: McpInstallationScope;
+        /** Per-call failure hook so callers can clear optimistic view state
+         *  (e.g. the pending-install id snapshot in McpServersView). */
+        onError?: () => void;
+      },
     ) => {
       setInstallingId(template.id);
-      installTemplateMutation.mutate({
-        template_id: template.id,
-        api_key: opts?.api_key,
-        scope: opts?.scope,
-      });
+      installTemplateMutation.mutate(
+        {
+          template_id: template.id,
+          api_key: opts?.api_key,
+          scope: opts?.scope,
+        },
+        { onError: opts?.onError },
+      );
     },
     [installTemplateMutation],
   );

--- a/packages/ui/src/features/mcp-servers/hooks/useMcpServers.ts
+++ b/packages/ui/src/features/mcp-servers/hooks/useMcpServers.ts
@@ -1,5 +1,6 @@
 import type {
   McpAuthType,
+  McpInstallationScope,
   McpRecommendedServer,
   McpServerInstallation,
 } from "@posthog/api-client/posthog-client";
@@ -101,8 +102,14 @@ export function useMcpServers() {
   );
 
   const installTemplateMutation = useAuthenticatedMutation(
-    (client, vars: { template_id: string; api_key?: string }) =>
-      installTemplateWithOAuth(client, oauth, vars),
+    (
+      client,
+      vars: {
+        template_id: string;
+        api_key?: string;
+        scope?: McpInstallationScope;
+      },
+    ) => installTemplateWithOAuth(client, oauth, vars),
     {
       onSuccess: (data) => {
         if (data && "success" in data && data.success) {
@@ -121,11 +128,15 @@ export function useMcpServers() {
   );
 
   const installTemplate = useCallback(
-    (template: McpRecommendedServer, opts?: { api_key?: string }) => {
+    (
+      template: McpRecommendedServer,
+      opts?: { api_key?: string; scope?: McpInstallationScope },
+    ) => {
       setInstallingId(template.id);
       installTemplateMutation.mutate({
         template_id: template.id,
         api_key: opts?.api_key,
+        scope: opts?.scope,
       });
     },
     [installTemplateMutation],
@@ -142,6 +153,7 @@ export function useMcpServers() {
         api_key?: string;
         client_id?: string;
         client_secret?: string;
+        scope?: McpInstallationScope;
       },
     ) => installCustomWithOAuth(client, oauth, vars),
     {

--- a/packages/workspace-server/src/services/agent/auth-adapter.test.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.test.ts
@@ -219,6 +219,49 @@ describe("AgentAuthAdapter", () => {
     expect(servers.map((s) => s.name)).toEqual(["posthog", "linear", "notion"]);
   });
 
+  it("keeps a shared installation without a URL even when a personal one also lacks a URL", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            {
+              id: "inst-personal-no-url",
+              proxy_url: "https://proxy.posthog.com/inst-personal-no-url/",
+              name: "asana",
+              display_name: "Asana",
+              auth_type: "oauth",
+              is_enabled: true,
+              pending_oauth: false,
+              needs_reauth: false,
+              scope: "personal",
+            },
+            {
+              id: "inst-shared-no-url",
+              proxy_url: "https://proxy.posthog.com/inst-shared-no-url/",
+              name: "jira",
+              display_name: "Jira (shared)",
+              auth_type: "oauth",
+              is_enabled: true,
+              pending_oauth: false,
+              needs_reauth: false,
+              scope: "shared",
+            },
+          ],
+        }),
+    });
+
+    const { servers } = await adapter.buildMcpServers(baseCredentials);
+
+    // Absent URLs say nothing about the servers being the same, so the
+    // personal-over-shared dedupe must not collapse these two rows.
+    expect(deps.mcpProxy.register).toHaveBeenCalledWith(
+      "installation-inst-shared-no-url",
+      "https://proxy.posthog.com/inst-shared-no-url/",
+    );
+    expect(servers.map((s) => s.name)).toEqual(["posthog", "asana", "jira"]);
+  });
+
   it("fetches tool approval states for installations", async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/packages/workspace-server/src/services/agent/auth-adapter.test.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.test.ts
@@ -153,6 +153,72 @@ describe("AgentAuthAdapter", () => {
     );
   });
 
+  it("prefers a personal installation over a shared one for the same URL", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            {
+              id: "inst-shared",
+              url: "https://linear.example.com/mcp",
+              proxy_url: "https://proxy.posthog.com/inst-shared/",
+              name: "linear",
+              display_name: "Linear (shared)",
+              auth_type: "oauth",
+              is_enabled: true,
+              pending_oauth: false,
+              needs_reauth: false,
+              scope: "shared",
+            },
+            {
+              id: "inst-personal",
+              url: "https://linear.example.com/mcp",
+              proxy_url: "https://proxy.posthog.com/inst-personal/",
+              name: "linear",
+              display_name: "Linear",
+              auth_type: "oauth",
+              is_enabled: true,
+              pending_oauth: false,
+              needs_reauth: false,
+              scope: "personal",
+            },
+            {
+              id: "inst-shared-only",
+              url: "https://notion.example.com/mcp",
+              proxy_url: "https://proxy.posthog.com/inst-shared-only/",
+              name: "notion",
+              display_name: "Notion (shared)",
+              auth_type: "oauth",
+              is_enabled: true,
+              pending_oauth: false,
+              needs_reauth: false,
+              scope: "shared",
+            },
+          ],
+        }),
+    });
+
+    const { servers } = await adapter.buildMcpServers(baseCredentials);
+
+    // The user's own Linear connection wins; the teammate's shared one is
+    // dropped. The shared Notion install has no personal counterpart, so it
+    // is kept.
+    expect(deps.mcpProxy.register).toHaveBeenCalledWith(
+      "installation-inst-personal",
+      "https://proxy.posthog.com/inst-personal/",
+    );
+    expect(deps.mcpProxy.register).not.toHaveBeenCalledWith(
+      "installation-inst-shared",
+      expect.anything(),
+    );
+    expect(deps.mcpProxy.register).toHaveBeenCalledWith(
+      "installation-inst-shared-only",
+      "https://proxy.posthog.com/inst-shared-only/",
+    );
+    expect(servers.map((s) => s.name)).toEqual(["posthog", "linear", "notion"]);
+  });
+
   it("fetches tool approval states for installations", async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -112,7 +112,10 @@ export class AgentAuthAdapter {
       if (installation.url === mcpUrl) continue;
 
       const name =
-        installation.name || installation.display_name || installation.url;
+        installation.name ||
+        installation.display_name ||
+        installation.url ||
+        installation.id;
 
       const proxiedUrl = this.mcpProxy.register(
         `installation-${installation.id}`,
@@ -206,7 +209,7 @@ export class AgentAuthAdapter {
     credentials: Credentials,
     installations: Array<{
       id: string;
-      url: string;
+      url?: string;
       name: string;
       display_name: string;
     }>,
@@ -221,7 +224,10 @@ export class AgentAuthAdapter {
     const results = await Promise.allSettled(
       installations.map(async (installation) => {
         const serverName = sanitizeMcpServerName(
-          installation.name || installation.display_name || installation.url,
+          installation.name ||
+            installation.display_name ||
+            installation.url ||
+            installation.id,
         );
         const toolsUrl = `${baseUrl}/api/environments/${credentials.projectId}/mcp_server_installations/${installation.id}/tools/`;
 
@@ -275,7 +281,7 @@ export class AgentAuthAdapter {
   private async fetchMcpInstallations(credentials: Credentials): Promise<
     Array<{
       id: string;
-      url: string;
+      url?: string;
       proxy_url: string;
       name: string;
       display_name: string;
@@ -303,7 +309,7 @@ export class AgentAuthAdapter {
       const data = (await response.json()) as {
         results?: Array<{
           id: string;
-          url: string;
+          url?: string;
           proxy_url?: string;
           name: string;
           display_name: string;
@@ -322,13 +328,17 @@ export class AgentAuthAdapter {
       // Personal wins over shared: when the user has their own connection to
       // the same server URL, agent sessions act as the user rather than
       // through a teammate's shared credential. Rows without a scope come
-      // from older backends and are personal by definition.
+      // from older backends and are personal by definition. Rows without a
+      // URL never dedupe against each other — they are not known to be the
+      // same server.
       const personalUrls = new Set(
-        active.filter((i) => i.scope !== "shared").map((i) => i.url),
+        active.filter((i) => i.scope !== "shared" && i.url).map((i) => i.url),
       );
 
       return active
-        .filter((i) => i.scope !== "shared" || !personalUrls.has(i.url))
+        .filter(
+          (i) => i.scope !== "shared" || !i.url || !personalUrls.has(i.url),
+        )
         .map((i) => ({
           ...i,
           proxy_url:

--- a/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -280,6 +280,7 @@ export class AgentAuthAdapter {
       name: string;
       display_name: string;
       auth_type: string;
+      scope?: "personal" | "shared";
     }>
   > {
     const baseUrl = this.getPostHogApiBaseUrl(credentials.apiHost);
@@ -310,14 +311,24 @@ export class AgentAuthAdapter {
           is_enabled?: boolean;
           pending_oauth: boolean;
           needs_reauth: boolean;
+          scope?: "personal" | "shared";
         }>;
       };
       const installations = data.results ?? [];
 
-      return installations
-        .filter(
-          (i) => !i.pending_oauth && !i.needs_reauth && i.is_enabled !== false,
-        )
+      const active = installations.filter(
+        (i) => !i.pending_oauth && !i.needs_reauth && i.is_enabled !== false,
+      );
+      // Personal wins over shared: when the user has their own connection to
+      // the same server URL, agent sessions act as the user rather than
+      // through a teammate's shared credential. Rows without a scope come
+      // from older backends and are personal by definition.
+      const personalUrls = new Set(
+        active.filter((i) => i.scope !== "shared").map((i) => i.url),
+      );
+
+      return active
+        .filter((i) => i.scope !== "shared" || !personalUrls.has(i.url))
         .map((i) => ({
           ...i,
           proxy_url:


### PR DESCRIPTION
## Problem

MCP Store installations are user-scoped only, so team-wide (shared) MCP connections aren't usable from PostHog Code, and autonomous agents can only use the task creator's personal connections. Backend support is being added in PostHog/posthog#69658 plus the stacked phase-1 branch `feat/shared-mcp-phase1` (share/unshare escalation, admin delete override, `is_owner`, sandbox dedupe, basic audit logging). This is the Code-client half of phase 1.

Phase 2 (tracked separately) covers full audit logs, richer in-session differentiation, correct attribution, and per-MCP access controls.

## Changes

<img width="1624" height="1061" alt="Screenshot 2026-07-09 at 2 52 25 PM" src="https://github.com/user-attachments/assets/147dbe22-14f2-4724-a171-d821f8721d8f" />

- **api-client**: `scope` (`personal` | `shared`) and `is_owner` on `MCPServerInstallation`; `scope` accepted by `install_custom`/`install_template`; new `shareMcpInstallation`/`unshareMcpInstallation` (POST `{id}/share|unshare/`).
- **core**: `scope` threaded through the custom-server form builder and OAuth install flows.
- **ui**:
  - Visibility (Personal/Shared) selector on the custom-server form; the Shared option is admin-gated (creation is admin-only server-side since a shared install exposes the installer's credential).
  - Template Connect stays one-click personal; **Share with project** escalation lives in the server detail view (owner + admin), behind a consent dialog spelling out that project members and autonomous agents will act as the sharer on the connected service. **Unshare** reverts (owner or admin).
  - Owner/admin gating from `is_owner`: tool policy, refresh, and enable/disable are owner-only on shared servers; Remove is owner-or-admin. Unknown `is_owner` (older backends) keeps controls usable — the backend enforces.
  - **Connect personally** on a teammate's shared server, so a shared install doesn't block members from connecting their own account.
  - Shared badge in the detail header and installed rail.
- **workspace-server**: agent session wiring dedupes installations by URL with **personal-over-shared** precedence — sessions act as the user whenever they have their own connection.

Forward-compatible with today's backend: without the posthog changes deployed, `scope` is ignored server-side, `is_owner`/share endpoints simply aren't exercised, and everything behaves as before.

## How did you test this?

- `pnpm typecheck` (23/23 packages)
- Unit tests: api-client 71, core 2162, ui 1421, workspace-server 656 — all passing; new coverage for scope pass-through (core install flows/form builder) and personal-over-shared dedupe (auth-adapter)
- `biome check` clean on all touched files; `biome lint packages/core` shows zero `noRestrictedImports`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?