### PR TITLE
fix(codex): restore mode approval behavior

### DIFF
--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -10,6 +10,7 @@ import type {
   AppServerRpc,
 } from "./app-server-client";
 import { CodexAppServerAgent } from "./codex-app-server-agent";
+import { sandboxPolicyFor } from "./session-config";
 
 // Required-field invariants the native codex app-server enforces on each request.
 const REQUIRED_FIELDS: Record<string, string[]> = {
@@ -348,28 +349,54 @@ describe("CodexAppServerAgent", () => {
     });
   });
 
-  it("surfaces Allow-always and echoes codex's remember decision when offered", async () => {
+  it("surfaces Allow-always and echoes codex's execpolicy amendment decision verbatim", async () => {
     const { agent, stub, permissionOptions } =
       makeApprovalAgent("allow_always");
     await agent.initialize(init);
     await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
 
-    // codex offers the command-prefix allowlist decision for this approval.
+    // codex offers the command-prefix allowlist decision for this approval. Exact
+    // 0.140 wire shape: serde renames only the VARIANT to camelCase, the field
+    // stays snake_case, and ExecPolicyAmendment is transparent over a string array.
+    const amendment = {
+      acceptWithExecpolicyAmendment: {
+        execpolicy_amendment: ["pnpm", "test"],
+      },
+    };
     const decision = await stub.invokeRequest(
       "item/commandExecution/requestApproval",
       {
         itemId: "c1",
         command: "pnpm test",
-        available_decisions: ["approved_execpolicy_amendment", "denied"],
+        availableDecisions: ["accept", amendment, "decline"],
       },
     );
 
     expect(permissionOptions[0].map((o) => o.kind)).toContain("allow_always");
-    // Picking it echoes codex's own decision so it applies the amendment.
-    expect(decision).toEqual({ decision: "approved_execpolicy_amendment" });
+    // Picking it echoes codex's own decision entry verbatim (same reference, no remapping).
+    expect((decision as { decision: unknown }).decision).toBe(amendment);
   });
 
-  it("omits Allow-always when codex offers no remember decision", async () => {
+  it("surfaces Allow-always for the session-scoped command decision", async () => {
+    const { agent, stub, permissionOptions } =
+      makeApprovalAgent("allow_always");
+    await agent.initialize(init);
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+
+    const decision = await stub.invokeRequest(
+      "item/commandExecution/requestApproval",
+      {
+        itemId: "c1",
+        command: "pnpm test",
+        availableDecisions: ["accept", "acceptForSession", "decline"],
+      },
+    );
+
+    expect(permissionOptions[0].map((o) => o.kind)).toContain("allow_always");
+    expect(decision).toEqual({ decision: "acceptForSession" });
+  });
+
+  it("omits Allow-always when codex offers no remember decision for a command", async () => {
     const { agent, stub, permissionOptions } = makeApprovalAgent("allow");
     await agent.initialize(init);
     await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
@@ -387,6 +414,46 @@ describe("CodexAppServerAgent", () => {
       "reject",
       "reject_with_feedback",
     ]);
+    expect(decision).toEqual({ decision: "accept" });
+  });
+
+  it("always offers Allow-always on file changes and answers acceptForSession", async () => {
+    const { agent, stub, permissionOptions } =
+      makeApprovalAgent("allow_always");
+    await agent.initialize(init);
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+
+    // File-change approvals carry no availableDecisions, but codex always
+    // accepts the session-scoped decision for them.
+    const decision = await stub.invokeRequest(
+      "item/fileChange/requestApproval",
+      {
+        itemId: "f1",
+        changes: [{ path: "src/a.ts", diff: "@@ -1 +1 @@\n-old\n+new\n" }],
+      },
+    );
+
+    expect(permissionOptions[0].map((o) => o.kind)).toContain("allow_always");
+    expect(decision).toEqual({ decision: "acceptForSession" });
+  });
+
+  it("honors an explicit file-change decision list without a remember option", async () => {
+    const { agent, stub, permissionOptions } = makeApprovalAgent("allow");
+    await agent.initialize(init);
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+
+    const decision = await stub.invokeRequest(
+      "item/fileChange/requestApproval",
+      {
+        itemId: "f1",
+        changes: [{ path: "src/a.ts", diff: "@@ -1 +1 @@\n-old\n+new\n" }],
+        availableDecisions: ["accept", "decline"],
+      },
+    );
+
+    expect(permissionOptions[0].map((o) => o.kind)).not.toContain(
+      "allow_always",
+    );
     expect(decision).toEqual({ decision: "accept" });
   });
 
@@ -706,7 +773,7 @@ describe("CodexAppServerAgent", () => {
     expect(params.approvalPolicy).toBe("on-request");
   });
 
-  it("omits sandboxPolicy for an editing preset (auto) so the spawned full-access stays", async () => {
+  it("restores the editable sandbox on auto turns (codex turn overrides are sticky)", async () => {
     const stub = makeStubRpc({
       "thread/start": { thread: { id: "t" } },
       "turn/start": { turn: { id: "turn_1" } },
@@ -717,7 +784,8 @@ describe("CodexAppServerAgent", () => {
       model: "gpt-5.5",
       rpcFactory: stub.factory,
     });
-    // Default mode is "auto" → editing allowed, no sandbox override.
+    // Default mode is "auto" → editing allowed. A prior plan/read-only turn's
+    // readOnly sandbox persists on the thread, so auto must state its sandbox.
     await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
     const done = agent.prompt({
       sessionId: "t",
@@ -731,12 +799,77 @@ describe("CodexAppServerAgent", () => {
       sandboxPolicy?: unknown;
       collaborationMode?: unknown;
     };
-    expect(params.sandboxPolicy).toBeUndefined();
+    expect(params.sandboxPolicy).toEqual(sandboxPolicyFor("auto"));
     // Default collaboration is pushed every turn so switching back from Plan reverts.
     expect(params.collaborationMode).toEqual({
       mode: "default",
       settings: { model: "gpt-5.5" },
     });
+  });
+
+  it("folds the session's additional directories into a workspaceWrite sandbox", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "t" } },
+      "turn/start": { turn: { id: "turn_1" } },
+    });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      model: "gpt-5.5",
+      rpcFactory: stub.factory,
+    });
+    await agent.newSession({
+      cwd: "/r",
+      additionalDirectories: ["/extra"],
+    } as unknown as NewSessionRequest);
+    const done = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "go" }],
+    } as unknown as PromptRequest);
+    stub.emit("turn/completed", { turn: { status: "completed" } });
+    await done;
+
+    const turnStart = stub.requests.find((r) => r.method === "turn/start");
+    const policy = (turnStart?.params as { sandboxPolicy?: { type?: string } })
+      .sandboxPolicy;
+    // Only the workspaceWrite shape carries writable roots; danger needs none.
+    if (policy?.type === "workspaceWrite") {
+      expect(policy).toEqual({
+        type: "workspaceWrite",
+        networkAccess: false,
+        writableRoots: ["/r", "/extra"],
+      });
+    } else {
+      expect(policy).toEqual({ type: "dangerFullAccess" });
+    }
+  });
+
+  it("skips the sandbox override entirely on cloud (a managed sandbox would panic)", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "t" } },
+      "turn/start": { turn: { id: "turn_1" } },
+    });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      model: "gpt-5.5",
+      rpcFactory: stub.factory,
+    });
+    await agent.newSession({
+      cwd: "/r",
+      _meta: { environment: "cloud" },
+    } as unknown as NewSessionRequest);
+    const done = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "go" }],
+    } as unknown as PromptRequest);
+    stub.emit("turn/completed", { turn: { status: "completed" } });
+    await done;
+
+    const turnStart = stub.requests.find((r) => r.method === "turn/start");
+    expect(
+      (turnStart?.params as { sandboxPolicy?: unknown }).sandboxPolicy,
+    ).toBeUndefined();
   });
 
   it("returns mode + model + thought_level configOptions and emits config_option_update", async () => {
@@ -852,7 +985,7 @@ describe("CodexAppServerAgent", () => {
     expect(modelOpt.currentValue).toBe("gpt-6");
   });
 
-  it("sends activePermissionProfile :read-only on turn/start in read-only mode", async () => {
+  it("restricts read-only mode via sandboxPolicy without inventing turn/start params", async () => {
     const stub = makeStubRpc({ "thread/start": { thread: { id: "t" } } });
     const { client } = makeFakeClient();
     const agent = new CodexAppServerAgent(client, {
@@ -873,12 +1006,13 @@ describe("CodexAppServerAgent", () => {
     stub.emit("turn/completed", { turn: { status: "completed" } });
     await done;
 
-    // codex 0.140.0 enforces the sandbox via the named profile, so read-only MUST send it alongside sandboxPolicy.
     const turnStart = stub.requests.find((r) => r.method === "turn/start");
     expect(turnStart?.params).toMatchObject({
-      activePermissionProfile: { extends: ":read-only" },
+      approvalPolicy: "untrusted",
       sandboxPolicy: { type: "readOnly" },
     });
+    // Not a codex turn/start param — the app-server would silently ignore it.
+    expect(turnStart?.params).not.toHaveProperty("activePermissionProfile");
   });
 
   it("resumeSession resumes the existing thread and returns configOptions", async () => {

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -61,7 +61,7 @@ import {
   APP_SERVER_NOTIFICATIONS,
   APP_SERVER_REQUESTS,
 } from "./protocol";
-import { SessionConfigState } from "./session-config";
+import { type CodexSandboxPolicy, SessionConfigState } from "./session-config";
 import {
   type CodexAppServerProcess,
   type CodexAppServerProcessOptions,
@@ -140,6 +140,10 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   /** Deployment environment; on "cloud" a non-danger sandbox would panic, so we skip the override. */
   private environment?: "local" | "cloud";
   private readonly commandOutputs = new Map<string, string>();
+  /** Extra writable roots for this session, folded into workspaceWrite sandbox turns. */
+  private additionalDirectories?: string[];
+  /** The session workspace stays writable when extra roots are applied per turn. */
+  private workspaceDirectory?: string;
   private readonly mcp = new McpManager();
   private readonly turns = new TurnController();
   private readonly usage = new UsageTracker();
@@ -351,6 +355,8 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     this.jsonSchema = params.meta?.jsonSchema ?? undefined;
     this.taskRunId = params.meta?.taskRunId;
     this.environment = params.meta?.environment;
+    this.additionalDirectories = params.additionalDirectories;
+    this.workspaceDirectory = params.cwd;
     this.config.setInitialMode(params.meta?.permissionMode);
     // Codex doesn't attribute input tokens by source; the baseline seeds the resident floor + system prompt.
     this.usage.setBaseline(buildBaseline(params.meta));
@@ -584,8 +590,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     const { completion, turn } = this.turns.begin();
     try {
       const approvalPolicy = this.config.approvalPolicy();
-      const sandboxPolicy = this.config.sandboxPolicy();
-      const activePermissionProfile = this.config.permissionProfile();
+      const sandboxPolicy = this.sandboxPolicyForTurn();
       await this.rpc.request(APP_SERVER_METHODS.TURN_START, {
         threadId: this.threadId,
         input,
@@ -593,18 +598,16 @@ export class CodexAppServerAgent extends BaseAcpAgent {
         ...(this.config.effort ? { effort: this.config.effort } : {}),
         // Always request a reasoning summary; the default "auto" can skip it on trivial turns.
         summary: "detailed",
-        // Picker preset applied per-turn. Skipped on cloud, where a non-danger sandbox
-        // re-engages the unavailable linux-sandbox and panics.
+        // Picker preset applied per-turn. codex keeps turn overrides for subsequent turns,
+        // so every mode sends its full policy — omitting a field would leave the previous
+        // mode's value active (e.g. plan's readOnly sandbox bleeding into auto).
         ...(approvalPolicy ? { approvalPolicy } : {}),
         // Pushed every turn — codex remembers the last mode, so switching back from plan must be explicit.
         collaborationMode: this.config.collaborationModeForTurn(),
+        // Skipped on cloud, where a non-danger sandbox re-engages the unavailable
+        // linux-sandbox and panics; the enclosing docker/Modal sandbox isolates instead.
         ...(this.environment !== "cloud" && sandboxPolicy
           ? { sandboxPolicy }
-          : {}),
-        // codex 0.140.0 enforces the sandbox via named profiles; sandboxPolicy alone is no
-        // longer honored, so plan/read-only also send this. Same cloud gating.
-        ...(this.environment !== "cloud" && activePermissionProfile
-          ? { activePermissionProfile }
           : {}),
         // Constrain the final message to the task schema for parseable structured output.
         ...(this.jsonSchema ? { outputSchema: this.jsonSchema } : {}),
@@ -613,6 +616,24 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     } finally {
       this.turns.finishPrompt(turn);
     }
+  }
+
+  /** The mode's sandbox with the session's extra writable roots folded into workspaceWrite. */
+  private sandboxPolicyForTurn(): CodexSandboxPolicy | undefined {
+    const policy = this.config.sandboxPolicy();
+    if (
+      policy?.type === "workspaceWrite" &&
+      this.additionalDirectories?.length
+    ) {
+      const writableRoots = [
+        this.workspaceDirectory,
+        ...this.additionalDirectories,
+      ].filter((root): root is string => !!root);
+      if (writableRoots.length) {
+        return { ...policy, writableRoots: [...new Set(writableRoots)] };
+      }
+    }
+    return policy;
   }
 
   /** Echo each user prompt block (text + image, so an image-only turn still renders) for the host log/UI. */
@@ -959,18 +980,31 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       itemId?: string;
       command?: string;
       changes?: AppServerItem["changes"];
-      available_decisions?: unknown;
+      availableDecisions?: unknown[];
     };
-    // codex tells us which decisions are valid here. When it offers an "approve and
-    // remember" decision (exec-policy allowlist / session approval), surface Allow-always.
-    const availableDecisions = Array.isArray(detail.available_decisions)
-      ? detail.available_decisions.filter(
-          (d): d is string => typeof d === "string",
-        )
+    // codex lists the decisions valid for this prompt. An "approve and remember"
+    // decision is echoed back verbatim: either the string "acceptForSession" or the
+    // acceptWithExecpolicyAmendment object carrying the proposed allowlist amendment.
+    const availableDecisions = Array.isArray(detail.availableDecisions)
+      ? detail.availableDecisions
       : [];
-    const rememberDecision =
-      availableDecisions.find((d) => d === "approved_execpolicy_amendment") ??
-      availableDecisions.find((d) => d === "approved_for_session");
+    const offeredRememberDecision =
+      availableDecisions.find(
+        (d) =>
+          !!d && typeof d === "object" && "acceptWithExecpolicyAmendment" in d,
+      ) ?? availableDecisions.find((d) => d === "acceptForSession");
+    // File-change approvals normally omit availableDecisions, but codex accepts the
+    // session-scoped decision for them. If codex sends an explicit list, honor it.
+    const rememberDecision: unknown =
+      isFileChange && detail.availableDecisions === undefined
+        ? "acceptForSession"
+        : offeredRememberDecision;
+    // Label the actual scope: an execpolicy amendment persists in the command
+    // allowlist; acceptForSession (commands and file changes) lasts one session.
+    const rememberLabel =
+      typeof rememberDecision === "object"
+        ? "Allow similar commands and don't ask again"
+        : "Allow for the rest of this session";
     const title =
       detail.command ?? (isFileChange ? "Apply file changes" : "Run command");
     const toolCallId = detail.itemId ?? "codex-approval";
@@ -1020,9 +1054,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
             ? [
                 {
                   optionId: "allow_always",
-                  name: isFileChange
-                    ? "Allow for the rest of this session"
-                    : "Allow and don't ask again",
+                  name: rememberLabel,
                   kind: "allow_always" as const,
                 },
               ]

--- a/packages/agent/src/adapters/codex-app-server/session-config.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/session-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildCodexModes,
   buildConfigOptions,
   CODEX_MODES,
   collaborationModeFor,
@@ -41,14 +42,57 @@ describe("sandboxPolicyFor", () => {
     });
   });
 
-  it("leaves auto + full-access at the spawned full-access sandbox (no override)", () => {
-    expect(sandboxPolicyFor("auto")).toBeUndefined();
-    expect(sandboxPolicyFor("full-access")).toBeUndefined();
+  it("restores an editable sandbox for auto + full-access (turn overrides are sticky)", () => {
+    expect(sandboxPolicyFor("full-access")).toEqual({
+      type: "dangerFullAccess",
+    });
+    expect(sandboxPolicyFor("auto")).toEqual(
+      process.platform === "darwin"
+        ? { type: "workspaceWrite", networkAccess: false }
+        : { type: "dangerFullAccess" },
+    );
   });
 
   it("returns undefined for unknown ids", () => {
     expect(sandboxPolicyFor("bypassPermissions")).toBeUndefined();
     expect(sandboxPolicyFor(undefined)).toBeUndefined();
+  });
+});
+
+describe("buildCodexModes", () => {
+  const sandboxFor = (platform: string, id: string) =>
+    buildCodexModes(platform).find((m) => m.id === id)?.sandboxPolicy;
+
+  it("gives auto the platform's editable sandbox (Seatbelt workspace-write on macOS, danger elsewhere)", () => {
+    // Network stays restricted: egress still goes through codex's escalation prompt.
+    expect(sandboxFor("darwin", "auto")).toEqual({
+      type: "workspaceWrite",
+      networkAccess: false,
+    });
+    expect(sandboxFor("linux", "auto")).toEqual({ type: "dangerFullAccess" });
+    expect(sandboxFor("win32", "auto")).toEqual({ type: "dangerFullAccess" });
+  });
+
+  it.each(["darwin", "linux", "win32"])(
+    "every mode states a full sandbox policy on %s so mode switches never inherit the previous sandbox",
+    (platform) => {
+      for (const mode of buildCodexModes(platform)) {
+        expect(mode.sandboxPolicy).toBeDefined();
+      }
+    },
+  );
+
+  it("keeps plan + read-only on a read-only sandbox on every platform", () => {
+    for (const platform of ["darwin", "linux", "win32"]) {
+      expect(sandboxFor(platform, "plan")).toEqual({
+        type: "readOnly",
+        networkAccess: true,
+      });
+      expect(sandboxFor(platform, "read-only")).toEqual({
+        type: "readOnly",
+        networkAccess: true,
+      });
+    }
   });
 });
 

--- a/packages/agent/src/adapters/codex-app-server/session-config.ts
+++ b/packages/agent/src/adapters/codex-app-server/session-config.ts
@@ -16,6 +16,7 @@ import { getReasoningEffortOptions } from "./models";
  */
 export type CodexSandboxPolicy =
   | { type: "readOnly"; networkAccess: boolean }
+  | { type: "workspaceWrite"; networkAccess: boolean; writableRoots?: string[] }
   | { type: "dangerFullAccess" };
 
 export interface CodexMode {
@@ -25,62 +26,75 @@ export interface CodexMode {
   /** codex AskForApproval the mode maps to, applied per-turn on turn/start. */
   approvalPolicy: string;
   /**
-   * Per-turn sandbox override; undefined keeps the spawned editable sandbox.
-   * Only applied off the cloud sandbox, where a non-danger policy would re-engage
-   * the unavailable linux-sandbox and panic.
+   * Per-turn sandbox, sent on every turn/start. codex keeps turn overrides for
+   * subsequent turns, so every mode states its full sandbox — omitting it would
+   * leave the previous mode's sandbox active (e.g. plan's readOnly bleeding
+   * into auto, which then prompts for every command and edit). Only applied off
+   * the cloud sandbox, where a non-danger policy would re-engage the
+   * unavailable linux-sandbox and panic.
    */
-  sandboxPolicy?: CodexSandboxPolicy;
+  sandboxPolicy: CodexSandboxPolicy;
   /**
    * codex's native collaboration mode (per-turn on `turn/start`). "plan" unlocks
    * plan proposals + `request_user_input`; everything else runs "default".
    */
   collaborationMode?: "plan" | "default";
-  /**
-   * codex's named permission profile (per-turn `activePermissionProfile.extends`).
-   * codex 0.140.0 enforces the sandbox through these built-in profiles; the raw
-   * `sandboxPolicy` is no longer honored alone. Undefined keeps the spawned default.
-   */
-  permissionProfile?: string;
+}
+
+/**
+ * The editable sandbox for a platform, mirroring spawn.ts's `sandbox_mode`:
+ * macOS Seatbelt supports workspace-write; linux/windows have no sandbox
+ * launcher (a managed sandbox would panic), so danger-full-access. Network
+ * stays restricted so commands that need egress still go through codex's
+ * escalation prompt — broadening that is a security decision, not a UX fix.
+ */
+function editableSandboxPolicy(platform: string): CodexSandboxPolicy {
+  return platform === "darwin"
+    ? { type: "workspaceWrite", networkAccess: false }
+    : { type: "dangerFullAccess" };
 }
 
 // Flattened Claude-style presets: the `{id, name, description}` literals live
 // in @posthog/shared (one copy for every picker); this map owns the behavior.
-// Restriction is driven by approvalPolicy + the named permissionProfile (codex
-// 0.140.0's enforced sandbox lever); plan/read-only block edits,
-// auto/full-access keep the spawned editable sandbox.
-const CODEX_MODE_POLICIES: Record<
+// Restriction is driven by approvalPolicy + sandboxPolicy: plan/read-only block
+// edits, auto/full-access restore the platform's editable sandbox.
+function modePolicies(
+  platform: string,
+): Record<
   CodexModePreset["id"],
-  Pick<
-    CodexMode,
-    | "approvalPolicy"
-    | "sandboxPolicy"
-    | "permissionProfile"
-    | "collaborationMode"
-  >
-> = {
-  plan: {
-    approvalPolicy: "on-request",
-    sandboxPolicy: { type: "readOnly", networkAccess: true },
-    permissionProfile: ":read-only",
-    collaborationMode: "plan",
-  },
-  "read-only": {
-    approvalPolicy: "untrusted",
-    sandboxPolicy: { type: "readOnly", networkAccess: true },
-    permissionProfile: ":read-only",
-  },
-  auto: {
-    approvalPolicy: "on-request",
-  },
-  "full-access": {
-    approvalPolicy: "never",
-  },
-};
+  Pick<CodexMode, "approvalPolicy" | "sandboxPolicy" | "collaborationMode">
+> {
+  return {
+    plan: {
+      approvalPolicy: "on-request",
+      sandboxPolicy: { type: "readOnly", networkAccess: true },
+      collaborationMode: "plan",
+    },
+    "read-only": {
+      approvalPolicy: "untrusted",
+      sandboxPolicy: { type: "readOnly", networkAccess: true },
+    },
+    auto: {
+      approvalPolicy: "on-request",
+      sandboxPolicy: editableSandboxPolicy(platform),
+    },
+    "full-access": {
+      approvalPolicy: "never",
+      sandboxPolicy: { type: "dangerFullAccess" },
+    },
+  };
+}
 
-export const CODEX_MODES: CodexMode[] = CODEX_MODE_PRESETS.map((preset) => ({
-  ...preset,
-  ...CODEX_MODE_POLICIES[preset.id],
-}));
+/** Test seam: the mode table for a given platform; CODEX_MODES uses the live one. */
+export function buildCodexModes(platform: string): CodexMode[] {
+  const policies = modePolicies(platform);
+  return CODEX_MODE_PRESETS.map((preset) => ({
+    ...preset,
+    ...policies[preset.id],
+  }));
+}
+
+export const CODEX_MODES: CodexMode[] = buildCodexModes(process.platform);
 
 export const DEFAULT_MODE = "auto";
 
@@ -90,18 +104,11 @@ export function modeApprovalPolicy(
   return CODEX_MODES.find((m) => m.id === modeId)?.approvalPolicy;
 }
 
-/** Per-turn sandbox for a mode id (undefined keeps the spawned full-access). */
+/** Per-turn sandbox for a mode id (sent every turn — codex turn overrides are sticky). */
 export function sandboxPolicyFor(
   modeId: string | undefined,
 ): CodexSandboxPolicy | undefined {
   return CODEX_MODES.find((m) => m.id === modeId)?.sandboxPolicy;
-}
-
-/** Named permission profile for a mode (undefined keeps the spawned default). */
-export function permissionProfileFor(
-  modeId: string | undefined,
-): string | undefined {
-  return CODEX_MODES.find((m) => m.id === modeId)?.permissionProfile;
 }
 
 /** codex collaboration mode for a preset — "plan" only for Plan, else "default". */
@@ -310,12 +317,6 @@ export class SessionConfigState {
 
   sandboxPolicy(): CodexSandboxPolicy | undefined {
     return sandboxPolicyFor(this._mode);
-  }
-
-  /** Per-turn `activePermissionProfile` (codex 0.140.0's enforced sandbox), or undefined. */
-  permissionProfile(): { extends: string } | undefined {
-    const profile = permissionProfileFor(this._mode);
-    return profile ? { extends: profile } : undefined;
   }
 
   private rebuild(): void {


### PR DESCRIPTION
## Problem

Codex keeps turn-level sandbox overrides for later turns. After using Plan or Read only, a session could remain restricted even after switching back to Auto, causing commands and edits to request approval unexpectedly.

The adapter also read the wrong approval-decision field and could not expose Codex's session-scoped approval options reliably.

## Changes

- Send the complete sandbox policy on every turn so each selected mode restores its intended permissions.
- Include additional session directories in workspace-write roots while preserving cloud sandbox gating.
- Remove the unsupported `activePermissionProfile` turn parameter.
- Read native `availableDecisions` and return Codex v2 decisions without remapping them.
- Offer session-scoped approval for file changes and clarify approval labels.
