### PR TITLE
feat(harness): brand hog with a hedgehog glyph instead of pi's π

### DIFF
--- a/packages/harness/src/extensions/hog-branding/extension.test.ts
+++ b/packages/harness/src/extensions/hog-branding/extension.test.ts
@@ -80,6 +80,7 @@ describe("createHogBrandingExtension", () => {
     const component = factory(undefined, fakeTheme());
     const lines = component.render(80);
 
+    expect(lines[0]).toContain("🦔");
     expect(lines[0]).toContain("Hog");
     expect(lines[0]).toContain("A Pi distribution by PostHog");
     expect(lines[0]).toContain("v9.9.9");
@@ -129,7 +130,7 @@ describe("createHogBrandingExtension", () => {
       {} as SessionStartEvent,
       fakeCtx({ cwd: "/home/user/my-project", setTitle: setTitleNoName }),
     );
-    expect(setTitleNoName).toHaveBeenCalledWith("hog - my-project");
+    expect(setTitleNoName).toHaveBeenCalledWith("🦔 hog - my-project");
 
     const setTitleWithName = vi.fn();
     await handlers.session_start[0]?.(
@@ -140,7 +141,9 @@ describe("createHogBrandingExtension", () => {
         setTitle: setTitleWithName,
       }),
     );
-    expect(setTitleWithName).toHaveBeenCalledWith("hog - fix-bug - my-project");
+    expect(setTitleWithName).toHaveBeenCalledWith(
+      "🦔 hog - fix-bug - my-project",
+    );
   });
 
   it("updates the terminal title on session_info_changed", async () => {
@@ -167,7 +170,7 @@ describe("createHogBrandingExtension", () => {
       }),
     );
 
-    expect(setTitle).toHaveBeenCalledWith("hog - renamed - my-project");
+    expect(setTitle).toHaveBeenCalledWith("🦔 hog - renamed - my-project");
   });
 
   it("re-applies the branded title on the next tick to win the race against pi's own updateTerminalTitle()", async () => {
@@ -183,7 +186,7 @@ describe("createHogBrandingExtension", () => {
 
       // Set immediately...
       expect(setTitle).toHaveBeenCalledTimes(1);
-      expect(setTitle).toHaveBeenLastCalledWith("hog - my-project");
+      expect(setTitle).toHaveBeenLastCalledWith("🦔 hog - my-project");
 
       // Simulate pi's own interactive-mode stomping the title synchronously
       // right after our handler resolves, as it does in practice.
@@ -192,7 +195,7 @@ describe("createHogBrandingExtension", () => {
 
       // ...and re-applied on the next tick, winning the race.
       vi.runAllTimers();
-      expect(setTitle).toHaveBeenLastCalledWith("hog - my-project");
+      expect(setTitle).toHaveBeenLastCalledWith("🦔 hog - my-project");
     } finally {
       vi.useRealTimers();
     }

--- a/packages/harness/src/extensions/hog-branding/extension.ts
+++ b/packages/harness/src/extensions/hog-branding/extension.ts
@@ -20,6 +20,10 @@ export interface HogBrandingOptions {
 
 const BRAND_NAME = "hog";
 const BRAND_TAGLINE = "A Pi distribution by PostHog";
+// Our mascot, in place of pi's default `π`. PostHog's hedgehog is the whole
+// point of the "hog" name, so it fronts both the TUI header and the OS
+// terminal title.
+const BRAND_GLYPH = "🦔";
 
 type ExpandableHeaderComponent = Component & {
   setExpanded(expanded: boolean): void;
@@ -30,7 +34,7 @@ function brandLine(theme: Theme, version: string): string {
   const brand = theme.bold(theme.fg("accent", BRAND_NAME));
   const tagline = theme.fg("dim", ` (${BRAND_TAGLINE})`);
   const versionText = theme.fg("dim", ` v${version}`);
-  return `${brand}${tagline}${versionText}`;
+  return `${BRAND_GLYPH} ${brand}${tagline}${versionText}`;
 }
 
 function createHeaderComponent(
@@ -87,9 +91,10 @@ function createHeaderComponent(
 function terminalTitle(ctx: ExtensionContext): string {
   const cwdBasename = path.basename(ctx.sessionManager.getCwd());
   const sessionName = ctx.sessionManager.getSessionName();
-  return sessionName
+  const label = sessionName
     ? `${BRAND_NAME} - ${sessionName} - ${cwdBasename}`
     : `${BRAND_NAME} - ${cwdBasename}`;
+  return `${BRAND_GLYPH} ${label}`;
 }
 
 // pi's own interactive mode calls its internal `updateTerminalTitle()`


### PR DESCRIPTION
## Problem

The `hog` harness is built on [pi](https://pi.dev), and pi's default terminal title/header uses a `π` glyph. The `hog-branding` extension already strips that prefix down to a plain `hog`, but nothing carries PostHog's hedgehog mascot through — so the branding reads as pi's leftover symbol rather than as PostHog.

**Why:** Requested to make the harness header feel fun and on-brand — a hedgehog instead of the pi symbol.

## Changes

- Add a `BRAND_GLYPH` (🦔) constant to the `hog-branding` extension and front both the TUI header line and the OS terminal title with it, so they render as `🦔 hog …` in place of pi's `π`.

Header line: `🦔 hog (A Pi distribution by PostHog) v<version>`
Terminal title: `🦔 hog - <session> - <cwd>`

## How did you test this?

- `pnpm --filter @posthog/harness exec vitest run` — full harness suite passes (472 tests), including the updated `hog-branding` header/title assertions.
- `pnpm --filter @posthog/harness typecheck` — clean.
- `biome lint packages/harness/src/extensions/hog-branding/` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*