### PR TITLE
feat(agent): report cloud rtk token savings

### DIFF
--- a/packages/agent/src/acp-extensions.ts
+++ b/packages/agent/src/acp-extensions.ts
@@ -83,6 +83,9 @@ export const POSTHOG_NOTIFICATIONS = {
 
   /** Permission request resolved, persisted so a reconnecting client can tell it is no longer pending */
   PERMISSION_RESOLVED: "_posthog/permission_resolved",
+
+  /** RTK output-compression token savings tallied at the end of a run */
+  RTK_SAVINGS: "_posthog/rtk_savings",
 } as const;
 
 /**

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -553,6 +553,7 @@ describe("AgentServer HTTP Mode", () => {
         mode: "interactive",
         taskId: "test-task-id",
         runId: "test-run-id",
+        resolveRtkSavings: async () => null,
       }) as unknown as {
         eventStreamSender: {
           enqueue: (event: Record<string, unknown>) => void;
@@ -630,6 +631,7 @@ describe("AgentServer HTTP Mode", () => {
         mode: "interactive",
         taskId: "test-task-id",
         runId: "test-run-id",
+        resolveRtkSavings: async () => null,
       }) as unknown as {
         eventStreamSender: {
           enqueue: (event: Record<string, unknown>) => void;

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -406,6 +406,7 @@ describe("AgentServer HTTP Mode", () => {
       mode: "interactive",
       taskId: "test-task-id",
       runId: "test-run-id",
+      resolveRtkSavings: async () => null,
       ...overrides,
     });
     return server;
@@ -445,6 +446,7 @@ describe("AgentServer HTTP Mode", () => {
 
   describe("turn completion", () => {
     function stubSessionCleanup(testServer: unknown): {
+      session: unknown;
       cleanupSession: (options?: {
         completeEventStream?: boolean;
       }) => Promise<void>;
@@ -495,6 +497,48 @@ describe("AgentServer HTTP Mode", () => {
 
       expect(testServer.eventStreamSender.enqueue).not.toHaveBeenCalled();
       expect(testServer.eventStreamSender.stop).toHaveBeenCalledOnce();
+    });
+
+    it("emits rtk savings once before terminal event ingest stops", async () => {
+      const testServer = stubSessionCleanup(
+        createServer({
+          resolveRtkSavings: async () => ({
+            totalCommands: 4,
+            inputTokens: 1000,
+            outputTokens: 350,
+            tokensSaved: 650,
+          }),
+        }),
+      );
+      const session = testServer.session;
+
+      await testServer.cleanupSession({ completeEventStream: true });
+      testServer.session = session;
+      await testServer.cleanupSession({ completeEventStream: true });
+
+      expect(testServer.eventStreamSender.enqueue).toHaveBeenCalledOnce();
+      expect(testServer.eventStreamSender.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notification: expect.objectContaining({
+            method: "_posthog/rtk_savings",
+            params: expect.objectContaining({
+              task_id: "test-task-id",
+              run_id: "test-run-id",
+              team_id: 1,
+              counter_id: "test-task-id",
+              cumulative_commands: 4,
+              cumulative_input_tokens: 1000,
+              cumulative_output_tokens: 350,
+              cumulative_tokens_saved: 650,
+            }),
+          }),
+        }),
+      );
+      expect(
+        testServer.eventStreamSender.enqueue.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        testServer.eventStreamSender.stop.mock.invocationCallOrder[0],
+      );
     });
 
     it("writes terminal failure status before completing event ingest", async () => {

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -89,6 +89,7 @@ import {
 } from "./cloud-prompt";
 import { TaskRunEventStreamSender } from "./event-stream-sender";
 import { type JwtPayload, JwtValidationError, validateJwt } from "./jwt";
+import { resolveRtkSavings } from "./rtk-savings";
 import { RunUsageAccumulator } from "./run-usage";
 import {
   handoffLocalGitStateSchema,
@@ -321,6 +322,7 @@ export class AgentServer {
   private app: Hono;
   private posthogAPI: PostHogAPIClient;
   private eventStreamSender: TaskRunEventStreamSender | null = null;
+  private rtkSavingsAttempted = false;
   private questionRelayedToSlack = false;
   private adapterEmittedTurnComplete = false;
   private runUsage = new RunUsageAccumulator();
@@ -3093,6 +3095,7 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
     } catch (error) {
       this.logger.error("Failed to signal task completion", error);
     } finally {
+      await this.emitRtkSavings();
       await this.eventStreamSender?.stop();
     }
   }
@@ -3699,6 +3702,7 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
     }
 
     if (completeEventStream) {
+      await this.emitRtkSavings();
       await this.eventStreamSender?.stop();
     }
 
@@ -3708,6 +3712,41 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
     // with a different run_id) must not inherit the previous run's totals.
     this.runUsage = new RunUsageAccumulator();
     this.session = null;
+  }
+
+  private async emitRtkSavings(): Promise<void> {
+    if (!this.eventStreamSender || this.rtkSavingsAttempted) return;
+    this.rtkSavingsAttempted = true;
+
+    try {
+      const savings = await (
+        this.config.resolveRtkSavings ?? resolveRtkSavings
+      )();
+      if (!savings) return;
+
+      this.eventStreamSender.enqueue({
+        type: "notification",
+        timestamp: new Date().toISOString(),
+        notification: {
+          jsonrpc: "2.0",
+          method: POSTHOG_NOTIFICATIONS.RTK_SAVINGS,
+          params: {
+            task_id: this.config.taskId,
+            run_id: this.config.runId,
+            team_id: this.config.projectId,
+            counter_id: this.config.taskId,
+            cumulative_commands: savings.totalCommands,
+            cumulative_input_tokens: savings.inputTokens,
+            cumulative_output_tokens: savings.outputTokens,
+            cumulative_tokens_saved: savings.tokensSaved,
+            runtime_adapter: this.config.runtimeAdapter,
+            model: this.config.model,
+          },
+        },
+      });
+    } catch (error) {
+      this.logger.debug("Failed to emit rtk savings", { error });
+    }
   }
 
   private async captureCheckpointState(

--- a/packages/agent/src/server/rtk-savings.test.ts
+++ b/packages/agent/src/server/rtk-savings.test.ts
@@ -66,9 +66,14 @@ describe("scrubbedGainEnv", () => {
       scrubbedGainEnv({
         PATH: "/usr/bin",
         HOME: "/home/posthog",
+        RTK_DB_PATH: "/tmp/posthog-rtk.db",
         GITHUB_TOKEN: "secret",
         ANTHROPIC_API_KEY: "secret",
       }),
-    ).toEqual({ PATH: "/usr/bin", HOME: "/home/posthog" });
+    ).toEqual({
+      PATH: "/usr/bin",
+      HOME: "/home/posthog",
+      RTK_DB_PATH: "/tmp/posthog-rtk.db",
+    });
   });
 });

--- a/packages/agent/src/server/rtk-savings.test.ts
+++ b/packages/agent/src/server/rtk-savings.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveRtkSavings, scrubbedGainEnv } from "./rtk-savings";
+
+const GAIN_JSON = JSON.stringify({
+  summary: {
+    total_commands: 2,
+    total_input: 502691,
+    total_output: 5835,
+    total_saved: 496856,
+  },
+});
+
+function gain(stdout: string) {
+  return vi.fn().mockResolvedValue(stdout);
+}
+
+describe("resolveRtkSavings", () => {
+  it("parses the rtk gain summary", async () => {
+    const runGain = gain(GAIN_JSON);
+
+    await expect(
+      resolveRtkSavings({
+        resolveBinary: () => "/bundled/rtk",
+        runGain,
+      }),
+    ).resolves.toEqual({
+      totalCommands: 2,
+      inputTokens: 502691,
+      outputTokens: 5835,
+      tokensSaved: 496856,
+    });
+    expect(runGain).toHaveBeenCalledWith("/bundled/rtk", expect.anything());
+  });
+
+  it.each([
+    ["the binary is unavailable", undefined, GAIN_JSON],
+    ["nothing was tracked", "/bundled/rtk", JSON.stringify({ summary: { total_commands: 0 } })],
+    ["the output is malformed", "/bundled/rtk", "not json"],
+    ["the summary is missing", "/bundled/rtk", JSON.stringify({ daily: [] })],
+  ])("returns null when %s", async (_label, binary, stdout) => {
+    const runGain = gain(stdout);
+
+    await expect(resolveRtkSavings({ resolveBinary: () => binary, runGain })).resolves.toBeNull();
+    if (!binary) expect(runGain).not.toHaveBeenCalled();
+  });
+
+  it("returns null when rtk gain fails", async () => {
+    await expect(
+      resolveRtkSavings({
+        resolveBinary: () => "/bundled/rtk",
+        runGain: vi.fn().mockRejectedValue(new Error("rtk failed")),
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("scrubbedGainEnv", () => {
+  it("keeps platform paths without forwarding secrets", () => {
+    expect(
+      scrubbedGainEnv({
+        PATH: "/usr/bin",
+        HOME: "/home/posthog",
+        GITHUB_TOKEN: "secret",
+        ANTHROPIC_API_KEY: "secret",
+      }),
+    ).toEqual({ PATH: "/usr/bin", HOME: "/home/posthog" });
+  });
+});

--- a/packages/agent/src/server/rtk-savings.test.ts
+++ b/packages/agent/src/server/rtk-savings.test.ts
@@ -34,13 +34,19 @@ describe("resolveRtkSavings", () => {
 
   it.each([
     ["the binary is unavailable", undefined, GAIN_JSON],
-    ["nothing was tracked", "/bundled/rtk", JSON.stringify({ summary: { total_commands: 0 } })],
+    [
+      "nothing was tracked",
+      "/bundled/rtk",
+      JSON.stringify({ summary: { total_commands: 0 } }),
+    ],
     ["the output is malformed", "/bundled/rtk", "not json"],
     ["the summary is missing", "/bundled/rtk", JSON.stringify({ daily: [] })],
   ])("returns null when %s", async (_label, binary, stdout) => {
     const runGain = gain(stdout);
 
-    await expect(resolveRtkSavings({ resolveBinary: () => binary, runGain })).resolves.toBeNull();
+    await expect(
+      resolveRtkSavings({ resolveBinary: () => binary, runGain }),
+    ).resolves.toBeNull();
     if (!binary) expect(runGain).not.toHaveBeenCalled();
   });
 

--- a/packages/agent/src/server/rtk-savings.ts
+++ b/packages/agent/src/server/rtk-savings.ts
@@ -59,6 +59,7 @@ const GAIN_ENV_ALLOWLIST = [
   "TEMP",
   "TMP",
   "SystemRoot",
+  "RTK_DB_PATH",
 ];
 
 export function scrubbedGainEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {

--- a/packages/agent/src/server/rtk-savings.ts
+++ b/packages/agent/src/server/rtk-savings.ts
@@ -35,7 +35,10 @@ function parseGainSummary(stdout: string): RtkSavingsSummary | null {
   };
 }
 
-async function defaultRunGain(binary: string, env: NodeJS.ProcessEnv): Promise<string> {
+async function defaultRunGain(
+  binary: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
   const { stdout } = await execFileAsync(binary, ["gain", "--format", "json"], {
     timeout: 5_000,
     maxBuffer: 10 * 1024 * 1024,
@@ -60,7 +63,10 @@ const GAIN_ENV_ALLOWLIST = [
 
 export function scrubbedGainEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return Object.fromEntries(
-    GAIN_ENV_ALLOWLIST.filter((key) => env[key] !== undefined).map((key) => [key, env[key]]),
+    GAIN_ENV_ALLOWLIST.filter((key) => env[key] !== undefined).map((key) => [
+      key,
+      env[key],
+    ]),
   );
 }
 

--- a/packages/agent/src/server/rtk-savings.ts
+++ b/packages/agent/src/server/rtk-savings.ts
@@ -1,0 +1,81 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { resolveRtkPrefix } from "../adapters/claude/session/rtk";
+
+const execFileAsync = promisify(execFile);
+
+export interface RtkSavingsSummary {
+  totalCommands: number;
+  inputTokens: number;
+  outputTokens: number;
+  tokensSaved: number;
+}
+
+interface ResolveRtkSavingsOptions {
+  env?: NodeJS.ProcessEnv;
+  resolveBinary?: (env: NodeJS.ProcessEnv) => string | undefined;
+  runGain?: (binary: string, env: NodeJS.ProcessEnv) => Promise<string>;
+}
+
+function toFiniteNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function parseGainSummary(stdout: string): RtkSavingsSummary | null {
+  const parsed: unknown = JSON.parse(stdout);
+  if (!parsed || typeof parsed !== "object") return null;
+  const summary = (parsed as { summary?: Record<string, unknown> }).summary;
+  if (!summary || typeof summary !== "object") return null;
+
+  return {
+    totalCommands: toFiniteNumber(summary.total_commands),
+    inputTokens: toFiniteNumber(summary.total_input),
+    outputTokens: toFiniteNumber(summary.total_output),
+    tokensSaved: toFiniteNumber(summary.total_saved),
+  };
+}
+
+async function defaultRunGain(binary: string, env: NodeJS.ProcessEnv): Promise<string> {
+  const { stdout } = await execFileAsync(binary, ["gain", "--format", "json"], {
+    timeout: 5_000,
+    maxBuffer: 10 * 1024 * 1024,
+    env: scrubbedGainEnv(env),
+  });
+  return stdout;
+}
+
+const GAIN_ENV_ALLOWLIST = [
+  "PATH",
+  "HOME",
+  "USERPROFILE",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "SystemRoot",
+];
+
+export function scrubbedGainEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    GAIN_ENV_ALLOWLIST.filter((key) => env[key] !== undefined).map((key) => [key, env[key]]),
+  );
+}
+
+export async function resolveRtkSavings({
+  env = process.env,
+  resolveBinary = resolveRtkPrefix,
+  runGain = defaultRunGain,
+}: ResolveRtkSavingsOptions = {}): Promise<RtkSavingsSummary | null> {
+  const binary = resolveBinary(env);
+  if (!binary) return null;
+
+  try {
+    const summary = parseGainSummary(await runGain(binary, env));
+    return summary && summary.totalCommands > 0 ? summary : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/agent/src/server/types.ts
+++ b/packages/agent/src/server/types.ts
@@ -1,5 +1,6 @@
 import type { Adapter } from "@posthog/shared";
 import type { AgentMode } from "../types";
+import type { RtkSavingsSummary } from "./rtk-savings";
 import type { RemoteMcpServer } from "./schemas";
 
 export interface ClaudeCodeConfig {
@@ -37,4 +38,5 @@ export interface AgentServerConfig {
   runtimeAdapter?: Adapter;
   model?: string;
   reasoningEffort?: "low" | "medium" | "high" | "xhigh" | "max";
+  resolveRtkSavings?: () => Promise<RtkSavingsSummary | null>;
 }


### PR DESCRIPTION
## Problem

Cloud runs can use RTK to compress verbose command output, but current production telemetry only compares total run tokens between rollout cohorts. That comparison is affected by workload and run length, so it cannot measure the command-output savings directly.

## Changes

- Read RTK's cumulative `gain` summary at terminal cleanup without exposing process secrets to the subprocess.
- Emit a once-only `_posthog/rtk_savings` event before event ingest closes, including runtime and model context.
- Keep the reporting path best-effort so missing, malformed, or failing RTK telemetry never affects a run.
- Isolate terminal-failure tests from RTK resolution so they continue to assert event ordering deterministically.