### PR TITLE
feat(code-review): add revert all local changes button

### DIFF
--- a/packages/ui/src/features/code-review/components/ReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewPage.tsx
@@ -15,6 +15,7 @@ import { usePrDetails } from "../../git-interaction/usePrDetails";
 import { makeFileKey } from "../../git-interaction/utils/fileKey";
 import { usePanelLayoutStore } from "../../panels/panelLayoutStore";
 import { useCwd } from "../../sidebar/useCwd";
+import { useDiscardAllChanges } from "../../task-detail/hooks/useDiscardAllChanges";
 import { useDiscardFile } from "../../task-detail/hooks/useDiscardFile";
 import { useStageToggle } from "../../task-detail/hooks/useStageToggle";
 import { REVIEW_FILE_CACHE_TIME_MS, REVIEW_MAX_FILE_LINES } from "../constants";
@@ -267,6 +268,7 @@ function LocalReviewContent({
   usePrefetchUntrackedFileContents(repoPath, untrackedFiles, true);
 
   const discardFile = useDiscardFile(repoPath);
+  const discardAllChanges = useDiscardAllChanges(repoPath);
   const stageToggle = useStageToggle(repoPath);
   const filesByKey = useMemo(() => {
     const map = new Map<string, ChangedFile>();
@@ -392,6 +394,7 @@ function LocalReviewContent({
       onCollapseAll={collapseAll}
       onUncollapseFile={uncollapseFile}
       onRefresh={refetch}
+      onDiscardAll={totalFileCount > 0 ? discardAllChanges : undefined}
       effectiveSource={effectiveSource}
       branchSourceAvailable={branchSourceAvailable}
       prSourceAvailable={prSourceAvailable}

--- a/packages/ui/src/features/code-review/components/ReviewShell.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewShell.tsx
@@ -108,6 +108,7 @@ export function ReviewShell({
   onExpandAll,
   onCollapseAll,
   onRefresh,
+  onDiscardAll,
   effectiveSource,
   branchSourceAvailable,
   prSourceAvailable,
@@ -229,6 +230,7 @@ export function ReviewShell({
           onExpandAll={onExpandAll}
           onCollapseAll={onCollapseAll}
           onRefresh={onRefresh}
+          onDiscardAll={onDiscardAll}
           effectiveSource={effectiveSource}
           branchSourceAvailable={branchSourceAvailable}
           prSourceAvailable={prSourceAvailable}

--- a/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
@@ -1,4 +1,10 @@
-import { ArrowsClockwise, Columns, Rows, X } from "@phosphor-icons/react";
+import {
+  ArrowCounterClockwise,
+  ArrowsClockwise,
+  Columns,
+  Rows,
+  X,
+} from "@phosphor-icons/react";
 import type { ResolvedDiffSource } from "@posthog/core/code-review/resolveDiffSource";
 import { Button } from "@posthog/quill";
 import { useDiffViewerStore } from "@posthog/ui/features/code-editor/diffViewerStore";
@@ -22,6 +28,7 @@ interface ReviewToolbarProps {
   onExpandAll: () => void;
   onCollapseAll: () => void;
   onRefresh?: () => void;
+  onDiscardAll?: () => void;
   effectiveSource?: ResolvedDiffSource;
   branchSourceAvailable?: boolean;
   prSourceAvailable?: boolean;
@@ -35,6 +42,7 @@ export const ReviewToolbar = memo(function ReviewToolbar({
   onExpandAll,
   onCollapseAll,
   onRefresh,
+  onDiscardAll,
   effectiveSource,
   branchSourceAvailable,
   prSourceAvailable,
@@ -87,6 +95,18 @@ export const ReviewToolbar = memo(function ReviewToolbar({
           <Tooltip content="Refresh diff">
             <Button size="icon-sm" onClick={onRefresh} className="rounded-xs">
               <ArrowsClockwise size={14} />
+            </Button>
+          </Tooltip>
+        )}
+
+        {onDiscardAll && (
+          <Tooltip content="Revert all local changes">
+            <Button
+              size="icon-sm"
+              onClick={onDiscardAll}
+              className="rounded-xs"
+            >
+              <ArrowCounterClockwise size={14} />
             </Button>
           </Tooltip>
         )}

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -119,6 +119,7 @@ export interface ReviewShellProps {
   onExpandAll: () => void;
   onCollapseAll: () => void;
   onRefresh?: () => void;
+  onDiscardAll?: () => void;
   effectiveSource?: ResolvedDiffSource;
   branchSourceAvailable?: boolean;
   prSourceAvailable?: boolean;

--- a/packages/ui/src/features/task-detail/hooks/useDiscardAllChanges.ts
+++ b/packages/ui/src/features/task-detail/hooks/useDiscardAllChanges.ts
@@ -1,0 +1,37 @@
+import { useWorkspaceTRPC } from "@posthog/workspace-client/trpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { showMessageBox } from "../../../utils/dialog";
+import { updateGitCacheFromSnapshot } from "../../git-interaction/utils/updateGitCache";
+
+export function useDiscardAllChanges(repoPath: string | undefined) {
+  const queryClient = useQueryClient();
+  const trpc = useWorkspaceTRPC();
+  const discardAllChanges = useMutation(
+    trpc.git.discardAllChanges.mutationOptions(),
+  );
+
+  return useCallback(async () => {
+    if (!repoPath) return;
+
+    const dialogResult = await showMessageBox({
+      type: "warning",
+      title: "Revert all local changes",
+      message:
+        "This will discard all uncommitted changes, including new files. A backup will be kept in a git stash.",
+      buttons: ["Cancel", "Revert All"],
+      defaultId: 1,
+      cancelId: 0,
+    });
+
+    if (dialogResult.response !== 1) return;
+
+    const result = await discardAllChanges.mutateAsync({
+      directoryPath: repoPath,
+    });
+
+    if (result.state) {
+      updateGitCacheFromSnapshot(queryClient, repoPath, result.state);
+    }
+  }, [repoPath, queryClient, discardAllChanges]);
+}

--- a/packages/workspace-server/src/services/git/schemas.ts
+++ b/packages/workspace-server/src/services/git/schemas.ts
@@ -167,6 +167,10 @@ export const discardFileChangesOutput = z.object({
 
 export type DiscardFileChangesOutput = z.infer<typeof discardFileChangesOutput>;
 
+export const discardAllChangesInput = z.object({
+  directoryPath: z.string(),
+});
+
 export const getGitSyncStatusInput = z.object({
   directoryPath: z.string(),
   /**

--- a/packages/workspace-server/src/services/git/service.ts
+++ b/packages/workspace-server/src/services/git/service.ts
@@ -37,6 +37,7 @@ import {
   ResetToDefaultBranchSaga,
   SwitchBranchSaga,
 } from "@posthog/git/sagas/branch";
+import { CleanWorkingTreeSaga } from "@posthog/git/sagas/clean";
 import { CloneSaga } from "@posthog/git/sagas/clone";
 import { CommitSaga } from "@posthog/git/sagas/commit";
 import { DiscardFileChangesSaga } from "@posthog/git/sagas/discard";
@@ -597,6 +598,23 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
       filePath,
       fileStatus,
     });
+    if (!result.success) {
+      return { success: false };
+    }
+
+    const state = await this.getStateSnapshot(directoryPath, {
+      includeSyncStatus: false,
+      includeLatestCommit: false,
+    });
+
+    return { success: true, state };
+  }
+
+  async discardAllChanges(
+    directoryPath: string,
+  ): Promise<DiscardFileChangesOutput> {
+    const saga = new CleanWorkingTreeSaga();
+    const result = await saga.run({ baseDir: directoryPath });
     if (!result.success) {
       return { success: false };
     }

--- a/packages/workspace-server/src/trpc.ts
+++ b/packages/workspace-server/src/trpc.ts
@@ -64,6 +64,7 @@ import {
   diffStatsInput,
   diffStatsSchema,
   directoryPathInput,
+  discardAllChangesInput,
   discardFileChangesInput,
   discardFileChangesOutput,
   filePathInput,
@@ -480,6 +481,13 @@ export function createAppRouter({
             input.filePath,
             input.fileStatus,
           ),
+        ),
+
+      discardAllChanges: t.procedure
+        .input(discardAllChangesInput)
+        .output(discardFileChangesOutput)
+        .mutation(({ input }) =>
+          gitService().discardAllChanges(input.directoryPath),
         ),
 
       push: t.procedure


### PR DESCRIPTION
## Problem

Reviewing local changes only lets you refresh the diff or discard files one at a time. No quick way to blow away all uncommitted changes at once.

## Changes

https://github.com/user-attachments/assets/fa142bfc-9487-4513-ada9-e1abceb117d0


- Added `git.discardAllChanges` tRPC mutation on workspace-server, reusing the existing `CleanWorkingTreeSaga` (stashes a backup before reset/clean)
- Added `useDiscardAllChanges` hook with a confirm dialog before reverting
- Added a "Revert all local changes" button next to Refresh in the review toolbar, shown only when there are local changes

## How did you test this?

- `pnpm typecheck` on `@posthog/ui`, `@posthog/git`, `@posthog/workspace-server` (ran via pre-commit hook)
- `qa-swarm` review (paul-reviewer, xp-reviewer, security-audit) — no correctness or security findings; addressed the one convergent nit (confirm dialog now mentions untracked-file deletion and the backup stash)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*