### PR TITLE
Channels: persistent reply row to stop feed scroll jitter

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -383,9 +383,6 @@ function ReplyFooter({
             </AvatarFallback>
           </Avatar>
         </AvatarGroup>
-        {/* Muted, not the teaser's --primary accent: on an always-present row
-            the accent should stay earned by real replies, not shout on every
-            card. Matches the grey of the populated state's "Last reply" meta. */}
         <ThreadItemRepliesLabel className="text-(--muted-foreground)">
           Reply
         </ThreadItemRepliesLabel>

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -383,7 +383,12 @@ function ReplyFooter({
             </AvatarFallback>
           </Avatar>
         </AvatarGroup>
-        <ThreadItemRepliesLabel>Reply</ThreadItemRepliesLabel>
+        {/* Muted, not the teaser's --primary accent: on an always-present row
+            the accent should stay earned by real replies, not shout on every
+            card. Matches the grey of the populated state's "Last reply" meta. */}
+        <ThreadItemRepliesLabel className="text-(--muted-foreground)">
+          Reply
+        </ThreadItemRepliesLabel>
       </ThreadItemReplies>
     );
   }

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -461,16 +461,12 @@ const FeedItem = memo(function FeedItem({
         />
       </ThreadItemContent>
 
-      {/* Actions anchor to the row's top-right corner; a top tooltip there
-          overhangs the panel edge and gets clipped by the scroll container, so
-          open tooltips toward the content instead. */}
+      {/* Replying now lives in the always-visible ReplyFooter, so the hover
+          toolbar only carries the distinct "Open task" action. Actions anchor
+          to the row's top-right corner; a top tooltip there overhangs the panel
+          edge and gets clipped by the scroll container, so open tooltips toward
+          the content instead. */}
       <ThreadItemActions aria-label="Message actions" className="inset-bs-2">
-        <ThreadItemAction
-          label="Reply in thread"
-          onClick={() => onOpenThread(task)}
-        >
-          <ChatCircleIcon size={15} />
-        </ThreadItemAction>
         <ThreadItemAction label="Open task" onClick={() => onOpenTask(task)}>
           <ArrowSquareOutIcon size={15} />
         </ThreadItemAction>

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -340,18 +340,27 @@ function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
   );
 }
 
-// Slack-style thread teaser under the card: reply-author facepile, count, and
-// last-reply time. Only renders once the thread has messages; starting a
-// thread lives in the row's hover toolbar.
-function RepliesRow({
+// The reply row under the card, always present at a constant height: the
+// Slack-style teaser (author facepile, count, last-reply time) once the thread
+// has messages, and a quiet "Reply" affordance otherwise. Keeping the row
+// mounted at a fixed height means the teaser swaps in after the thread fetch
+// lands without shifting the feed — and it surfaces an always-visible way into
+// the thread instead of hiding it in the hover toolbar.
+//
+// The fetch/poll only runs for near-viewport rows (`inView`); off-screen rows
+// render the static affordance and idle, so a long feed isn't polling per row.
+function ReplyFooter({
   taskId,
+  inView,
   onOpenThread,
 }: {
   taskId: string;
+  inView: boolean;
   onOpenThread: () => void;
 }) {
   const { messages } = useTaskThread(taskId, {
     pollIntervalMs: FEED_REPLIES_POLL_INTERVAL_MS,
+    enabled: inView,
   });
   const authors = useMemo(() => {
     const seen = new Map<string, (typeof messages)[number]["author"]>();
@@ -362,9 +371,24 @@ function RepliesRow({
     return [...seen.values()].slice(0, 4);
   }, [messages]);
 
-  if (messages.length === 0) return null;
-  const last = messages[messages.length - 1];
+  if (messages.length === 0) {
+    // A single avatar-sized slot keeps this row the exact height of the
+    // populated teaser, so swapping to it after the fetch never shifts the feed.
+    return (
+      <ThreadItemReplies onClick={onOpenThread} className="mt-1">
+        <AvatarGroup size="xs">
+          <Avatar size="xs">
+            <AvatarFallback>
+              <ChatCircleIcon size={12} />
+            </AvatarFallback>
+          </Avatar>
+        </AvatarGroup>
+        <ThreadItemRepliesLabel>Reply</ThreadItemRepliesLabel>
+      </ThreadItemReplies>
+    );
+  }
 
+  const last = messages[messages.length - 1];
   return (
     <ThreadItemReplies onClick={onOpenThread} className="mt-1">
       <AvatarGroup size="xs">
@@ -430,15 +454,11 @@ const FeedItem = memo(function FeedItem({
         </ThreadItemBody>
 
         <TaskCard task={task} onOpen={() => onOpenTask(task)} />
-        {/* Off-screen rows drop the reply teaser so a long feed isn't running a
-            15s poll timer per row; the wide inView margin mounts it well before
-            the row scrolls into view, so nothing pops in. */}
-        {inView && (
-          <RepliesRow
-            taskId={task.id}
-            onOpenThread={() => onOpenThread(task)}
-          />
-        )}
+        <ReplyFooter
+          taskId={task.id}
+          inView={inView}
+          onOpenThread={() => onOpenThread(task)}
+        />
       </ThreadItemContent>
 
       {/* Actions anchor to the row's top-right corner; a top tooltip there

--- a/packages/ui/src/features/canvas/hooks/useTaskThread.ts
+++ b/packages/ui/src/features/canvas/hooks/useTaskThread.ts
@@ -16,17 +16,23 @@ export function useTaskThread(
   options?: {
     /** Poll cadence override; feed rows poll slower than the open panel. */
     pollIntervalMs?: number;
+    /**
+     * Gate the fetch/poll. Feed rows pass `inView` so only near-viewport rows
+     * hit the network; off-screen rows keep any cached messages but idle.
+     */
+    enabled?: boolean;
   },
 ): {
   messages: TaskThreadMessage[];
   isLoading: boolean;
 } {
   const pollIntervalMs = options?.pollIntervalMs ?? THREAD_POLL_INTERVAL_MS;
+  const enabled = options?.enabled ?? true;
   const query = useAuthenticatedQuery<TaskThreadMessage[]>(
     taskThreadQueryKey(taskId),
     (client) => client.getTaskThreadMessages(taskId as string),
     {
-      enabled: !!taskId,
+      enabled: !!taskId && enabled,
       refetchInterval: pollIntervalMs,
       // Fresh-within-the-poll-window so focus/remount doesn't refire every
       // feed row's thread query on top of the interval.


### PR DESCRIPTION
## Problem

In channels, scrolling up through the feed caused visible layout jitter: a message with a human thread would come into view, and a beat later its "N replies" teaser would pop in and push the feed down. The teaser was only mounted once a row scrolled near the viewport, and rendered nothing until its thread fetch resolved — so on the first scroll up from the bottom (rows that have never been fetched) the fetch routinely landed *after* the row was already visible.

**Why:** Reported from the Channels (project-bluebird) experience — the late-attaching reply teaser makes scrolling feel unstable, and the existing way to start a thread was hidden in the hover toolbar.

## Changes

- Replace the in-view-gated `RepliesRow` with a persistent `ReplyFooter`, rendered at a constant height for every message: the reply teaser once the thread has messages, and a quiet always-visible **Reply** affordance otherwise. Both states share the same avatar-sized row, so the teaser swaps in after the fetch with **no layout shift**.
- The Reply affordance is now always visible, instead of being tucked into the hover toolbar.
- Add an `enabled` flag to `useTaskThread` so only near-viewport rows fetch/poll; off-screen rows show the static affordance and idle, keeping a long feed from polling every row.

Height parity between the two states relies on both using the same `AvatarGroup size="xs"` row — worth an eyeball in review, but the swap is now a content change, not a `0 → teaser` height jump.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` — passes.
- Biome `check` on the two changed files — clean.
- No manual/visual run of the app in this environment; the persistent-height claim should be confirmed visually before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
