### PR TITLE
feat(channels): add Canvas mode to the channel composer's mode selector

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -871,7 +871,8 @@ export type ChannelActionType =
   | "copy_link"
   | "mention_member"
   | "view_activity"
-  | "open_mention";
+  | "open_mention"
+  | "canvas_mode_toggle";
 
 export interface ChannelActionProperties {
   action_type: ChannelActionType;
@@ -888,6 +889,8 @@ export interface ChannelActionProperties {
   mentioned_user_id?: string;
   /** For new_task_suggestion: the starter-prompt card label. */
   suggestion_label?: string;
+  /** For canvas_mode_toggle: whether canvas mode is being armed. */
+  armed?: boolean;
   /** Whether the underlying mutation resolved successfully. */
   success?: boolean;
 }

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -1,6 +1,7 @@
 import { isValidConfigValue } from "@posthog/core/task-detail/configOptions";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
   forwardRef,
@@ -11,6 +12,7 @@ import {
 } from "react";
 import { useConnectivity } from "../../../hooks/useConnectivity";
 import { track } from "../../../shell/analytics";
+import { useOptionalAuthenticatedClient } from "../../auth/authClient";
 import { useUserRepositoryIntegration } from "../../integrations/useIntegrations";
 import { PromptInput } from "../../message-editor/components/PromptInput";
 import { useDraftStore } from "../../message-editor/draftStore";
@@ -32,11 +34,16 @@ import { usePreviewConfig } from "../../task-detail/hooks/usePreviewConfig";
 import { useTaskCreation } from "../../task-detail/hooks/useTaskCreation";
 import { resolveWorkspaceModePreference } from "../../task-detail/hooks/workspaceModePreference";
 import { trackAndCreateCanvas } from "../createCanvasAnalytics";
+import { channelFeedQueryKey } from "../hooks/useChannelFeed";
 import {
   UNTITLED_CANVAS_NAME,
   useDashboardMutations,
 } from "../hooks/useDashboards";
 import { useGenerateFreeformCanvas } from "../hooks/useGenerateFreeformCanvas";
+import {
+  normalizeChannelName,
+  PERSONAL_CHANNEL_NAME,
+} from "../hooks/useTaskChannels";
 
 export interface ChannelHomeComposerHandle {
   /** Drop a starter prompt into the editor and apply its mode, if any. */
@@ -97,39 +104,6 @@ export const ChannelHomeComposer = forwardRef<
     });
     setCanvasArmed(!canvasArmed);
   }, [channelId, canvasArmed]);
-
-  const handleCanvasSubmit = useCallback(async () => {
-    const instruction = editorRef.current?.getText().trim();
-    if (!instruction || isStartingCanvas) return;
-    let record: { id: string; name: string };
-    try {
-      record = await trackAndCreateCanvas(
-        channelId,
-        "freeform",
-        "channel_home",
-        () => createDashboard(channelId, UNTITLED_CANVAS_NAME, "freeform"),
-      );
-    } catch (error) {
-      toastError("Couldn't create canvas", error);
-      return;
-    }
-    // generate() surfaces its own failure toasts; on success it files the task
-    // to the channel and tracks completion for the finished-generation toast.
-    const taskId = await generateCanvas({
-      dashboardId: record.id,
-      name: record.name,
-      templateId: "freeform",
-      instruction,
-      useStarter: true,
-    });
-    if (!taskId) return;
-    editorRef.current?.clear();
-    setCanvasArmed(false);
-    void navigate({
-      to: "/website/$channelId/dashboards/$dashboardId",
-      params: { channelId, dashboardId: record.id },
-    });
-  }, [channelId, createDashboard, generateCanvas, isStartingCanvas, navigate]);
 
   const {
     lastUsedAdapter,
@@ -192,6 +166,81 @@ export const ChannelHomeComposer = forwardRef<
     modeFallback;
   const currentReasoningLevel =
     thoughtOption?.type === "select" ? thoughtOption.currentValue : undefined;
+
+  const queryClient = useQueryClient();
+  const apiClient = useOptionalAuthenticatedClient();
+  const handleCanvasSubmit = useCallback(async () => {
+    const instruction = editorRef.current?.getText().trim();
+    if (!instruction || isStartingCanvas) return;
+    // The folder→backend channel mapping can still be resolving when the user
+    // submits (fresh channel, cold channels list). Resolve it here rather than
+    // silently creating a run the feed will never show. The personal channel
+    // can't be resolved by name; it only arrives via the channels list.
+    let feedChannelId = backendChannelId;
+    const normalizedName = channelName ? normalizeChannelName(channelName) : "";
+    if (
+      !feedChannelId &&
+      apiClient &&
+      normalizedName &&
+      normalizedName !== PERSONAL_CHANNEL_NAME
+    ) {
+      feedChannelId = await apiClient
+        .resolveTaskChannel(normalizedName)
+        .then((c) => c.id)
+        .catch(() => undefined);
+    }
+    let record: { id: string; name: string };
+    try {
+      record = await trackAndCreateCanvas(
+        channelId,
+        "freeform",
+        "channel_home",
+        () => createDashboard(channelId, UNTITLED_CANVAS_NAME, "freeform"),
+      );
+    } catch (error) {
+      toastError("Couldn't create canvas", error);
+      return;
+    }
+    // generate() surfaces its own failure toasts; on success it files the task
+    // to the channel and tracks completion for the finished-generation toast.
+    const taskId = await generateCanvas({
+      dashboardId: record.id,
+      name: record.name,
+      templateId: "freeform",
+      instruction,
+      // Owned by the backend channel so the run shows as a card in the feed,
+      // like a plain composer submit.
+      backendChannelId: feedChannelId,
+      adapter: adapter ?? "claude",
+      model: currentModel,
+      reasoningLevel: currentReasoningLevel,
+      useStarter: true,
+    });
+    if (!taskId) return;
+    // Surface the new card without waiting for the feed's next poll.
+    void queryClient.invalidateQueries({
+      queryKey: channelFeedQueryKey(feedChannelId),
+    });
+    editorRef.current?.clear();
+    setCanvasArmed(false);
+    void navigate({
+      to: "/website/$channelId/dashboards/$dashboardId",
+      params: { channelId, dashboardId: record.id },
+    });
+  }, [
+    channelId,
+    channelName,
+    backendChannelId,
+    apiClient,
+    adapter,
+    currentModel,
+    currentReasoningLevel,
+    createDashboard,
+    generateCanvas,
+    isStartingCanvas,
+    navigate,
+    queryClient,
+  ]);
 
   const { isCreatingTask, canSubmit, handleSubmit } = useTaskCreation({
     editorRef,
@@ -303,21 +352,17 @@ export const ChannelHomeComposer = forwardRef<
         enableCommands
         enableBashMode={false}
         modelSelector={
-          // Canvas generation resolves the adapter's default model itself.
-          canvasArmed ? null : (
-            <UnifiedModelSelector
-              modelOption={modelOption}
-              adapter={adapter ?? "claude"}
-              onAdapterChange={setAdapter}
-              disabled={isBusy}
-              isConnecting={isLoading}
-              onModelChange={handleModelChange}
-            />
-          )
+          <UnifiedModelSelector
+            modelOption={modelOption}
+            adapter={adapter ?? "claude"}
+            onAdapterChange={setAdapter}
+            disabled={isBusy}
+            isConnecting={isLoading}
+            onModelChange={handleModelChange}
+          />
         }
         reasoningSelector={
-          !isLoading &&
-          !canvasArmed && (
+          !isLoading && (
             <ReasoningLevelSelector
               thoughtOption={thoughtOption}
               adapter={adapter}

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -1,5 +1,7 @@
 import { isValidConfigValue } from "@posthog/core/task-detail/configOptions";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
+import { useNavigate } from "@tanstack/react-router";
 import {
   forwardRef,
   useCallback,
@@ -8,6 +10,8 @@ import {
   useState,
 } from "react";
 import { useConnectivity } from "../../../hooks/useConnectivity";
+import { toast } from "../../../primitives/toast";
+import { track } from "../../../shell/analytics";
 import { useUserRepositoryIntegration } from "../../integrations/useIntegrations";
 import { PromptInput } from "../../message-editor/components/PromptInput";
 import { useDraftStore } from "../../message-editor/draftStore";
@@ -27,6 +31,11 @@ import { useCloudModeEnabled } from "../../task-detail/hooks/useCloudModeEnabled
 import { usePreviewConfig } from "../../task-detail/hooks/usePreviewConfig";
 import { useTaskCreation } from "../../task-detail/hooks/useTaskCreation";
 import { resolveWorkspaceModePreference } from "../../task-detail/hooks/workspaceModePreference";
+import {
+  UNTITLED_CANVAS_NAME,
+  useDashboardMutations,
+} from "../hooks/useDashboards";
+import { useGenerateFreeformCanvas } from "../hooks/useGenerateFreeformCanvas";
 
 export interface ChannelHomeComposerHandle {
   /** Drop a starter prompt into the editor and apply its mode, if any. */
@@ -60,6 +69,69 @@ export const ChannelHomeComposer = forwardRef<
   const editorRef = useRef<EditorHandle>(null);
   const [editorIsEmpty, setEditorIsEmpty] = useState(true);
   const { isOnline } = useConnectivity();
+  const navigate = useNavigate();
+
+  // Canvas mode, armed from the mode selector (like Autoresearch on the
+  // new-task composer): the next submit generates a canvas from the prompt —
+  // create a canvas in the channel, kick off freeform generation, and open it —
+  // instead of creating a plain task. This replaces the prompt-to-canvas entry
+  // the old channel landing had.
+  const [canvasArmed, setCanvasArmed] = useState(false);
+  const { createDashboard } = useDashboardMutations();
+  const { generate: generateCanvas, isStarting: isStartingCanvas } =
+    useGenerateFreeformCanvas({ channelId, channelName: channelName ?? "" });
+
+  const toggleCanvasMode = useCallback(() => {
+    setCanvasArmed((armed) => {
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "canvas_mode_toggle",
+        surface: "channel_home",
+        channel_id: channelId,
+        armed: !armed,
+      });
+      return !armed;
+    });
+  }, [channelId]);
+
+  const handleCanvasSubmit = useCallback(async () => {
+    const instruction = editorRef.current?.getText().trim();
+    if (!instruction || isStartingCanvas) return;
+    track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+      action_type: "create",
+      surface: "channel_home",
+      channel_id: channelId,
+      template_id: "freeform",
+    });
+    let record: { id: string; name: string };
+    try {
+      record = await createDashboard(
+        channelId,
+        UNTITLED_CANVAS_NAME,
+        "freeform",
+      );
+    } catch (error) {
+      toast.error("Couldn't create canvas", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+    // generate() surfaces its own failure toasts; on success it files the task
+    // to the channel and tracks completion for the finished-generation toast.
+    const taskId = await generateCanvas({
+      dashboardId: record.id,
+      name: record.name,
+      templateId: "freeform",
+      instruction,
+      useStarter: true,
+    });
+    if (!taskId) return;
+    editorRef.current?.clear();
+    setCanvasArmed(false);
+    void navigate({
+      to: "/website/$channelId/dashboards/$dashboardId",
+      params: { channelId, dashboardId: record.id },
+    });
+  }, [channelId, createDashboard, generateCanvas, isStartingCanvas, navigate]);
 
   const {
     lastUsedAdapter,
@@ -187,62 +259,82 @@ export const ChannelHomeComposer = forwardRef<
   );
 
   const hints = ["@ to add files", "/ for skills"].join(", ");
+  const isBusy = isCreatingTask || isStartingCanvas;
 
   return (
     <div className="flex w-full flex-col">
-      <div className="mb-2 flex items-center gap-2">
-        <WorkspaceModeSelect
-          value={workspaceMode}
-          onChange={setWorkspaceMode}
-          overrideModes={["local", "cloud"]}
-          selectedCloudEnvironmentId={selectedCloudEnvId}
-          onCloudEnvironmentChange={setSelectedCloudEnvId}
-          size="1"
-          disabled={isCreatingTask}
-        />
-      </div>
+      {/* Canvas generation always runs in the cloud, so the local/cloud pick
+          doesn't apply while canvas mode is armed. */}
+      {!canvasArmed && (
+        <div className="mb-2 flex items-center gap-2">
+          <WorkspaceModeSelect
+            value={workspaceMode}
+            onChange={setWorkspaceMode}
+            overrideModes={["local", "cloud"]}
+            selectedCloudEnvironmentId={selectedCloudEnvId}
+            onCloudEnvironmentChange={setSelectedCloudEnvId}
+            size="1"
+            disabled={isBusy}
+          />
+        </div>
+      )}
 
       <PromptInput
         ref={editorRef}
         sessionId={sessionId}
-        placeholder={`What do you want to ship? ${hints}`}
+        placeholder={
+          canvasArmed
+            ? "Describe the canvas to build — the agent generates and publishes it"
+            : `What do you want to ship? ${hints}`
+        }
         editorHeight="large"
-        disabled={isCreatingTask}
-        isLoading={isCreatingTask}
+        disabled={isBusy}
+        isLoading={isBusy}
         autoFocus
         clearOnSubmit={false}
         submitDisabledExternal={
-          !canSubmit || isCreatingTask || !isOnline || isLoading
+          canvasArmed
+            ? editorIsEmpty || isBusy || !isOnline
+            : !canSubmit || isBusy || !isOnline || isLoading
         }
         modeOption={modeOption}
         onModeChange={handleModeChange}
         allowBypassPermissions={allowBypassPermissions}
+        canvas={{ active: canvasArmed, onToggle: toggleCanvasMode }}
         enableCommands
         enableBashMode={false}
         modelSelector={
-          <UnifiedModelSelector
-            modelOption={modelOption}
-            adapter={adapter ?? "claude"}
-            onAdapterChange={setAdapter}
-            disabled={isCreatingTask}
-            isConnecting={isLoading}
-            onModelChange={handleModelChange}
-          />
+          // Canvas generation resolves the adapter's default model itself.
+          canvasArmed ? null : (
+            <UnifiedModelSelector
+              modelOption={modelOption}
+              adapter={adapter ?? "claude"}
+              onAdapterChange={setAdapter}
+              disabled={isBusy}
+              isConnecting={isLoading}
+              onModelChange={handleModelChange}
+            />
+          )
         }
         reasoningSelector={
-          !isLoading && (
+          !isLoading &&
+          !canvasArmed && (
             <ReasoningLevelSelector
               thoughtOption={thoughtOption}
               adapter={adapter}
               onChange={handleThoughtChange}
-              disabled={isCreatingTask}
+              disabled={isBusy}
             />
           )
         }
         onEmptyChange={setEditorIsEmpty}
-        onSubmitClick={handleSubmit}
+        onSubmitClick={() => {
+          if (canvasArmed) void handleCanvasSubmit();
+          else handleSubmit();
+        }}
         onSubmit={() => {
-          if (canSubmit) handleSubmit();
+          if (canvasArmed) void handleCanvasSubmit();
+          else if (canSubmit) handleSubmit();
         }}
       />
     </div>

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -10,12 +10,12 @@ import {
   useState,
 } from "react";
 import { useConnectivity } from "../../../hooks/useConnectivity";
-import { toast } from "../../../primitives/toast";
 import { track } from "../../../shell/analytics";
 import { useUserRepositoryIntegration } from "../../integrations/useIntegrations";
 import { PromptInput } from "../../message-editor/components/PromptInput";
 import { useDraftStore } from "../../message-editor/draftStore";
 import type { EditorHandle } from "../../message-editor/types";
+import { toastError } from "../../notifications/errorDetails";
 import { ReasoningLevelSelector } from "../../sessions/components/ReasoningLevelSelector";
 import { UnifiedModelSelector } from "../../sessions/components/UnifiedModelSelector";
 import { getCurrentModeFromConfigOptions } from "../../sessions/sessionStore";
@@ -36,6 +36,7 @@ import {
   useDashboardMutations,
 } from "../hooks/useDashboards";
 import { useGenerateFreeformCanvas } from "../hooks/useGenerateFreeformCanvas";
+import { trackAndCreateCanvas } from "./NewCanvasMenu";
 
 export interface ChannelHomeComposerHandle {
   /** Drop a starter prompt into the editor and apply its mode, if any. */
@@ -79,40 +80,37 @@ export const ChannelHomeComposer = forwardRef<
   const [canvasArmed, setCanvasArmed] = useState(false);
   const { createDashboard } = useDashboardMutations();
   const { generate: generateCanvas, isStarting: isStartingCanvas } =
-    useGenerateFreeformCanvas({ channelId, channelName: channelName ?? "" });
+    useGenerateFreeformCanvas({
+      channelId,
+      channelName: channelName ?? "",
+      // The parent already fetches the channel CONTEXT.md; passing it keeps
+      // the hook from running its own duplicate fetch.
+      channelContext,
+    });
 
   const toggleCanvasMode = useCallback(() => {
-    setCanvasArmed((armed) => {
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
-        action_type: "canvas_mode_toggle",
-        surface: "channel_home",
-        channel_id: channelId,
-        armed: !armed,
-      });
-      return !armed;
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "canvas_mode_toggle",
+      surface: "channel_home",
+      channel_id: channelId,
+      armed: !canvasArmed,
     });
-  }, [channelId]);
+    setCanvasArmed(!canvasArmed);
+  }, [channelId, canvasArmed]);
 
   const handleCanvasSubmit = useCallback(async () => {
     const instruction = editorRef.current?.getText().trim();
     if (!instruction || isStartingCanvas) return;
-    track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
-      action_type: "create",
-      surface: "channel_home",
-      channel_id: channelId,
-      template_id: "freeform",
-    });
     let record: { id: string; name: string };
     try {
-      record = await createDashboard(
+      record = await trackAndCreateCanvas(
         channelId,
-        UNTITLED_CANVAS_NAME,
         "freeform",
+        "channel_home",
+        () => createDashboard(channelId, UNTITLED_CANVAS_NAME, "freeform"),
       );
     } catch (error) {
-      toast.error("Couldn't create canvas", {
-        description: error instanceof Error ? error.message : String(error),
-      });
+      toastError("Couldn't create canvas", error);
       return;
     }
     // generate() surfaces its own failure toasts; on success it files the task
@@ -260,6 +258,7 @@ export const ChannelHomeComposer = forwardRef<
 
   const hints = ["@ to add files", "/ for skills"].join(", ");
   const isBusy = isCreatingTask || isStartingCanvas;
+  const submitComposer = canvasArmed ? handleCanvasSubmit : handleSubmit;
 
   return (
     <div className="flex w-full flex-col">
@@ -328,13 +327,9 @@ export const ChannelHomeComposer = forwardRef<
           )
         }
         onEmptyChange={setEditorIsEmpty}
-        onSubmitClick={() => {
-          if (canvasArmed) void handleCanvasSubmit();
-          else handleSubmit();
-        }}
+        onSubmitClick={() => void submitComposer()}
         onSubmit={() => {
-          if (canvasArmed) void handleCanvasSubmit();
-          else if (canSubmit) handleSubmit();
+          if (canvasArmed || canSubmit) void submitComposer();
         }}
       />
     </div>

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -31,12 +31,12 @@ import { useCloudModeEnabled } from "../../task-detail/hooks/useCloudModeEnabled
 import { usePreviewConfig } from "../../task-detail/hooks/usePreviewConfig";
 import { useTaskCreation } from "../../task-detail/hooks/useTaskCreation";
 import { resolveWorkspaceModePreference } from "../../task-detail/hooks/workspaceModePreference";
+import { trackAndCreateCanvas } from "../createCanvasAnalytics";
 import {
   UNTITLED_CANVAS_NAME,
   useDashboardMutations,
 } from "../hooks/useDashboards";
 import { useGenerateFreeformCanvas } from "../hooks/useGenerateFreeformCanvas";
-import { trackAndCreateCanvas } from "./NewCanvasMenu";
 
 export interface ChannelHomeComposerHandle {
   /** Drop a starter prompt into the editor and apply its mode, if any. */

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -39,8 +39,8 @@ import {
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { CreateChannelModal } from "@posthog/ui/features/canvas/components/CreateChannelModal";
-import { trackAndCreateCanvas } from "@posthog/ui/features/canvas/components/NewCanvasMenu";
 import { RenameChannelModal } from "@posthog/ui/features/canvas/components/RenameChannelModal";
+import { trackAndCreateCanvas } from "@posthog/ui/features/canvas/createCanvasAnalytics";
 import {
   useChannelStars,
   useChannelStarToggle,

--- a/packages/ui/src/features/canvas/components/NewCanvasMenu.tsx
+++ b/packages/ui/src/features/canvas/components/NewCanvasMenu.tsx
@@ -8,33 +8,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@posthog/quill";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import {
+  type CreateSurface,
+  trackAndCreateCanvas,
+} from "@posthog/ui/features/canvas/createCanvasAnalytics";
 import { useCanvasTemplates } from "@posthog/ui/features/canvas/hooks/useCanvasTemplates";
 import { useCreateAndOpenDashboard } from "@posthog/ui/features/canvas/hooks/useDashboards";
-import { track } from "@posthog/ui/shell/analytics";
 import { useState } from "react";
-
-// Where a canvas create was triggered from, for analytics.
-export type CreateSurface = "dashboards_grid" | "sidebar" | "channel_home";
-
-// Fire the "create" DASHBOARD_ACTION, then create + open the canvas. Exported so
-// other entry points (the sidebar "+" dropdown, the channel composer's canvas
-// mode) report creation the same way. Returns `create`'s result so callers that
-// need the created record can await it.
-export function trackAndCreateCanvas<T>(
-  channelId: string | undefined,
-  templateId: string | undefined,
-  surface: CreateSurface,
-  create: () => T,
-): T {
-  track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
-    action_type: "create",
-    surface,
-    channel_id: channelId,
-    template_id: templateId,
-  });
-  return create();
-}
 
 // The list of template options shared by the canvas-create surfaces (the
 // dashboards-grid dialog and the sidebar "+" dropdown). Picking a template

--- a/packages/ui/src/features/canvas/components/NewCanvasMenu.tsx
+++ b/packages/ui/src/features/canvas/components/NewCanvasMenu.tsx
@@ -15,23 +15,25 @@ import { track } from "@posthog/ui/shell/analytics";
 import { useState } from "react";
 
 // Where a canvas create was triggered from, for analytics.
-export type CreateSurface = "dashboards_grid" | "sidebar";
+export type CreateSurface = "dashboards_grid" | "sidebar" | "channel_home";
 
 // Fire the "create" DASHBOARD_ACTION, then create + open the canvas. Exported so
-// other entry points (the sidebar "+" dropdown) report creation the same way.
-export function trackAndCreateCanvas(
+// other entry points (the sidebar "+" dropdown, the channel composer's canvas
+// mode) report creation the same way. Returns `create`'s result so callers that
+// need the created record can await it.
+export function trackAndCreateCanvas<T>(
   channelId: string | undefined,
   templateId: string | undefined,
   surface: CreateSurface,
-  create: () => void,
-) {
+  create: () => T,
+): T {
   track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
     action_type: "create",
     surface,
     channel_id: channelId,
     template_id: templateId,
   });
-  create();
+  return create();
 }
 
 // The list of template options shared by the canvas-create surfaces (the

--- a/packages/ui/src/features/canvas/createCanvasAnalytics.ts
+++ b/packages/ui/src/features/canvas/createCanvasAnalytics.ts
@@ -1,0 +1,25 @@
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { track } from "@posthog/ui/shell/analytics";
+
+// Where a canvas create was triggered from, for analytics.
+export type CreateSurface = "dashboards_grid" | "sidebar" | "channel_home";
+
+// Fire the "create" DASHBOARD_ACTION, then create + open the canvas. Shared so
+// every canvas-create entry point (the dashboards-grid dialog, the sidebar "+"
+// dropdown, the channel composer's canvas mode) reports creation the same way.
+// Returns `create`'s result so callers that need the created record can await
+// it.
+export function trackAndCreateCanvas<T>(
+  channelId: string | undefined,
+  templateId: string | undefined,
+  surface: CreateSurface,
+  create: () => T,
+): T {
+  track(ANALYTICS_EVENTS.DASHBOARD_ACTION, {
+    action_type: "create",
+    surface,
+    channel_id: channelId,
+    template_id: templateId,
+  });
+  return create();
+}

--- a/packages/ui/src/features/canvas/freeform/FreeformGenerateBar.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformGenerateBar.tsx
@@ -46,11 +46,8 @@ export const FreeformGenerateBar = forwardRef<
   ref,
 ) {
   const { generate, isStarting } = useGenerateFreeformCanvas({
-    dashboardId,
     channelId,
-    name,
     channelName,
-    templateId,
   });
 
   // On a FIRST build we seed the agent with a known-good starter scaffold by
@@ -68,6 +65,9 @@ export const FreeformGenerateBar = forwardRef<
     const instruction = text.trim();
     if (!instruction) return;
     const taskId = await generate({
+      dashboardId,
+      name,
+      templateId,
       instruction,
       currentCode,
       useStarter: !isEdit && useStarter,

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -35,13 +35,10 @@ import { useCallback, useState } from "react";
 // server-side regardless of which client kicked it off, and the agent publishes
 // the result via the `desktop-file-system-canvas-partial-update` MCP tool.
 export function useGenerateFreeformCanvas(args: {
-  dashboardId: string;
   channelId: string;
-  name: string;
   channelName: string;
-  templateId?: string;
 }) {
-  const { dashboardId, channelId, name, channelName, templateId } = args;
+  const { channelId, channelName } = args;
   const taskService = useService<TaskService>(TASK_SERVICE);
   const modelResolver = useService<ReportModelResolver>(REPORT_MODEL_RESOLVER);
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
@@ -61,6 +58,11 @@ export function useGenerateFreeformCanvas(args: {
 
   const generate = useCallback(
     async (opts: {
+      // The canvas being generated — per call, so surfaces that create the
+      // canvas at submit time (the channel composer) can use one hook instance.
+      dashboardId: string;
+      name: string;
+      templateId?: string;
       instruction: string;
       currentCode?: string;
       // Default on (opt out in the bar): seed the starter scaffold on first build.
@@ -70,6 +72,7 @@ export function useGenerateFreeformCanvas(args: {
       // always runs in the cloud — see the default below.
       workspaceMode?: WorkspaceMode;
     }): Promise<string | null> => {
+      const { dashboardId, name, templateId } = opts;
       setIsStarting(true);
       try {
         // Defaults to a cloud run — canvas generation should never tie up (or
@@ -178,11 +181,8 @@ export function useGenerateFreeformCanvas(args: {
       fileTask,
       setGenerationTask,
       renameDashboard,
-      dashboardId,
       channelId,
-      name,
       channelName,
-      templateId,
       channelContext,
     ],
   );

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -37,6 +37,13 @@ import { useCallback, useState } from "react";
 export function useGenerateFreeformCanvas(args: {
   channelId: string;
   channelName: string;
+  /**
+   * The channel's CONTEXT.md, when the surface already fetched it (the channel
+   * composer receives it as a prop). Passing the property — even with an
+   * undefined value — marks the caller as its owner and skips this hook's own
+   * fetch; omit it entirely to let the hook fetch.
+   */
+  channelContext?: string;
 }) {
   const { channelId, channelName } = args;
   const taskService = useService<TaskService>(TASK_SERVICE);
@@ -52,8 +59,13 @@ export function useGenerateFreeformCanvas(args: {
   const { setGenerationTask, renameDashboard } = useDashboardMutations();
   // The channel's CONTEXT.md, passed to the agent as optional background so the
   // generated canvas starts with the shared context. Absent/empty is fine.
-  const { data: instructions } = useFolderInstructions(channelId);
-  const channelContext = instructions?.content;
+  const callerOwnsContext = "channelContext" in args;
+  const { data: instructions } = useFolderInstructions(channelId, {
+    enabled: !callerOwnsContext,
+  });
+  const channelContext = callerOwnsContext
+    ? args.channelContext
+    : instructions?.content;
   const [isStarting, setIsStarting] = useState(false);
 
   const generate = useCallback(
@@ -72,15 +84,21 @@ export function useGenerateFreeformCanvas(args: {
       // always runs in the cloud — see the default below.
       workspaceMode?: WorkspaceMode;
     }): Promise<string | null> => {
-      const { dashboardId, name, templateId } = opts;
-      setIsStarting(true);
-      try {
+      const {
+        dashboardId,
+        name,
+        templateId,
+        instruction,
+        currentCode,
+        useStarter,
         // Defaults to a cloud run — canvas generation should never tie up (or
         // depend on) the local machine, and it's never the sticky last-used
         // workspace mode. The dev-only picker can override to "local" to test a
         // local build of these features before merging.
-        const workspaceMode = opts.workspaceMode ?? "cloud";
-
+        workspaceMode = "cloud",
+      } = opts;
+      setIsStarting(true);
+      try {
         // A cloud run requires an explicit adapter + model (the API rejects a
         // cloud runtime without a model). Canvas has no model picker, so resolve
         // the adapter's server default the same way the inbox one-click flows do
@@ -109,9 +127,9 @@ export function useGenerateFreeformCanvas(args: {
               name,
               channelName,
               templateId,
-              instruction: opts.instruction,
-              currentCode: opts.currentCode,
-              useStarter: opts.useStarter,
+              instruction,
+              currentCode,
+              useStarter,
             }),
             taskDescription: `Generate canvas "${name}"`,
             // Unattended generation: run in auto mode so it doesn't stall on edit-approval prompts.
@@ -151,7 +169,7 @@ export function useGenerateFreeformCanvas(args: {
         // who already named the canvas) leaves the existing title untouched.
         if (isPlaceholderCanvasName(name)) {
           void titleGenerator
-            .generateCanvasName(opts.instruction)
+            .generateCanvasName(instruction)
             .then(async (generated) => {
               const title = generated?.trim();
               if (title) {

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -10,7 +10,11 @@ import {
 } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
-import { getCloudUrlFromRegion, type WorkspaceMode } from "@posthog/shared";
+import {
+  type Adapter,
+  getCloudUrlFromRegion,
+  type WorkspaceMode,
+} from "@posthog/shared";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { buildFreeformGenerationPrompt } from "@posthog/ui/features/canvas/freeformPrompt";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
@@ -77,6 +81,15 @@ export function useGenerateFreeformCanvas(args: {
       templateId?: string;
       instruction: string;
       currentCode?: string;
+      // Backend channel UUID that owns the created task, so it lands in the
+      // channel's task feed like a plain composer submit.
+      backendChannelId?: string;
+      // The composer's picks, when the surface exposes model/effort selectors.
+      // The model is validated against the gateway (falling back to the
+      // adapter's default) so a stale id can't 403 the run.
+      adapter?: Adapter;
+      model?: string;
+      reasoningLevel?: string;
       // Default on (opt out in the bar): seed the starter scaffold on first build.
       useStarter?: boolean;
       // Dev-only override (the bar exposes a local/cloud picker in dev so a
@@ -90,6 +103,9 @@ export function useGenerateFreeformCanvas(args: {
         templateId,
         instruction,
         currentCode,
+        backendChannelId,
+        adapter = "claude",
+        reasoningLevel,
         useStarter,
         // Defaults to a cloud run — canvas generation should never tie up (or
         // depend on) the local machine, and it's never the sticky last-used
@@ -100,16 +116,17 @@ export function useGenerateFreeformCanvas(args: {
       setIsStarting(true);
       try {
         // A cloud run requires an explicit adapter + model (the API rejects a
-        // cloud runtime without a model). Canvas has no model picker, so resolve
-        // the adapter's server default the same way the inbox one-click flows do
-        // — the resolver validates against the gateway, so a stale id can't slip
-        // through and 403 the run.
-        let model: string | undefined;
+        // cloud runtime without a model). Resolve the caller's pick — or the
+        // adapter's server default when none — the same way the inbox one-click
+        // flows do; the resolver validates against the gateway, so a stale id
+        // can't slip through and 403 the run.
+        let model: string | undefined = opts.model;
         if (workspaceMode === "cloud") {
           model = cloudRegion
             ? await modelResolver.resolveDefaultModel(
                 getCloudUrlFromRegion(cloudRegion),
-                "claude",
+                adapter,
+                opts.model,
               )
             : undefined;
           if (!model) {
@@ -135,11 +152,13 @@ export function useGenerateFreeformCanvas(args: {
             // Unattended generation: run in auto mode so it doesn't stall on edit-approval prompts.
             executionMode: "auto" as const,
             workspaceMode,
-            adapter: "claude",
+            adapter,
             model,
+            reasoningLevel,
             allowNoRepo: true,
             channelContext,
             channelName,
+            channelId: backendChannelId,
           },
           (output) => invalidateTasks(output.task),
         );
@@ -151,9 +170,12 @@ export function useGenerateFreeformCanvas(args: {
 
         const task = result.data.task;
         // File into the channel + record as the canvas's generation task. Both
-        // are best-effort: a failure here shouldn't undo a started task.
+        // are best-effort: a failure here shouldn't undo a started task. The
+        // generation-task write is awaited so a caller that navigates to the
+        // canvas right after generate() lands on the generating view (with the
+        // run in the side panel), not the empty hero.
         void fileTask(channelId, task.id, task.title).catch(() => {});
-        void setGenerationTask(dashboardId, task.id).catch(() => {});
+        await setGenerationTask(dashboardId, task.id).catch(() => {});
         // Track this run so a toast (with a link back here) fires when it
         // finishes, even after the user navigates to another canvas.
         useCanvasGenerationTrackerStore

--- a/packages/ui/src/features/message-editor/components/ModeSelector.test.tsx
+++ b/packages/ui/src/features/message-editor/components/ModeSelector.test.tsx
@@ -1,0 +1,47 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ModeSelector } from "./ModeSelector";
+
+function modeOption(currentValue = "plan"): SessionConfigOption {
+  return {
+    id: "mode",
+    name: "Mode",
+    type: "select",
+    category: "mode",
+    currentValue,
+    options: [
+      { value: "plan", name: "Plan" },
+      { value: "auto", name: "Auto" },
+    ],
+  } as SessionConfigOption;
+}
+
+describe("ModeSelector", () => {
+  it("shows the current mode on the trigger", () => {
+    render(
+      <ModeSelector
+        modeOption={modeOption("plan")}
+        onChange={vi.fn()}
+        allowBypassPermissions={false}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Mode" })).toHaveTextContent(
+      "Plan",
+    );
+  });
+
+  it("shows Canvas on the trigger while canvas mode is armed", () => {
+    render(
+      <ModeSelector
+        modeOption={modeOption("plan")}
+        onChange={vi.fn()}
+        allowBypassPermissions={false}
+        canvas={{ active: true, onToggle: vi.fn() }}
+      />,
+    );
+    const trigger = screen.getByRole("button", { name: "Mode" });
+    expect(trigger).toHaveTextContent("Canvas");
+    expect(trigger).not.toHaveTextContent("Plan");
+  });
+});

--- a/packages/ui/src/features/message-editor/components/ModeSelector.tsx
+++ b/packages/ui/src/features/message-editor/components/ModeSelector.tsx
@@ -1,5 +1,5 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
-import { CaretDown, ChartLineUp } from "@phosphor-icons/react";
+import { CaretDown, ChartLineUp, Shapes } from "@phosphor-icons/react";
 import {
   Button,
   DropdownMenu,
@@ -31,6 +31,16 @@ interface ModeSelectorProps {
     active: boolean;
     onToggle: () => void;
   };
+  /**
+   * When provided, a "Canvas" toggle renders in the same trailing section
+   * (channels composer only). Arming it makes the next submit generate a
+   * canvas from the prompt instead of creating a plain task; while armed the
+   * trigger reads "Canvas" so the composer's state is visible at a glance.
+   */
+  canvas?: {
+    active: boolean;
+    onToggle: () => void;
+  };
 }
 
 export function ModeSelector({
@@ -39,10 +49,12 @@ export function ModeSelector({
   allowBypassPermissions,
   disabled,
   autoresearch,
+  canvas,
 }: ModeSelectorProps) {
   const [open, setOpen] = useState(false);
   const pendingValueRef = useRef<string | null>(null);
   const pendingAutoresearchRef = useRef(false);
+  const pendingCanvasRef = useRef(false);
   const displayOption = useRetainedConfigOption(modeOption);
 
   if (!displayOption || displayOption.type !== "select") return null;
@@ -63,9 +75,14 @@ export function ModeSelector({
   if (options.length === 0) return null;
 
   const currentValue = displayOption.currentValue;
-  const currentStyle = getModeStyle(currentValue);
-  const currentLabel =
-    allOptions.find((opt) => opt.value === currentValue)?.name ?? currentValue;
+  const canvasActive = !!canvas?.active;
+  const currentStyle = canvasActive
+    ? { icon: <Shapes size={12} weight="fill" />, className: "text-teal-11" }
+    : getModeStyle(currentValue);
+  const currentLabel = canvasActive
+    ? "Canvas"
+    : (allOptions.find((opt) => opt.value === currentValue)?.name ??
+      currentValue);
 
   return (
     <DropdownMenu
@@ -76,10 +93,16 @@ export function ModeSelector({
         if (pendingValueRef.current !== null) {
           onChange(pendingValueRef.current);
           pendingValueRef.current = null;
+          // Picking a plain mode leaves canvas mode; the two are exclusive.
+          if (canvasActive) canvas?.onToggle();
         }
         if (pendingAutoresearchRef.current) {
           pendingAutoresearchRef.current = false;
           autoresearch?.onToggle();
+        }
+        if (pendingCanvasRef.current) {
+          pendingCanvasRef.current = false;
+          canvas?.onToggle();
         }
       }}
     >
@@ -110,7 +133,9 @@ export function ModeSelector({
       >
         <MenuLabel>Mode</MenuLabel>
         <DropdownMenuRadioGroup
-          value={currentValue}
+          // While canvas mode is armed it reads as the selected mode, so no
+          // plain-mode radio shows checked.
+          value={canvasActive ? "" : currentValue}
           onValueChange={(value) => {
             pendingValueRef.current = value;
             setOpen(false);
@@ -126,22 +151,34 @@ export function ModeSelector({
             );
           })}
         </DropdownMenuRadioGroup>
+        {(autoresearch || canvas) && <DropdownMenuSeparator />}
+        {canvas && (
+          <DropdownMenuCheckboxItem
+            checked={canvas.active}
+            onCheckedChange={() => {
+              pendingCanvasRef.current = true;
+              setOpen(false);
+            }}
+          >
+            <span className="text-teal-11">
+              <Shapes size={12} weight="fill" />
+            </span>
+            <span className="whitespace-nowrap">Canvas</span>
+          </DropdownMenuCheckboxItem>
+        )}
         {autoresearch && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuCheckboxItem
-              checked={autoresearch.active}
-              onCheckedChange={() => {
-                pendingAutoresearchRef.current = true;
-                setOpen(false);
-              }}
-            >
-              <span className="text-violet-11">
-                <ChartLineUp size={12} />
-              </span>
-              <span className="whitespace-nowrap">Autoresearch</span>
-            </DropdownMenuCheckboxItem>
-          </>
+          <DropdownMenuCheckboxItem
+            checked={autoresearch.active}
+            onCheckedChange={() => {
+              pendingAutoresearchRef.current = true;
+              setOpen(false);
+            }}
+          >
+            <span className="text-violet-11">
+              <ChartLineUp size={12} />
+            </span>
+            <span className="whitespace-nowrap">Autoresearch</span>
+          </DropdownMenuCheckboxItem>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/packages/ui/src/features/message-editor/components/ModeSelector.tsx
+++ b/packages/ui/src/features/message-editor/components/ModeSelector.tsx
@@ -53,8 +53,9 @@ export function ModeSelector({
 }: ModeSelectorProps) {
   const [open, setOpen] = useState(false);
   const pendingValueRef = useRef<string | null>(null);
-  const pendingAutoresearchRef = useRef(false);
-  const pendingCanvasRef = useRef(false);
+  // A toggle picked from the menu, applied after the menu closes (like a mode
+  // change) so the composer doesn't relayout under the closing menu.
+  const pendingToggleRef = useRef<(() => void) | null>(null);
   const displayOption = useRetainedConfigOption(modeOption);
 
   if (!displayOption || displayOption.type !== "select") return null;
@@ -84,6 +85,30 @@ export function ModeSelector({
     : (allOptions.find((opt) => opt.value === currentValue)?.name ??
       currentValue);
 
+  const toggles: Array<{
+    label: string;
+    active: boolean;
+    onToggle: () => void;
+    icon: React.ReactNode;
+    className: string;
+  }> = [];
+  if (canvas) {
+    toggles.push({
+      label: "Canvas",
+      ...canvas,
+      icon: <Shapes size={12} weight="fill" />,
+      className: "text-teal-11",
+    });
+  }
+  if (autoresearch) {
+    toggles.push({
+      label: "Autoresearch",
+      ...autoresearch,
+      icon: <ChartLineUp size={12} />,
+      className: "text-violet-11",
+    });
+  }
+
   return (
     <DropdownMenu
       open={open}
@@ -96,14 +121,9 @@ export function ModeSelector({
           // Picking a plain mode leaves canvas mode; the two are exclusive.
           if (canvasActive) canvas?.onToggle();
         }
-        if (pendingAutoresearchRef.current) {
-          pendingAutoresearchRef.current = false;
-          autoresearch?.onToggle();
-        }
-        if (pendingCanvasRef.current) {
-          pendingCanvasRef.current = false;
-          canvas?.onToggle();
-        }
+        const pendingToggle = pendingToggleRef.current;
+        pendingToggleRef.current = null;
+        pendingToggle?.();
       }}
     >
       <DropdownMenuTrigger
@@ -151,35 +171,20 @@ export function ModeSelector({
             );
           })}
         </DropdownMenuRadioGroup>
-        {(autoresearch || canvas) && <DropdownMenuSeparator />}
-        {canvas && (
+        {toggles.length > 0 && <DropdownMenuSeparator />}
+        {toggles.map((toggle) => (
           <DropdownMenuCheckboxItem
-            checked={canvas.active}
+            key={toggle.label}
+            checked={toggle.active}
             onCheckedChange={() => {
-              pendingCanvasRef.current = true;
+              pendingToggleRef.current = toggle.onToggle;
               setOpen(false);
             }}
           >
-            <span className="text-teal-11">
-              <Shapes size={12} weight="fill" />
-            </span>
-            <span className="whitespace-nowrap">Canvas</span>
+            <span className={toggle.className}>{toggle.icon}</span>
+            <span className="whitespace-nowrap">{toggle.label}</span>
           </DropdownMenuCheckboxItem>
-        )}
-        {autoresearch && (
-          <DropdownMenuCheckboxItem
-            checked={autoresearch.active}
-            onCheckedChange={() => {
-              pendingAutoresearchRef.current = true;
-              setOpen(false);
-            }}
-          >
-            <span className="text-violet-11">
-              <ChartLineUp size={12} />
-            </span>
-            <span className="whitespace-nowrap">Autoresearch</span>
-          </DropdownMenuCheckboxItem>
-        )}
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -48,6 +48,14 @@ export interface PromptInputProps {
     active: boolean;
     onToggle: () => void;
   };
+  /**
+   * When provided, the mode dropdown gains a "Canvas" toggle (channels
+   * composer only). `active` drives its checkmark and the trigger label.
+   */
+  canvas?: {
+    active: boolean;
+    onToggle: () => void;
+  };
   // capabilities
   enableBashMode?: boolean;
   enableCommands?: boolean;
@@ -103,6 +111,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
       onModeChange,
       allowBypassPermissions = false,
       autoresearch,
+      canvas,
       enableBashMode = false,
       enableCommands = true,
       modelSelector,
@@ -405,6 +414,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
                       allowBypassPermissions={allowBypassPermissions}
                       disabled={disabled}
                       autoresearch={autoresearch}
+                      canvas={canvas}
                     />
                   )}
                   {modelSelector && <span>{modelSelector}</span>}


### PR DESCRIPTION
## Problem

Since the move to the new channel UX (feed composer + Home/History/Artifacts tabs), the prompt-to-canvas entry the old channel landing had is gone — the only way to generate a canvas is the "New canvas" button, which opens an empty canvas first.

## Changes

Canvas generation is now a mode in the channel composer's mode selector, following the existing Autoresearch pattern:

- `ModeSelector`/`PromptInput` gain an optional "Canvas" toggle; while armed the trigger reads "Canvas", and picking a plain mode disarms it.
- In `ChannelHomeComposer`, submitting with Canvas armed creates a freeform canvas in the channel, kicks off generation from the prompt (filed to the channel feed like other generation runs), and navigates to the canvas. Model/reasoning/workspace pickers hide while armed since generation resolves its own model and always runs in the cloud.
- `useGenerateFreeformCanvas` now takes the dashboard per `generate()` call so the composer can create the canvas at submit time.
- Instrumented with the existing `Channel action` / `Dashboard action` events (new `canvas_mode_toggle` action type). Whole surface remains behind the project-bluebird flag.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` and `pnpm --filter @posthog/shared typecheck`
- Ran the canvas + message-editor vitest suites (123 tests passing), including a new `ModeSelector` test covering the armed trigger state.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*