### PR TITLE
fix(agent): seed hydrated transcripts with estimated context usage

### DIFF
--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.test.ts
@@ -496,6 +496,29 @@ describe("conversationTurnsToJsonlEntries", () => {
     expect(conv[1].parentUuid).toBe(conv[0].uuid);
   });
 
+  it("seeds only the last assistant message with the estimated context size", () => {
+    const lines = conversationTurnsToJsonlEntries(
+      [
+        { role: "user", content: [{ type: "text", text: "q".repeat(400) }] },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "a".repeat(400) }],
+        },
+        { role: "user", content: [{ type: "text", text: "more" }] },
+        { role: "assistant", content: [{ type: "text", text: "final" }] },
+      ],
+      config,
+    );
+
+    const assistants = parseConversationEntries(lines).filter(
+      (entry) => entry.type === "assistant",
+    );
+    expect(assistants.at(-1)?.message.usage.input_tokens).toBeGreaterThan(0);
+    for (const entry of assistants.slice(0, -1)) {
+      expect(entry.message.usage.input_tokens).toBe(0);
+    }
+  });
+
   it("emits one line per assistant block with shared message id", () => {
     const lines = conversationTurnsToJsonlEntries(
       [

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -584,6 +584,24 @@ export function conversationTurnsToJsonlEntries(
     }
   }
 
+  // Seed the last assistant message with the estimated context size so the
+  // SDK's auto-compact accounting isn't blind until the first API response.
+  const estimatedTokens = turns.reduce(
+    (sum, turn) => sum + estimateTurnTokens(turn),
+    0,
+  );
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const parsed = JSON.parse(lines[i]) as {
+      type?: string;
+      message?: { usage?: { input_tokens?: number } };
+    };
+    if (parsed.type === "assistant" && parsed.message?.usage) {
+      parsed.message.usage.input_tokens = estimatedTokens;
+      lines[i] = JSON.stringify(parsed);
+      break;
+    }
+  }
+
   return lines;
 }
 

--- a/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
+++ b/packages/agent/src/adapters/claude/session/jsonl-hydration.ts
@@ -421,6 +421,13 @@ export function conversationTurnsToJsonlEntries(
   const permissionMode = config.permissionMode ?? "default";
   const baseTime = Date.now() - turns.length * 3000;
   let turnIndex = 0;
+  // Seed the last assistant message with the estimated context size so the
+  // SDK's auto-compact accounting isn't blind until the first API response.
+  const estimatedTokens = turns.reduce(
+    (sum, turn) => sum + estimateTurnTokens(turn),
+    0,
+  );
+  const lastAssistantTurn = turns.findLast((turn) => turn.role === "assistant");
 
   for (const turn of turns) {
     const timestamp = new Date(baseTime + turnIndex * 3000).toISOString();
@@ -530,7 +537,8 @@ export function conversationTurnsToJsonlEntries(
               stop_reason: isLast ? lastStopReason : null,
               stop_sequence: null,
               usage: {
-                input_tokens: 0,
+                input_tokens:
+                  turn === lastAssistantTurn && isLast ? estimatedTokens : 0,
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 0,
                 output_tokens: 0,
@@ -581,24 +589,6 @@ export function conversationTurnsToJsonlEntries(
           parentUuid = uuid;
         }
       }
-    }
-  }
-
-  // Seed the last assistant message with the estimated context size so the
-  // SDK's auto-compact accounting isn't blind until the first API response.
-  const estimatedTokens = turns.reduce(
-    (sum, turn) => sum + estimateTurnTokens(turn),
-    0,
-  );
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const parsed = JSON.parse(lines[i]) as {
-      type?: string;
-      message?: { usage?: { input_tokens?: number } };
-    };
-    if (parsed.type === "assistant" && parsed.message?.usage) {
-      parsed.message.usage.input_tokens = estimatedTokens;
-      lines[i] = JSON.stringify(parsed);
-      break;
     }
   }
 


### PR DESCRIPTION
## Problem

When a cold resume rebuilds the session transcript from S3 logs, every rebuilt message carries `usage: 0`. The resumed SDK session therefore believes its context is nearly empty: it cannot trigger auto-compaction proactively and only learns the real context size from the first API response — or from a "prompt is too long" rejection, at which point compaction itself is already impossible. This was visible in a real failure where the SDK reported a compact boundary of ~16k pre-tokens while the actual request weighed over 1.1M tokens.

Follow-up to #3331.

## Changes

- After building the hydrated JSONL, seed the last assistant message's `usage.input_tokens` with the estimated token count of the rebuilt conversation, so the SDK's context accounting starts near reality and auto-compaction can fire before the first API call when warranted.

## How did you test this?

- New test: only the last assistant entry carries the non-zero estimate; earlier entries stay at zero.
- `pnpm exec vitest run src/adapters/claude/session/jsonl-hydration.test.ts` — 58 passed, 1 pre-existing failure (`sanitizeSessionJsonl` warn-path test) that also fails on `main`.
- `tsc --noEmit` on the agent package.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*