### PR TITLE
fix(bluebird): prefix channel name with # in CONTEXT.md empty state

### DIFF
--- a/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -415,7 +415,7 @@ function EmptyState({
         <EmptyTitle>No CONTEXT.md yet</EmptyTitle>
         <EmptyDescription>
           CONTEXT.md tells agents the specific details they need to know when
-          working in <strong>{channelName}</strong> — conventions, gotchas, key
+          working in <strong>#{channelName}</strong> — conventions, gotchas, key
           files, and anything else that isn't obvious from the code.
         </EmptyDescription>
       </EmptyHeader>


### PR DESCRIPTION
## Problem

**Why:** In the Project Bluebird (Channels/Website space) UI, the "No CONTEXT.md yet" empty state showed the channel name in bold but without the `#` prefix, unlike every other place a channel is referenced.

## Changes

Added the `#` prefix (inside the existing bold) to the channel name in the CONTEXT.md empty state, so it reads `#channel` — matching the convention used in breadcrumbs, the channel welcome heading, and the context tabs.

```diff
-          working in <strong>{channelName}</strong> — conventions, gotchas, key
+          working in <strong>#{channelName}</strong> — conventions, gotchas, key
```

## How did you test this?

No automated tests were run — this is a one-character copy change to JSX prose in the empty state (no test asserts this string). Verified by inspection and against the `#${channelName}` convention used elsewhere in `packages/ui`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*