### PR TITLE
Cap sidebar task rows in by-project mode

### DIFF
--- a/packages/core/src/sidebar/buildSidebarData.test.ts
+++ b/packages/core/src/sidebar/buildSidebarData.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { limitTasksPerGroup, sliceVisibleTasks } from "./buildSidebarData";
+import type { TaskData, TaskGroup } from "./sidebarData.types";
+
+function makeTask(id: string): TaskData {
+  return {
+    id,
+    title: `Task ${id}`,
+    createdAt: 0,
+    lastActivityAt: 0,
+    isGenerating: false,
+    isUnread: false,
+    isPinned: false,
+    needsPermission: false,
+    repository: null,
+    isSuspended: false,
+    folderPath: null,
+    cloudPrUrl: null,
+    branchName: null,
+    linkedBranch: null,
+  };
+}
+
+function makeGroup(id: string, taskCount: number): TaskGroup {
+  return {
+    id,
+    name: id,
+    tasks: Array.from({ length: taskCount }, (_, i) => makeTask(`${id}-${i}`)),
+  };
+}
+
+describe("sliceVisibleTasks", () => {
+  it("caps the flat list to the visible count and reports hasMore", () => {
+    const tasks = Array.from({ length: 30 }, (_, i) => makeTask(String(i)));
+    const { flatTasks, hasMore } = sliceVisibleTasks(tasks, 25);
+    expect(flatTasks).toHaveLength(25);
+    expect(flatTasks[0]?.id).toBe("0");
+    expect(hasMore).toBe(true);
+  });
+
+  it("returns every task and hasMore=false when under the cap", () => {
+    const tasks = Array.from({ length: 10 }, (_, i) => makeTask(String(i)));
+    const { flatTasks, hasMore } = sliceVisibleTasks(tasks, 25);
+    expect(flatTasks).toHaveLength(10);
+    expect(hasMore).toBe(false);
+  });
+
+  it("reports hasMore=false when the count exactly matches the cap", () => {
+    const tasks = Array.from({ length: 25 }, (_, i) => makeTask(String(i)));
+    expect(sliceVisibleTasks(tasks, 25).hasMore).toBe(false);
+  });
+});
+
+describe("limitTasksPerGroup", () => {
+  it("caps each group independently so quiet groups still show tasks", () => {
+    const groups = [makeGroup("busy", 40), makeGroup("quiet", 3)];
+    const { groups: limited, hasMore } = limitTasksPerGroup(groups, 25);
+    expect(limited[0]?.tasks).toHaveLength(25);
+    expect(limited[1]?.tasks).toHaveLength(3);
+    expect(hasMore).toBe(true);
+  });
+
+  it("keeps empty groups (e.g. registered folders with no tasks)", () => {
+    const groups = [makeGroup("empty", 0)];
+    const { groups: limited, hasMore } = limitTasksPerGroup(groups, 25);
+    expect(limited[0]?.tasks).toHaveLength(0);
+    expect(hasMore).toBe(false);
+  });
+
+  it("does not clone groups that are under the cap", () => {
+    const groups = [makeGroup("small", 5)];
+    const { groups: limited, hasMore } = limitTasksPerGroup(groups, 25);
+    expect(limited[0]).toBe(groups[0]);
+    expect(hasMore).toBe(false);
+  });
+});

--- a/packages/core/src/sidebar/buildSidebarData.ts
+++ b/packages/core/src/sidebar/buildSidebarData.ts
@@ -1,7 +1,7 @@
 import { readPrUrls, type WorkspaceMode } from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
 import { getRepositoryInfo } from "./groupTasks";
-import type { TaskData } from "./sidebarData.types";
+import type { TaskData, TaskGroup } from "./sidebarData.types";
 
 export type SortMode = "updated" | "created";
 export type OrganizeMode = "by-project" | "chronological";
@@ -255,21 +255,50 @@ export function partitionAndSortTasks(
   };
 }
 
-export interface ChronologicalSlice {
+export interface VisibleTasksSlice {
   flatTasks: TaskData[];
   hasMore: boolean;
 }
 
-export function sliceChronological(
+/**
+ * Caps the flat (chronological) task list to the current history window. The
+ * cap is a render bound, not a cosmetic one: every rendered task row mounts its
+ * own workspace and PR-status queries, so an uncapped list of thousands of
+ * tasks fires thousands of per-row requests and floods the DOM. Pinned tasks
+ * are rendered separately and are never capped.
+ */
+export function sliceVisibleTasks(
   sortedUnpinnedTasks: TaskData[],
-  organizeMode: OrganizeMode,
-  historyVisibleCount: number,
-): ChronologicalSlice {
-  if (organizeMode !== "chronological") {
-    return { flatTasks: sortedUnpinnedTasks, hasMore: false };
-  }
+  visibleCount: number,
+): VisibleTasksSlice {
   return {
-    flatTasks: sortedUnpinnedTasks.slice(0, historyVisibleCount),
-    hasMore: sortedUnpinnedTasks.length > historyVisibleCount,
+    flatTasks: sortedUnpinnedTasks.slice(0, visibleCount),
+    hasMore: sortedUnpinnedTasks.length > visibleCount,
   };
+}
+
+export interface LimitedGroupsSlice {
+  groups: TaskGroup[];
+  hasMore: boolean;
+}
+
+/**
+ * Caps how many tasks each project group renders in "by-project" mode. A
+ * per-group window (rather than a single global cap) keeps every project
+ * showing its most-recent tasks, so a busy project can't starve quieter ones
+ * out of view entirely. Like {@link sliceVisibleTasks}, this exists to bound
+ * the number of mounted task rows — and therefore the per-row workspace and
+ * PR-status queries — when a project has accumulated thousands of tasks.
+ */
+export function limitTasksPerGroup(
+  groups: TaskGroup[],
+  limitPerGroup: number,
+): LimitedGroupsSlice {
+  let hasMore = false;
+  const limited = groups.map((group) => {
+    if (group.tasks.length <= limitPerGroup) return group;
+    hasMore = true;
+    return { ...group, tasks: group.tasks.slice(0, limitPerGroup) };
+  });
+  return { groups: limited, hasMore };
 }

--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -404,18 +404,21 @@ export function TaskListView({
               ))}
             </Fragment>
           ))}
-          {hasMore && (
-            <div className="px-2 py-2">
-              <button
-                type="button"
-                className="w-full rounded-md px-2 py-1 text-left text-[13px] text-gray-11 transition-colors hover:bg-gray-3"
-                onClick={loadMoreHistory}
-              >
-                Show more
-              </button>
-            </div>
-          )}
         </Flex>
+      )}
+
+      {/* Rendered for both organize modes: "by-project" caps each group and
+          "chronological" caps the flat list, so either can have more to load. */}
+      {hasMore && (
+        <div className="px-2 py-2">
+          <button
+            type="button"
+            className="w-full rounded-md px-2 py-1 text-left text-[13px] text-gray-11 transition-colors hover:bg-gray-3"
+            onClick={loadMoreHistory}
+          >
+            Show more
+          </button>
+        </div>
       )}
     </Flex>
   );

--- a/packages/ui/src/features/sidebar/useSidebarData.ts
+++ b/packages/ui/src/features/sidebar/useSidebarData.ts
@@ -3,10 +3,11 @@ import {
   type FullTask,
   filterByWorkspaceMode,
   filterVisibleTasks,
+  limitTasksPerGroup,
   narrowFullTask,
   partitionAndSortTasks,
   type SidebarTask,
-  sliceChronological,
+  sliceVisibleTasks,
 } from "@posthog/core/sidebar/buildSidebarData";
 import { groupByRepository } from "@posthog/core/sidebar/groupTasks";
 import type {
@@ -178,27 +179,35 @@ export function useSidebarData({
     [filteredTaskData, sortMode],
   );
 
-  const { flatTasks, hasMore } = useMemo(
-    () =>
-      sliceChronological(
-        sortedUnpinnedTasks,
-        organizeMode,
-        historyVisibleCount,
-      ),
-    [sortedUnpinnedTasks, organizeMode, historyVisibleCount],
+  const { flatTasks, hasMore: flatHasMore } = useMemo(
+    () => sliceVisibleTasks(sortedUnpinnedTasks, historyVisibleCount),
+    [sortedUnpinnedTasks, historyVisibleCount],
   );
 
   const { folders } = useFolders();
 
-  const groupedTasks = useMemo(
+  // Group the full task set (grouping is cheap, pure JS), then cap each group
+  // so "by-project" mode never mounts thousands of rows for a busy project.
+  const { groups: groupedTasks, hasMore: groupedHasMore } = useMemo(
     () =>
-      groupByRepository(
-        sortedUnpinnedTasks,
-        folderOrder,
-        organizeMode === "by-project" ? folders : [],
+      limitTasksPerGroup(
+        groupByRepository(
+          sortedUnpinnedTasks,
+          folderOrder,
+          organizeMode === "by-project" ? folders : [],
+        ),
+        historyVisibleCount,
       ),
-    [sortedUnpinnedTasks, folderOrder, folders, organizeMode],
+    [
+      sortedUnpinnedTasks,
+      folderOrder,
+      folders,
+      organizeMode,
+      historyVisibleCount,
+    ],
   );
+
+  const hasMore = organizeMode === "by-project" ? groupedHasMore : flatHasMore;
 
   const groupIdsRef = useRef<string[]>([]);
   useEffect(() => {


### PR DESCRIPTION
## Problem

The Code desktop app becomes laggy and sluggish for users with hundreds or thousands of past tasks. The default sidebar "by-project" organize mode rendered **every** past task with no limit — only the "chronological" mode respected the `historyVisibleCount` window. Each rendered task row also mounts its own workspace/folders query subscriptions plus a **per-task `getTaskPrStatus` tRPC call**, so an uncapped list didn't just bloat the DOM — it fired one IPC request per task. That query storm is the main driver of the sluggishness.

## Changes

- Bound the rendered task rows in **both** organize modes:
  - `sliceVisibleTasks` caps the flat/chronological list to the history window (unchanged behavior).
  - New `limitTasksPerGroup` caps each project group to the same window. A per-group window (rather than one global cap) keeps every project showing its most-recent tasks, so a busy project can't push quieter ones entirely out of view.
- The existing "Show more" button is now rendered in both modes (it was previously only in chronological), so the window can be expanded on demand.
- Pinned tasks are still rendered in full and are never capped.

## How did you test this?

- Added unit tests for `sliceVisibleTasks` and `limitTasksPerGroup` (`packages/core/src/sidebar/buildSidebarData.test.ts`).
- `pnpm --filter @posthog/core test sidebar` — 80 tests pass.
- `pnpm --filter @posthog/core typecheck` and `pnpm --filter @posthog/ui typecheck` — clean.
- `biome lint` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*