### PR TITLE
fix(ci): require org member permission for release checks

### DIFF
--- a/.github/workflows/code-tag.yml
+++ b/.github/workflows/code-tag.yml
@@ -75,8 +75,8 @@ jobs:
           fi
 
           if ! MEMBERS=$(gh api "orgs/${REPOSITORY%%/*}/teams/${TEAM_SLUG}/members" --paginate --jq '.[].login'); then
-            skip "Could not verify ${TEAM_SLUG} membership (GitHub API error)."
-            exit 0
+            echo "::error::Could not verify ${TEAM_SLUG} membership. Grant the Array Releaser GitHub App 'Organization members: read' permission, then approve the updated installation permissions."
+            exit 1
           fi
 
           if echo "$MEMBERS" | grep -qixF "$LABELER"; then

--- a/.github/workflows/code-tag.yml
+++ b/.github/workflows/code-tag.yml
@@ -61,9 +61,13 @@ jobs:
               --body "$1 Auto-release is limited to Team PostHog Code members, so this will ship with the next scheduled release instead." || true
           }
 
-          LABELER=$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate \
-            --jq '.[] | select(.event == "labeled" and (.label.name | ascii_downcase) == "create release") | "\(.id) \(.actor.login)"' \
-            | sort -n | tail -1 | cut -d" " -f2)
+          if ! LABEL_EVENTS=$(GH_TOKEN="$COMMENT_TOKEN" gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate \
+            --jq '.[] | select(.event == "labeled" and (.label.name | ascii_downcase) == "create release") | "\(.id) \(.actor.login)"'); then
+            skip "Could not determine who added the 'Create release' label (GitHub API error)."
+            exit 0
+          fi
+
+          LABELER=$(echo "$LABEL_EVENTS" | sort -n | tail -1 | cut -d" " -f2)
 
           if [ -z "$LABELER" ]; then
             skip "Could not determine who added the 'Create release' label."


### PR DESCRIPTION
## Problem

The `Create release` authorization check needs to verify that the labeler belongs to `team-posthog-code`, but the Array Releaser GitHub App currently lacks organization member access.

**Why:** The workflow should perform the membership check successfully rather than silently defer releases when its App is misconfigured.

## Changes

- Read repository label events with the workflow token, which already has issue access.
- Fail with an actionable error when team membership cannot be read, identifying the required Array Releaser App permission.
- Keep the existing graceful deferral only for genuine non-members or missing label attribution.

After merging, grant the Array Releaser GitHub App **Organization permissions → Members: Read-only**, then approve the updated installation permissions for the PostHog organization.

## How did you test this?

- Ran `bash -n` against the extracted workflow script.
- Ran mocked member, non-member, and missing-scope cases; membership succeeds, non-members defer, and missing scope fails with the configuration guidance.
- Ran `git diff --check`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
