### PR TITLE
fix(sessions): stop chat-title regeneration on every view remount

### DIFF
--- a/packages/core/src/sessions/chatTitle.test.ts
+++ b/packages/core/src/sessions/chatTitle.test.ts
@@ -103,6 +103,83 @@ describe("decideTitleGeneration", () => {
     });
     expect(decision.shouldGenerateFromTaskDescription).toBe(true);
   });
+
+  it.each([
+    {
+      name: "skips a catch-up fire when the title is locked and a summary exists",
+      promptCount: 1 + REGENERATE_INTERVAL,
+      lastGeneratedAtCount: 0,
+      initialDescriptionHandled: false,
+      titleLocked: true,
+      hasSummary: true,
+      expected: false,
+    },
+    {
+      name: "runs a catch-up fire when no summary exists yet",
+      promptCount: 1 + REGENERATE_INTERVAL,
+      lastGeneratedAtCount: 0,
+      initialDescriptionHandled: false,
+      titleLocked: true,
+      hasSummary: false,
+      expected: true,
+    },
+    {
+      name: "runs a catch-up fire when the title is not locked",
+      promptCount: 1 + REGENERATE_INTERVAL,
+      lastGeneratedAtCount: 0,
+      initialDescriptionHandled: false,
+      titleLocked: false,
+      hasSummary: true,
+      expected: true,
+    },
+    {
+      name: "still refreshes the summary at the interval while locked",
+      promptCount: 1 + REGENERATE_INTERVAL,
+      lastGeneratedAtCount: 1,
+      initialDescriptionHandled: false,
+      titleLocked: true,
+      hasSummary: true,
+      expected: true,
+    },
+    {
+      name: "still generates on the first prompt while locked",
+      promptCount: 1,
+      lastGeneratedAtCount: 0,
+      initialDescriptionHandled: false,
+      titleLocked: true,
+      hasSummary: false,
+      expected: true,
+    },
+    {
+      name: "treats a description-handled interval fire as organic while locked",
+      promptCount: REGENERATE_INTERVAL,
+      lastGeneratedAtCount: 0,
+      initialDescriptionHandled: true,
+      titleLocked: true,
+      hasSummary: true,
+      expected: true,
+    },
+  ])(
+    "$name",
+    ({
+      promptCount,
+      lastGeneratedAtCount,
+      initialDescriptionHandled,
+      titleLocked,
+      hasSummary,
+      expected,
+    }) => {
+      const decision = decideTitleGeneration({
+        promptCount,
+        lastGeneratedAtCount,
+        initialDescriptionHandled,
+        task: { title: "Custom", description: "d" },
+        titleLocked,
+        hasSummary,
+      });
+      expect(decision.shouldGenerateFromPrompts).toBe(expected);
+    },
+  );
 });
 
 describe("selectPromptsForTitle", () => {

--- a/packages/core/src/sessions/chatTitle.test.ts
+++ b/packages/core/src/sessions/chatTitle.test.ts
@@ -174,7 +174,7 @@ describe("decideTitleGeneration", () => {
         lastGeneratedAtCount,
         initialDescriptionHandled,
         task: { title: "Custom", description: "d" },
-        titleLocked,
+        isTitleLocked: () => titleLocked,
         hasSummary,
       });
       expect(decision.shouldGenerateFromPrompts).toBe(expected);

--- a/packages/core/src/sessions/chatTitle.ts
+++ b/packages/core/src/sessions/chatTitle.ts
@@ -37,9 +37,7 @@ export function decideTitleGeneration(input: {
   lastGeneratedAtCount: number;
   initialDescriptionHandled: boolean;
   task: Pick<Task, "title" | "description">;
-  /** The user renamed the task, so a generated title would be discarded. */
-  titleLocked?: boolean;
-  /** A conversation summary is already stored for the session. */
+  isTitleLocked?: () => boolean;
   hasSummary?: boolean;
 }): TitleGenerationDecision {
   const {
@@ -47,22 +45,23 @@ export function decideTitleGeneration(input: {
     lastGeneratedAtCount,
     initialDescriptionHandled,
     task,
-    titleLocked = false,
+    isTitleLocked,
     hasSummary = false,
   } = input;
 
-  // A first fire on a conversation that is already several prompts deep is a
-  // catch-up (e.g. after an app restart), not an organic trigger. When the
-  // title is locked and a summary is already stored, the generated title would
-  // be discarded and the summary merely re-derived, so skip the LLM call.
-  // Organic triggers (first prompt, or REGENERATE_INTERVAL new prompts) still
-  // run while locked: the summary must stay current.
-  const isCatchUpFire =
-    promptCount > 1 && lastGeneratedAtCount === 0 && !initialDescriptionHandled;
-  const isDeadGeneration = isCatchUpFire && titleLocked && hasSummary;
+  // A first fire on an already-long conversation whose title the user renamed
+  // and whose summary is already stored would produce nothing usable. Organic
+  // triggers (first prompt, every REGENERATE_INTERVAL prompts) still run while
+  // renamed so the summary stays current.
+  const skipStaleFire =
+    promptCount > 1 &&
+    lastGeneratedAtCount === 0 &&
+    !initialDescriptionHandled &&
+    hasSummary &&
+    (isTitleLocked?.() ?? false);
 
   const shouldGenerateFromPrompts =
-    !isDeadGeneration &&
+    !skipStaleFire &&
     ((promptCount === 1 &&
       lastGeneratedAtCount === 0 &&
       !initialDescriptionHandled) ||

--- a/packages/core/src/sessions/chatTitle.ts
+++ b/packages/core/src/sessions/chatTitle.ts
@@ -37,16 +37,37 @@ export function decideTitleGeneration(input: {
   lastGeneratedAtCount: number;
   initialDescriptionHandled: boolean;
   task: Pick<Task, "title" | "description">;
+  /** The user renamed the task, so a generated title would be discarded. */
+  titleLocked?: boolean;
+  /** A conversation summary is already stored for the session. */
+  hasSummary?: boolean;
 }): TitleGenerationDecision {
-  const { promptCount, lastGeneratedAtCount, initialDescriptionHandled, task } =
-    input;
+  const {
+    promptCount,
+    lastGeneratedAtCount,
+    initialDescriptionHandled,
+    task,
+    titleLocked = false,
+    hasSummary = false,
+  } = input;
+
+  // A first fire on a conversation that is already several prompts deep is a
+  // catch-up (e.g. after an app restart), not an organic trigger. When the
+  // title is locked and a summary is already stored, the generated title would
+  // be discarded and the summary merely re-derived, so skip the LLM call.
+  // Organic triggers (first prompt, or REGENERATE_INTERVAL new prompts) still
+  // run while locked: the summary must stay current.
+  const isCatchUpFire =
+    promptCount > 1 && lastGeneratedAtCount === 0 && !initialDescriptionHandled;
+  const isDeadGeneration = isCatchUpFire && titleLocked && hasSummary;
 
   const shouldGenerateFromPrompts =
-    (promptCount === 1 &&
+    !isDeadGeneration &&
+    ((promptCount === 1 &&
       lastGeneratedAtCount === 0 &&
       !initialDescriptionHandled) ||
-    (promptCount > 1 &&
-      promptCount - lastGeneratedAtCount >= REGENERATE_INTERVAL);
+      (promptCount > 1 &&
+        promptCount - lastGeneratedAtCount >= REGENERATE_INTERVAL));
 
   const shouldGenerateFromTaskDescription =
     promptCount === 0 &&

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -99,7 +99,7 @@ vi.mock("@posthog/ui/features/sessions/sessionStore", () => {
   };
 });
 
-import { titleGenerationStoreApi } from "@posthog/ui/features/sessions/titleGenerationStore";
+import { useTitleGenerationStore } from "@posthog/ui/features/sessions/titleGenerationStore";
 import { useChatTitleGenerator } from "./useChatTitleGenerator";
 
 const TASK_ID = "task-1";
@@ -132,7 +132,7 @@ interface TitleAndSummaryResult {
 describe("useChatTitleGenerator", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    titleGenerationStoreApi.reset();
+    useTitleGenerationStore.setState({ byTaskId: {} });
     mockIsAuthenticated.value = true;
     mockPrompts.value = [];
     mockSessionSummary.value = undefined;

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -13,6 +13,9 @@ const mockSetQueriesData = vi.hoisted(() => vi.fn());
 const mockSetQueryData = vi.hoisted(() => vi.fn());
 const mockUpdateSessionTaskTitle = vi.hoisted(() => vi.fn());
 const mockPrompts = vi.hoisted(() => ({ value: [] as string[] }));
+const mockSessionSummary = vi.hoisted(() => ({
+  value: undefined as string | undefined,
+}));
 const mockSessionStoreSetters = vi.hoisted(() => ({ updateSession: vi.fn() }));
 const mockTitleAttachmentPaths = vi.hoisted(() => ({ value: [] as string[] }));
 const mockTitleAttachmentClear = vi.hoisted(() => vi.fn());
@@ -77,7 +80,14 @@ vi.mock("@posthog/ui/shell/titleAttachmentStore", () => ({
 vi.mock("@posthog/ui/features/sessions/sessionStore", () => {
   const state = {
     taskIdIndex: { "task-1": "run-1" },
-    sessions: { "run-1": { events: mockPrompts.value } },
+    get sessions() {
+      return {
+        "run-1": {
+          events: mockPrompts.value,
+          conversationSummary: mockSessionSummary.value,
+        },
+      };
+    },
   };
   const fn = Object.assign(
     (selector: (s: typeof state) => unknown) => selector(state),
@@ -89,6 +99,7 @@ vi.mock("@posthog/ui/features/sessions/sessionStore", () => {
   };
 });
 
+import { titleGenerationStoreApi } from "@posthog/ui/features/sessions/titleGenerationStore";
 import { useChatTitleGenerator } from "./useChatTitleGenerator";
 
 const TASK_ID = "task-1";
@@ -113,11 +124,18 @@ function cacheTask(task: Task): void {
   mockGetQueriesData.mockReturnValue([[["tasks", "list"], [task]]]);
 }
 
+interface TitleAndSummaryResult {
+  title: string;
+  summary: string;
+}
+
 describe("useChatTitleGenerator", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    titleGenerationStoreApi.reset();
     mockIsAuthenticated.value = true;
     mockPrompts.value = [];
+    mockSessionSummary.value = undefined;
     mockTitleAttachmentPaths.value = [];
     mockEnrichDescription.mockImplementation((desc: string) =>
       Promise.resolve(desc),
@@ -381,5 +399,90 @@ describe("useChatTitleGenerator", () => {
     renderHook(() => useChatTitleGenerator(createTask()));
 
     expect(mockGenerateTitle).not.toHaveBeenCalled();
+  });
+
+  it("does not regenerate when the chat view remounts after a generation", async () => {
+    mockGenerateTitle.mockResolvedValue({
+      title: "Fix login bug",
+      summary: "User is fixing a login issue",
+    });
+    mockPrompts.value = ["Fix the login bug"];
+
+    const first = renderHook(() =>
+      useChatTitleGenerator(createTask({ title: "Raw prompt title" })),
+    );
+    await waitFor(() => {
+      expect(mockGenerateTitle).toHaveBeenCalledTimes(1);
+    });
+    first.unmount();
+
+    renderHook(() =>
+      useChatTitleGenerator(createTask({ title: "Fix login bug" })),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockGenerateTitle).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one in-flight guard across simultaneously mounted views", async () => {
+    let resolveGeneration!: (value: TitleAndSummaryResult) => void;
+    mockGenerateTitle.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGeneration = resolve;
+      }),
+    );
+    mockPrompts.value = ["Fix the login bug"];
+
+    renderHook(() =>
+      useChatTitleGenerator(createTask({ title: "Raw prompt title" })),
+    );
+    renderHook(() =>
+      useChatTitleGenerator(createTask({ title: "Raw prompt title" })),
+    );
+
+    await waitFor(() => {
+      expect(mockGenerateTitle).toHaveBeenCalledTimes(1);
+    });
+
+    resolveGeneration({ title: "Fix login bug", summary: "" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockGenerateTitle).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips catch-up generation when the title is locked and a summary exists", async () => {
+    const lockedTask = createTask({
+      title: "Custom auth title",
+      description: "fix auth",
+      title_manually_set: true,
+    });
+    cacheTask(lockedTask);
+    mockSessionSummary.value = "User wants to fix auth";
+    mockPrompts.value = Array.from({ length: 8 }, (_, i) => `prompt ${i}`);
+
+    renderHook(() => useChatTitleGenerator(lockedTask));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockGenerateTitle).not.toHaveBeenCalled();
+  });
+
+  it("runs catch-up generation for a locked title when no summary exists yet", async () => {
+    const lockedTask = createTask({
+      title: "Custom auth title",
+      description: "fix auth",
+      title_manually_set: true,
+    });
+    cacheTask(lockedTask);
+    mockGenerateTitle.mockResolvedValue({
+      title: "Auto title",
+      summary: "User wants to fix auth",
+    });
+    mockPrompts.value = Array.from({ length: 8 }, (_, i) => `prompt ${i}`);
+
+    renderHook(() => useChatTitleGenerator(lockedTask));
+
+    await waitFor(() => {
+      expect(mockGenerateTitle).toHaveBeenCalledTimes(1);
+    });
+    expect(mockUpdateTask).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
@@ -18,7 +18,10 @@ import {
   sessionStoreSetters,
   useSessionStore,
 } from "@posthog/ui/features/sessions/sessionStore";
-import { titleGenerationStoreApi } from "@posthog/ui/features/sessions/titleGenerationStore";
+import {
+  type TitleGenerationEntry,
+  titleGenerationStoreApi,
+} from "@posthog/ui/features/sessions/titleGenerationStore";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { logger } from "@posthog/ui/shell/logger";
 import { titleAttachmentStoreApi } from "@posthog/ui/shell/titleAttachmentStore";
@@ -60,32 +63,22 @@ export function useChatTitleGenerator(task: Task): void {
   useEffect(() => {
     if (!isAuthenticated) return;
 
-    // Bookkeeping lives in a shared store rather than refs so that remounting
-    // a chat view does not re-fire generation for a conversation whose title
-    // and summary are already current, and so that simultaneously mounted
-    // views of the same task share one in-flight guard.
     const bookkeeping = titleGenerationStoreApi.get(taskId);
     if (bookkeeping.inFlight) return;
 
     const state = useSessionStore.getState();
     const taskRunId = state.taskIdIndex[taskId];
     const session = taskRunId ? state.sessions[taskRunId] : undefined;
+    const isTitleLocked = () =>
+      isAutoTitleLocked(getCachedTask(queryClient, taskId) ?? task);
 
     const { shouldGenerateFromPrompts, shouldGenerateFromTaskDescription } =
       decideTitleGeneration({
         promptCount,
-        // A newer task run can restart the event log with fewer prompts than
-        // the recorded count; clamping keeps the regeneration interval from
-        // stretching by the difference.
-        lastGeneratedAtCount: Math.min(
-          bookkeeping.lastGeneratedAtCount,
-          promptCount,
-        ),
+        lastGeneratedAtCount: bookkeeping.lastGeneratedAtCount,
         initialDescriptionHandled: bookkeeping.initialDescriptionHandled,
         task,
-        titleLocked: isAutoTitleLocked(
-          getCachedTask(queryClient, taskId) ?? task,
-        ),
+        isTitleLocked,
         hasSummary: !!session?.conversationSummary,
       });
 
@@ -124,11 +117,8 @@ export function useChatTitleGenerator(task: Task): void {
           // up and try again with the file contents.
           titleAttachmentStoreApi.clear(taskId);
           const { title, summary } = result;
-          const titleLocked = isAutoTitleLocked(
-            getCachedTask(queryClient, taskId) ?? task,
-          );
 
-          if (title && titleLocked) {
+          if (title && isTitleLocked()) {
             log.debug("Skipping auto-title, user renamed task", { taskId });
           } else if (title) {
             if (client) {
@@ -172,15 +162,14 @@ export function useChatTitleGenerator(task: Task): void {
       } catch (error) {
         log.error("Failed to update task title", { taskId, error });
       } finally {
-        titleGenerationStoreApi.update(taskId, {
-          ...(shouldGenerateFromPrompts
-            ? { lastGeneratedAtCount: promptCount }
-            : {}),
-          ...(shouldGenerateFromTaskDescription
-            ? { initialDescriptionHandled: true }
-            : {}),
-          inFlight: false,
-        });
+        const patch: Partial<TitleGenerationEntry> = { inFlight: false };
+        if (shouldGenerateFromPrompts) {
+          patch.lastGeneratedAtCount = promptCount;
+        }
+        if (shouldGenerateFromTaskDescription) {
+          patch.initialDescriptionHandled = true;
+        }
+        titleGenerationStoreApi.update(taskId, patch);
       }
     };
 

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
@@ -18,11 +18,12 @@ import {
   sessionStoreSetters,
   useSessionStore,
 } from "@posthog/ui/features/sessions/sessionStore";
+import { titleGenerationStoreApi } from "@posthog/ui/features/sessions/titleGenerationStore";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { logger } from "@posthog/ui/shell/logger";
 import { titleAttachmentStoreApi } from "@posthog/ui/shell/titleAttachmentStore";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 const log = logger.scope("chat-title-generator");
 
@@ -44,9 +45,6 @@ export function useChatTitleGenerator(task: Task): void {
   );
   const queryClient = useQueryClient();
   const client = useOptionalAuthenticatedClient();
-  const lastGeneratedAtCount = useRef(0);
-  const initialDescriptionHandled = useRef(false);
-  const isGenerating = useRef(false);
   const isAuthenticated = useAuthStateValue(
     (state) => state.status === "authenticated" && !!state.cloudRegion,
   );
@@ -61,30 +59,47 @@ export function useChatTitleGenerator(task: Task): void {
 
   useEffect(() => {
     if (!isAuthenticated) return;
-    if (isGenerating.current) return;
+
+    // Bookkeeping lives in a shared store rather than refs so that remounting
+    // a chat view does not re-fire generation for a conversation whose title
+    // and summary are already current, and so that simultaneously mounted
+    // views of the same task share one in-flight guard.
+    const bookkeeping = titleGenerationStoreApi.get(taskId);
+    if (bookkeeping.inFlight) return;
+
+    const state = useSessionStore.getState();
+    const taskRunId = state.taskIdIndex[taskId];
+    const session = taskRunId ? state.sessions[taskRunId] : undefined;
 
     const { shouldGenerateFromPrompts, shouldGenerateFromTaskDescription } =
       decideTitleGeneration({
         promptCount,
-        lastGeneratedAtCount: lastGeneratedAtCount.current,
-        initialDescriptionHandled: initialDescriptionHandled.current,
+        // A newer task run can restart the event log with fewer prompts than
+        // the recorded count; clamping keeps the regeneration interval from
+        // stretching by the difference.
+        lastGeneratedAtCount: Math.min(
+          bookkeeping.lastGeneratedAtCount,
+          promptCount,
+        ),
+        initialDescriptionHandled: bookkeeping.initialDescriptionHandled,
         task,
+        titleLocked: isAutoTitleLocked(
+          getCachedTask(queryClient, taskId) ?? task,
+        ),
+        hasSummary: !!session?.conversationSummary,
       });
 
     if (!shouldGenerateFromPrompts && !shouldGenerateFromTaskDescription) {
       return;
     }
 
-    isGenerating.current = true;
+    titleGenerationStoreApi.update(taskId, { inFlight: true });
 
-    const state = useSessionStore.getState();
-    const taskRunId = state.taskIdIndex[taskId];
-    const session = taskRunId ? state.sessions[taskRunId] : undefined;
     let rawContent = task.description;
 
     if (shouldGenerateFromPrompts) {
       if (!session?.events) {
-        isGenerating.current = false;
+        titleGenerationStoreApi.update(taskId, { inFlight: false });
         return;
       }
 
@@ -157,13 +172,15 @@ export function useChatTitleGenerator(task: Task): void {
       } catch (error) {
         log.error("Failed to update task title", { taskId, error });
       } finally {
-        if (shouldGenerateFromPrompts) {
-          lastGeneratedAtCount.current = promptCount;
-        }
-        if (shouldGenerateFromTaskDescription) {
-          initialDescriptionHandled.current = true;
-        }
-        isGenerating.current = false;
+        titleGenerationStoreApi.update(taskId, {
+          ...(shouldGenerateFromPrompts
+            ? { lastGeneratedAtCount: promptCount }
+            : {}),
+          ...(shouldGenerateFromTaskDescription
+            ? { initialDescriptionHandled: true }
+            : {}),
+          inFlight: false,
+        });
       }
     };
 

--- a/packages/ui/src/features/sessions/titleGenerationStore.ts
+++ b/packages/ui/src/features/sessions/titleGenerationStore.ts
@@ -1,0 +1,57 @@
+import { create } from "zustand";
+
+/**
+ * Chat-title generation bookkeeping, keyed by task id, shared across every
+ * mounted chat view of a task.
+ *
+ * Why this exists: the generator used to track "how many prompts had been seen
+ * at the last generation" in refs inside useChatTitleGenerator. Refs reset on
+ * every mount, so merely reopening a task whose conversation already had one
+ * prompt (or REGENERATE_INTERVAL+) re-fired a fresh LLM title/summary call on
+ * each view switch, and two simultaneously mounted views of the same task
+ * (embedded chat + logs tab) could double-fire. Keeping the bookkeeping here
+ * makes it survive remounts and lets concurrent mounts share one in-flight
+ * guard. In-memory only: after an app restart each task gets at most one
+ * catch-up generation.
+ */
+export interface TitleGenerationEntry {
+  /** Prompt count of the session when a title/summary was last generated. */
+  lastGeneratedAtCount: number;
+  /** The task description has been turned into a title once already. */
+  initialDescriptionHandled: boolean;
+  /** A generation is currently running for this task. */
+  inFlight: boolean;
+}
+
+const EMPTY_ENTRY: TitleGenerationEntry = {
+  lastGeneratedAtCount: 0,
+  initialDescriptionHandled: false,
+  inFlight: false,
+};
+
+interface TitleGenerationStore {
+  byTaskId: Record<string, TitleGenerationEntry>;
+  update: (taskId: string, patch: Partial<TitleGenerationEntry>) => void;
+  reset: () => void;
+}
+
+const useTitleGenerationStore = create<TitleGenerationStore>((set) => ({
+  byTaskId: {},
+  update: (taskId, patch) =>
+    set((state) => ({
+      byTaskId: {
+        ...state.byTaskId,
+        [taskId]: { ...(state.byTaskId[taskId] ?? EMPTY_ENTRY), ...patch },
+      },
+    })),
+  reset: () => set({ byTaskId: {} }),
+}));
+
+export const titleGenerationStoreApi = {
+  get: (taskId: string): TitleGenerationEntry =>
+    useTitleGenerationStore.getState().byTaskId[taskId] ?? EMPTY_ENTRY,
+  update: (taskId: string, patch: Partial<TitleGenerationEntry>) =>
+    useTitleGenerationStore.getState().update(taskId, patch),
+  /** Drop all bookkeeping. Intended for tests. */
+  reset: () => useTitleGenerationStore.getState().reset(),
+};

--- a/packages/ui/src/features/sessions/titleGenerationStore.ts
+++ b/packages/ui/src/features/sessions/titleGenerationStore.ts
@@ -1,25 +1,10 @@
 import { create } from "zustand";
 
-/**
- * Chat-title generation bookkeeping, keyed by task id, shared across every
- * mounted chat view of a task.
- *
- * Why this exists: the generator used to track "how many prompts had been seen
- * at the last generation" in refs inside useChatTitleGenerator. Refs reset on
- * every mount, so merely reopening a task whose conversation already had one
- * prompt (or REGENERATE_INTERVAL+) re-fired a fresh LLM title/summary call on
- * each view switch, and two simultaneously mounted views of the same task
- * (embedded chat + logs tab) could double-fire. Keeping the bookkeeping here
- * makes it survive remounts and lets concurrent mounts share one in-flight
- * guard. In-memory only: after an app restart each task gets at most one
- * catch-up generation.
- */
+// Shared across all mounted chat views of a task (refs would reset on every
+// mount, re-firing LLM title generation per view switch). In-memory only.
 export interface TitleGenerationEntry {
-  /** Prompt count of the session when a title/summary was last generated. */
   lastGeneratedAtCount: number;
-  /** The task description has been turned into a title once already. */
   initialDescriptionHandled: boolean;
-  /** A generation is currently running for this task. */
   inFlight: boolean;
 }
 
@@ -32,10 +17,9 @@ const EMPTY_ENTRY: TitleGenerationEntry = {
 interface TitleGenerationStore {
   byTaskId: Record<string, TitleGenerationEntry>;
   update: (taskId: string, patch: Partial<TitleGenerationEntry>) => void;
-  reset: () => void;
 }
 
-const useTitleGenerationStore = create<TitleGenerationStore>((set) => ({
+export const useTitleGenerationStore = create<TitleGenerationStore>((set) => ({
   byTaskId: {},
   update: (taskId, patch) =>
     set((state) => ({
@@ -44,7 +28,6 @@ const useTitleGenerationStore = create<TitleGenerationStore>((set) => ({
         [taskId]: { ...(state.byTaskId[taskId] ?? EMPTY_ENTRY), ...patch },
       },
     })),
-  reset: () => set({ byTaskId: {} }),
 }));
 
 export const titleGenerationStoreApi = {
@@ -52,6 +35,4 @@ export const titleGenerationStoreApi = {
     useTitleGenerationStore.getState().byTaskId[taskId] ?? EMPTY_ENTRY,
   update: (taskId: string, patch: Partial<TitleGenerationEntry>) =>
     useTitleGenerationStore.getState().update(taskId, patch),
-  /** Drop all bookkeeping. Intended for tests. */
-  reset: () => useTitleGenerationStore.getState().reset(),
 };


### PR DESCRIPTION
## Problem

Opening or switching to a task chat view re-fired the LLM title/summary generation even when nothing had changed. 

~14,000–21,000 eliminated LLM calls/week
~15–20M gateway tokens/week that stop counting against users' metered LLM usage
Per user roughly one fewer 2.2s background gateway request + IPC round trip on most task-view

## Changes

- move title generation state into a shared Zustand store keyed by task ID, preserving generation state across remounts and preventing concurrent generation.

- skip catch-up title generation when the title is locked and a summary already exists, while continuing normal generation triggers so summaries stay up to date.

- clamp prompt counts to prevent newer task runs with shorter event logs from resetting generation state.