### PR TITLE
feat(sessions): show progress bar and elapsed time while compacting

### DIFF
--- a/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -257,7 +257,12 @@ describe("buildConversationItems", () => {
     );
     // Spinner row (now complete) + the failure row.
     expect(statusItems.map((i) => i.update)).toEqual([
-      { sessionUpdate: "status", status: "compacting", isComplete: true },
+      {
+        sessionUpdate: "status",
+        status: "compacting",
+        isComplete: true,
+        startedAt: 2,
+      },
       {
         sessionUpdate: "status",
         status: "compacting_failed",

--- a/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -599,6 +599,7 @@ function handleNotification(
       sessionUpdate: "status",
       status: params.status,
       isComplete: params.isComplete,
+      startedAt: ts,
     });
     return;
   }
@@ -689,9 +690,15 @@ function markCompactingStatusComplete(b: ItemBuilder) {
     if (
       item.type === "session_update" &&
       item.update.sessionUpdate === "status" &&
-      item.update.status === "compacting"
+      item.update.status === "compacting" &&
+      !item.update.isComplete
     ) {
-      item.update.isComplete = true;
+      // Replace the row and its update with fresh objects rather than mutating
+      // in place. The incremental builder reuses item identity so memoized rows
+      // skip re-render; an in-place flip can be missed, leaving the finished row
+      // stuck with its spinner and a still-ticking timer. A new reference forces
+      // the completion to render (and the row to unmount).
+      b.items[i] = { ...item, update: { ...item.update, isComplete: true } };
       return;
     }
   }

--- a/packages/ui/src/features/sessions/components/session-update/SessionUpdateView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/SessionUpdateView.tsx
@@ -33,6 +33,8 @@ export type RenderItem =
       sessionUpdate: "status";
       status: string;
       isComplete?: boolean;
+      /** Epoch ms a `compacting` status began; drives the elapsed timer. */
+      startedAt?: number;
       /** Set when a status ends in failure (e.g. a failed compaction) so the row renders the error. */
       error?: string;
       /** Refusal statuses: display-only stop_details.explanation from the API. */
@@ -130,6 +132,7 @@ export const SessionUpdateView = memo(function SessionUpdateView({
         <StatusNotificationView
           status={item.status}
           isComplete={item.isComplete}
+          startedAt={item.startedAt}
           error={item.error}
           explanation={item.explanation}
           fromModel={item.fromModel}

--- a/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
@@ -6,7 +6,9 @@ import {
 } from "@phosphor-icons/react";
 import { ChatMarker, ChatMarkerContent } from "@posthog/quill";
 import { Box, Callout, Flex, Text } from "@radix-ui/themes";
+import { useEffect, useState } from "react";
 import { useChatThreadChrome } from "../chat-thread/chatThreadChrome";
+import { formatDuration } from "../GeneratingIndicator";
 
 interface StatusNotificationViewProps {
   status: string;
@@ -107,16 +109,7 @@ export function StatusNotificationView({
     if (isComplete) {
       return null;
     }
-    return (
-      <Box className="my-1 border-blue-6 border-l-2 py-1 pl-3 dark:border-blue-8">
-        <Flex align="center" gap="2">
-          <Spinner size={14} className="animate-spin text-blue-9" />
-          <Text className="text-[13px] text-gray-11">
-            Compacting conversation history...
-          </Text>
-        </Flex>
-      </Box>
-    );
+    return <CompactingStatusView />;
   }
 
   // Generic status display for other statuses
@@ -125,6 +118,43 @@ export function StatusNotificationView({
       <Flex align="center" gap="2">
         <Text className="text-[13px] text-gray-11">Status: {status}</Text>
       </Flex>
+    </Box>
+  );
+}
+
+/**
+ * In-flight compaction row. Compaction is a single streaming summarization call
+ * with no measurable percentage, so we pair the spinner with an indeterminate
+ * progress bar (constant motion, so it never reads as frozen) and a live
+ * elapsed-time counter, which is the one honest progress signal we have.
+ */
+function CompactingStatusView() {
+  const [startedAt] = useState(() => Date.now());
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setElapsed(Date.now() - startedAt);
+    }, 100);
+    return () => clearInterval(interval);
+  }, [startedAt]);
+
+  return (
+    <Box className="my-1 border-blue-6 border-l-2 px-3 py-1 dark:border-blue-8">
+      <Flex align="center" gap="2">
+        <Spinner size={14} className="animate-spin text-blue-9" />
+        <Text className="text-[13px] text-gray-11">
+          Compacting conversation history...
+        </Text>
+        <Text className="text-[13px] text-gray-10 tabular-nums">
+          {formatDuration(elapsed, 1)}
+        </Text>
+      </Flex>
+      <div
+        className="compacting-progress mt-1.5"
+        role="progressbar"
+        aria-label="Compacting conversation history"
+      />
     </Box>
   );
 }

--- a/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
@@ -13,6 +13,9 @@ import { formatDuration } from "../GeneratingIndicator";
 interface StatusNotificationViewProps {
   status: string;
   isComplete?: boolean;
+  /** Epoch ms when a `compacting` status began; anchors the elapsed timer so it
+   *  survives unmount/remount in the virtualized list instead of resetting. */
+  startedAt?: number;
   /** Failure reason, set on a `compacting_failed` status. */
   error?: string;
   /** Refusal statuses: display-only stop_details.explanation from the API. */
@@ -26,6 +29,7 @@ interface StatusNotificationViewProps {
 export function StatusNotificationView({
   status,
   isComplete,
+  startedAt,
   error,
   explanation,
   fromModel,
@@ -109,7 +113,7 @@ export function StatusNotificationView({
     if (isComplete) {
       return null;
     }
-    return <CompactingStatusView />;
+    return <CompactingStatusView startedAt={startedAt} />;
   }
 
   // Generic status display for other statuses
@@ -128,16 +132,22 @@ export function StatusNotificationView({
  * progress bar (constant motion, so it never reads as frozen) and a live
  * elapsed-time counter, which is the one honest progress signal we have.
  */
-function CompactingStatusView() {
-  const [elapsed, setElapsed] = useState(0);
+function CompactingStatusView({ startedAt }: { startedAt?: number }) {
+  const [elapsed, setElapsed] = useState(() =>
+    startedAt ? Date.now() - startedAt : 0,
+  );
 
   useEffect(() => {
-    const startedAt = Date.now();
-    const interval = setInterval(() => {
-      setElapsed(Date.now() - startedAt);
-    }, 100);
+    // Anchor to the persisted compaction start time so remounting this row
+    // (e.g. scrolling it out of and back into the virtualized list while
+    // compaction runs) keeps counting from when compaction began rather than
+    // resetting to zero. Fall back to mount time only if it's missing.
+    const start = startedAt ?? Date.now();
+    const tick = () => setElapsed(Date.now() - start);
+    tick();
+    const interval = setInterval(tick, 100);
     return () => clearInterval(interval);
-  }, []);
+  }, [startedAt]);
 
   return (
     <Box className="my-1 border-blue-6 border-l-2 px-3 py-1 dark:border-blue-8">

--- a/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
@@ -129,15 +129,15 @@ export function StatusNotificationView({
  * elapsed-time counter, which is the one honest progress signal we have.
  */
 function CompactingStatusView() {
-  const [startedAt] = useState(() => Date.now());
   const [elapsed, setElapsed] = useState(0);
 
   useEffect(() => {
+    const startedAt = Date.now();
     const interval = setInterval(() => {
       setElapsed(Date.now() - startedAt);
     }, 100);
     return () => clearInterval(interval);
-  }, [startedAt]);
+  }, []);
 
   return (
     <Box className="my-1 border-blue-6 border-l-2 px-3 py-1 dark:border-blue-8">

--- a/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
@@ -150,11 +150,8 @@ function CompactingStatusView() {
           {formatDuration(elapsed, 1)}
         </Text>
       </Flex>
-      <div
-        className="compacting-progress mt-1.5"
-        role="progressbar"
-        aria-label="Compacting conversation history"
-      />
+      {/* Decorative: the spinner and the text above carry the accessible status. */}
+      <div className="compacting-progress mt-1.5" aria-hidden="true" />
     </Box>
   );
 }

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -111,6 +111,43 @@
 }
 
 /*
+ * Indeterminate progress bar for the in-flight conversation-compaction row.
+ * Compaction is a single streaming summarization call with no measurable
+ * percentage, so the bar swoops continuously (reusing the section-loading
+ * keyframe above) to signal ongoing work while the row's elapsed timer carries
+ * the concrete progress signal. Blue-tinted to match the compaction status row.
+ */
+.compacting-progress {
+  position: relative;
+  width: 100%;
+  height: 0.1875rem;
+  overflow: hidden;
+  border-radius: 9999px;
+  background: color-mix(in oklab, var(--blue-9) 15%, transparent);
+}
+
+.compacting-progress::after {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50%;
+  height: 100%;
+  content: "";
+  border-radius: 9999px;
+  background: var(--blue-9);
+  animation: quill-section-loading-swoop 1.5s linear infinite;
+}
+
+/* No swoop when the user prefers reduced motion; leave a static filled track. */
+@media (prefers-reduced-motion: reduce) {
+  .compacting-progress::after {
+    width: 100%;
+    animation: none;
+    opacity: 0.6;
+  }
+}
+
+/*
  * Quill ships its dialog backdrop at `opacity-20` (light) / `opacity-70`
  * (dark). The light value is barely visible — bump it so dialogs feel
  * properly modal across the app, matching Radix Themes.


### PR DESCRIPTION
## Problem

When the agent compacts the conversation, the "Compacting conversation history..." row showed only a static spinner. That gives no signal about whether compaction is making progress or has stalled, and since compaction can take 10-20s on long sessions a motionless spinner tends to read as frozen.

https://github.com/user-attachments/assets/e6cf5b7a-3005-4009-844f-4fc829fdc71f

## Changes

- Add an indeterminate progress bar and a live elapsed-time counter to the in-flight compaction row (`StatusNotificationView`), keeping the existing spinner.
- Compaction is a single streaming summarization call with **no measurable percent-complete** (the SDK only reports pre-compaction token count at the boundary, i.e. after the fact). So rather than fabricate a percentage, the bar is intentionally indeterminate (constant motion, so it never reads as frozen) and the elapsed timer carries the concrete progress signal.
- The bar reuses the existing section-loading swoop keyframe, is tinted to match the row's blue accent, and degrades to a static filled track under `prefers-reduced-motion`.

Note on approach: I checked how other harnesses handle this before picking indeterminate. No coding-agent harness ships a verified real-percentage compaction bar the Claude Code CLI request for one ([anthropics/claude-code#30115](https://github.com/anthropics/claude-code/issues/30115)) was closed "not planned", and the "percentage" it references from the desktop app has no documented mechanism. An indeterminate bar plus a real elapsed timer is both honest and directly fixes the "appears frozen" complaint.

