### PR TITLE
fix(usage): rename "(no tool)" label to "Text response"

### DIFF
--- a/packages/ui/src/features/usage/components/SpendBreakdownTables.tsx
+++ b/packages/ui/src/features/usage/components/SpendBreakdownTables.tsx
@@ -55,7 +55,7 @@ export function ToolBreakdownCard({ rows }: { rows: SpendAnalysisToolRow[] }) {
       >
         {rows.slice(0, 10).map((r) => (
           <Table.Row key={r.tool ?? "(null)"}>
-            <Table.Cell>{r.tool ?? "(no tool)"}</Table.Cell>
+            <Table.Cell>{r.tool ?? "Text response"}</Table.Cell>
             <Table.Cell>{r.generation_count.toLocaleString()}</Table.Cell>
             <Table.Cell>{formatTokens(r.avg_input_tokens)}</Table.Cell>
             <Table.Cell>{formatUsd(r.cost_usd)}</Table.Cell>


### PR DESCRIPTION
## Problem

The AI observability "By tool" usage table showed `(no tool)` for generations with no tool call, which didn't explain what that meant.

## Changes

Renamed the label to "Text response" in `SpendBreakdownTables.tsx`.

## How did you test this?

Visual code review only, no functional logic changed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*