### PR TITLE
fix(bluebird): hide redundant task title under Thread heading in task view

### DIFF
--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -135,6 +135,7 @@ export function ThreadPanel({
   onClose,
   collapsed,
   onToggleCollapsed,
+  showTaskTitle = true,
 }: {
   taskId: string;
   /** The thread's task when the caller already has it; fetched otherwise. */
@@ -142,6 +143,11 @@ export function ThreadPanel({
   onClose?: () => void;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
+  /**
+   * Show the task title under the "Thread" heading. Hidden in the task detail
+   * view, where the TaskDetail header already names the task.
+   */
+  showTaskTitle?: boolean;
 }) {
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
@@ -240,7 +246,7 @@ export function ThreadPanel({
           <Text size="2" weight="medium" className="block">
             Thread
           </Text>
-          {task && (
+          {showTaskTitle && task && (
             <Text size="1" className="block truncate text-muted-foreground">
               {task.title || "Untitled task"}
             </Text>

--- a/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
@@ -14,11 +14,14 @@ export function ThreadSidebar({
   taskId,
   task,
   onClose,
+  showTaskTitle,
 }: {
   taskId: string;
   /** The thread's task when the caller already has it; fetched otherwise. */
   task?: Task;
   onClose?: () => void;
+  /** Forwarded to ThreadPanel; hidden in the task detail view. */
+  showTaskTitle?: boolean;
 }) {
   const collapsed = useThreadPanelStore((s) => s.collapsed);
   const width = useThreadPanelStore((s) => s.width);
@@ -60,6 +63,7 @@ export function ThreadSidebar({
         task={task}
         onClose={onClose}
         onToggleCollapsed={() => toggleCollapsed(true)}
+        showTaskTitle={showTaskTitle}
       />
     </ResizableSidebar>
   );

--- a/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
+++ b/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
@@ -68,7 +68,7 @@ function ChannelTaskDetailRoute() {
           channelId={channelId}
         />
       </div>
-      <ThreadSidebar taskId={taskId} task={task} />
+      <ThreadSidebar taskId={taskId} task={task} showTaskTitle={false} />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

**Why:** In the Project Bluebird channels task view, the docked thread sidebar repeated the task title directly beneath its "Thread" heading. When you're already inside a task, the `TaskDetail` header next to the sidebar already names it — so the echoed line was redundant noise.

## Changes

- Added an optional `showTaskTitle` prop (default `true`) to `ThreadPanel`, forwarded through `ThreadSidebar`.
- The channels task route now passes `showTaskTitle={false}`, leaving a clean single-line "Thread" header.
- The channel home feed is unchanged (keeps the default), where the title still usefully identifies which task's thread was opened.

Scoped, presentational change — no new events or flags (the whole `/website` space is already gated behind `project-bluebird`).

## How did you test this?

- `pnpm turbo run typecheck --filter=@posthog/ui` — passes.
- `biome check` on the three changed files — clean.
- Did not run the desktop app manually in this environment; change is presentational (a conditional render of an existing text line).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
