### PR TITLE
fix(agent): stop resume hydration from overfilling the context window

### DIFF
--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -243,8 +243,8 @@ export function rebuildConversation(
 
 // JSON-heavy tool payloads tokenize at ~2.5-3 chars/token, so estimate low.
 const CHARS_PER_TOKEN = 3;
-// Target ~half the context window: hydrated transcripts carry no usage
-// metadata, so the SDK can't auto-compact before the first API call.
+// Target ~half the context window, leaving headroom for the system prompt,
+// tools, skills, estimation error, and the resumed run's own work.
 const DEFAULT_MAX_TOKENS = 80_000;
 const LARGE_CONTEXT_MAX_TOKENS = 400_000;
 

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -241,9 +241,18 @@ export function rebuildConversation(
   return turns;
 }
 
-const CHARS_PER_TOKEN = 4;
-const DEFAULT_MAX_TOKENS = 150_000;
-const LARGE_CONTEXT_MAX_TOKENS = 800_000;
+// JSON-heavy tool payloads tokenize at ~2.5-3 chars/token, so estimate low:
+// overestimating a turn's cost just drops more history, underestimating
+// overfills the context window.
+const CHARS_PER_TOKEN = 3;
+// Budgets must leave the window room for the system prompt, tools, skills,
+// and the resumed run's own work. The rebuilt transcript carries zero usage
+// metadata, so the SDK can't see the real context size and auto-compact
+// before the first API call — if the hydrated history overfills the window,
+// every request (including compaction itself) fails with "prompt is too
+// long" and the run dies. Target roughly half the window in real tokens.
+const DEFAULT_MAX_TOKENS = 80_000;
+const LARGE_CONTEXT_MAX_TOKENS = 400_000;
 
 function estimateTurnTokens(turn: ConversationTurn): number {
   let chars = 0;

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -241,16 +241,10 @@ export function rebuildConversation(
   return turns;
 }
 
-// JSON-heavy tool payloads tokenize at ~2.5-3 chars/token, so estimate low:
-// overestimating a turn's cost just drops more history, underestimating
-// overfills the context window.
+// JSON-heavy tool payloads tokenize at ~2.5-3 chars/token, so estimate low.
 const CHARS_PER_TOKEN = 3;
-// Budgets must leave the window room for the system prompt, tools, skills,
-// and the resumed run's own work. The rebuilt transcript carries zero usage
-// metadata, so the SDK can't see the real context size and auto-compact
-// before the first API call — if the hydrated history overfills the window,
-// every request (including compaction itself) fails with "prompt is too
-// long" and the run dies. Target roughly half the window in real tokens.
+// Target ~half the context window: hydrated transcripts carry no usage
+// metadata, so the SDK can't auto-compact before the first API call.
 const DEFAULT_MAX_TOKENS = 80_000;
 const LARGE_CONTEXT_MAX_TOKENS = 400_000;
 


### PR DESCRIPTION
## Problem

Resuming a long-lived cloud task can fail hard with `Internal error: Prompt is too long`, and once it does, every subsequent resume of that task fails the same way so the task is permanently stuck

<img width="769" height="371" alt="image" src="https://github.com/user-attachments/assets/baeb4313-f3d3-4054-8469-e51d01013160" />

Loosely:

1. Directory resume snapshots only cover the workspace, not `~/.claude`, so the native session transcript is never on disk after a resume (`warm: false`). Every resume goes through `hydrateSessionJsonl`, which rebuilds a transcript from the task's ACP notification logs.
2. The logs endpoint concatenates the entire resume chain (oldest ancestor first), and in-session compactions are invisible in that log, so hydration resurrects history the session had already compacted away.
3. `selectRecentTurns` budgets 800k estimated tokens for 1M-context models at 4 chars/token. JSON-heavy tool payloads actually tokenize at ~2.5–3 chars/token, so the "800k" selection can be well over 1M real tokens. In the failing run, hydration kept 66 turns (~2.9M chars, estimated 732k tokens) that the API counted as 1,155,179 tokens against a 1,000,000 window. The 200k-window budget (150k estimated) has the same overflow, just less headroom to hide it.
4. The rebuilt transcript writes `usage: 0` on every message, so the SDK's context accounting starts near zero: it can't auto-compact before the first API call (the run's `compact_boundary` reported `preTokens: 16250` while `getContextUsage()` said 1.15M). The first call 400s, the SDK's recovery compaction can't help, and the turn fails as a non-recoverable `agent_error`.

## Changes

- Estimate turn cost at 3 chars/token instead of 4, so JSON-heavy payloads are no longer undercounted
- Lower the hydration budgets to target roughly half the real window: 400k estimated for 1M-context models (worst case ~500k real), 80k for 200k-window models. This leaves room for system prompt, tools, skills, and the resumed run's own work, and un-bricks existing tasks (the next resume re-hydrates within budget)