### PR TITLE
feat(ui): add tooltip to subagent robot icon

### DIFF
--- a/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
@@ -3,13 +3,13 @@ import {
   ArrowsOutSimple as ArrowsOutSimpleIcon,
   Robot,
 } from "@phosphor-icons/react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@posthog/quill";
 import {
   LoadingIcon,
   StatusIndicators,
   type ToolViewProps,
   useToolCallStatus,
 } from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
-import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import { useState } from "react";
 import type { ConversationItem, TurnContext } from "../buildConversationItems";
@@ -69,14 +69,21 @@ export function SubagentToolView({
           className="flex w-full cursor-pointer items-center justify-between border-none bg-transparent px-3 py-2"
         >
           <Flex align="center" gap="2">
-            <Tooltip content="Delegated to a subagent">
-              <span className="flex items-center">
-                <LoadingIcon
-                  icon={Robot}
-                  isLoading={isLoading}
-                  className="text-gray-10"
-                />
-              </span>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span className="flex items-center">
+                    <LoadingIcon
+                      icon={Robot}
+                      isLoading={isLoading}
+                      className="text-gray-10"
+                    />
+                  </span>
+                }
+              />
+              <TooltipContent side="top">
+                Delegated to a subagent
+              </TooltipContent>
             </Tooltip>
             <Text className="text-[13px] text-gray-10">
               {title || "Subagent"}
@@ -112,10 +119,15 @@ export function SubagentToolView({
     <div>
       <ToolRow
         leading={
-          <Tooltip content="Delegated to a subagent">
-            <span className="flex items-center">
-              <LoadingIcon icon={Robot} isLoading={isLoading} />
-            </span>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <span className="flex items-center">
+                  <LoadingIcon icon={Robot} isLoading={isLoading} />
+                </span>
+              }
+            />
+            <TooltipContent side="top">Delegated to a subagent</TooltipContent>
           </Tooltip>
         }
         isLoading={isLoading}

--- a/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
@@ -9,6 +9,7 @@ import {
   type ToolViewProps,
   useToolCallStatus,
 } from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import { useState } from "react";
 import type { ConversationItem, TurnContext } from "../buildConversationItems";
@@ -68,11 +69,15 @@ export function SubagentToolView({
           className="flex w-full cursor-pointer items-center justify-between border-none bg-transparent px-3 py-2"
         >
           <Flex align="center" gap="2">
-            <LoadingIcon
-              icon={Robot}
-              isLoading={isLoading}
-              className="text-gray-10"
-            />
+            <Tooltip content="Delegated to a subagent">
+              <span className="flex items-center">
+                <LoadingIcon
+                  icon={Robot}
+                  isLoading={isLoading}
+                  className="text-gray-10"
+                />
+              </span>
+            </Tooltip>
             <Text className="text-[13px] text-gray-10">
               {title || "Subagent"}
             </Text>
@@ -106,7 +111,13 @@ export function SubagentToolView({
   return (
     <div>
       <ToolRow
-        icon={Robot}
+        leading={
+          <Tooltip content="Delegated to a subagent">
+            <span className="flex items-center">
+              <LoadingIcon icon={Robot} isLoading={isLoading} />
+            </span>
+          </Tooltip>
+        }
         isLoading={isLoading}
         isFailed={isFailed}
         wasCancelled={wasCancelled}


### PR DESCRIPTION
## Problem

We would delegate to subagents, but it was difficult to tell exactly in the new experimental chat ui when it was a subagent running it.


The Robot icon shown for subagent (Task/Agent) tool calls in the new thread view has no explanation of what it represents.

## Changes

Wrapped the Robot icon in `SubagentToolView.tsx` with a `Tooltip` ("Delegated to a subagent"), for both the new-thread and legacy-thread render paths.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*