### PR TITLE
fix(codex): improve pr attribution for codex adapter

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1893,7 +1893,13 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       McpSdkServerConfigWithInstance
     > => {
       const server = createLocalToolsMcpServer(
-        { cwd, token: resolveGithubToken(), taskId, baseBranch },
+        {
+          cwd,
+          token: resolveGithubToken(),
+          taskId,
+          taskRunId: meta?.taskRunId,
+          baseBranch,
+        },
         { environment },
       );
       return server ? { [LOCAL_TOOLS_MCP_NAME]: server } : {};

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -133,6 +133,58 @@ describe("CodexAppServerAgent", () => {
     });
   });
 
+  it("includes buffered command output when completion omits aggregatedOutput", async () => {
+    const stub = makeStubRpc({
+      initialize: {},
+      "thread/start": { thread: { id: "thr_1" } },
+    });
+    const { client, sessionUpdates } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/bundle/codex" },
+      model: "gpt-5.5",
+      rpcFactory: stub.factory,
+    });
+
+    await agent.initialize(init);
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+
+    stub.emit("item/commandExecution/outputDelta", {
+      itemId: "cmd_1",
+      delta: "https://github.com/PostHog/posthog/p",
+    });
+    stub.emit("item/commandExecution/outputDelta", {
+      itemId: "cmd_1",
+      delta: "ull/12345\n",
+    });
+    stub.emit("item/completed", {
+      item: {
+        type: "commandExecution",
+        id: "cmd_1",
+        command: "gh pr create --draft",
+        status: "completed",
+        aggregatedOutput: null,
+      },
+    });
+
+    expect(sessionUpdates).toContainEqual({
+      sessionId: "thr_1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "cmd_1",
+        status: "completed",
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "https://github.com/PostHog/posthog/pull/12345\n",
+            },
+          },
+        ],
+      },
+    });
+  });
+
   it("enriches an MCP tool-call approval with the structured posthog channel", async () => {
     const stub = makeStubRpc({
       initialize: {},

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -139,6 +139,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   private taskRunId?: string;
   /** Deployment environment; on "cloud" a non-danger sandbox would panic, so we skip the override. */
   private environment?: "local" | "cloud";
+  private readonly commandOutputs = new Map<string, string>();
   private readonly mcp = new McpManager();
   private readonly turns = new TurnController();
   private readonly usage = new UsageTracker();
@@ -422,6 +423,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       environment: meta.environment,
       channelMode: meta.channelMode,
       taskId: meta.taskId,
+      taskRunId: meta.taskRunId,
       persistence: meta.persistence,
       baseBranch: meta.baseBranch,
     };
@@ -651,6 +653,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   }
 
   async closeSession(): Promise<void> {
+    this.commandOutputs.clear();
     this.session.abortController.abort();
     this.turns.close("cancelled");
     this.session.settingsManager.dispose();
@@ -664,11 +667,12 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   }
 
   private handleNotification(method: string, params: unknown): void {
+    const mappedParams = this.withBufferedCommandOutput(method, params);
     if (this.sessionId && !this.session.cancelled) {
       const notification = mapAppServerNotification(
         this.sessionId,
         method,
-        params,
+        mappedParams,
       );
       if (notification) {
         void this.client
@@ -723,6 +727,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     }
 
     if (method === APP_SERVER_NOTIFICATIONS.TURN_COMPLETED) {
+      this.commandOutputs.clear();
       const turn = (params as { turn?: { id?: string; status?: string } })
         ?.turn;
       // Drop the late completion of an already-interrupted turn (else it cancels the follow-up).
@@ -740,6 +745,51 @@ export class CodexAppServerAgent extends BaseAcpAgent {
         void this.finalizeTurn("refusal");
       }
     }
+  }
+
+  private withBufferedCommandOutput(method: string, params: unknown): unknown {
+    if (!params || typeof params !== "object") {
+      return params;
+    }
+    const value = params as {
+      itemId?: unknown;
+      delta?: unknown;
+      item?: Record<string, unknown>;
+    };
+
+    if (method === APP_SERVER_NOTIFICATIONS.COMMAND_OUTPUT_DELTA) {
+      if (typeof value.itemId === "string" && typeof value.delta === "string") {
+        this.commandOutputs.set(
+          value.itemId,
+          `${this.commandOutputs.get(value.itemId) ?? ""}${value.delta}`,
+        );
+      }
+      return params;
+    }
+
+    if (method !== APP_SERVER_NOTIFICATIONS.ITEM_COMPLETED) {
+      return params;
+    }
+
+    const itemId = value.item?.id;
+    if (typeof itemId !== "string") {
+      return params;
+    }
+
+    const output = this.commandOutputs.get(itemId);
+    this.commandOutputs.delete(itemId);
+    if (
+      value.item?.type !== "commandExecution" ||
+      value.item.aggregatedOutput != null ||
+      !output
+    ) {
+      return params;
+    }
+
+    return {
+      ...value,
+      item: { ...value.item, aggregatedOutput: output },
+    };
   }
 
   /** Track the latest assistant message so the final one feeds structured output. */

--- a/packages/agent/src/adapters/codex-app-server/local-tools-mcp.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/local-tools-mcp.test.ts
@@ -43,7 +43,12 @@ describe("buildLocalToolsServer", () => {
 
     const server = buildLocalToolsServer(
       { cwd: "/repo" },
-      { environment: "cloud" },
+      {
+        environment: "cloud",
+        taskId: "task-1",
+        taskRunId: "run-1",
+        baseBranch: "master",
+      },
     );
 
     expect(server).not.toBeNull();
@@ -74,6 +79,9 @@ describe("buildLocalToolsServer", () => {
     );
     expect(ctx.cwd).toBe("/repo");
     expect(ctx.token).toBe("ghs_test");
+    expect(ctx.taskId).toBe("task-1");
+    expect(ctx.taskRunId).toBe("run-1");
+    expect(ctx.baseBranch).toBe("master");
   });
 
   it("returns a server but omits token env vars when no token is present", () => {

--- a/packages/agent/src/adapters/codex-app-server/local-tools-mcp.ts
+++ b/packages/agent/src/adapters/codex-app-server/local-tools-mcp.ts
@@ -24,6 +24,7 @@ import { resolveTaskId } from "../session-meta";
  */
 export interface LocalToolsMeta extends LocalToolGateMeta {
   taskId?: string;
+  taskRunId?: string;
   persistence?: { taskId?: string };
   baseBranch?: string;
 }
@@ -78,6 +79,7 @@ export function buildLocalToolsServer(
     cwd,
     token: resolveGithubToken(),
     taskId: resolveTaskId(meta),
+    taskRunId: meta?.taskRunId,
     baseBranch: meta?.baseBranch,
   };
   const tools = enabledLocalTools(toolCtx, meta);

--- a/packages/agent/src/adapters/local-tools/registry.ts
+++ b/packages/agent/src/adapters/local-tools/registry.ts
@@ -15,6 +15,7 @@ export interface LocalToolCtx {
   /** GitHub token available to the sandbox, if any. */
   token?: string;
   taskId?: string;
+  taskRunId?: string;
   /**
    * Base branch of the task's repo (e.g. "master"); the signed-git tools fall
    * back to origin/HEAD detection when unset.

--- a/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
+++ b/packages/agent/src/adapters/local-tools/tools/signed-commit.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const createSignedCommit = vi.fn();
+const reportCommitArtefacts = vi.fn();
+const reportTaskRunBranch = vi.fn();
 
 vi.mock("@posthog/git/signed-commit", async (importOriginal) => {
   const actual =
@@ -11,6 +13,11 @@ vi.mock("@posthog/git/signed-commit", async (importOriginal) => {
   };
 });
 
+vi.mock("../../../signed-commit-artefacts", () => ({
+  reportCommitArtefacts: (...args: unknown[]) => reportCommitArtefacts(...args),
+  reportTaskRunBranch: (...args: unknown[]) => reportTaskRunBranch(...args),
+}));
+
 // Importing the tool after the mock so its transitive `createSignedCommit`
 // reference resolves to the mock above.
 const { signedCommitTool } = await import("./signed-commit");
@@ -20,6 +27,8 @@ describe("signed-commit tool handler", () => {
 
   beforeEach(() => {
     createSignedCommit.mockReset();
+    reportCommitArtefacts.mockReset();
+    reportTaskRunBranch.mockReset();
     createSignedCommit.mockResolvedValue({
       branch: "posthog-code/feature",
       repository: "x/y",
@@ -88,6 +97,24 @@ describe("signed-commit tool handler", () => {
     );
     const [ctx] = createSignedCommit.mock.calls[0];
     expect(ctx.baseBranch).toBe("master");
+  });
+
+  it("persists the created branch for the task run", async () => {
+    await signedCommitTool.handler(
+      {
+        cwd: "/tmp/workspace/repos/posthog/code",
+        token: "ghs_x",
+        taskId: "task-1",
+        taskRunId: "run-1",
+      },
+      { message: "chore: bump" },
+    );
+
+    expect(reportTaskRunBranch).toHaveBeenCalledWith({
+      taskId: "task-1",
+      taskRunId: "run-1",
+      branch: "posthog-code/feature",
+    });
   });
 
   it("returns the no-token error without invoking createSignedCommit", async () => {

--- a/packages/agent/src/adapters/local-tools/tools/signed-git-tool.ts
+++ b/packages/agent/src/adapters/local-tools/tools/signed-git-tool.ts
@@ -1,9 +1,11 @@
 import * as path from "node:path";
-import type { SignedCommitCtx } from "@posthog/git/signed-commit";
 import type { z } from "zod";
 import { isCloudRun } from "../../../utils/common";
 import { resolveGithubToken } from "../../../utils/github-token";
-import type { SignedCommitToolResult } from "../../signed-commit-shared";
+import type {
+  SignedCommitToolCtx,
+  SignedCommitToolResult,
+} from "../../signed-commit-shared";
 import { defineLocalTool, type LocalTool } from "../registry";
 
 /**
@@ -16,7 +18,7 @@ export function defineSignedGitTool<S extends z.ZodRawShape, R>(opts: {
   name: string;
   description: string;
   schema: S;
-  run: (ctx: SignedCommitCtx, input: R) => Promise<SignedCommitToolResult>;
+  run: (ctx: SignedCommitToolCtx, input: R) => Promise<SignedCommitToolResult>;
 }): LocalTool {
   return defineLocalTool({
     name: opts.name,
@@ -43,7 +45,13 @@ export function defineSignedGitTool<S extends z.ZodRawShape, R>(opts: {
       >;
       const cwd = argCwd ? path.resolve(ctx.cwd, argCwd) : ctx.cwd;
       return opts.run(
-        { cwd, token, taskId: ctx.taskId, baseBranch: ctx.baseBranch },
+        {
+          cwd,
+          token,
+          taskId: ctx.taskId,
+          taskRunId: ctx.taskRunId,
+          baseBranch: ctx.baseBranch,
+        },
         input as R,
       );
     },

--- a/packages/agent/src/adapters/signed-commit-shared.ts
+++ b/packages/agent/src/adapters/signed-commit-shared.ts
@@ -9,7 +9,10 @@ import {
   type SignedRewriteInput,
 } from "@posthog/git/signed-commit";
 import { z } from "zod";
-import { reportCommitArtefacts } from "../signed-commit-artefacts";
+import {
+  reportCommitArtefacts,
+  reportTaskRunBranch,
+} from "../signed-commit-artefacts";
 import { qualifiedLocalToolName } from "./local-tools/registry";
 
 /**
@@ -132,6 +135,8 @@ export interface SignedCommitToolResult {
   [key: string]: unknown;
 }
 
+export type SignedCommitToolCtx = SignedCommitCtx & { taskRunId?: string };
+
 async function runSignedTool<A>(
   toolName: string,
   op: (ctx: SignedCommitCtx, args: A) => Promise<SignedCommitResult>,
@@ -164,13 +169,18 @@ async function runSignedTool<A>(
 }
 
 export function runSignedCommitTool(
-  ctx: SignedCommitCtx,
+  ctx: SignedCommitToolCtx,
   args: SignedCommitInput,
 ): Promise<SignedCommitToolResult> {
   return runSignedTool(
     SIGNED_COMMIT_TOOL_NAME,
     async (c, a: SignedCommitInput) => {
       const result = await createSignedCommit(c, a);
+      await reportTaskRunBranch({
+        taskId: ctx.taskId,
+        taskRunId: ctx.taskRunId,
+        branch: result.branch,
+      });
       // The "commit hook": every pushed commit becomes a `commit` artefact on the signal
       // reports this task is associated with. Best-effort and awaited inside the tool's
       // try/catch-free success path — reportCommitArtefacts never throws, so a failed

--- a/packages/agent/src/signed-commit-artefacts.test.ts
+++ b/packages/agent/src/signed-commit-artefacts.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { reportCommitArtefacts } from "./signed-commit-artefacts";
+import {
+  reportCommitArtefacts,
+  reportTaskRunBranch,
+} from "./signed-commit-artefacts";
 
 const ENV = {
   POSTHOG_API_URL: "https://us.posthog.com",
@@ -141,5 +144,50 @@ describe("reportCommitArtefacts", () => {
 
     // Both commits attempted despite the first failing.
     expect(postCount).toBe(2);
+  });
+});
+
+describe("reportTaskRunBranch", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("persists the signed commit branch on the task run", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await reportTaskRunBranch({
+      taskId: "task-1",
+      taskRunId: "run-1",
+      branch: "posthog-code/fix-foo",
+      env: ENV,
+      envFilePath: NO_ENV_FILE,
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(
+      "https://us.posthog.com/api/projects/7/tasks/task-1/runs/run-1/",
+    );
+    expect(init).toMatchObject({
+      method: "PATCH",
+      body: JSON.stringify({
+        branch: "posthog-code/fix-foo",
+        output: { head_branch: "posthog-code/fix-foo" },
+      }),
+    });
   });
 });

--- a/packages/agent/src/signed-commit-artefacts.ts
+++ b/packages/agent/src/signed-commit-artefacts.ts
@@ -57,6 +57,21 @@ export function resolveSandboxPosthogApi(
   return { apiUrl, apiKey, projectId };
 }
 
+function createSandboxPosthogClient(
+  env?: Record<string, string | undefined>,
+  envFilePath?: string,
+): PostHogAPIClient | undefined {
+  const api = resolveSandboxPosthogApi(env, envFilePath);
+  if (!api) {
+    return undefined;
+  }
+  return new PostHogAPIClient({
+    apiUrl: api.apiUrl,
+    projectId: api.projectId,
+    getApiKey: () => api.apiKey,
+  });
+}
+
 export async function reportCommitArtefacts(opts: {
   taskId: string | undefined;
   result: SignedCommitResult;
@@ -70,15 +85,10 @@ export async function reportCommitArtefacts(opts: {
     return; // Local/desktop run — no task to attribute or associate through.
   }
   try {
-    const api = resolveSandboxPosthogApi(opts.env, opts.envFilePath);
-    if (!api) {
+    const client = createSandboxPosthogClient(opts.env, opts.envFilePath);
+    if (!client) {
       return; // No sandbox PostHog credentials — nothing to report to.
     }
-    const client = new PostHogAPIClient({
-      apiUrl: api.apiUrl,
-      projectId: api.projectId,
-      getApiKey: () => api.apiKey,
-    });
     const reportIds = await client.getSignalReportIdsForTask(taskId);
     for (const reportId of reportIds) {
       for (const commit of result.commits) {
@@ -101,6 +111,30 @@ export async function reportCommitArtefacts(opts: {
     }
   } catch (err) {
     warn(`failed to record commit artefacts: ${err}`);
+  }
+}
+
+export async function reportTaskRunBranch(opts: {
+  taskId: string | undefined;
+  taskRunId: string | undefined;
+  branch: string;
+  env?: Record<string, string | undefined>;
+  envFilePath?: string;
+}): Promise<void> {
+  if (!opts.taskId || !opts.taskRunId) {
+    return;
+  }
+  try {
+    const client = createSandboxPosthogClient(opts.env, opts.envFilePath);
+    if (!client) {
+      return;
+    }
+    await client.updateTaskRun(opts.taskId, opts.taskRunId, {
+      branch: opts.branch,
+      output: { head_branch: opts.branch },
+    });
+  } catch (err) {
+    warn(`failed to attach branch ${opts.branch} to task run: ${err}`);
   }
 }
 


### PR DESCRIPTION
looking at codex traces, it was failing to attribute PRs correctly - this also improves branch attribution by seting the task run branch when the agent uses the signed commit tool