### PR TITLE
fix(chat): make file/image paths clickable in new chat thread

### DIFF
--- a/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
@@ -14,6 +14,12 @@ import {
   parseOpenFence,
   splitMarkdownBlocks,
 } from "@posthog/ui/features/editor/components/splitMarkdownBlocks";
+import {
+  BareFileLink,
+  hasDirectoryPath,
+  InlineFileLink,
+  looksLikeBareFilename,
+} from "@posthog/ui/features/sessions/components/session-update/fileLinkChips";
 import { HighlightedCode } from "@posthog/ui/primitives/HighlightedCode";
 import { useCopy } from "@posthog/ui/primitives/useCopy";
 import { IconButton } from "@radix-ui/themes";
@@ -98,11 +104,18 @@ const components: Components = {
         </ChatCodeBlock>
       );
     }
-    return (
+    const fallback = (
       <code className="rounded rounded-sm border border-border bg-muted/50 px-1 font-mono text-xs">
         {children}
       </code>
     );
+    if (hasDirectoryPath(text)) {
+      return <InlineFileLink text={text} />;
+    }
+    if (looksLikeBareFilename(text)) {
+      return <BareFileLink text={text} fallback={fallback} />;
+    }
+    return fallback;
   },
   pre: ({ children }) => <>{children}</>,
   h1: ({ children }) => (

--- a/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
@@ -1,110 +1,18 @@
 import { Check, Copy } from "@phosphor-icons/react";
 import { Box, Code, IconButton } from "@radix-ui/themes";
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useState } from "react";
 import type { Components } from "react-markdown";
 import { HighlightedCode } from "../../../../primitives/HighlightedCode";
 import { Tooltip } from "../../../../primitives/Tooltip";
-import { usePendingScrollStore } from "../../../code-editor/pendingScrollStore";
 import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
 import { StreamingMarkdown } from "../../../editor/components/StreamingMarkdown";
 import { useSmoothedText } from "../../../editor/components/useSmoothedText";
-import { usePanelLayoutStore } from "../../../panels/panelLayoutStore";
-import type { FileItem } from "../../../repo-files/useRepoFiles";
-import { useRepoFiles } from "../../../repo-files/useRepoFiles";
-import { useCwd } from "../../../sidebar/useCwd";
-import { useSessionTaskId } from "../../useSessionTaskId";
-
-const FILE_WITH_DIR_RE =
-  /^(?:\/|\.\.?\/|[a-zA-Z]:\\)?(?:[\w.@-]+\/)+[\w.@-]+\.\w+(?::\d+(?:-\d+)?)?$/;
-const BARE_FILE_RE = /^[\w.@-]+\.\w+(?::\d+(?:-\d+)?)?$/;
-
-function hasDirectoryPath(text: string): boolean {
-  return FILE_WITH_DIR_RE.test(text);
-}
-
-function looksLikeBareFilename(text: string): boolean {
-  return BARE_FILE_RE.test(text);
-}
-
-function parseFilePath(text: string): { filePath: string; lineSuffix: string } {
-  const match = text.match(/^(.+?)(?::(\d+(?:-\d+)?))?$/);
-  if (!match) return { filePath: text, lineSuffix: "" };
-  return { filePath: match[1], lineSuffix: match[2] ?? "" };
-}
-
-function resolveFilename(filename: string, files: FileItem[]): FileItem | null {
-  const matches = files.filter((f) => f.name === filename);
-  if (matches.length === 1) return matches[0];
-  return null;
-}
-
-function InlineFileLink({
-  text,
-  resolvedPath,
-}: {
-  text: string;
-  resolvedPath?: string;
-}) {
-  const { filePath: rawPath, lineSuffix } = parseFilePath(text);
-  const filePath = resolvedPath ?? rawPath;
-  const filename = rawPath.split("/").pop() ?? rawPath;
-  const taskId = useSessionTaskId();
-  const repoPath = useCwd(taskId ?? "");
-  const openFileInSplit = usePanelLayoutStore((s) => s.openFileInSplit);
-  const requestScroll = usePendingScrollStore((s) => s.requestScroll);
-
-  const handleClick = useCallback(() => {
-    if (!taskId) return;
-    const relativePath =
-      repoPath && filePath.startsWith(`${repoPath}/`)
-        ? filePath.slice(repoPath.length + 1)
-        : filePath;
-    const absolutePath = repoPath
-      ? `${repoPath}/${relativePath}`
-      : relativePath;
-    if (lineSuffix) {
-      const line = Number.parseInt(lineSuffix.split("-")[0], 10);
-      if (line > 0) requestScroll(absolutePath, line);
-    }
-    openFileInSplit(taskId, relativePath, true);
-  }, [taskId, filePath, lineSuffix, repoPath, openFileInSplit, requestScroll]);
-
-  const tooltipText = resolvedPath ?? text;
-
-  return (
-    <Tooltip content={tooltipText}>
-      <button
-        type="button"
-        onClick={taskId ? handleClick : undefined}
-        disabled={!taskId}
-        className={`m-0 inline border-0 bg-transparent p-0 font-[inherit] text-(--accent-11) text-[length:inherit] ${taskId ? "cursor-pointer underline decoration-(--accent-a8) underline-offset-2 hover:decoration-(--accent-11)" : ""}`}
-      >
-        {filename}
-        {lineSuffix ? `:${lineSuffix}` : ""}
-      </button>
-    </Tooltip>
-  );
-}
-
-function BareFileLink({ text }: { text: string }) {
-  const { filePath: bareFilename } = parseFilePath(text);
-  const taskId = useSessionTaskId();
-  const repoPath = useCwd(taskId ?? "");
-  const { files } = useRepoFiles(repoPath ?? undefined);
-  const resolved = useMemo(
-    () => resolveFilename(bareFilename, files),
-    [bareFilename, files],
-  );
-
-  if (!resolved) {
-    return (
-      <Code variant="ghost" className="border border-border text-[13px]">
-        {text}
-      </Code>
-    );
-  }
-  return <InlineFileLink text={text} resolvedPath={resolved.path} />;
-}
+import {
+  BareFileLink,
+  hasDirectoryPath,
+  InlineFileLink,
+  looksLikeBareFilename,
+} from "./fileLinkChips";
 
 const agentComponents: Partial<Components> = {
   code: ({ children, className }) => {
@@ -123,11 +31,7 @@ const agentComponents: Partial<Components> = {
       return <InlineFileLink text={text} />;
     }
 
-    if (looksLikeBareFilename(text)) {
-      return <BareFileLink text={text} />;
-    }
-
-    return (
+    const fallback = (
       <Code
         variant="ghost"
         className="border border-border bg-gray-3 text-[13px]"
@@ -135,6 +39,12 @@ const agentComponents: Partial<Components> = {
         {children}
       </Code>
     );
+
+    if (looksLikeBareFilename(text)) {
+      return <BareFileLink text={text} fallback={fallback} />;
+    }
+
+    return fallback;
   },
 };
 

--- a/packages/ui/src/features/sessions/components/session-update/fileLinkChips.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/fileLinkChips.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react";
+import { useCallback, useMemo } from "react";
+import { Tooltip } from "../../../../primitives/Tooltip";
+import { usePendingScrollStore } from "../../../code-editor/pendingScrollStore";
+import { usePanelLayoutStore } from "../../../panels/panelLayoutStore";
+import type { FileItem } from "../../../repo-files/useRepoFiles";
+import { useRepoFiles } from "../../../repo-files/useRepoFiles";
+import { useCwd } from "../../../sidebar/useCwd";
+import { useSessionTaskId } from "../../useSessionTaskId";
+
+const FILE_WITH_DIR_RE =
+  /^(?:\/|\.\.?\/|[a-zA-Z]:\\)?(?:[\w.@-]+\/)+[\w.@-]+\.\w+(?::\d+(?:-\d+)?)?$/;
+const BARE_FILE_RE = /^[\w.@-]+\.\w+(?::\d+(?:-\d+)?)?$/;
+
+export function hasDirectoryPath(text: string): boolean {
+  return FILE_WITH_DIR_RE.test(text);
+}
+
+export function looksLikeBareFilename(text: string): boolean {
+  return BARE_FILE_RE.test(text);
+}
+
+function parseFilePath(text: string): { filePath: string; lineSuffix: string } {
+  const match = text.match(/^(.+?)(?::(\d+(?:-\d+)?))?$/);
+  if (!match) return { filePath: text, lineSuffix: "" };
+  return { filePath: match[1], lineSuffix: match[2] ?? "" };
+}
+
+function resolveFilename(filename: string, files: FileItem[]): FileItem | null {
+  const matches = files.filter((f) => f.name === filename);
+  if (matches.length === 1) return matches[0];
+  return null;
+}
+
+export function InlineFileLink({
+  text,
+  resolvedPath,
+}: {
+  text: string;
+  resolvedPath?: string;
+}) {
+  const { filePath: rawPath, lineSuffix } = parseFilePath(text);
+  const filePath = resolvedPath ?? rawPath;
+  const filename = rawPath.split("/").pop() ?? rawPath;
+  const taskId = useSessionTaskId();
+  const repoPath = useCwd(taskId ?? "");
+  const openFileInSplit = usePanelLayoutStore((s) => s.openFileInSplit);
+  const requestScroll = usePendingScrollStore((s) => s.requestScroll);
+
+  const handleClick = useCallback(() => {
+    if (!taskId) return;
+    const relativePath =
+      repoPath && filePath.startsWith(`${repoPath}/`)
+        ? filePath.slice(repoPath.length + 1)
+        : filePath;
+    const absolutePath = repoPath
+      ? `${repoPath}/${relativePath}`
+      : relativePath;
+    if (lineSuffix) {
+      const line = Number.parseInt(lineSuffix.split("-")[0], 10);
+      if (line > 0) requestScroll(absolutePath, line);
+    }
+    openFileInSplit(taskId, relativePath, true);
+  }, [taskId, filePath, lineSuffix, repoPath, openFileInSplit, requestScroll]);
+
+  const tooltipText = resolvedPath ?? text;
+
+  return (
+    <Tooltip content={tooltipText}>
+      <button
+        type="button"
+        onClick={taskId ? handleClick : undefined}
+        disabled={!taskId}
+        className={`m-0 inline border-0 bg-transparent p-0 font-[inherit] text-(--accent-11) text-[length:inherit] ${taskId ? "cursor-pointer underline decoration-(--accent-a8) underline-offset-2 hover:decoration-(--accent-11)" : ""}`}
+      >
+        {filename}
+        {lineSuffix ? `:${lineSuffix}` : ""}
+      </button>
+    </Tooltip>
+  );
+}
+
+export function BareFileLink({
+  text,
+  fallback,
+}: {
+  text: string;
+  fallback: ReactNode;
+}) {
+  const { filePath: bareFilename } = parseFilePath(text);
+  const taskId = useSessionTaskId();
+  const repoPath = useCwd(taskId ?? "");
+  const { files } = useRepoFiles(repoPath ?? undefined);
+  const resolved = useMemo(
+    () => resolveFilename(bareFilename, files),
+    [bareFilename, files],
+  );
+
+  if (!resolved) return <>{fallback}</>;
+  return <InlineFileLink text={text} resolvedPath={resolved.path} />;
+}


### PR DESCRIPTION
## Problem

When the agent generates a file (e.g. an image at `/tmp/pr-card.png`), the path renders as a plain, non-clickable chip in the **new chat thread** UI (`useNewChatThread`) — there's no way to open or preview it.

The older agent view (`AgentMessage`) already makes these chips clickable, opening an inline preview in the split editor panel. `ChatMarkdown` just never got that behavior.

## Changes

- Extract the clickable file-link chips (`InlineFileLink` / `BareFileLink` + path-detection helpers) out of `AgentMessage` into a shared `fileLinkChips` module.
- Wire them into `ChatMarkdown`'s inline-code renderer, so directory paths and repo-resolvable filenames become clickable and open an inline preview (images already supported by `CodeEditorPanel`).
- `BareFileLink` takes a caller-supplied `fallback` chip, so the unresolved-filename styling matches each surface instead of leaking `AgentMessage`'s.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` and Biome pass on the changed files (pre-commit hook re-ran both).
- Not yet verified in the running app — worth a manual check: generate an image, click the path chip in the new chat thread, confirm the preview opens.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*