### PR TITLE
test: pin personalization file-sync boot, wiring, and persistence

### DIFF
--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -226,6 +226,13 @@ const mockNotificationService = vi.hoisted(() => ({
 
 const mockSettingsState = vi.hoisted(() => ({
   customInstructions: "",
+  syncCustomInstructionsFromFile: false,
+  syncedCustomInstructions: null as {
+    path: string;
+    displayPath: string;
+    content: string;
+    truncated: boolean;
+  } | null,
 }));
 
 vi.mock(
@@ -403,6 +410,8 @@ describe("SessionService", () => {
     mockConvertStoredEntriesToEvents.mockImplementation(() => []);
     resetSessionService();
     mockSettingsState.customInstructions = "";
+    mockSettingsState.syncCustomInstructionsFromFile = false;
+    mockSettingsState.syncedCustomInstructions = null;
     mockGetIsOnline.mockReturnValue(true);
     mockGetConfigOptionByCategory.mockReturnValue(undefined);
     mockBuildAuthenticatedClient.mockReturnValue(mockAuthenticatedClient);
@@ -541,6 +550,42 @@ describe("SessionService", () => {
       });
 
       expect(mockTrpcAgent.start.mutate).not.toHaveBeenCalled();
+    });
+
+    it("starts the session with the synced file content when file sync is on", async () => {
+      // Pins the host wiring at sessionServiceHost.ts: the settings getter runs
+      // the store through getEffectiveCustomInstructions, so the synced file -
+      // not the hand-typed instructions - reaches agent.start. Reverting that
+      // to a plain state.customInstructions pass-through would send "typed".
+      const service = getSessionService();
+      mockSettingsState.customInstructions = "typed";
+      mockSettingsState.syncCustomInstructionsFromFile = true;
+      mockSettingsState.syncedCustomInstructions = {
+        path: "/home/u/.claude/CLAUDE.md",
+        displayPath: "~/.claude/CLAUDE.md",
+        content: "synced from file",
+        truncated: false,
+      };
+
+      mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(undefined);
+      mockBuildAuthenticatedClient.mockReturnValue({
+        ...mockAuthenticatedClient,
+        createTaskRun: vi.fn().mockResolvedValue({ id: "run-789" }),
+        appendTaskRunLog: vi.fn(),
+      });
+      mockTrpcAgent.start.mutate.mockResolvedValue({
+        channel: "test-channel",
+        configOptions: [],
+      });
+
+      await service.connectToTask({
+        task: createMockTask(),
+        repoPath: "/repo",
+      });
+
+      expect(mockTrpcAgent.start.mutate).toHaveBeenCalledWith(
+        expect.objectContaining({ customInstructions: "synced from file" }),
+      );
     });
 
     it("deduplicates concurrent connection attempts", async () => {

--- a/packages/ui/src/features/settings/customInstructionsSync.contribution.test.ts
+++ b/packages/ui/src/features/settings/customInstructionsSync.contribution.test.ts
@@ -59,6 +59,28 @@ describe("CustomInstructionsSyncContribution", () => {
     }
   });
 
+  it("reads the file when hydration completes with sync already on at boot", async () => {
+    // The headline boot behaviour: the contribution starts before persist
+    // rehydration flips _hasHydrated, and sync is persisted-on. The read must
+    // fire on that false -> true transition, not only on a later toggle flip -
+    // otherwise a user with sync persisted-on gets no file read at startup.
+    useSettingsStore.setState({
+      _hasHydrated: false,
+      syncCustomInstructionsFromFile: true,
+      syncedCustomInstructions: null,
+    });
+    query.mockResolvedValue(freshFile);
+
+    // Rehydration flips this asynchronously, after start() has already run.
+    useSettingsStore.setState({ _hasHydrated: true });
+    await flush();
+
+    expect(query).toHaveBeenCalled();
+    expect(useSettingsStore.getState().syncedCustomInstructions).toEqual(
+      freshFile,
+    );
+  });
+
   it("mirrors the file into the store when sync turns on", async () => {
     query.mockResolvedValueOnce(freshFile);
 

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -337,6 +337,42 @@ describe("getEffectiveCustomInstructions", () => {
   });
 });
 
+describe("feature settingsStore custom instructions sync persistence", () => {
+  beforeEach(async () => {
+    await resetPersistenceMocks();
+
+    useSettingsStore.setState({
+      syncCustomInstructionsFromFile: false,
+      syncedCustomInstructions: null,
+    });
+  });
+
+  it("persists the sync toggle but never the runtime snapshot", async () => {
+    // The toggle is durable preference; the snapshot is re-read on boot by the
+    // sync contribution. Persisting the snapshot would let a stale file rehydrate
+    // and reach a session created before the contribution's re-read finishes.
+    useSettingsStore.setState({
+      syncCustomInstructionsFromFile: true,
+      syncedCustomInstructions: {
+        path: "/home/u/.claude/CLAUDE.md",
+        displayPath: "~/.claude/CLAUDE.md",
+        content: "from file",
+        truncated: false,
+      },
+    });
+    // Nudge a persisted write via a partialized field.
+    useSettingsStore.getState().setCustomInstructions("touch");
+
+    await waitForPersistedWrite();
+
+    const lastCall = setItem.mock.calls[setItem.mock.calls.length - 1];
+    const persisted = JSON.parse(lastCall[1]);
+
+    expect(persisted.state.syncCustomInstructionsFromFile).toBe(true);
+    expect(persisted.state).not.toHaveProperty("syncedCustomInstructions");
+  });
+});
+
 describe("feature settingsStore terminal font", () => {
   beforeEach(async () => {
     await resetPersistenceMocks();


### PR DESCRIPTION
## Problem

Follow-up to #3286. A review from roborich (@richardsolomou) arrived just after that PR merged and flagged three test-coverage gaps: the AGENTS.md/CLAUDE.md personalization-sync feature could silently break — the file never read at boot, the synced content never reaching a session, or a stale snapshot rehydrating — while the existing suite stayed green, because the mocks omitted the new store fields.

**Why:** the feature is only as safe as the tests guarding it; each gap is a regression that would pass CI today.

## Changes

Three tests, each mutation-checked to confirm it fails on the corresponding regression and passes on correct code:

- **customInstructionsSync.contribution** — assert the file read fires on the unhydrated → hydrated boot transition when sync is persisted-on (the headline boot path the suite never ran).
- **sessionServiceHost** — give the store mock the sync fields and assert the synced file content, not the hand-typed instructions, reaches the `agent.start` payload.
- **settingsStore** — assert the sync toggle persists but the runtime snapshot stays out of `partialize`, so a stale snapshot can't rehydrate into a session.

No production code changed.

## How did you test this?

- `pnpm --filter @posthog/ui exec vitest run` on all three files — 170 tests pass.
- Mutation-checked each new test: reverting the sync wiring, shrinking the boot subscription guard, and leaking the snapshot into `partialize` each make exactly the relevant test fail.
- `biome check` on the three files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*