### PR TITLE
feat(autoresearch): improve setup and run observability

### DIFF
--- a/packages/core/src/autoresearch/autoresearch.test.ts
+++ b/packages/core/src/autoresearch/autoresearch.test.ts
@@ -388,9 +388,13 @@ describe("AutoresearchService", () => {
       beginTurn();
       service.registerRun(baseConfig);
 
-      streamTurnText(reportText(10, "baseline"));
-      streamTurnText(reportText(12, "iteration 2"));
-      streamTurnText(reportText(14, "iteration 3"));
+      streamTurnText(`${reportText(10, "baseline")}\nIteration 2 starts now.`);
+      streamTurnText(
+        `${reportText(12, "iteration 2")}\nIteration 3 starts now.`,
+      );
+      streamTurnText(
+        `${reportText(14, "iteration 3")}\nIteration 4 starts now.`,
+      );
 
       expect(activeRun().iterations).toEqual([
         expect.objectContaining({ index: 1, value: 10 }),
@@ -414,7 +418,7 @@ describe("AutoresearchService", () => {
       };
       internals.promptCursor.set(run.id, 1);
 
-      streamTurnText(reportText(10, "baseline"));
+      streamTurnText(`${reportText(10, "baseline")}\nIteration 2 starts now.`);
 
       expect(activeRun().iterations).toEqual([
         expect.objectContaining({ index: 1, value: 10 }),
@@ -428,10 +432,10 @@ describe("AutoresearchService", () => {
   });
 
   describe("iteration loop", () => {
-    it("records a completed metric block before the agent turn ends", () => {
+    it("records a metric block after the next iteration starts", () => {
       service.startRun(baseConfig);
       beginTurn();
-      streamTurnText(reportText(10, "baseline"));
+      streamTurnText(`${reportText(10, "baseline")}\nIteration 2 starts now.`);
 
       expect(activeRun().iterations).toEqual([
         expect.objectContaining({ index: 1, value: 10, summary: "baseline" }),
@@ -447,6 +451,30 @@ describe("AutoresearchService", () => {
       expect(sentPrompts.at(-1)?.prompt).toContain(
         "Then make the next focused change",
       );
+    });
+
+    it("keeps the tail report provisional until the turn ends", () => {
+      service.startRun({ ...baseConfig, maxIterations: 1 });
+      beginTurn();
+      streamTurnText(reportText(10, "draft baseline"));
+
+      expect(activeRun().iterations).toHaveLength(0);
+      expect(activeRun().status).toBe("running");
+
+      streamTurnText(reportText(12, "corrected baseline"));
+      expect(activeRun().iterations).toHaveLength(0);
+
+      completeTurn("Finalized the corrected report.");
+
+      expect(activeRun().iterations).toEqual([
+        expect.objectContaining({
+          index: 1,
+          value: 12,
+          summary: "corrected baseline",
+        }),
+      ]);
+      expect(activeRun().status).toBe("completed");
+      expect(activeRun().endReason).toBe("max-iterations");
     });
 
     it("records prebaseline research without consuming an iteration", () => {

--- a/packages/core/src/autoresearch/autoresearch.test.ts
+++ b/packages/core/src/autoresearch/autoresearch.test.ts
@@ -142,6 +142,14 @@ function reportText(value: number, summary = "tweak"): string {
   return `Done.\n\`\`\`autoresearch\nmetric: ${value}\nsummary: ${summary}\n\`\`\``;
 }
 
+function researchText(
+  summary = "Mapped the execution path",
+  finding = "The metric is computed in the workspace server.",
+  nextStep = "Trace the benchmark command",
+): string {
+  return `Investigated.\n\`\`\`autoresearch\ntype: research\nsummary: ${summary}\nfinding: ${finding}\nnext: ${nextStep}\n\`\`\``;
+}
+
 /** A session `model` config option (and optional `thought_level`). */
 function modelConfig(
   currentValue: string,
@@ -202,6 +210,14 @@ function completeTurn(text: string, taskRunId = TASK_RUN_ID): void {
   });
 }
 
+function streamTurnText(text: string, taskRunId = TASK_RUN_ID): void {
+  const events = sessionStore.getState().sessions[taskRunId]?.events ?? [];
+  sessionStoreSetters.updateSession(taskRunId, {
+    isPromptPending: true,
+    events: [...events, agentChunkEvent(text)],
+  });
+}
+
 function runTurn(text: string, taskRunId = TASK_RUN_ID): void {
   beginTurn(taskRunId);
   completeTurn(text, taskRunId);
@@ -251,6 +267,7 @@ function makeRun(
     phase: null,
     originalModel: null,
     originalEffort: null,
+    researchFindings: [],
     iterations: [],
     startedAt: 1_000,
     endedAt: null,
@@ -350,7 +367,7 @@ describe("AutoresearchService", () => {
   });
 
   describe("registerRun", () => {
-    it("registers without sending — the kickoff rode the task's initial prompt", () => {
+    it("registers without sending because the kickoff rode the task initial prompt", () => {
       const run = service.registerRun(baseConfig);
 
       expect(run.status).toBe("running");
@@ -367,6 +384,43 @@ describe("AutoresearchService", () => {
       expect(sentPrompts[0].prompt).toContain("iteration 2");
     });
 
+    it("tracks reports from an initial prompt already in progress", () => {
+      beginTurn();
+      service.registerRun(baseConfig);
+
+      streamTurnText(reportText(10, "baseline"));
+      streamTurnText(reportText(12, "iteration 2"));
+      streamTurnText(reportText(14, "iteration 3"));
+
+      expect(activeRun().iterations).toEqual([
+        expect.objectContaining({ index: 1, value: 10 }),
+        expect.objectContaining({ index: 2, value: 12 }),
+        expect.objectContaining({ index: 3, value: 14 }),
+      ]);
+      expect(sentPrompts).toHaveLength(0);
+
+      completeTurn("Continuing after the reported iterations.");
+
+      expect(activeRun().iterations).toHaveLength(3);
+      expect(sentPrompts).toHaveLength(1);
+      expect(sentPrompts[0].prompt).toContain("iteration 4");
+    });
+
+    it("recovers when an active prompt was incorrectly marked handled", () => {
+      beginTurn();
+      const run = service.registerRun(baseConfig);
+      const internals = service as unknown as {
+        promptCursor: Map<string, number>;
+      };
+      internals.promptCursor.set(run.id, 1);
+
+      streamTurnText(reportText(10, "baseline"));
+
+      expect(activeRun().iterations).toEqual([
+        expect.objectContaining({ index: 1, value: 10 }),
+      ]);
+    });
+
     it("shares the one-live-run-per-task guard with startRun", () => {
       service.registerRun(baseConfig);
       expect(() => service.startRun(baseConfig)).toThrow(/already running/);
@@ -374,6 +428,73 @@ describe("AutoresearchService", () => {
   });
 
   describe("iteration loop", () => {
+    it("records a completed metric block before the agent turn ends", () => {
+      service.startRun(baseConfig);
+      beginTurn();
+      streamTurnText(reportText(10, "baseline"));
+
+      expect(activeRun().iterations).toEqual([
+        expect.objectContaining({ index: 1, value: 10, summary: "baseline" }),
+      ]);
+      expect(sentPrompts).toHaveLength(1);
+
+      streamTurnText("Continuing to inspect the next change.");
+      expect(activeRun().iterations).toHaveLength(1);
+
+      completeTurn("Finished the turn.");
+      expect(activeRun().iterations).toHaveLength(1);
+      expect(sentPrompts).toHaveLength(2);
+      expect(sentPrompts.at(-1)?.prompt).toContain(
+        "Then make the next focused change",
+      );
+    });
+
+    it("records prebaseline research without consuming an iteration", () => {
+      service.startRun(baseConfig);
+      runTurn(researchText());
+
+      const researchingRun = activeRun();
+      expect(researchingRun.researchFindings).toEqual([
+        expect.objectContaining({
+          index: 1,
+          summary: "Mapped the execution path",
+          finding: "The metric is computed in the workspace server.",
+          nextStep: "Trace the benchmark command",
+        }),
+      ]);
+      expect(researchingRun.iterations).toHaveLength(0);
+      expect(sentPrompts.at(-1)?.prompt).toContain(
+        "Continue investigating the codebase or establish the baseline measurement",
+      );
+
+      runTurn(reportText(10, "baseline"));
+
+      expect(activeRun().iterations).toEqual([
+        expect.objectContaining({ index: 1, value: 10, summary: "baseline" }),
+      ]);
+    });
+
+    it("does not accept research checkpoints after the baseline", async () => {
+      service.startRun(baseConfig);
+      runTurn(reportText(10, "baseline"));
+      runTurn(researchText());
+      await passReminderGrace();
+
+      expect(activeRun().researchFindings).toHaveLength(0);
+      expect(activeRun().iterations).toHaveLength(1);
+      expect(sentPrompts.at(-1)?.prompt).toContain("did not include");
+    });
+
+    it("prefers a metric when a prebaseline reply contains both report types", () => {
+      service.startRun(baseConfig);
+      runTurn(`${researchText()}\n${reportText(10, "baseline")}`);
+
+      expect(activeRun().researchFindings).toHaveLength(0);
+      expect(activeRun().iterations).toEqual([
+        expect.objectContaining({ index: 1, value: 10, summary: "baseline" }),
+      ]);
+    });
+
     it("records an iteration and sends a continuation prompt", () => {
       service.startRun(baseConfig);
       runTurn(reportText(10, "baseline"));
@@ -534,7 +655,7 @@ describe("AutoresearchService", () => {
       );
       expect(activeRun().metricUnit).toBe("kB");
 
-      // First unit wins, like the name — a stable unit keeps values readable.
+      // First unit wins, like the name. A stable unit keeps values readable.
       runTurn("```autoresearch\nmetric: 400000\nunit: bytes\n```");
       expect(activeRun().metricUnit).toBe("kB");
     });
@@ -572,7 +693,7 @@ describe("AutoresearchService", () => {
       expect(modelSwitches).toEqual([
         { taskId: TASK_ID, model: "claude-opus-4-8" },
       ]);
-      expect(sentPrompts.at(-1)?.prompt).toContain("implementation phase");
+      expect(sentPrompts.at(-1)?.prompt).toContain("Implementation phase");
       expect(sentPrompts.at(-1)?.prompt).toContain(
         "Do NOT run the measurement",
       );
@@ -610,7 +731,7 @@ describe("AutoresearchService", () => {
 
       expect(activeRun().iterations).toHaveLength(2);
       expect(activeRun().phase).toBe("implement");
-      expect(sentPrompts.at(-1)?.prompt).toContain("implementation phase");
+      expect(sentPrompts.at(-1)?.prompt).toContain("Implementation phase");
     });
 
     it("still fails a measure turn that never reports", async () => {
@@ -988,6 +1109,9 @@ describe("AutoresearchService", () => {
             bestValue: 10,
             delta: null,
             summary: "baseline",
+            hypothesis: null,
+            plan: null,
+            approach: null,
             at: 1_000,
           },
         ],
@@ -1024,7 +1148,7 @@ describe("AutoresearchService", () => {
         ]);
       await service.rehydrate();
 
-      // No session exists for task-9 yet — recovery asks the host to
+      // No session exists for task 9 yet. Recovery asks the host to
       // reconnect it.
       await passRecoveryDelay();
       expect(reconnectCalls).toEqual(["task-9"]);
@@ -1074,7 +1198,7 @@ describe("AutoresearchService", () => {
       // The in-memory run (with its recorded iteration) wins over the row.
       expect(state.runs[live.id]?.iterations).toHaveLength(1);
       expect(state.runs["ar-past"]?.status).toBe("completed");
-      // The live run stays the active one — it started later.
+      // The live run stays active because it started later.
       expect(state.activeRunIdByTask[TASK_ID]).toBe(live.id);
     });
 
@@ -1203,7 +1327,9 @@ describe("AutoresearchService", () => {
 
       // No phase alternation: the next prompt is a plain continuation.
       expect(activeRun().phase).toBeNull();
-      expect(sentPrompts.at(-1)?.prompt).toContain("Continue:");
+      expect(sentPrompts.at(-1)?.prompt).toContain(
+        "Then make the next focused change",
+      );
     });
   });
 

--- a/packages/core/src/autoresearch/autoresearch.ts
+++ b/packages/core/src/autoresearch/autoresearch.ts
@@ -28,10 +28,12 @@ import {
   buildMeasurePrompt,
   buildPhasePrompt,
   buildReportReminderPrompt,
+  buildResearchContinuationPrompt,
   buildResumePrompt,
   countPromptRequests,
   extractLastAgentTurnText,
-  parseMetricReport,
+  parseMetricReports,
+  parseResearchReports,
 } from "./prompts";
 import {
   type AutoresearchConfigInput,
@@ -68,7 +70,7 @@ export const MAX_RECOVERY_ATTEMPTS = 20;
  *
  * Infrastructure obstacles (session drop, idle-kill, usage limit, app
  * restart) never end a run: they mark it `interrupted` and the service keeps
- * trying to bring it back — reconnecting the session when it can and
+ * trying to bring it back by reconnecting the session when it can and
  * resuming the loop once the session is usable again. Only the user
  * (pause/stop), the iteration budget, the target, or a protocol breakdown
  * (the agent repeatedly not reporting) ends a run. Every mutation is
@@ -107,10 +109,14 @@ export class AutoresearchService {
   private pendingReactions = new Map<string, ReturnType<typeof setTimeout>>();
   /**
    * Count of session/prompt requests already handled per run. A turn
-   * completion is only processed when the count moved past this cursor —
+   * completion is only processed when the count moved past this cursor.
    * `isPromptPending` flips without a new prompt when a send fails.
    */
   private promptCursor = new Map<string, number>();
+  private streamedReportCursor = new Map<
+    string,
+    { promptCount: number; metricCount: number; researchCount: number }
+  >();
   private recoveryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private recoveryAttempts = new Map<string, number>();
   /** Per-run write-through chain so persisted saves land in call order. */
@@ -125,7 +131,7 @@ export class AutoresearchService {
   private rehydrated = false;
 
   /**
-   * Register a run whose kickoff prompt the host has already delivered —
+   * Register a run whose kickoff prompt the host has already delivered.
    * the create-task flow sends it as the new task's initial prompt. The
    * engine takes over from the agent's first reply.
    */
@@ -152,6 +158,7 @@ export class AutoresearchService {
       phase: null,
       originalModel: session ? currentSessionModel(session) : null,
       originalEffort: session ? currentSessionEffort(session) : null,
+      researchFindings: [],
       iterations: [],
       startedAt: Date.now(),
       endedAt: null,
@@ -162,9 +169,10 @@ export class AutoresearchService {
 
     autoresearchStoreActions.upsertRun(run);
     this.liveRunIds.add(run.id);
+    const promptCount = session ? countPromptRequests(session.events) : 0;
     this.promptCursor.set(
       run.id,
-      session ? countPromptRequests(session.events) : 0,
+      Math.max(0, promptCount - (session?.isPromptPending ? 1 : 0)),
     );
     this.persist(run.id);
     this.ensureSubscribed();
@@ -180,7 +188,7 @@ export class AutoresearchService {
    * Register a run and send its kickoff into the task's existing session.
    * Used to start a fresh run on a task that already ran autoresearch.
    * (For composer-created tasks the kickoff rides the initial prompt and the
-   * baseline turn runs on the task's creation model — stage models take over
+   * baseline turn runs on the task's creation model. Stage models take over
    * from iteration 2.)
    */
   startRun(input: AutoresearchConfigInput): AutoresearchRun {
@@ -233,7 +241,7 @@ export class AutoresearchService {
       (session.isPromptPending || session.isCompacting)
     ) {
       // A turn is already in flight; the loop re-engages when it completes.
-      // Don't move the cursor — that in-flight prompt is the next turn.
+      // Do not move the cursor. That prompt in progress is the next turn.
       autoresearchStoreActions.setRunStatus(runId, "running");
       this.persist(runId);
       this.log.info("Autoresearch run resumed", { runId });
@@ -241,7 +249,7 @@ export class AutoresearchService {
     }
     if (!session || !isSessionUsable(session)) {
       // The session is down; let the recovery machinery bring it back and
-      // resume the loop. Attempt immediately — the user asked for it now.
+      // resume the loop. Attempt immediately because the user asked for it now.
       // A manual resume is a fresh start, so it does not spend the automatic
       // recovery budget.
       this.recoveryAttempts.delete(runId);
@@ -285,7 +293,7 @@ export class AutoresearchService {
     if (this.rehydrated) return;
     this.rehydrated = true;
 
-    // Feature-flagged: for ungated users the whole feature stays dormant —
+    // Feature flagged: for ungated users the whole feature stays dormant.
     // no restored runs, no auto-resume, no session subscription.
     if (!(await this.gate.isEnabled())) {
       this.log.info("Autoresearch disabled by feature flag; skipping restore");
@@ -409,7 +417,7 @@ export class AutoresearchService {
       }
 
       if (run.status === "interrupted") {
-        // Resume as soon as the session comes back — the reconnect may have
+        // Resume as soon as the session comes back. The reconnect may have
         // been ours (recovery) or the app's own reconciliation.
         if (isSessionUsable(session) && !isSessionUsable(prevSession)) {
           this.resumeFromInterruption(run.id);
@@ -420,31 +428,108 @@ export class AutoresearchService {
       const turnCompleted =
         prevSession?.isPromptPending === true &&
         session.isPromptPending === false;
+      const promptCount = countPromptRequests(session.events);
+
+      if (session.isPromptPending) {
+        if (promptCount === 0) continue;
+        this.ingestCompletedReports(run, session);
+        continue;
+      }
+      if (promptCount <= (this.promptCursor.get(run.id) ?? 0)) continue;
       if (!turnCompleted) continue;
 
-      const promptCount = countPromptRequests(session.events);
-      if (promptCount <= (this.promptCursor.get(run.id) ?? 0)) continue;
+      const reports = this.ingestCompletedReports(run, session);
       this.promptCursor.set(run.id, promptCount);
-      this.onAgentTurnComplete(run, session);
+      this.onAgentTurnComplete(run.id, reports);
     }
   }
 
-  private onAgentTurnComplete(
+  private ingestCompletedReports(
     run: AutoresearchRun,
     session: AgentSession,
-  ): void {
+  ): { hasMetric: boolean; hasResearch: boolean } {
     const text = extractLastAgentTurnText(session.events);
-    const report = parseMetricReport(text);
+    const metricReports = parseMetricReports(text);
+    const researchReports = parseResearchReports(text);
+    const promptCount = countPromptRequests(session.events);
+    const existing = this.streamedReportCursor.get(run.id);
+    const cursor =
+      existing?.promptCount === promptCount
+        ? existing
+        : { promptCount, metricCount: 0, researchCount: 0 };
 
-    if (!report) {
-      // Deferred: a reportless turn is either a split-run implement turn
-      // (advance to measure) or a genuine missing report (remind). Both wait
-      // out the grace window so a cancel/rate-limit resolving in the
-      // meantime pauses/interrupts the run first.
-      this.scheduleReportlessReaction(run.id);
+    if (metricReports.length === 0) {
+      for (const report of researchReports.slice(cursor.researchCount)) {
+        const current = autoresearchStore.getState().runs[run.id];
+        if (!current || isTerminal(current)) break;
+        if (current.iterations.length > 0) break;
+        this.recordResearchFinding(current, report);
+      }
+    }
+    for (const report of metricReports.slice(cursor.metricCount)) {
+      const current = autoresearchStore.getState().runs[run.id];
+      if (!current || isTerminal(current)) break;
+      this.recordMetricReport(current, report);
+    }
+    this.streamedReportCursor.set(run.id, {
+      promptCount,
+      metricCount: metricReports.length,
+      researchCount: researchReports.length,
+    });
+    return {
+      hasMetric: metricReports.length > 0,
+      hasResearch: metricReports.length === 0 && researchReports.length > 0,
+    };
+  }
+
+  private recordResearchFinding(
+    run: AutoresearchRun,
+    researchReport: ReturnType<typeof parseResearchReports>[number],
+  ): void {
+    this.clearPendingReaction(run.id);
+    this.remindersSent.delete(run.id);
+    this.recoveryAttempts.delete(run.id);
+    autoresearchStoreActions.appendResearchFinding(run.id, {
+      index: run.researchFindings.length + 1,
+      summary: researchReport.summary,
+      finding: researchReport.finding,
+      nextStep: researchReport.nextStep,
+      area: researchReport.area,
+      at: Date.now(),
+    });
+    this.persist(run.id);
+  }
+
+  private onAgentTurnComplete(
+    runId: string,
+    reports: { hasMetric: boolean; hasResearch: boolean },
+  ): void {
+    const run = autoresearchStore.getState().runs[runId];
+    if (!run || run.status !== "running") return;
+    if (reports.hasMetric) {
+      this.continueLoop(run);
+      return;
+    }
+    if (reports.hasResearch && run.iterations.length === 0) {
+      void this.send(
+        run.id,
+        run.config.taskId,
+        buildResearchContinuationPrompt(run),
+      );
       return;
     }
 
+    // Deferred: a reportless turn is either a split-run implement turn
+    // (advance to measure) or a genuine missing report (remind). Both wait
+    // out the grace window so a cancel/rate-limit resolving in the
+    // meantime pauses/interrupts the run first.
+    this.scheduleReportlessReaction(run.id);
+  }
+
+  private recordMetricReport(
+    run: AutoresearchRun,
+    report: AutoresearchReport,
+  ): void {
     this.clearPendingReaction(run.id);
     this.remindersSent.delete(run.id);
     // The loop is demonstrably turning again; future interruptions restart
@@ -478,8 +563,6 @@ export class AutoresearchService {
       });
       return;
     }
-
-    this.continueLoop(updated);
   }
 
   /** Kick off the next iteration after a recorded report. */
@@ -517,7 +600,7 @@ export class AutoresearchService {
   }
 
   /**
-   * Switch the session's stage (model and/or effort), then send — in that
+   * Switch the session stage, including model or effort, then send in that
    * order, so the turn runs on the intended configuration rather than racing
    * the switch. A stage with nothing to set skips straight to the send with
    * no await, so ordering is unchanged for it. When there is a switch, a run
@@ -541,7 +624,7 @@ export class AutoresearchService {
   }
 
   /**
-   * Apply a stage's model/effort to the session. Failures only warn — the
+   * Apply a stage model or effort to the session. Failures only warn. The
    * turn falls back to whatever the session currently has (effort options
    * can also legitimately differ per model, so a stale effort may be
    * rejected by the session).
@@ -588,7 +671,7 @@ export class AutoresearchService {
    * React to a reportless turn once the grace window has passed and no
    * cancel/rate-limit/interruption intervened. In a split run's implement
    * phase that means advancing to the measure phase; otherwise it is a
-   * missing report — remind once, then fail.
+   * missing report. Remind once, then fail.
    */
   private scheduleReportlessReaction(runId: string): void {
     const run = autoresearchStore.getState().runs[runId];
@@ -646,6 +729,9 @@ export class AutoresearchService {
       bestValue,
       delta: previous ? report.value - previous.value : null,
       summary: report.summary,
+      hypothesis: report.hypothesis,
+      plan: report.plan,
+      approach: report.approach,
       at: Date.now(),
     });
   }
@@ -667,7 +753,7 @@ export class AutoresearchService {
           "Usage limit reached. The loop retries automatically.",
         );
       } else if (stopReason === "cancelled") {
-        // The user stopped the turn — hand them the wheel instead of
+        // The user stopped the turn. Hand them control instead of
         // immediately re-prompting the agent they just silenced.
         const run = autoresearchStore.getState().runs[runId];
         if (run?.status === "running") {
@@ -682,7 +768,7 @@ export class AutoresearchService {
         }
       } else if (stopReason === "queued") {
         // The session was busy (a turn/compaction in flight), so our prompt
-        // sits in the session queue and drains when it frees up — producing
+        // sits in the session queue and drains when it frees up, producing
         // a turn the subscription processes normally. Nothing to do but note
         // it; if the session never frees, its error path drives recovery.
         this.log.warn("Autoresearch prompt queued behind a busy session", {
@@ -831,6 +917,7 @@ export class AutoresearchService {
     this.remindersSent.delete(runId);
     this.recoveryAttempts.delete(runId);
     this.promptCursor.delete(runId);
+    this.streamedReportCursor.delete(runId);
     this.liveRunIds.delete(runId);
     if (run) this.restoreOriginalStage(run);
   }
@@ -849,7 +936,7 @@ export class AutoresearchService {
 
   /**
    * Write-through persistence. Saves for a run are chained so they land in
-   * call order — a later transition can never be overwritten by an in-flight
+   * call order. A later transition can never be overwritten by a pending
    * earlier one. The in-memory store stays authoritative.
    */
   private persist(runId: string): void {
@@ -897,7 +984,7 @@ function measureStage(run: AutoresearchRun): AutoresearchStage {
 
 /**
  * Split runs alternate an implement turn and a measure turn per iteration.
- * Any difference between the stages — model or effort — makes the run split;
+ * Any difference between the stages, model or effort, makes the run split;
  * identical stages run as single turns with no mid-loop switching.
  */
 function isSplitRun(run: AutoresearchRun): boolean {

--- a/packages/core/src/autoresearch/autoresearch.ts
+++ b/packages/core/src/autoresearch/autoresearch.ts
@@ -34,6 +34,7 @@ import {
   extractLastAgentTurnText,
   parseMetricReports,
   parseResearchReports,
+  parseStreamedMetricReports,
 } from "./prompts";
 import {
   type AutoresearchConfigInput,
@@ -432,13 +433,13 @@ export class AutoresearchService {
 
       if (session.isPromptPending) {
         if (promptCount === 0) continue;
-        this.ingestCompletedReports(run, session);
+        this.ingestCompletedReports(run, session, false);
         continue;
       }
       if (promptCount <= (this.promptCursor.get(run.id) ?? 0)) continue;
       if (!turnCompleted) continue;
 
-      const reports = this.ingestCompletedReports(run, session);
+      const reports = this.ingestCompletedReports(run, session, true);
       this.promptCursor.set(run.id, promptCount);
       this.onAgentTurnComplete(run.id, reports);
     }
@@ -447,9 +448,18 @@ export class AutoresearchService {
   private ingestCompletedReports(
     run: AutoresearchRun,
     session: AgentSession,
+    turnComplete: boolean,
   ): { hasMetric: boolean; hasResearch: boolean } {
     const text = extractLastAgentTurnText(session.events);
-    const metricReports = parseMetricReports(text);
+    const streamedMetricReports = parseStreamedMetricReports(text);
+    const allMetricReports = turnComplete ? parseMetricReports(text) : [];
+    const finalMetricReport =
+      allMetricReports.length > streamedMetricReports.length
+        ? allMetricReports.at(-1)
+        : null;
+    const metricReports = finalMetricReport
+      ? [...streamedMetricReports, finalMetricReport]
+      : streamedMetricReports;
     const researchReports = parseResearchReports(text);
     const promptCount = countPromptRequests(session.events);
     const existing = this.streamedReportCursor.get(run.id);
@@ -507,7 +517,17 @@ export class AutoresearchService {
     const run = autoresearchStore.getState().runs[runId];
     if (!run || run.status !== "running") return;
     if (reports.hasMetric) {
-      this.continueLoop(run);
+      const decision = evaluateContinuation(run);
+      if (decision.done) {
+        this.endRun(run.id, "completed", { endReason: decision.reason });
+        this.log.info("Autoresearch run completed", {
+          runId: run.id,
+          reason: decision.reason,
+          iterations: run.iterations.length,
+        });
+      } else {
+        this.continueLoop(run);
+      }
       return;
     }
     if (reports.hasResearch && run.iterations.length === 0) {
@@ -549,20 +569,6 @@ export class AutoresearchService {
       }
     }
     this.persist(run.id);
-
-    const updated = autoresearchStore.getState().runs[run.id];
-    if (!updated || updated.status !== "running") return;
-
-    const decision = evaluateContinuation(updated);
-    if (decision.done) {
-      this.endRun(run.id, "completed", { endReason: decision.reason });
-      this.log.info("Autoresearch run completed", {
-        runId: run.id,
-        reason: decision.reason,
-        iterations: updated.iterations.length,
-      });
-      return;
-    }
   }
 
   /** Kick off the next iteration after a recorded report. */

--- a/packages/core/src/autoresearch/autoresearchStore.ts
+++ b/packages/core/src/autoresearch/autoresearchStore.ts
@@ -4,6 +4,7 @@ import {
   type AutoresearchInterruptionReason,
   type AutoresearchIteration,
   type AutoresearchPhase,
+  type AutoresearchResearchFinding,
   type AutoresearchRun,
   type AutoresearchRunStatus,
   isTerminalRunStatus,
@@ -47,6 +48,16 @@ export const autoresearchStoreActions = {
     updateRun(runId, (run) => ({
       ...run,
       iterations: [...run.iterations, iteration],
+    }));
+  },
+
+  appendResearchFinding(
+    runId: string,
+    finding: AutoresearchResearchFinding,
+  ): void {
+    updateRun(runId, (run) => ({
+      ...run,
+      researchFindings: [...run.researchFindings, finding],
     }));
   },
 

--- a/packages/core/src/autoresearch/identifiers.ts
+++ b/packages/core/src/autoresearch/identifiers.ts
@@ -40,7 +40,7 @@ export interface StoredAutoresearchRun {
  */
 export interface AutoresearchStorageClient {
   save(run: StoredAutoresearchRun): Promise<void>;
-  /** Runs not yet terminal — the ones worth resuming after a restart. */
+  /** Runs not yet terminal. These are worth resuming after a restart. */
   listOpen(): Promise<StoredAutoresearchRun[]>;
   listByTask(taskId: string): Promise<StoredAutoresearchRun[]>;
 }

--- a/packages/core/src/autoresearch/prompts.test.ts
+++ b/packages/core/src/autoresearch/prompts.test.ts
@@ -13,6 +13,7 @@ import {
   parseMetricReport,
   parsePlanReport,
   parseResearchReport,
+  parseStreamedMetricReports,
 } from "./prompts";
 import type {
   AutoresearchConfig,
@@ -187,6 +188,20 @@ describe("parseMetricReport", () => {
         "```autoresearch\ntype: research\nsummary: traced routing\nfinding: routes are contributed by UI modules\n```",
       ),
     ).toBeNull();
+  });
+});
+
+describe("parseStreamedMetricReports", () => {
+  it("ignores a report at the streaming tail", () => {
+    expect(parseStreamedMetricReports(report("10", "draft"))).toEqual([]);
+  });
+
+  it("accepts a report once the next iteration starts", () => {
+    expect(
+      parseStreamedMetricReports(
+        `${report("10", "baseline")}\nIteration 2 starts now.`,
+      ),
+    ).toEqual([expect.objectContaining({ value: 10, summary: "baseline" })]);
   });
 });
 

--- a/packages/core/src/autoresearch/prompts.test.ts
+++ b/packages/core/src/autoresearch/prompts.test.ts
@@ -2,13 +2,17 @@ import type { AcpMessage } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
 import {
   buildContinuationPrompt,
+  buildImplementPrompt,
   buildKickoffPreamble,
   buildKickoffPrompt,
+  buildMeasurePrompt,
   buildReportReminderPrompt,
   buildResumePrompt,
   countPromptRequests,
   extractLastAgentTurnText,
   parseMetricReport,
+  parsePlanReport,
+  parseResearchReport,
 } from "./prompts";
 import type {
   AutoresearchConfig,
@@ -38,7 +42,17 @@ function makeIteration(
   value: number,
   summary: string | null = null,
 ): AutoresearchIteration {
-  return { index, value, bestValue: value, delta: null, summary, at: index };
+  return {
+    index,
+    value,
+    bestValue: value,
+    delta: null,
+    summary,
+    hypothesis: null,
+    plan: null,
+    approach: null,
+    at: index,
+  };
 }
 
 function makeRun(
@@ -54,6 +68,7 @@ function makeRun(
     phase: null,
     originalModel: null,
     originalEffort: null,
+    researchFindings: [],
     iterations,
     startedAt: 0,
     endedAt: null,
@@ -77,6 +92,9 @@ describe("parseMetricReport", () => {
       name: null,
       unit: null,
       summary: "swapped JSON parser",
+      hypothesis: null,
+      plan: null,
+      approach: null,
     });
   });
 
@@ -86,6 +104,9 @@ describe("parseMetricReport", () => {
       name: null,
       unit: null,
       summary: null,
+      hypothesis: null,
+      plan: null,
+      approach: null,
     });
   });
 
@@ -104,6 +125,9 @@ describe("parseMetricReport", () => {
       name: null,
       unit: null,
       summary: "final",
+      hypothesis: null,
+      plan: null,
+      approach: null,
     });
   });
 
@@ -114,6 +138,9 @@ describe("parseMetricReport", () => {
       name: null,
       unit: null,
       summary: "good",
+      hypothesis: null,
+      plan: null,
+      approach: null,
     });
   });
 
@@ -132,7 +159,103 @@ describe("parseMetricReport", () => {
       name: null,
       unit: null,
       summary: "tidy",
+      hypothesis: null,
+      plan: null,
+      approach: null,
     });
+  });
+
+  it("parses experiment context from a metric report", () => {
+    expect(
+      parseMetricReport(
+        "```autoresearch\nmetric: 90\nsummary: memoized selectors\nhypothesis: repeated selectors dominate render time\nplan: memoize selectors and rerun the benchmark\napproach: rendering\n```",
+      ),
+    ).toEqual({
+      value: 90,
+      name: null,
+      unit: null,
+      summary: "memoized selectors",
+      hypothesis: "repeated selectors dominate render time",
+      plan: "memoize selectors and rerun the benchmark",
+      approach: "rendering",
+    });
+  });
+
+  it("ignores research only blocks", () => {
+    expect(
+      parseMetricReport(
+        "```autoresearch\ntype: research\nsummary: traced routing\nfinding: routes are contributed by UI modules\n```",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("parseResearchReport", () => {
+  it("parses a valid research checkpoint", () => {
+    expect(
+      parseResearchReport(
+        "```autoresearch\ntype: research\nsummary: traced routing\nfinding: routes are contributed by UI modules\nnext: inspect the contribution\n```",
+      ),
+    ).toEqual({
+      summary: "traced routing",
+      finding: "routes are contributed by UI modules",
+      nextStep: "inspect the contribution",
+      area: null,
+    });
+  });
+
+  it.each([
+    ["missing type", "summary: traced routing\nfinding: found it"],
+    ["missing summary", "type: research\nfinding: found it"],
+    ["missing finding", "type: research\nsummary: traced routing"],
+  ])("rejects a checkpoint with %s", (_name, body) => {
+    expect(
+      parseResearchReport(`\`\`\`autoresearch\n${body}\n\`\`\``),
+    ).toBeNull();
+  });
+
+  it("uses the last valid research checkpoint", () => {
+    const text = [
+      "```autoresearch",
+      "type: research",
+      "summary: first",
+      "finding: initial finding",
+      "```",
+      "```autoresearch",
+      "type: research",
+      "summary: second",
+      "finding: final finding",
+      "```",
+    ].join("\n");
+
+    expect(parseResearchReport(text)).toEqual({
+      summary: "second",
+      finding: "final finding",
+      nextStep: null,
+      area: null,
+    });
+  });
+});
+
+describe("parsePlanReport", () => {
+  it("parses a complete experiment plan", () => {
+    expect(
+      parsePlanReport(
+        "```autoresearch\ntype: plan\nhypothesis: repeated queries dominate latency\nplan: cache the query and rerun the benchmark\napproach: caching\n```",
+      ),
+    ).toEqual({
+      hypothesis: "repeated queries dominate latency",
+      plan: "cache the query and rerun the benchmark",
+      approach: "caching",
+    });
+  });
+
+  it("requires every plan field", () => {
+    expect(
+      parsePlanReport(
+        "```autoresearch\ntype: plan\nhypothesis: repeated queries dominate latency\n```",
+      ),
+    ).toBeNull();
   });
 });
 
@@ -260,6 +383,12 @@ describe("buildKickoffPreamble", () => {
       "Optimize the HTTP handler throughput benchmark.",
     );
   });
+
+  it("requires autoresearch pull request attribution", () => {
+    const preamble = buildKickoffPreamble(makeConfig());
+    expect(preamble).toContain("feat(autoresearch): <descriptive title>");
+    expect(preamble).toContain('"Created with Autoresearch."');
+  });
 });
 
 describe("buildContinuationPrompt", () => {
@@ -276,14 +405,34 @@ describe("buildContinuationPrompt", () => {
     expect(prompt).toContain("```autoresearch");
   });
 
+  it("preserves the pull request convention in later iterations", () => {
+    const run = makeRun([makeIteration(1, 100, "baseline")]);
+    expect(buildContinuationPrompt(run)).toContain(
+      "feat(autoresearch): <descriptive title>",
+    );
+    expect(buildImplementPrompt(run)).toContain('"Created with Autoresearch."');
+    expect(buildMeasurePrompt(run)).toContain(
+      "feat(autoresearch): <descriptive title>",
+    );
+  });
+
+  it("requests an experiment plan in every implementation path", () => {
+    const run = makeRun([makeIteration(1, 100, "baseline")]);
+    expect(buildContinuationPrompt(run)).toContain("type: plan");
+    expect(buildImplementPrompt(run)).toContain("type: plan");
+    expect(buildMeasurePrompt(run)).toContain(
+      "Repeat the hypothesis, plan, and approach",
+    );
+  });
+
   it("only lists the five most recent iterations", () => {
     const run = makeRun(
       Array.from({ length: 7 }, (_, i) => makeIteration(i + 1, i + 1)),
     );
     const prompt = buildContinuationPrompt(run);
-    expect(prompt).not.toContain("- Iteration 2:");
-    expect(prompt).toContain("- Iteration 3:");
-    expect(prompt).toContain("- Iteration 7:");
+    expect(prompt).not.toContain("Iteration 2:");
+    expect(prompt).toContain("Iteration 3:");
+    expect(prompt).toContain("Iteration 7:");
   });
 });
 
@@ -308,7 +457,7 @@ describe("buildResumePrompt", () => {
   it("warns about half-applied changes from the aborted iteration", () => {
     const prompt = buildResumePrompt(makeRun([]), "app-restart");
     expect(prompt).toContain("the app restarted");
-    expect(prompt).toContain("half-applied change");
+    expect(prompt).toContain("partially applied change");
   });
 });
 
@@ -321,6 +470,9 @@ describe("unit parsing and rendering", () => {
       name: "bundle size",
       unit: "kB",
       summary: "trimmed deps",
+      hypothesis: null,
+      plan: null,
+      approach: null,
     });
   });
 
@@ -336,7 +488,7 @@ describe("unit parsing and rendering", () => {
       metricUnit: "ms",
     };
     const prompt = buildContinuationPrompt(run);
-    expect(prompt).toContain("- Iteration 1: 100 ms — baseline");
+    expect(prompt).toContain("Iteration 1: 100 ms. baseline");
     expect(prompt).toContain("Best so far: 100 ms (iteration 1)");
     expect(prompt).toContain("Last: 100 ms");
   });

--- a/packages/core/src/autoresearch/prompts.ts
+++ b/packages/core/src/autoresearch/prompts.ts
@@ -2,14 +2,16 @@
  * The autoresearch protocol: how we brief the agent, how the agent reports
  * metric measurements back, and how we read those reports out of the session
  * transcript. Prompt builders and the report parser are two sides of the same
- * contract — keep them in sync.
+ * contract. Keep them in sync.
  */
 import type { AcpMessage } from "@posthog/shared";
 import { isJsonRpcNotification, isJsonRpcRequest } from "@posthog/shared";
 import type {
   AutoresearchDraftConfig,
   AutoresearchInterruptionReason,
+  AutoresearchPlanReport,
   AutoresearchReport,
+  AutoresearchResearchReport,
   AutoresearchRun,
 } from "./schemas";
 import { computeBest } from "./stats";
@@ -17,17 +19,43 @@ import { computeBest } from "./stats";
 const REPORT_BLOCK_EXAMPLE = [
   "```autoresearch",
   "metric: <number>",
-  "name: <short metric label, e.g. bundle size — keep it identical every time>",
-  "unit: <the metric's unit, e.g. kB, ms, % — omit for unitless counts>",
+  "name: <short metric label, e.g. bundle size; keep it identical every time>",
+  "unit: <the metric's unit, e.g. kB, ms, %; omit for unitless counts>",
   "summary: <one line describing what you changed>",
+  "hypothesis: <why this change should improve the metric>",
+  "plan: <the implementation and measurement plan>",
+  "approach: <short category such as caching, rendering, query, algorithm>",
   "```",
 ].join("\n");
+
+const RESEARCH_BLOCK_EXAMPLE = [
+  "```autoresearch",
+  "type: research",
+  "summary: <short description of what you investigated>",
+  "area: <codebase area such as frontend, database, build, API>",
+  "finding: <specific technical finding about the codebase>",
+  "next: <next research or measurement step>",
+  "```",
+].join("\n");
+
+const PLAN_BLOCK_EXAMPLE = [
+  "```autoresearch",
+  "type: plan",
+  "hypothesis: <why the proposed change should improve the metric>",
+  "plan: <the focused change and how you will measure it>",
+  "approach: <short category such as caching, rendering, query, algorithm>",
+  "```",
+].join("\n");
+
+const PULL_REQUEST_CONVENTION = `Pull requests created during this run must follow both rules:
+Title: \`feat(autoresearch): <descriptive title>\`
+Description: include the sentence "Created with Autoresearch."`;
 
 function directionPhrase(config: AutoresearchDraftConfig): string {
   return config.direction === "maximize" ? "maximize" : "minimize";
 }
 
-/** The metric as we can name it so far — reports define it, the brief implies it. */
+/** Reports define the metric name. Until then, the brief only implies it. */
 function metricPhrase(run: AutoresearchRun): string {
   return run.metricName ? `"${run.metricName}"` : "the metric";
 }
@@ -42,20 +70,30 @@ function targetLine(config: AutoresearchDraftConfig): string {
  * Everything the kickoff says before the optimization brief. Hosts that
  * deliver the kickoff as a new task's initial prompt prepend this to the
  * user's own prompt content, so file/folder chips survive untouched.
- * The metric is not named here — the brief defines it and the agent labels
+ * The metric is not named here. The brief defines it and the agent labels
  * it in every report's `name:` line.
  */
 export function buildKickoffPreamble(config: AutoresearchDraftConfig): string {
   return `You are now in autoresearch mode: an iterative optimization loop to ${directionPhrase(config)} the metric defined by the brief below.
 
 Protocol for every iteration:
-1. Make ONE focused change aimed at improving the metric. Keep changes small and attributable.
-2. Measure the metric after your change.
-3. End your reply with exactly one report block in this format (plain number, no units or thousands separators):
+1. Before editing, emit one plan block describing the hypothesis, plan, and approach:
+
+${PLAN_BLOCK_EXAMPLE}
+
+2. Make ONE focused change aimed at improving the metric. Keep changes small and attributable.
+3. Measure the metric after your change.
+4. End your reply with exactly one report block in this format (plain number, no units or thousands separators):
 
 ${REPORT_BLOCK_EXAMPLE}
 
-The report block is parsed by a machine — without it the iteration does not count. Budget: up to ${config.maxIterations} iterations.${targetLine(config)}
+Before the baseline is available, codebase research can take multiple turns. When a research turn produces useful information but no metric yet, end the reply with this checkpoint instead:
+
+${RESEARCH_BLOCK_EXAMPLE}
+
+The report block is parsed by a machine. Without it, the iteration does not count. Budget: up to ${config.maxIterations} iterations.${targetLine(config)}
+
+${PULL_REQUEST_CONVENTION}
 
 Iteration 1 starts now. First establish and report the baseline measurement (your change for this iteration is the measurement setup itself if nothing exists yet), then keep improving in later iterations. If a change regresses the metric, revert it in the next iteration and try a different approach.
 
@@ -78,7 +116,7 @@ function historyBlock(run: AutoresearchRun): string {
     .slice(-5)
     .map(
       (iteration) =>
-        `- Iteration ${iteration.index}: ${iteration.value}${unit}${iteration.summary ? ` — ${iteration.summary}` : ""}`,
+        `Iteration ${iteration.index}: ${iteration.value}${unit}${iteration.summary ? `. ${iteration.summary}` : ""}`,
     )
     .join("\n");
 
@@ -96,32 +134,65 @@ export function buildContinuationPrompt(run: AutoresearchRun): string {
 
 ${historyBlock(run)}
 
-Continue: make the next focused change, measure ${metricPhrase(run)}, and end your reply with the report block:
+${PULL_REQUEST_CONVENTION}
+
+Before editing, emit the experiment plan:
+
+${PLAN_BLOCK_EXAMPLE}
+
+Then make the next focused change, measure ${metricPhrase(run)}, and end your reply with the report block:
 
 ${REPORT_BLOCK_EXAMPLE}`;
 }
 
+export function buildResearchContinuationPrompt(run: AutoresearchRun): string {
+  const latest = run.researchFindings[run.researchFindings.length - 1];
+  return `Autoresearch research checkpoint ${run.researchFindings.length} recorded.${latest?.nextStep ? ` Next step: ${latest.nextStep}.` : ""}
+
+Continue investigating the codebase or establish the baseline measurement. Before editing or measuring, emit the experiment plan:
+
+${PLAN_BLOCK_EXAMPLE}
+
+When you have a metric, end with the metric report block:
+
+${REPORT_BLOCK_EXAMPLE}
+
+If another research turn produces a useful finding but no metric, end with a research checkpoint:
+
+${RESEARCH_BLOCK_EXAMPLE}`;
+}
+
 /**
  * First half of a split iteration: think and change, don't measure. Runs on
- * the implement-stage model.
+ * the implementation stage model.
  */
 export function buildImplementPrompt(run: AutoresearchRun): string {
   const nextIndex = run.iterations.length + 1;
 
-  return `Autoresearch iteration ${nextIndex} of ${run.config.maxIterations} for ${metricPhrase(run)} (${directionPhrase(run.config)}) — implementation phase.
+  return `Autoresearch iteration ${nextIndex} of ${run.config.maxIterations} for ${metricPhrase(run)} (${directionPhrase(run.config)}). Implementation phase.
 
 ${historyBlock(run)}
 
-Plan and implement ONE focused change aimed at improving the metric. Do NOT run the measurement in this turn — a separate measurement turn follows. Reply with a one-line summary of what you changed and why.`;
+${PULL_REQUEST_CONVENTION}
+
+Start by emitting the experiment plan:
+
+${PLAN_BLOCK_EXAMPLE}
+
+Then implement ONE focused change aimed at improving the metric. Do NOT run the measurement in this turn. A separate measurement turn follows. Reply with a single line summary of what you changed and why.`;
 }
 
 /**
  * Second half of a split iteration: run the measurement and report. Runs on
- * the measure-stage model, which can be a cheap one — this turn is tool
+ * the measurement stage model, which can be a cheap one. This turn is tool
  * calls, not thinking.
  */
 export function buildMeasurePrompt(run: AutoresearchRun): string {
-  return `Measurement phase: run the measurement for ${metricPhrase(run)} exactly as the brief describes, without changing any code. End your reply with the report block:
+  return `Measurement phase: run the measurement for ${metricPhrase(run)} exactly as the brief describes, without changing any code.
+
+${PULL_REQUEST_CONVENTION}
+
+End your reply with the report block. Repeat the hypothesis, plan, and approach from the implementation phase so the experiment is recorded:
 
 ${REPORT_BLOCK_EXAMPLE}`;
 }
@@ -134,7 +205,7 @@ const INTERRUPTION_PHRASE: Record<AutoresearchInterruptionReason, string> = {
 };
 
 /**
- * The prompt that (re-)enters the loop at the run's current phase — the
+ * The prompt that enters the loop again at the run's current phase. This is the
  * single source of truth for phase → prompt, shared by resume and the manual
  * resume path so the two can't drift.
  */
@@ -147,14 +218,14 @@ export function buildPhasePrompt(run: AutoresearchRun): string {
 /**
  * Continuation sent when the loop re-engages after an interruption. States
  * why the loop went quiet so the agent can re-check the workspace state
- * (a half-applied change from the aborted iteration must be measured or
+ * (a partially applied change from the aborted iteration must be measured or
  * reverted, not assumed), then re-enters at the phase the run was in.
  */
 export function buildResumePrompt(
   run: AutoresearchRun,
   reason: AutoresearchInterruptionReason,
 ): string {
-  return `The autoresearch loop was interrupted (${INTERRUPTION_PHRASE[reason]}) and is resuming now. Check the working tree for any half-applied change from the aborted iteration before continuing.
+  return `The autoresearch loop was interrupted (${INTERRUPTION_PHRASE[reason]}) and is resuming now. Check the working tree for any partially applied change from the aborted iteration before continuing.
 
 ${buildPhasePrompt(run)}`;
 }
@@ -168,14 +239,44 @@ ${REPORT_BLOCK_EXAMPLE}`;
 const REPORT_BLOCK_REGEX = /```autoresearch\s*\n([\s\S]*?)```/g;
 
 /**
- * Parse the agent's metric report from a reply. The last well-formed
+ * Parse the agent's metric report from a reply. The last valid
  * ```autoresearch fenced block wins, so an agent quoting the protocol and
  * then reporting still parses correctly.
  */
 export function parseMetricReport(text: string): AutoresearchReport | null {
-  let report: AutoresearchReport | null = null;
+  return parseMetricReports(text).at(-1) ?? null;
+}
+
+export function parseMetricReports(text: string): AutoresearchReport[] {
+  const reports: AutoresearchReport[] = [];
   for (const match of text.matchAll(REPORT_BLOCK_REGEX)) {
     const parsed = parseReportBody(match[1]);
+    if (parsed) reports.push(parsed);
+  }
+  return reports;
+}
+
+export function parseResearchReport(
+  text: string,
+): AutoresearchResearchReport | null {
+  return parseResearchReports(text).at(-1) ?? null;
+}
+
+export function parseResearchReports(
+  text: string,
+): AutoresearchResearchReport[] {
+  const reports: AutoresearchResearchReport[] = [];
+  for (const match of text.matchAll(REPORT_BLOCK_REGEX)) {
+    const parsed = parseResearchBody(match[1]);
+    if (parsed) reports.push(parsed);
+  }
+  return reports;
+}
+
+export function parsePlanReport(text: string): AutoresearchPlanReport | null {
+  let report: AutoresearchPlanReport | null = null;
+  for (const match of text.matchAll(REPORT_BLOCK_REGEX)) {
+    const parsed = parsePlanBody(match[1]);
     if (parsed) report = parsed;
   }
   return report;
@@ -189,6 +290,9 @@ function parseReportBody(body: string): AutoresearchReport | null {
   let name: string | null = null;
   let unit: string | null = null;
   let summary: string | null = null;
+  let hypothesis: string | null = null;
+  let plan: string | null = null;
+  let approach: string | null = null;
   for (const line of body.split("\n")) {
     const separator = line.indexOf(":");
     if (separator === -1) continue;
@@ -207,9 +311,57 @@ function parseReportBody(body: string): AutoresearchReport | null {
       unit = raw;
     } else if (key === "summary" && raw.length > 0) {
       summary = raw;
+    } else if (key === "hypothesis" && raw.length > 0) {
+      hypothesis = raw;
+    } else if (key === "plan" && raw.length > 0) {
+      plan = raw;
+    } else if (key === "approach" && raw.length > 0) {
+      approach = raw;
     }
   }
-  return value === null ? null : { value, name, unit, summary };
+  return value === null
+    ? null
+    : { value, name, unit, summary, hypothesis, plan, approach };
+}
+
+function parseResearchBody(body: string): AutoresearchResearchReport | null {
+  let type: string | null = null;
+  let summary: string | null = null;
+  let finding: string | null = null;
+  let nextStep: string | null = null;
+  let area: string | null = null;
+  for (const line of body.split("\n")) {
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim().toLowerCase();
+    const raw = line.slice(separator + 1).trim();
+    if (key === "type") type = raw.toLowerCase();
+    else if (key === "summary" && raw.length > 0) summary = raw;
+    else if (key === "finding" && raw.length > 0) finding = raw;
+    else if (key === "next" && raw.length > 0) nextStep = raw;
+    else if (key === "area" && raw.length > 0) area = raw;
+  }
+  if (type !== "research" || !summary || !finding) return null;
+  return { summary, finding, nextStep, area };
+}
+
+function parsePlanBody(body: string): AutoresearchPlanReport | null {
+  let type: string | null = null;
+  let hypothesis: string | null = null;
+  let plan: string | null = null;
+  let approach: string | null = null;
+  for (const line of body.split("\n")) {
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim().toLowerCase();
+    const raw = line.slice(separator + 1).trim();
+    if (key === "type") type = raw.toLowerCase();
+    else if (key === "hypothesis" && raw.length > 0) hypothesis = raw;
+    else if (key === "plan" && raw.length > 0) plan = raw;
+    else if (key === "approach" && raw.length > 0) approach = raw;
+  }
+  if (type !== "plan" || !hypothesis || !plan || !approach) return null;
+  return { hypothesis, plan, approach };
 }
 
 interface AgentMessageChunkUpdate {
@@ -222,8 +374,8 @@ interface AgentMessageChunkUpdate {
 /**
  * Number of session/prompt requests in the transcript. Used as a turn
  * cursor: `isPromptPending` can flip false without a turn having run (a
- * rate-limited or failed send resets it), so a completion only counts when
- * the prompt-request count moved past the last one handled. The count is
+ * a rate limit or failed send resets it), so a completion only counts when
+ * the prompt request count moved past the last one handled. The count is
  * stable across transcript replays, unlike event indexes.
  */
 export function countPromptRequests(events: AcpMessage[]): number {

--- a/packages/core/src/autoresearch/prompts.ts
+++ b/packages/core/src/autoresearch/prompts.ts
@@ -248,12 +248,33 @@ export function parseMetricReport(text: string): AutoresearchReport | null {
 }
 
 export function parseMetricReports(text: string): AutoresearchReport[] {
-  const reports: AutoresearchReport[] = [];
+  return parseMetricReportBlocks(text).map(({ report }) => report);
+}
+
+export function parseStreamedMetricReports(text: string): AutoresearchReport[] {
+  return parseMetricReportBlocks(text)
+    .filter(({ end }) => startsAnotherIteration(text.slice(end)))
+    .map(({ report }) => report);
+}
+
+function parseMetricReportBlocks(
+  text: string,
+): Array<{ report: AutoresearchReport; end: number }> {
+  const reports: Array<{ report: AutoresearchReport; end: number }> = [];
   for (const match of text.matchAll(REPORT_BLOCK_REGEX)) {
     const parsed = parseReportBody(match[1]);
-    if (parsed) reports.push(parsed);
+    if (parsed) {
+      reports.push({
+        report: parsed,
+        end: (match.index ?? 0) + match[0].length,
+      });
+    }
   }
   return reports;
+}
+
+function startsAnotherIteration(text: string): boolean {
+  return /\b(?:for\s+)?iteration\s+\d+\b/i.test(text);
 }
 
 export function parseResearchReport(

--- a/packages/core/src/autoresearch/schemas.test.ts
+++ b/packages/core/src/autoresearch/schemas.test.ts
@@ -100,6 +100,11 @@ describe("parseStoredAutoresearchRun", () => {
     );
   });
 
+  it("defaults research findings for legacy persisted runs", () => {
+    const run = parseStoredAutoresearchRun(storedRun("paused"));
+    expect(run?.researchFindings).toEqual([]);
+  });
+
   it.each([
     ["corrupt JSON", "{nope"],
     ["schema mismatch", JSON.stringify({ id: "ar-1" })],

--- a/packages/core/src/autoresearch/schemas.ts
+++ b/packages/core/src/autoresearch/schemas.ts
@@ -51,7 +51,7 @@ export const autoresearchConfigSchema = z.object({
    * Stage configuration. When the implement and measure stages differ (in
    * model or effort), each iteration runs as two turns: an
    * ideation/implementation turn on the implement stage and a measurement
-   * turn on the measure stage (typically a cheaper model/effort — measuring
+   * turn on the measure stage, typically with a cheaper model or effort. Measuring
    * is tool calls, not thinking). When the stages are identical, iterations
    * are single turns. Null fields mean "leave the session's current value
    * alone".
@@ -63,7 +63,7 @@ export const autoresearchConfigSchema = z.object({
   /**
    * Free-form instructions for the agent: what to optimize, how to measure
    * the metric, and any constraints to respect. The metric itself is not
-   * configured anywhere — the agent names it in its reports based on this
+   * configured anywhere. The agent names it in its reports based on this
    * brief.
    */
   instructions: z.string().trim().min(1),
@@ -94,9 +94,24 @@ export const autoresearchIterationSchema = z.object({
   delta: z.number().finite().nullable(),
   /** Agent's one-line description of what it changed. */
   summary: z.string().nullable(),
+  hypothesis: z.string().nullable().default(null),
+  plan: z.string().nullable().default(null),
+  approach: z.string().nullable().default(null),
   at: z.number(),
 });
 export type AutoresearchIteration = z.infer<typeof autoresearchIterationSchema>;
+
+export const autoresearchResearchFindingSchema = z.object({
+  index: z.number().int().min(1),
+  summary: z.string().min(1),
+  finding: z.string().min(1),
+  nextStep: z.string().nullable(),
+  area: z.string().nullable().default(null),
+  at: z.number(),
+});
+export type AutoresearchResearchFinding = z.infer<
+  typeof autoresearchResearchFindingSchema
+>;
 
 export function isTerminalRunStatus(status: AutoresearchRunStatus): boolean {
   return status === "completed" || status === "stopped" || status === "failed";
@@ -132,6 +147,7 @@ export const autoresearchRunSchema = z.object({
    */
   originalModel: z.string().nullable().default(null),
   originalEffort: z.string().nullable().default(null),
+  researchFindings: z.array(autoresearchResearchFindingSchema).default([]),
   iterations: z.array(autoresearchIterationSchema),
   startedAt: z.number(),
   endedAt: z.number().nullable(),
@@ -177,4 +193,20 @@ export interface AutoresearchReport {
   /** The metric's unit, e.g. "kB", "ms", "%"; null for unitless counts. */
   unit: string | null;
   summary: string | null;
+  hypothesis: string | null;
+  plan: string | null;
+  approach: string | null;
+}
+
+export interface AutoresearchResearchReport {
+  summary: string;
+  finding: string;
+  nextStep: string | null;
+  area: string | null;
+}
+
+export interface AutoresearchPlanReport {
+  hypothesis: string;
+  plan: string;
+  approach: string;
 }

--- a/packages/core/src/autoresearch/stats.test.ts
+++ b/packages/core/src/autoresearch/stats.test.ts
@@ -19,6 +19,9 @@ function iteration(
     bestValue: value,
     delta: null,
     summary: null,
+    hypothesis: null,
+    plan: null,
+    approach: null,
     at: 1000 + index,
     ...overrides,
   };
@@ -49,6 +52,7 @@ function makeRun(overrides: {
     phase: null,
     originalModel: null,
     originalEffort: null,
+    researchFindings: [],
     iterations: overrides.iterations ?? [],
     startedAt: 0,
     endedAt: null,

--- a/packages/ui/src/features/autoresearch/AutoresearchComposerControls.test.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchComposerControls.test.tsx
@@ -1,0 +1,128 @@
+import type { AutoresearchDraftConfig } from "@posthog/core/autoresearch/schemas";
+import { Theme } from "@radix-ui/themes";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AutoresearchComposerControls } from "./AutoresearchComposerControls";
+
+const draft: AutoresearchDraftConfig = {
+  direction: "maximize",
+  targetValue: null,
+  maxIterations: 10,
+  implementModel: "model-a",
+  measureModel: "model-a",
+  implementEffort: "medium",
+  measureEffort: "medium",
+};
+
+function renderControls(
+  overrides: Partial<AutoresearchDraftConfig> = {},
+  onChange = vi.fn(),
+) {
+  render(
+    <Theme>
+      <AutoresearchComposerControls
+        draft={{ ...draft, ...overrides }}
+        modelOptions={[{ value: "model-a", label: "Model A" }]}
+        effortOptions={[{ value: "medium", label: "Medium" }]}
+        onChange={onChange}
+        onExit={vi.fn()}
+      />
+    </Theme>,
+  );
+  return onChange;
+}
+
+describe("AutoresearchComposerControls", () => {
+  it("explains the workflow without hiding the prompt requirements", () => {
+    renderControls();
+
+    expect(screen.getByText("Autoresearch")).toBeVisible();
+    expect(
+      screen.getByText(
+        /modifies the codebase and evaluates a user defined metric/i,
+      ),
+    ).toBeVisible();
+    expect(screen.getByText("Include in your prompt")).toBeVisible();
+    expect(screen.getByText("The metric to optimize")).toBeVisible();
+    expect(
+      screen.getByText("The command or steps to measure it"),
+    ).toBeVisible();
+    expect(
+      screen.getByText("Constraints the agent must preserve"),
+    ).toBeVisible();
+  });
+
+  it("updates the attempt limit from the primary setup", () => {
+    const onChange = renderControls();
+
+    fireEvent.change(screen.getByLabelText("Maximum attempts"), {
+      target: { value: "6" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({ maxIterations: 6 });
+  });
+
+  it("shows both metric directions and updates the selected direction", async () => {
+    const user = userEvent.setup();
+    const onChange = renderControls();
+
+    expect(screen.getByRole("radio", { name: "Increase" })).toBeVisible();
+    expect(screen.getByRole("radio", { name: "Decrease" })).toBeVisible();
+
+    await user.click(screen.getByRole("radio", { name: "Decrease" }));
+
+    expect(onChange).toHaveBeenCalledWith({ direction: "minimize" });
+  });
+
+  it("keeps target configuration behind advanced settings", async () => {
+    const user = userEvent.setup();
+    const onChange = renderControls();
+
+    expect(
+      screen.queryByLabelText("Target metric value to stop at"),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Advanced autoresearch settings" }),
+    );
+    fireEvent.change(screen.getByLabelText("Target metric value to stop at"), {
+      target: { value: "95" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({ targetValue: 95 });
+  });
+
+  it("explains the autoresearch loop in a help dialog", async () => {
+    const user = userEvent.setup();
+    renderControls();
+
+    await user.click(
+      screen.getByRole("button", { name: "What is autoresearch?" }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "What is autoresearch?" }),
+    ).toBeVisible();
+    expect(screen.getByText("Measure a baseline")).toBeVisible();
+    expect(screen.getByText("Try an improvement")).toBeVisible();
+    expect(screen.getByText("Repeat until it stops")).toBeVisible();
+    expect(
+      screen.getByRole("img", {
+        name: /Example autoresearch metric improving over five attempts/,
+      }),
+    ).toBeVisible();
+    expect(screen.getByText("55 ms")).toBeVisible();
+    expect(screen.getByText("Example prompt")).toBeVisible();
+    expect(screen.getByRole("radio", { name: "Performance" })).toBeVisible();
+    expect(screen.getByRole("radio", { name: "Bundle size" })).toBeVisible();
+    expect(
+      screen.getByRole("radio", { name: "Test reliability" }),
+    ).toBeVisible();
+    expect(screen.getByText(/pnpm bench:search/)).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Send feedback or report a bug" }),
+    ).toBeVisible();
+    expect(screen.getByText("autoresearch@posthog.com")).toBeVisible();
+  });
+});

--- a/packages/ui/src/features/autoresearch/AutoresearchComposerControls.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchComposerControls.tsx
@@ -25,7 +25,7 @@ import {
   Text,
   TextField,
 } from "@radix-ui/themes";
-import { motion, useReducedMotion } from "framer-motion";
+import { domAnimation, LazyMotion, m, useReducedMotion } from "framer-motion";
 import { useState } from "react";
 import { openExternalUrl } from "../../shell/openExternal";
 import {
@@ -212,21 +212,23 @@ function DirectionOption({
 
   return (
     <span className="inline-flex items-center gap-1.5">
-      <motion.span
-        className="inline-flex"
-        animate={
-          reducedMotion || !selected
-            ? { y: 0 }
-            : { y: direction === "maximize" ? [0, -2, 0] : [0, 2, 0] }
-        }
-        transition={{
-          duration: 0.8,
-          repeat: selected ? Number.POSITIVE_INFINITY : 0,
-          repeatDelay: 1.4,
-        }}
-      >
-        <Icon size={12} weight="bold" />
-      </motion.span>
+      <LazyMotion features={domAnimation}>
+        <m.span
+          className="inline-flex"
+          animate={
+            reducedMotion || !selected
+              ? { y: 0 }
+              : { y: direction === "maximize" ? [0, -2, 0] : [0, 2, 0] }
+          }
+          transition={{
+            duration: 0.8,
+            repeat: selected ? Number.POSITIVE_INFINITY : 0,
+            repeatDelay: 1.4,
+          }}
+        >
+          <Icon size={12} weight="bold" />
+        </m.span>
+      </LazyMotion>
       {label}
     </span>
   );
@@ -441,55 +443,59 @@ function ExperimentLoopVisual() {
           />
         ))}
 
-        <motion.path
-          d={path}
-          fill="none"
-          stroke="var(--gray-10)"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          initial={reducedMotion ? false : { pathLength: 0 }}
-          animate={{ pathLength: 1 }}
-          transition={{ duration: 1.1, ease: "easeOut" }}
-        />
+        <LazyMotion features={domAnimation}>
+          <m.path
+            d={path}
+            fill="none"
+            stroke="var(--gray-10)"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            initial={reducedMotion ? false : { pathLength: 0 }}
+            animate={{ pathLength: 1 }}
+            transition={{ duration: 1.1, ease: "easeOut" }}
+          />
 
-        {EXPERIMENT_POINTS.map((point, index) => (
-          <motion.g
-            key={point.label}
-            initial={reducedMotion ? false : { opacity: 0, scale: 0.65, y: 4 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            transition={{ delay: 0.18 + index * 0.18, duration: 0.25 }}
-            style={{ transformOrigin: `${point.x}px ${point.y}px` }}
-          >
-            <circle
-              cx={point.x}
-              cy={point.y}
-              r={index === EXPERIMENT_POINTS.length - 1 ? 5 : 4}
-              fill={point.improved ? "var(--green-9)" : "var(--orange-9)"}
-              stroke="var(--gray-2)"
-              strokeWidth="2"
-            />
-            <text
-              x={point.x}
-              y={point.y - 10}
-              textAnchor="middle"
-              fill="var(--gray-12)"
-              fontSize="10"
-              fontWeight="500"
+          {EXPERIMENT_POINTS.map((point, index) => (
+            <m.g
+              key={point.label}
+              initial={
+                reducedMotion ? false : { opacity: 0, scale: 0.65, y: 4 }
+              }
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              transition={{ delay: 0.18 + index * 0.18, duration: 0.25 }}
+              style={{ transformOrigin: `${point.x}px ${point.y}px` }}
             >
-              {point.value}
-            </text>
-            <text
-              x={point.x}
-              y="119"
-              textAnchor="middle"
-              fill="var(--gray-10)"
-              fontSize="9"
-            >
-              {index === 0 ? "Baseline" : index}
-            </text>
-          </motion.g>
-        ))}
+              <circle
+                cx={point.x}
+                cy={point.y}
+                r={index === EXPERIMENT_POINTS.length - 1 ? 5 : 4}
+                fill={point.improved ? "var(--green-9)" : "var(--orange-9)"}
+                stroke="var(--gray-2)"
+                strokeWidth="2"
+              />
+              <text
+                x={point.x}
+                y={point.y - 10}
+                textAnchor="middle"
+                fill="var(--gray-12)"
+                fontSize="10"
+                fontWeight="500"
+              >
+                {point.value}
+              </text>
+              <text
+                x={point.x}
+                y="119"
+                textAnchor="middle"
+                fill="var(--gray-10)"
+                fontSize="9"
+              >
+                {index === 0 ? "Baseline" : index}
+              </text>
+            </m.g>
+          ))}
+        </LazyMotion>
       </svg>
 
       <figcaption className="flex items-center gap-3 border-gray-5 border-t px-3 py-1.5 text-gray-10 text-xs">

--- a/packages/ui/src/features/autoresearch/AutoresearchComposerControls.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchComposerControls.tsx
@@ -1,10 +1,33 @@
-import { ChartLineUp, SlidersHorizontal, X } from "@phosphor-icons/react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChartLineUp,
+  Command,
+  EnvelopeSimple,
+  Gauge,
+  LockKey,
+  Package,
+  Question,
+  SlidersHorizontal,
+  Speedometer,
+  TestTube,
+  X,
+} from "@phosphor-icons/react";
 import type {
   AutoresearchDirection,
   AutoresearchDraftConfig,
 } from "@posthog/core/autoresearch/schemas";
-import { Button, Popover, Select, Text, TextField } from "@radix-ui/themes";
-import { Tooltip } from "../../primitives/Tooltip";
+import {
+  Button,
+  Dialog,
+  Popover,
+  SegmentedControl,
+  Text,
+  TextField,
+} from "@radix-ui/themes";
+import { motion, useReducedMotion } from "framer-motion";
+import { useState } from "react";
+import { openExternalUrl } from "../../shell/openExternal";
 import {
   type AutoresearchModelOption,
   clampMaxIterations,
@@ -21,17 +44,13 @@ interface AutoresearchComposerControlsProps {
   onExit: () => void;
 }
 
+const AUTORESEARCH_FEEDBACK_MAILTO =
+  "mailto:autoresearch@posthog.com?subject=PostHog%20Code%20Autoresearch%20feedback";
+
 /**
- * Autoresearch settings shown as a bar above the composer while the mode is
- * armed. It reads as one sentence — "Optimize to maximize until it reaches N
- * or after K iterations using <model>" — so each control explains itself in
- * place; tooltips on the labels add the detail.
- *
- * There is deliberately no metric or instructions field: the prompt IS the
- * optimization brief, and the agent names the metric in its reports.
- *
- * While armed, the composer's own model/effort pickers are hidden and the
- * stage popover here is the single place models and efforts are chosen.
+ * Compact autoresearch setup inside the new task composer. The prompt remains
+ * the primary input; this row only exposes the two choices most people need.
+ * Targets and per-stage model tuning stay behind advanced settings.
  */
 export function AutoresearchComposerControls({
   draft,
@@ -42,109 +61,471 @@ export function AutoresearchComposerControls({
   onExit,
 }: AutoresearchComposerControlsProps) {
   return (
-    <div className="flex w-full flex-wrap items-center gap-x-2 gap-y-1.5 text-[12px]">
-      <Tooltip content="Runs an autonomous optimization loop: it measures a baseline from your brief, then edits the code and re-measures each round — keeping changes that move the metric and reverting the ones that don't. It stops when the metric reaches your target or hits the iteration cap, whichever comes first.">
-        <span className="flex shrink-0 cursor-help items-center gap-1 font-medium text-violet-11">
-          <ChartLineUp size={13} />
-          Autoresearch
-        </span>
-      </Tooltip>
-
-      {/* The goal: which way to push the metric the brief describes. */}
-      <span className="flex items-center gap-1.5 whitespace-nowrap text-(--gray-11)">
-        <Tooltip content="Whether the agent should drive the metric from your brief up or down.">
-          <span className="cursor-help">Optimize to</span>
-        </Tooltip>
-        <Select.Root
-          size="1"
-          value={draft.direction}
-          onValueChange={(value) =>
-            onChange({ direction: value as AutoresearchDirection })
-          }
-          disabled={disabled}
+    <div className="flex w-full flex-col gap-3">
+      <div className="flex items-start gap-2.5">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded bg-gray-4 text-gray-11">
+          <ChartLineUp size={13} weight="bold" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <Text size="2" weight="medium">
+            Autoresearch
+          </Text>
+          <Text as="p" size="1" color="gray" className="mt-0.5 leading-4">
+            Iteratively modifies the codebase and evaluates a user defined
+            metric.
+          </Text>
+        </div>
+        <button
+          type="button"
+          onClick={onExit}
+          aria-label="Turn off autoresearch"
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-gray-10 hover:bg-gray-4 hover:text-gray-12"
         >
-          <Select.Trigger variant="soft" aria-label="Optimization direction" />
-          <Select.Content>
-            <Select.Item value="maximize">maximize</Select.Item>
-            <Select.Item value="minimize">minimize</Select.Item>
-          </Select.Content>
-        </Select.Root>
-      </span>
+          <X size={13} />
+        </button>
+      </div>
 
-      {/* Two stop conditions, whichever comes first: the metric hits the
-          target value, or the run exhausts its iteration budget. Only the
-          label text is wrapped in a tooltip — never the input — so focusing
-          the field to type doesn't pop the tooltip open. */}
-      <span className="flex items-center gap-1.5 whitespace-nowrap text-(--gray-11)">
-        <Tooltip content="Finish early once the metric reaches this value. Leave blank to always run the full iteration budget.">
-          <span className="cursor-help">until it reaches</span>
-        </Tooltip>
-        <TextField.Root
-          size="1"
-          className="w-24"
-          value={draft.targetValue === null ? "" : String(draft.targetValue)}
-          onChange={(event) => {
-            const raw = event.target.value.trim();
-            const numeric = Number(raw);
-            onChange({
-              targetValue:
-                raw === "" || !Number.isFinite(numeric) ? null : numeric,
-            });
-          }}
-          placeholder="optional"
-          inputMode="decimal"
-          aria-label="Target metric value to stop at (optional)"
-          disabled={disabled}
-        />
-      </span>
-      <span className="flex items-center gap-1.5 whitespace-nowrap text-(--gray-11)">
-        or after
-        <TextField.Root
-          size="1"
-          className="w-14"
-          value={String(draft.maxIterations)}
-          onChange={(event) =>
-            onChange({
-              maxIterations: clampMaxIterations(
-                Number.parseInt(event.target.value, 10),
-              ),
-            })
-          }
-          inputMode="numeric"
-          aria-label="Maximum iterations"
-          disabled={disabled}
-        />
-        <Tooltip content="Hard cap on build-and-measure rounds before the run stops.">
-          <span className="cursor-help">iterations</span>
-        </Tooltip>
-      </span>
-
-      {/* The engine: model + effort per stage. */}
-      <span className="flex items-center gap-1.5 whitespace-nowrap text-(--gray-11)">
-        <Tooltip content="Model and reasoning effort the loop runs on. Set the build and measure stages to different models to measure with a cheaper one.">
-          <span className="cursor-help">using</span>
-        </Tooltip>
-        <StagesPopover
-          draft={draft}
-          modelOptions={modelOptions}
-          effortOptions={effortOptions}
-          disabled={disabled}
-          onChange={onChange}
-        />
-      </span>
-
-      <span className="ml-auto flex shrink-0 items-center">
-        <Tooltip content="Exit autoresearch mode">
-          <button
-            type="button"
-            onClick={onExit}
-            aria-label="Exit autoresearch mode"
-            className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-(--gray-10) hover:bg-(--gray-4) hover:text-(--gray-12)"
+      <div className="flex flex-wrap items-end gap-x-5 gap-y-3 border-gray-5 border-t pt-3">
+        <div>
+          <Text
+            as="label"
+            htmlFor="autoresearch-direction"
+            size="1"
+            weight="medium"
+            className="mb-1.5 block text-gray-11"
           >
-            <X size={12} />
-          </button>
-        </Tooltip>
-      </span>
+            Goal
+          </Text>
+          <SegmentedControl.Root
+            size="1"
+            value={draft.direction}
+            onValueChange={(value) =>
+              onChange({ direction: value as AutoresearchDirection })
+            }
+            disabled={disabled}
+            aria-label="Metric goal"
+          >
+            <SegmentedControl.Item value="maximize">
+              <DirectionOption
+                direction="maximize"
+                selected={draft.direction === "maximize"}
+              />
+            </SegmentedControl.Item>
+            <SegmentedControl.Item value="minimize">
+              <DirectionOption
+                direction="minimize"
+                selected={draft.direction === "minimize"}
+              />
+            </SegmentedControl.Item>
+          </SegmentedControl.Root>
+        </div>
+
+        <div>
+          <Text
+            as="label"
+            htmlFor="autoresearch-attempts"
+            size="1"
+            weight="medium"
+            className="mb-1.5 block text-gray-11"
+          >
+            Maximum attempts
+          </Text>
+          <div className="flex items-center gap-1.5">
+            <TextField.Root
+              size="1"
+              id="autoresearch-attempts"
+              className="w-16"
+              value={String(draft.maxIterations)}
+              onChange={(event) =>
+                onChange({
+                  maxIterations: clampMaxIterations(
+                    Number.parseInt(event.target.value, 10),
+                  ),
+                })
+              }
+              inputMode="numeric"
+              aria-label="Maximum attempts"
+              disabled={disabled}
+            />
+          </div>
+        </div>
+
+        <div className="ml-auto">
+          <AdvancedSettings
+            draft={draft}
+            modelOptions={modelOptions}
+            effortOptions={effortOptions}
+            disabled={disabled}
+            onChange={onChange}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-end justify-between gap-3 pt-0.5">
+        <div>
+          <Text as="div" size="1" weight="medium" color="gray">
+            Include in your prompt
+          </Text>
+          <ul className="mt-1.5 flex flex-col gap-1">
+            <PromptRequirement icon={Gauge} label="The metric to optimize" />
+            <PromptRequirement
+              icon={Command}
+              label="The command or steps to measure it"
+            />
+            <PromptRequirement
+              icon={LockKey}
+              label="Constraints the agent must preserve"
+            />
+          </ul>
+        </div>
+        <AutoresearchInfoDialog />
+      </div>
+    </div>
+  );
+}
+
+function PromptRequirement({
+  icon: Icon,
+  label,
+}: {
+  icon: typeof Gauge;
+  label: string;
+}) {
+  return (
+    <li className="flex items-center gap-1.5 text-gray-10 text-xs">
+      <Icon size={13} className="shrink-0" />
+      <span>{label}</span>
+    </li>
+  );
+}
+
+function DirectionOption({
+  direction,
+  selected,
+}: {
+  direction: AutoresearchDirection;
+  selected: boolean;
+}) {
+  const reducedMotion = useReducedMotion();
+  const Icon = direction === "maximize" ? ArrowUp : ArrowDown;
+  const label = direction === "maximize" ? "Increase" : "Decrease";
+
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <motion.span
+        className="inline-flex"
+        animate={
+          reducedMotion || !selected
+            ? { y: 0 }
+            : { y: direction === "maximize" ? [0, -2, 0] : [0, 2, 0] }
+        }
+        transition={{
+          duration: 0.8,
+          repeat: selected ? Number.POSITIVE_INFINITY : 0,
+          repeatDelay: 1.4,
+        }}
+      >
+        <Icon size={12} weight="bold" />
+      </motion.span>
+      {label}
+    </span>
+  );
+}
+
+function AutoresearchInfoDialog() {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger>
+        <Button
+          size="1"
+          variant="ghost"
+          color="gray"
+          aria-label="What is autoresearch?"
+          className="text-gray-10"
+        >
+          <Question size={13} />
+          See how it works
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content maxWidth="720px" size="2">
+        <Dialog.Title className="text-base">What is autoresearch?</Dialog.Title>
+        <Dialog.Description className="text-sm" color="gray">
+          Autoresearch runs a bounded experiment loop inside this task.
+        </Dialog.Description>
+
+        <div className="mt-4 grid gap-4 sm:grid-cols-[minmax(0,1.35fr)_minmax(220px,1fr)]">
+          <ExperimentLoopVisual />
+          <div className="flex flex-col justify-center gap-3 text-sm">
+            <InfoRow
+              number="1"
+              title="Measure a baseline"
+              description="Run the measurement from your prompt."
+            />
+            <InfoRow
+              number="2"
+              title="Try an improvement"
+              description="Change the code and measure again."
+            />
+            <InfoRow
+              number="3"
+              title="Repeat until it stops"
+              description="Stop at the attempt limit or target value."
+            />
+          </div>
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5 rounded-md border border-gray-5 bg-gray-2 px-3 py-2">
+          <Text size="1" weight="medium">
+            Prompt requirements
+          </Text>
+          <PromptRequirement icon={Gauge} label="Metric" />
+          <PromptRequirement icon={Command} label="Measurement" />
+          <PromptRequirement icon={LockKey} label="Constraints" />
+        </div>
+
+        <PromptExamples />
+
+        <Text as="p" size="1" color="gray" className="mt-2 leading-4">
+          Autoresearch does not invent or independently verify the metric. It
+          follows the measurement instructions in your prompt.
+        </Text>
+
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-gray-5 border-t pt-3">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              color="gray"
+              onClick={() => openExternalUrl(AUTORESEARCH_FEEDBACK_MAILTO)}
+            >
+              <EnvelopeSimple size={14} />
+              Send feedback or report a bug
+            </Button>
+            <Text size="1" color="gray" className="hidden sm:inline">
+              autoresearch@posthog.com
+            </Text>
+          </div>
+          <Dialog.Close>
+            <Button variant="soft" color="gray">
+              Got it
+            </Button>
+          </Dialog.Close>
+        </div>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}
+
+const PROMPT_EXAMPLES = {
+  performance: {
+    icon: Speedometer,
+    title: "Performance",
+    prompt:
+      "Reduce the p95 response time of the search endpoint. Measure with `pnpm bench:search` and minimize the reported p95 milliseconds. Preserve response behavior and API compatibility.",
+  },
+  bundle: {
+    icon: Package,
+    title: "Bundle size",
+    prompt:
+      "Reduce the gzipped JavaScript bundle size reported by `pnpm build:analyze`. Minimize total kB without removing features or changing browser support.",
+  },
+  reliability: {
+    icon: TestTube,
+    title: "Test reliability",
+    prompt:
+      "Reduce failures in the checkout E2E suite. Measure by running `pnpm test:e2e checkout --repeat-each=20` and minimize failed runs without increasing test timeouts.",
+  },
+} as const;
+
+type PromptExampleKey = keyof typeof PROMPT_EXAMPLES;
+
+function PromptExamples() {
+  const [selected, setSelected] = useState<PromptExampleKey>("performance");
+  const example = PROMPT_EXAMPLES[selected];
+  const Icon = example.icon;
+
+  return (
+    <div className="mt-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Text as="div" size="2" weight="medium">
+          Example prompt
+        </Text>
+        <SegmentedControl.Root
+          size="1"
+          value={selected}
+          onValueChange={(value) => {
+            if (value in PROMPT_EXAMPLES)
+              setSelected(value as PromptExampleKey);
+          }}
+          aria-label="Example prompt"
+        >
+          {Object.entries(PROMPT_EXAMPLES).map(([key, item]) => (
+            <SegmentedControl.Item key={key} value={key}>
+              {item.title}
+            </SegmentedControl.Item>
+          ))}
+        </SegmentedControl.Root>
+      </div>
+      <div className="mt-2 rounded-md border border-gray-5 px-3 py-2.5">
+        <div className="flex items-center gap-1.5">
+          <Icon size={13} className="text-gray-10" />
+          <Text size="1" weight="medium">
+            {example.title}
+          </Text>
+        </div>
+        <Text as="p" size="1" color="gray" className="mt-1 font-mono leading-4">
+          {example.prompt}
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+const EXPERIMENT_POINTS = [
+  { x: 38, y: 91, value: 72, label: "Baseline", improved: true },
+  { x: 106, y: 70, value: 66, label: "Attempt 1", improved: true },
+  { x: 174, y: 79, value: 69, label: "Attempt 2", improved: false },
+  { x: 242, y: 45, value: 60, label: "Attempt 3", improved: true },
+  { x: 310, y: 27, value: 55, label: "Best", improved: true },
+] as const;
+
+function ExperimentLoopVisual() {
+  const reducedMotion = useReducedMotion();
+  const path = EXPERIMENT_POINTS.map(
+    (point, index) => `${index === 0 ? "M" : "L"}${point.x} ${point.y}`,
+  ).join(" ");
+
+  return (
+    <figure className="overflow-hidden rounded-md border border-gray-5 bg-gray-2">
+      <div className="flex items-center justify-between border-gray-5 border-b px-3 py-2">
+        <div>
+          <Text as="div" size="1" weight="medium">
+            Example: reduce page load time
+          </Text>
+          <Text as="div" size="1" color="gray">
+            Lower is better · 5 attempts
+          </Text>
+        </div>
+        <div className="text-right">
+          <Text as="div" size="1" color="gray">
+            Best result
+          </Text>
+          <Text as="div" size="2" weight="medium" className="text-green-11">
+            55 ms
+          </Text>
+        </div>
+      </div>
+
+      <svg
+        viewBox="0 0 348 132"
+        className="block h-32 w-full"
+        role="img"
+        aria-labelledby="autoresearch-chart-title autoresearch-chart-description"
+      >
+        <title id="autoresearch-chart-title">
+          Example autoresearch metric improving over five attempts
+        </title>
+        <desc id="autoresearch-chart-description">
+          Page load time starts at 72 milliseconds, briefly regresses, and
+          reaches a best result of 55 milliseconds.
+        </desc>
+
+        {[30, 60, 90].map((y) => (
+          <line
+            key={y}
+            x1="28"
+            x2="322"
+            y1={y}
+            y2={y}
+            stroke="var(--gray-5)"
+            strokeWidth="1"
+          />
+        ))}
+
+        <motion.path
+          d={path}
+          fill="none"
+          stroke="var(--gray-10)"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          initial={reducedMotion ? false : { pathLength: 0 }}
+          animate={{ pathLength: 1 }}
+          transition={{ duration: 1.1, ease: "easeOut" }}
+        />
+
+        {EXPERIMENT_POINTS.map((point, index) => (
+          <motion.g
+            key={point.label}
+            initial={reducedMotion ? false : { opacity: 0, scale: 0.65, y: 4 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            transition={{ delay: 0.18 + index * 0.18, duration: 0.25 }}
+            style={{ transformOrigin: `${point.x}px ${point.y}px` }}
+          >
+            <circle
+              cx={point.x}
+              cy={point.y}
+              r={index === EXPERIMENT_POINTS.length - 1 ? 5 : 4}
+              fill={point.improved ? "var(--green-9)" : "var(--orange-9)"}
+              stroke="var(--gray-2)"
+              strokeWidth="2"
+            />
+            <text
+              x={point.x}
+              y={point.y - 10}
+              textAnchor="middle"
+              fill="var(--gray-12)"
+              fontSize="10"
+              fontWeight="500"
+            >
+              {point.value}
+            </text>
+            <text
+              x={point.x}
+              y="119"
+              textAnchor="middle"
+              fill="var(--gray-10)"
+              fontSize="9"
+            >
+              {index === 0 ? "Baseline" : index}
+            </text>
+          </motion.g>
+        ))}
+      </svg>
+
+      <figcaption className="flex items-center gap-3 border-gray-5 border-t px-3 py-1.5 text-gray-10 text-xs">
+        <span className="flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full bg-green-9" /> improved
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="h-2 w-2 rounded-full bg-orange-9" /> regressed
+        </span>
+      </figcaption>
+    </figure>
+  );
+}
+
+function InfoRow({
+  number,
+  title,
+  description,
+}: {
+  number: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex gap-3">
+      <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-gray-4 font-medium text-gray-11 text-xs">
+        {number}
+      </div>
+      <div>
+        <Text as="div" size="2" weight="medium">
+          {title}
+        </Text>
+        <Text as="p" size="1" color="gray" className="mt-0.5 leading-4">
+          {description}
+        </Text>
+      </div>
     </div>
   );
 }
@@ -160,14 +541,7 @@ function stageSummary(
   return effortLabel ? `${modelLabel} · ${effortLabel}` : modelLabel;
 }
 
-/**
- * Per-stage model and effort. While autoresearch is armed this popover is
- * the composer's only model/effort control, so the trigger always shows a
- * summary of what the run will use. Identical stages mean single-turn
- * iterations; any difference splits each iteration into a build turn and a
- * measure turn, switching between the stages.
- */
-function StagesPopover({
+function AdvancedSettings({
   draft,
   modelOptions,
   effortOptions,
@@ -183,18 +557,7 @@ function StagesPopover({
   const split =
     draft.implementModel !== draft.measureModel ||
     draft.implementEffort !== draft.measureEffort;
-  const buildSummary = stageSummary(
-    draft.implementModel,
-    draft.implementEffort,
-    modelOptions,
-    effortOptions,
-  );
-  const measureSummary = stageSummary(
-    draft.measureModel,
-    draft.measureEffort,
-    modelOptions,
-    effortOptions,
-  );
+  const hasTarget = draft.targetValue !== null;
 
   return (
     <Popover.Root>
@@ -202,18 +565,60 @@ function StagesPopover({
         <Button
           size="1"
           variant="ghost"
-          color={split ? "violet" : "gray"}
+          color="gray"
           disabled={disabled}
-          aria-label="Stage models and effort"
+          aria-label="Advanced autoresearch settings"
         >
-          <SlidersHorizontal size={12} />
-          {split ? `${buildSummary} → ${measureSummary}` : buildSummary}
+          <SlidersHorizontal size={14} />
+          Advanced
+          {(split || hasTarget) && <span aria-hidden>•</span>}
         </Button>
       </Popover.Trigger>
-      <Popover.Content size="1" width="320px">
-        <div className="flex flex-col gap-3">
+      <Popover.Content size="2" width="360px">
+        <div className="flex flex-col gap-4">
+          <div>
+            <Text as="div" size="2" weight="medium">
+              Advanced settings
+            </Text>
+            <Text as="p" size="1" color="gray" className="mt-0.5">
+              Optional stopping and model controls.
+            </Text>
+          </div>
+
+          <div>
+            <Text
+              as="label"
+              htmlFor="autoresearch-target"
+              size="1"
+              weight="medium"
+              className="mb-1 block"
+            >
+              Stop early at this metric value
+            </Text>
+            <TextField.Root
+              size="2"
+              id="autoresearch-target"
+              value={
+                draft.targetValue === null ? "" : String(draft.targetValue)
+              }
+              onChange={(event) => {
+                const raw = event.target.value.trim();
+                const numeric = Number(raw);
+                onChange({
+                  targetValue:
+                    raw === "" || !Number.isFinite(numeric) ? null : numeric,
+                });
+              }}
+              placeholder="Optional"
+              inputMode="decimal"
+              aria-label="Target metric value to stop at"
+              disabled={disabled}
+            />
+          </div>
+
           <StageFields
-            legend="Implementation (ideate & build)"
+            legend="Build improvements"
+            description="Used to analyze the result and change the code."
             model={draft.implementModel}
             effort={draft.implementEffort}
             modelOptions={modelOptions}
@@ -222,7 +627,8 @@ function StagesPopover({
             onEffortChange={(value) => onChange({ implementEffort: value })}
           />
           <StageFields
-            legend="Experiment (measure)"
+            legend="Measure results"
+            description="Used to run the measurement without changing code."
             model={draft.measureModel}
             effort={draft.measureEffort}
             modelOptions={modelOptions}
@@ -230,11 +636,26 @@ function StagesPopover({
             onModelChange={(value) => onChange({ measureModel: value })}
             onEffortChange={(value) => onChange({ measureEffort: value })}
           />
-          <Text size="1" color="gray">
-            Identical stages run each iteration as one turn. Different stages
-            split every iteration: build on the first, measure on the second —
-            pick a cheap model or low effort for measuring.
-          </Text>
+
+          {split && (
+            <Text size="1" color="gray">
+              Build:{" "}
+              {stageSummary(
+                draft.implementModel,
+                draft.implementEffort,
+                modelOptions,
+                effortOptions,
+              )}
+              . Measure:{" "}
+              {stageSummary(
+                draft.measureModel,
+                draft.measureEffort,
+                modelOptions,
+                effortOptions,
+              )}
+              .
+            </Text>
+          )}
         </div>
       </Popover.Content>
     </Popover.Root>
@@ -243,6 +664,7 @@ function StagesPopover({
 
 function StageFields({
   legend,
+  description,
   model,
   effort,
   modelOptions,
@@ -251,6 +673,7 @@ function StageFields({
   onEffortChange,
 }: {
   legend: string;
+  description: string;
   model: string | null;
   effort: string | null;
   modelOptions: AutoresearchModelOption[];
@@ -260,8 +683,11 @@ function StageFields({
 }) {
   return (
     <div>
-      <Text as="div" size="1" weight="medium" className="mb-1">
+      <Text as="div" size="1" weight="medium">
         {legend}
+      </Text>
+      <Text as="div" size="1" color="gray" className="mb-1.5">
+        {description}
       </Text>
       <div className="flex gap-2">
         <StageModelSelect

--- a/packages/ui/src/features/autoresearch/AutoresearchConfigDialog.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchConfigDialog.tsx
@@ -41,7 +41,7 @@ interface AutoresearchConfigDialogProps {
   /** Session effort options for the stage-effort selects; hidden when empty. */
   effortOptions?: AutoresearchModelOption[];
   initial?: Partial<AutoresearchConfigValues>;
-  /** May throw — the message is shown inline and the dialog stays open. */
+  /** May throw. The message is shown inline and the dialog stays open. */
   onSubmit: (values: AutoresearchConfigValues) => void;
 }
 
@@ -248,8 +248,8 @@ function ConfigForm({
             />
             <Text as="div" size="1" color="gray">
               Identical stages run each iteration as one turn. Different stages
-              split every iteration: build on the first, measure on the second —
-              pick a cheap model or low effort for measuring.
+              split every iteration: build on the first, then measure on the
+              second. pick a cheap model or low effort for measuring.
             </Text>
           </div>
         )}

--- a/packages/ui/src/features/autoresearch/AutoresearchFullDashboard.stories.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchFullDashboard.stories.tsx
@@ -1,0 +1,334 @@
+import type {
+  AutoresearchDirection,
+  AutoresearchIteration,
+  AutoresearchRun,
+  AutoresearchRunStatus,
+} from "@posthog/core/autoresearch/schemas";
+import type { AcpMessage } from "@posthog/shared";
+import { Badge, Button, Flex, Text } from "@radix-ui/themes";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AutoresearchObservability } from "./AutoresearchObservability";
+import { RunStats, RunSummary } from "./AutoresearchPanel";
+import { AutoresearchRuntimeStats } from "./AutoresearchRuntimeStats";
+import { IterationsTable } from "./IterationsTable";
+import { MetricChart } from "./MetricChart";
+import { PreBaselineState } from "./PreBaselineState";
+
+interface FullDashboardStoryProps {
+  status: AutoresearchRunStatus;
+  direction: AutoresearchDirection;
+  iterationCount: number;
+  maxIterations: number;
+  baselineValue: number;
+  changePerIteration: number;
+  targetValue: number;
+  showTarget: boolean;
+  metricName: string;
+  metricUnit: string;
+  showResearch: boolean;
+  showActivity: boolean;
+  showContextUsage: boolean;
+  contextUsed: number;
+  contextSize: number;
+  hypothesis: string;
+  iterationPlan: string;
+  approach: string;
+}
+
+const STORY_NOW = Date.now();
+const STARTED_AT = STORY_NOW - 26 * 60_000;
+
+function FullDashboardStory(props: FullDashboardStoryProps) {
+  const run = buildRun(props);
+  const events = buildEvents(props);
+  const usage = props.showContextUsage
+    ? {
+        used: props.contextUsed,
+        size: props.contextSize,
+        percentage:
+          props.contextSize > 0
+            ? Math.round((props.contextUsed / props.contextSize) * 100)
+            : 0,
+        cost: null,
+        breakdown: null,
+      }
+    : null;
+
+  return (
+    <div className="mx-auto min-h-screen max-w-[900px] bg-gray-1 p-5">
+      <Flex direction="column" gap="4">
+        <DashboardHeader run={run} />
+        {run.iterations.length === 0 ? (
+          <PreBaselineState
+            run={run}
+            sessionActivity={{
+              status: "connected",
+              isPromptPending: run.status === "running",
+              isCompacting: false,
+            }}
+          />
+        ) : (
+          <>
+            <RunStats run={run} />
+            <MetricChart
+              iterations={run.iterations}
+              direction={run.config.direction}
+              targetValue={run.config.targetValue}
+              metricName={run.metricName ?? "the metric"}
+              unit={run.metricUnit}
+            />
+            <IterationsTable
+              iterations={run.iterations}
+              direction={run.config.direction}
+              unit={run.metricUnit}
+            />
+            {run.endedAt !== null && <RunSummary run={run} />}
+          </>
+        )}
+        <AutoresearchRuntimeStats run={run} usage={usage} />
+        <AutoresearchObservability run={run} events={events} />
+      </Flex>
+    </div>
+  );
+}
+
+function DashboardHeader({ run }: { run: AutoresearchRun }) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Text size="5" weight="bold">
+            Autoresearch
+          </Text>
+          <Badge color="gray">{run.config.direction}</Badge>
+          <Badge color={run.status === "running" ? "blue" : "gray"}>
+            {run.status}
+          </Badge>
+        </div>
+        <Text as="p" size="1" color="gray" className="mt-1">
+          Agent is testing focused changes against{" "}
+          {run.metricName ?? "the metric"}.
+        </Text>
+      </div>
+      <div className="flex gap-2">
+        <Button variant="soft" color="gray" disabled={run.status !== "running"}>
+          Pause
+        </Button>
+        <Button variant="soft" color="red" disabled={run.endedAt !== null}>
+          Stop
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function buildRun(props: FullDashboardStoryProps): AutoresearchRun {
+  const ended =
+    props.status === "completed" ||
+    props.status === "stopped" ||
+    props.status === "failed";
+  return {
+    id: "run-configurable-dashboard",
+    config: {
+      taskId: "task-1",
+      direction: props.direction,
+      targetValue: props.showTarget ? props.targetValue : null,
+      maxIterations: props.maxIterations,
+      implementModel: null,
+      measureModel: null,
+      implementEffort: null,
+      measureEffort: null,
+      instructions: `Optimize ${props.metricName}.`,
+    },
+    status: props.status,
+    metricName: props.metricName,
+    metricUnit: props.metricUnit || null,
+    phase: null,
+    originalModel: null,
+    originalEffort: null,
+    researchFindings: props.showResearch
+      ? [
+          {
+            index: 1,
+            area: "build",
+            summary: "Located the measurement path",
+            finding:
+              "The metric can be reproduced from production build output.",
+            nextStep: "Measure the baseline",
+            at: STARTED_AT + 60_000,
+          },
+          {
+            index: 2,
+            area: "frontend",
+            summary: "Mapped the eager dependency graph",
+            finding: "Several modal modules load before the user opens them.",
+            nextStep: "Test a lazy loading boundary",
+            at: STARTED_AT + 3 * 60_000,
+          },
+        ]
+      : [],
+    iterations: buildIterations(props),
+    startedAt: STARTED_AT,
+    endedAt: ended ? STORY_NOW : null,
+    endReason:
+      props.status === "completed"
+        ? "max-iterations"
+        : props.status === "stopped"
+          ? "stopped-by-user"
+          : null,
+    interruptedReason: props.status === "interrupted" ? "session-error" : null,
+    lastError:
+      props.status === "failed"
+        ? "The agent stopped reporting the metric."
+        : null,
+  };
+}
+
+function buildIterations(
+  props: FullDashboardStoryProps,
+): AutoresearchIteration[] {
+  let best: number | null = null;
+  let previous: number | null = null;
+  return Array.from({ length: props.iterationCount }, (_, offset) => {
+    const index = offset + 1;
+    const directionMultiplier = props.direction === "minimize" ? -1 : 1;
+    const noise =
+      offset > 0 && offset % 3 === 0 ? props.changePerIteration * -0.35 : 0;
+    const value =
+      props.baselineValue +
+      directionMultiplier * props.changePerIteration * offset +
+      noise;
+    const improved =
+      best === null ||
+      (props.direction === "minimize" ? value < best : value > best);
+    if (improved) best = value;
+    const iteration: AutoresearchIteration = {
+      index,
+      value,
+      bestValue: best ?? value,
+      delta: previous === null ? null : value - previous,
+      summary:
+        index === 1
+          ? "Established the baseline"
+          : index % 3 === 1
+            ? "Measured a regression and changed direction"
+            : `Completed focused experiment ${index}`,
+      hypothesis:
+        index === 1
+          ? "The baseline captures the current production behavior"
+          : props.hypothesis,
+      plan:
+        index === 1
+          ? "Run the reproducible baseline measurement"
+          : props.iterationPlan,
+      approach: index === 1 ? "baseline" : props.approach,
+      at: STARTED_AT + index * 3 * 60_000,
+    };
+    previous = value;
+    return iteration;
+  });
+}
+
+function buildEvents(props: FullDashboardStoryProps): AcpMessage[] {
+  if (!props.showActivity) return [];
+  return [
+    sessionEvent(STARTED_AT + 12 * 60_000, {
+      sessionUpdate: "agent_message_chunk",
+      content: {
+        type: "text",
+        text: `\`\`\`autoresearch\ntype: plan\nhypothesis: ${props.hypothesis}\nplan: ${props.iterationPlan}\napproach: ${props.approach}\n\`\`\``,
+      },
+    }),
+    sessionEvent(STARTED_AT + 13 * 60_000, {
+      sessionUpdate: "tool_call",
+      title: "Search relevant modules",
+      kind: "search",
+      status: "completed",
+    }),
+    sessionEvent(STARTED_AT + 17 * 60_000, {
+      sessionUpdate: "tool_call",
+      title: "Edit the selected implementation",
+      kind: "edit",
+      status: "completed",
+    }),
+    sessionEvent(STARTED_AT + 22 * 60_000, {
+      sessionUpdate: "tool_call",
+      title: "Run the metric measurement",
+      kind: "execute",
+      status: props.status === "running" ? "in_progress" : "completed",
+    }),
+  ];
+}
+
+function sessionEvent(ts: number, update: Record<string, unknown>): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: { update },
+    },
+  } as AcpMessage;
+}
+
+const meta = {
+  title: "Autoresearch/Configurable Full Dashboard",
+  component: FullDashboardStory,
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    status: {
+      control: "select",
+      options: [
+        "running",
+        "paused",
+        "interrupted",
+        "completed",
+        "stopped",
+        "failed",
+      ],
+    },
+    direction: { control: "inline-radio", options: ["minimize", "maximize"] },
+    iterationCount: { control: { type: "range", min: 0, max: 12, step: 1 } },
+    maxIterations: { control: { type: "range", min: 1, max: 20, step: 1 } },
+    baselineValue: { control: { type: "number", step: 10 } },
+    changePerIteration: { control: { type: "number", step: 1 } },
+    targetValue: { control: { type: "number", step: 10 } },
+    contextUsed: { control: { type: "number", step: 1_000 } },
+    contextSize: { control: { type: "number", step: 10_000 } },
+  },
+  args: {
+    status: "running",
+    direction: "minimize",
+    iterationCount: 4,
+    maxIterations: 10,
+    baselineValue: 3850.7,
+    changePerIteration: 145,
+    targetValue: 3000,
+    showTarget: true,
+    metricName: "dashboard bundle",
+    metricUnit: "KiB",
+    showResearch: true,
+    showActivity: true,
+    showContextUsage: true,
+    contextUsed: 175_000,
+    contextSize: 1_000_000,
+    hypothesis: "Eager modal imports dominate the dashboard entry bundle",
+    iterationPlan:
+      "Lazy load dashboard modals and rerun the production bundle measurement",
+    approach: "code splitting",
+  },
+} satisfies Meta<typeof FullDashboardStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const BeforeBaseline: Story = {
+  args: { iterationCount: 0, showResearch: true, status: "running" },
+};
+
+export const CompletedRun: Story = {
+  args: { status: "completed", iterationCount: 8 },
+};

--- a/packages/ui/src/features/autoresearch/AutoresearchHeaderButton.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchHeaderButton.tsx
@@ -18,7 +18,7 @@ interface AutoresearchHeaderButtonProps {
 
 /**
  * Task-header shortcut to the autoresearch dashboard. Only rendered for
- * tasks that have a run — autoresearch tasks are created from the composer,
+ * tasks that have a run. Autoresearch tasks are created from the composer,
  * not retrofitted onto existing tasks.
  */
 export function AutoresearchHeaderButton({

--- a/packages/ui/src/features/autoresearch/AutoresearchObservability.stories.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchObservability.stories.tsx
@@ -1,0 +1,93 @@
+import type { AutoresearchRun } from "@posthog/core/autoresearch/schemas";
+import type { AcpMessage } from "@posthog/shared";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AutoresearchObservability } from "./AutoresearchObservability";
+
+const STARTED_AT = Date.parse("2026-07-10T14:00:00Z");
+
+const run: AutoresearchRun = {
+  id: "run-observability",
+  config: {
+    taskId: "task-1",
+    direction: "minimize",
+    targetValue: 300,
+    maxIterations: 10,
+    implementModel: null,
+    measureModel: null,
+    implementEffort: null,
+    measureEffort: null,
+    instructions: "Reduce dashboard loading time.",
+  },
+  status: "running",
+  metricName: "dashboard bundle",
+  metricUnit: "KiB",
+  phase: null,
+  originalModel: null,
+  originalEffort: null,
+  researchFindings: [],
+  iterations: [],
+  startedAt: STARTED_AT,
+  endedAt: STARTED_AT + 10 * 60_000,
+  endReason: null,
+  interruptedReason: null,
+  lastError: null,
+};
+
+function event(ts: number, update: Record<string, unknown>): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: { update },
+    },
+  } as AcpMessage;
+}
+
+const events = [
+  event(STARTED_AT + 30_000, {
+    sessionUpdate: "agent_message_chunk",
+    content: {
+      type: "text",
+      text: "```autoresearch\ntype: plan\nhypothesis: eager modal imports dominate the dashboard entry bundle\nplan: lazy load dashboard modals and rerun the bundle measurement\napproach: code splitting\n```",
+    },
+  }),
+  event(STARTED_AT + 60_000, {
+    sessionUpdate: "tool_call",
+    title: "Search dashboard imports",
+    kind: "search",
+    status: "completed",
+  }),
+  event(STARTED_AT + 3 * 60_000, {
+    sessionUpdate: "tool_call",
+    title: "Edit DashboardScene",
+    kind: "edit",
+    status: "completed",
+  }),
+  event(STARTED_AT + 7 * 60_000, {
+    sessionUpdate: "tool_call",
+    title: "Measure dashboard bundle",
+    kind: "execute",
+    status: "in_progress",
+  }),
+];
+
+const meta: Meta<typeof AutoresearchObservability> = {
+  title: "Autoresearch/Observability",
+  component: AutoresearchObservability,
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-[760px] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AutoresearchObservability>;
+
+export const ActiveExperiment: Story = { args: { run, events } };
+
+export const WaitingForPlan: Story = { args: { run, events: [] } };

--- a/packages/ui/src/features/autoresearch/AutoresearchObservability.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchObservability.tsx
@@ -1,0 +1,182 @@
+import {
+  Binoculars,
+  Code,
+  Compass,
+  Lightbulb,
+  ListChecks,
+  MagnifyingGlass,
+  TestTube,
+} from "@phosphor-icons/react";
+import type { AutoresearchRun } from "@posthog/core/autoresearch/schemas";
+import type { AcpMessage } from "@posthog/shared";
+import { Badge, Progress, Text } from "@radix-ui/themes";
+import { useEffect, useMemo, useState } from "react";
+import { formatDuration } from "../sessions/components/GeneratingIndicator";
+import {
+  type AutoresearchActivityKind,
+  analyzeAutoresearchActivity,
+} from "./autoresearchActivity";
+
+export function AutoresearchObservability({
+  run,
+  events,
+}: {
+  run: AutoresearchRun;
+  events: AcpMessage[];
+}) {
+  const now = useLiveNow(run.endedAt === null);
+  const activity = useMemo(
+    () => analyzeAutoresearchActivity(events, run.startedAt, run.endedAt, now),
+    [events, now, run.endedAt, run.startedAt],
+  );
+  const lastIteration = run.iterations.at(-1);
+  const hypothesis =
+    activity.currentPlan?.hypothesis ?? lastIteration?.hypothesis;
+  const plan = activity.currentPlan?.plan ?? lastIteration?.plan;
+  const approach = activity.currentPlan?.approach ?? lastIteration?.approach;
+
+  return (
+    <div className="grid gap-3 lg:grid-cols-2">
+      <section className="rounded-md border border-gray-5 p-3">
+        <SectionTitle
+          icon={<Lightbulb size={15} />}
+          title="Current experiment"
+        />
+        <Detail
+          label="Hypothesis"
+          value={hypothesis ?? "Waiting for the agent to state a hypothesis."}
+        />
+        <Detail
+          label="Iteration plan"
+          value={
+            plan ?? "The next focused experiment has not been announced yet."
+          }
+        />
+        {approach && (
+          <div className="mt-3">
+            <Badge color="gray" variant="soft">
+              {approach}
+            </Badge>
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-md border border-gray-5 p-3">
+        <SectionTitle icon={<Compass size={15} />} title="Observed time" />
+        <div className="mt-3 flex flex-col gap-2.5">
+          {(Object.keys(activity.timeByKind) as AutoresearchActivityKind[]).map(
+            (kind) => (
+              <TimeRow
+                key={kind}
+                kind={kind}
+                value={activity.timeByKind[kind]}
+                total={Math.max(1, (run.endedAt ?? now) - run.startedAt)}
+              />
+            ),
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-md border border-gray-5 p-3 lg:col-span-2">
+        <SectionTitle icon={<ListChecks size={15} />} title="Live activity" />
+        {activity.items.length === 0 ? (
+          <Text as="p" size="1" color="gray" className="mt-2">
+            Waiting for the first observable tool action.
+          </Text>
+        ) : (
+          <ol className="mt-2 grid gap-2 sm:grid-cols-2">
+            {activity.items.map((item) => (
+              <li
+                key={item.id}
+                className="flex items-center gap-2 rounded-sm bg-gray-2 px-2.5 py-2"
+              >
+                <ActivityIcon kind={item.kind} />
+                <Text size="1" className="min-w-0 flex-1 truncate">
+                  {item.label}
+                </Text>
+                {item.active && <Badge color="blue">Active</Badge>}
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function SectionTitle({
+  icon,
+  title,
+}: {
+  icon: React.ReactNode;
+  title: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-gray-11">
+      {icon}
+      <Text size="2" weight="medium">
+        {title}
+      </Text>
+    </div>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="mt-3">
+      <Text as="div" size="1" color="gray">
+        {label}
+      </Text>
+      <Text as="p" size="2" className="mt-0.5 leading-5">
+        {value}
+      </Text>
+    </div>
+  );
+}
+
+const TIME_LABEL: Record<AutoresearchActivityKind, string> = {
+  research: "Research",
+  implementation: "Implementation",
+  measurement: "Commands and measurement",
+  reasoning: "Reasoning and coordination",
+};
+
+function TimeRow({
+  kind,
+  value,
+  total,
+}: {
+  kind: AutoresearchActivityKind;
+  value: number;
+  total: number;
+}) {
+  const percentage = Math.round((value / total) * 100);
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <Text size="1">{TIME_LABEL[kind]}</Text>
+        <Text size="1" color="gray" className="tabular-nums">
+          {formatDuration(value, 0)}
+        </Text>
+      </div>
+      <Progress value={percentage} size="1" color="gray" />
+    </div>
+  );
+}
+
+function ActivityIcon({ kind }: { kind: AutoresearchActivityKind }) {
+  if (kind === "research") return <MagnifyingGlass size={14} />;
+  if (kind === "implementation") return <Code size={14} />;
+  if (kind === "measurement") return <TestTube size={14} />;
+  return <Binoculars size={14} />;
+}
+
+function useLiveNow(live: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!live) return;
+    const interval = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(interval);
+  }, [live]);
+  return now;
+}

--- a/packages/ui/src/features/autoresearch/AutoresearchPanel.stories.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchPanel.stories.tsx
@@ -5,15 +5,33 @@ import type {
 import { Flex } from "@radix-ui/themes";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { RunStats } from "./AutoresearchPanel";
+import { AutoresearchRuntimeStats } from "./AutoresearchRuntimeStats";
 import { IterationsTable } from "./IterationsTable";
 import { MetricChart } from "./MetricChart";
+import { PreBaselineState } from "./PreBaselineState";
 
 /**
- * The run dashboard's presentational stack — stat cards, metric chart, and
- * iterations table — as `AutoresearchPanel` composes them, minus the header
+ * The run dashboard presentational stack includes stat cards, the metric
+ * chart, and the iterations table. It matches `AutoresearchPanel` without header
  * controls and dialogs (which need a live service).
  */
 function RunDashboard({ run }: { run: AutoresearchRun }) {
+  if (run.iterations.length === 0) {
+    return (
+      <Flex direction="column" gap="4">
+        <PreBaselineState
+          run={run}
+          sessionActivity={{
+            status: "connected",
+            isPromptPending: true,
+            isCompacting: false,
+          }}
+        />
+        <AutoresearchRuntimeStats run={run} usage={null} />
+      </Flex>
+    );
+  }
+
   return (
     <Flex direction="column" gap="4">
       <RunStats run={run} />
@@ -23,6 +41,16 @@ function RunDashboard({ run }: { run: AutoresearchRun }) {
         targetValue={run.config.targetValue}
         metricName={run.metricName ?? "the metric"}
         unit={run.metricUnit}
+      />
+      <AutoresearchRuntimeStats
+        run={run}
+        usage={{
+          used: 42_800,
+          size: 200_000,
+          percentage: 21,
+          cost: null,
+          breakdown: null,
+        }}
       />
       <IterationsTable
         iterations={run.iterations}
@@ -76,6 +104,7 @@ const run = (overrides: Partial<AutoresearchRun> = {}): AutoresearchRun => ({
   phase: null,
   originalModel: null,
   originalEffort: null,
+  researchFindings: [],
   iterations: [],
   startedAt: BASE_AT,
   endedAt: null,
@@ -101,7 +130,7 @@ const meta: Meta<typeof RunDashboard> = {
 export default meta;
 type Story = StoryObj<typeof RunDashboard>;
 
-/** A minimize run mid-flight: noisy progress, best-so-far frontier, target line. */
+/** A minimize run in progress with noisy results, the best frontier, and a target. */
 export const MinimizeInProgress: Story = {
   args: {
     run: run({
@@ -123,7 +152,7 @@ export const MinimizeInProgress: Story = {
   },
 };
 
-/** A completed maximize run with no target — the loop spent its budget. */
+/** A completed maximize run with no target. The loop spent its budget. */
 export const MaximizeCompleted: Story = {
   args: {
     run: run({
@@ -158,7 +187,7 @@ export const MaximizeCompleted: Story = {
   },
 };
 
-/** Before the first metric report arrives: empty cards, chart, and table. */
+/** Before the first metric report arrives: active baseline measurement. */
 export const NoIterationsYet: Story = {
   args: { run: run() },
 };

--- a/packages/ui/src/features/autoresearch/AutoresearchPanel.test.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchPanel.test.tsx
@@ -1,0 +1,131 @@
+import type { AutoresearchRun } from "@posthog/core/autoresearch/schemas";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PreBaselineState } from "./PreBaselineState";
+
+function makeRun(overrides: Partial<AutoresearchRun> = {}): AutoresearchRun {
+  return {
+    id: "run-1",
+    config: {
+      taskId: "task-1",
+      direction: "minimize",
+      targetValue: null,
+      maxIterations: 10,
+      implementModel: null,
+      measureModel: null,
+      implementEffort: null,
+      measureEffort: null,
+      instructions: "Reduce memory usage.",
+    },
+    status: "running",
+    metricName: null,
+    metricUnit: null,
+    phase: null,
+    originalModel: null,
+    originalEffort: null,
+    researchFindings: [],
+    iterations: [],
+    startedAt: 0,
+    endedAt: null,
+    endReason: null,
+    interruptedReason: null,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+function renderState(
+  run: AutoresearchRun,
+  sessionActivity: React.ComponentProps<
+    typeof PreBaselineState
+  >["sessionActivity"],
+) {
+  return render(
+    <Theme>
+      <PreBaselineState run={run} sessionActivity={sessionActivity} />
+    </Theme>,
+  );
+}
+
+describe("PreBaselineState", () => {
+  it("shows active baseline progress and loading dashboard placeholders", () => {
+    renderState(makeRun(), {
+      status: "connected",
+      isPromptPending: true,
+      isCompacting: false,
+    });
+
+    expect(screen.getByText("Establishing the baseline")).toBeVisible();
+    expect(
+      screen.getByRole("status", { name: "Loading autoresearch metrics" }),
+    ).toBeVisible();
+    expect(screen.getByText("0 / 10")).toBeVisible();
+  });
+
+  it("surfaces codebase research while the baseline is pending", () => {
+    renderState(
+      makeRun({
+        researchFindings: [
+          {
+            index: 1,
+            summary: "Mapped the execution path",
+            finding: "The metric is computed in the workspace server.",
+            nextStep: "Trace the benchmark command",
+            area: "workspace server",
+            at: 1,
+          },
+        ],
+      }),
+      {
+        status: "connected",
+        isPromptPending: true,
+        isCompacting: false,
+      },
+    );
+
+    expect(screen.getByText("Researching the codebase")).toBeVisible();
+    expect(screen.getByText("Codebase research")).toBeVisible();
+    expect(screen.getByText("Mapped the execution path")).toBeVisible();
+    expect(
+      screen.getByText("The metric is computed in the workspace server."),
+    ).toBeVisible();
+    expect(screen.getByText("Next: Trace the benchmark command")).toBeVisible();
+    const metrics = screen.getByRole("status", {
+      name: "Loading autoresearch metrics",
+    });
+    const research = screen.getByText("Codebase research");
+    expect(
+      metrics.compareDocumentPosition(research) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("explains when baseline collection is paused", () => {
+    renderState(makeRun({ status: "paused" }), null);
+
+    expect(screen.getByText("Baseline measurement paused")).toBeVisible();
+    expect(
+      screen.queryByRole("status", { name: "Loading autoresearch metrics" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not imply loading after a run ends without a report", () => {
+    renderState(
+      makeRun({
+        status: "failed",
+        endReason: "missing-report",
+        endedAt: 1,
+        lastError: "The agent did not report a metric.",
+      }),
+      null,
+    );
+
+    expect(
+      screen.getByText("Run ended before the baseline was reported"),
+    ).toBeVisible();
+    expect(
+      screen.getByText("No metric report was recorded for this run."),
+    ).toBeVisible();
+  });
+});

--- a/packages/ui/src/features/autoresearch/AutoresearchPanel.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchPanel.tsx
@@ -15,17 +15,22 @@ import {
   EmptyTitle,
 } from "@posthog/quill";
 import { MetricCard } from "@posthog/quill-charts";
+import type { AcpMessage } from "@posthog/shared";
 import { Badge, Button, Callout, Flex, Select, Text } from "@radix-ui/themes";
 import { useEffect, useMemo, useState } from "react";
+import { useContextUsage } from "../sessions/hooks/useContextUsage";
 import {
   getConfigOptionByCategory,
   useSessionStore,
 } from "../sessions/sessionStore";
 import { usePendingPermissionsForTask } from "../sessions/useSession";
 import { AutoresearchConfigDialog } from "./AutoresearchConfigDialog";
+import { AutoresearchObservability } from "./AutoresearchObservability";
+import { AutoresearchRuntimeStats } from "./AutoresearchRuntimeStats";
 import { IterationsTable } from "./IterationsTable";
 import { MetricChart } from "./MetricChart";
 import { metricNumberFormat, withMetricUnit } from "./metricFormat";
+import { PreBaselineState } from "./PreBaselineState";
 import {
   type AutoresearchModelOption,
   stageValueLabel,
@@ -33,6 +38,8 @@ import {
 } from "./stageModels";
 import { useAutoresearchEnabled } from "./useAutoresearchEnabled";
 import { useAutoresearchRuns } from "./useAutoresearchStore";
+
+const EMPTY_SESSION_EVENTS: AcpMessage[] = [];
 
 const STATUS_BADGE: Record<
   AutoresearchRunStatus,
@@ -92,6 +99,24 @@ export function AutoresearchPanel({ taskId }: AutoresearchPanelProps) {
     const session = taskRunId ? state.sessions[taskRunId] : undefined;
     return getConfigOptionByCategory(session?.configOptions, "thought_level");
   });
+  const sessionActivity = useSessionStore((state) => {
+    const taskRunId = state.taskIdIndex[taskId];
+    const session = taskRunId ? state.sessions[taskRunId] : undefined;
+    return session
+      ? {
+          status: session.status,
+          isPromptPending: session.isPromptPending,
+          isCompacting: session.isCompacting,
+        }
+      : null;
+  });
+  const sessionEvents = useSessionStore((state) => {
+    const taskRunId = state.taskIdIndex[taskId];
+    return taskRunId
+      ? (state.sessions[taskRunId]?.events ?? EMPTY_SESSION_EVENTS)
+      : EMPTY_SESSION_EVENTS;
+  });
+  const contextUsage = useContextUsage(sessionEvents);
   const modelOptions = useMemo(
     () => toStageSelectOptions(modelOption),
     [modelOption],
@@ -100,7 +125,7 @@ export function AutoresearchPanel({ taskId }: AutoresearchPanelProps) {
     () => toStageSelectOptions(thoughtOption),
     [thoughtOption],
   );
-  // What the session is actually on right now — the loop switches these
+  // What the session is actually on right now. The loop switches these
   // between stages, and this reflects the switches live.
   const liveModel =
     modelOption?.type === "select" ? (modelOption.currentValue ?? null) : null;
@@ -113,6 +138,13 @@ export function AutoresearchPanel({ taskId }: AutoresearchPanelProps) {
   const selectedRun =
     (selectedRunId && runs.find((run) => run.id === selectedRunId)) ||
     latestRun;
+  const selectedRunUsage =
+    selectedRun?.id === latestRun?.id &&
+    (selectedRun?.status === "running" ||
+      selectedRun?.status === "paused" ||
+      selectedRun?.status === "interrupted")
+      ? contextUsage
+      : null;
 
   // A persisted panel tab can outlive access to the feature (web, or the
   // flag turned off). With runs already in the store, keep the dashboard
@@ -143,7 +175,7 @@ export function AutoresearchPanel({ taskId }: AutoresearchPanelProps) {
           <EmptyTitle>No autoresearch run</EmptyTitle>
           <EmptyDescription>
             This task wasn't created in autoresearch mode. Start one from the
-            new-task composer: arm the Autoresearch toggle, describe what to
+            new task composer: arm the Autoresearch toggle, describe what to
             optimize and how to measure it, and submit.
           </EmptyDescription>
         </EmptyHeader>
@@ -166,19 +198,31 @@ export function AutoresearchPanel({ taskId }: AutoresearchPanelProps) {
           onNewRun={() => setDialogOpen(true)}
         />
         <PendingPermissionNotice taskId={taskId} run={selectedRun} />
-        <RunStats run={selectedRun} />
-        <MetricChart
-          iterations={selectedRun.iterations}
-          direction={selectedRun.config.direction}
-          targetValue={selectedRun.config.targetValue}
-          metricName={selectedRun.metricName ?? "the metric"}
-          unit={selectedRun.metricUnit}
-        />
-        <IterationsTable
-          iterations={selectedRun.iterations}
-          direction={selectedRun.config.direction}
-          unit={selectedRun.metricUnit}
-        />
+        {selectedRun.iterations.length === 0 ? (
+          <PreBaselineState
+            run={selectedRun}
+            sessionActivity={sessionActivity}
+          />
+        ) : (
+          <>
+            <RunStats run={selectedRun} />
+            <MetricChart
+              iterations={selectedRun.iterations}
+              direction={selectedRun.config.direction}
+              targetValue={selectedRun.config.targetValue}
+              metricName={selectedRun.metricName ?? "the metric"}
+              unit={selectedRun.metricUnit}
+            />
+            <IterationsTable
+              iterations={selectedRun.iterations}
+              direction={selectedRun.config.direction}
+              unit={selectedRun.metricUnit}
+            />
+            {selectedRun.endedAt !== null && <RunSummary run={selectedRun} />}
+          </>
+        )}
+        <AutoresearchRuntimeStats run={selectedRun} usage={selectedRunUsage} />
+        <AutoresearchObservability run={selectedRun} events={sessionEvents} />
       </Flex>
       <AutoresearchConfigDialog
         open={dialogOpen}
@@ -261,7 +305,7 @@ function RunHeader({
               <Select.Content>
                 {runs.map((candidate, index) => (
                   <Select.Item key={candidate.id} value={candidate.id}>
-                    Run {index + 1} — {STATUS_BADGE[candidate.status].label}
+                    Run {index + 1}: {STATUS_BADGE[candidate.status].label}
                   </Select.Item>
                 ))}
               </Select.Content>
@@ -327,21 +371,21 @@ function RunHeader({
           {liveEffort
             ? ` · ${stageValueLabel(liveEffort, effortOptions) ?? liveEffort} effort`
             : ""}
-          {isSplit && run.phase ? ` — ${run.phase} phase` : ""}
+          {isSplit && run.phase ? ` (${run.phase} phase)` : ""}
         </Text>
       )}
       {run.status === "interrupted" && (
         <Text size="1" color="orange">
           {INTERRUPTION_LABEL[run.interruptedReason ?? ""] ??
             "Loop interrupted"}
-          {run.lastError ? ` — ${run.lastError}` : ""}. Resumes automatically;
+          {run.lastError ? `. ${run.lastError}` : ""}. Resumes automatically;
           Resume retries now.
         </Text>
       )}
       {run.endReason && (
         <Text size="1" color="gray">
           {END_REASON_LABEL[run.endReason] ?? run.endReason}
-          {run.lastError ? ` — ${run.lastError}` : ""}
+          {run.lastError ? `. ${run.lastError}` : ""}
         </Text>
       )}
     </Flex>
@@ -380,7 +424,7 @@ export function RunStats({ run }: { run: AutoresearchRun }) {
   const unit = run.metricUnit;
   const formatMetricValue = (value: number) =>
     Number.isNaN(value)
-      ? "—"
+      ? "Not available"
       : withMetricUnit(metricNumberFormat.format(value), unit);
   const cardClassName = "rounded-md border border-(--gray-5) p-3";
 
@@ -420,6 +464,47 @@ export function RunStats({ run }: { run: AutoresearchRun }) {
         dataAttr="autoresearch-stat-target"
       />
     </div>
+  );
+}
+
+export function RunSummary({ run }: { run: AutoresearchRun }) {
+  const summary = summarizeRun(run);
+  const bestIteration = run.iterations.find(
+    (iteration) => iteration.index === summary.best?.index,
+  );
+  const approaches = Array.from(
+    new Set(
+      run.iterations.map((iteration) => iteration.approach).filter(Boolean),
+    ),
+  );
+  return (
+    <section className="rounded-md border border-gray-5 bg-gray-2 p-3">
+      <Text as="div" size="2" weight="medium">
+        Run summary
+      </Text>
+      <Text as="p" size="2" className="mt-2 leading-5">
+        {summary.best
+          ? `Best result was iteration ${summary.best.index} at ${withMetricUnit(metricNumberFormat.format(summary.best.value), run.metricUnit)}.`
+          : "The run ended without a metric result."}
+        {summary.improvementFromBaseline !== null
+          ? ` Change from baseline: ${withMetricUnit(metricNumberFormat.format(summary.improvementFromBaseline), run.metricUnit)}.`
+          : ""}
+      </Text>
+      {bestIteration?.hypothesis && (
+        <Text as="p" size="1" color="gray" className="mt-2 leading-4">
+          Best hypothesis: {bestIteration.hypothesis}
+        </Text>
+      )}
+      {approaches.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {approaches.map((approach) => (
+            <Badge key={approach} color="gray" variant="soft">
+              {approach}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/packages/ui/src/features/autoresearch/AutoresearchPanel.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchPanel.tsx
@@ -474,7 +474,9 @@ export function RunSummary({ run }: { run: AutoresearchRun }) {
   );
   const approaches = Array.from(
     new Set(
-      run.iterations.map((iteration) => iteration.approach).filter(Boolean),
+      run.iterations.flatMap((iteration) =>
+        iteration.approach ? [iteration.approach] : [],
+      ),
     ),
   );
   return (

--- a/packages/ui/src/features/autoresearch/AutoresearchResults.stories.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchResults.stories.tsx
@@ -1,0 +1,110 @@
+import type { AutoresearchRun } from "@posthog/core/autoresearch/schemas";
+import { Flex } from "@radix-ui/themes";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RunStats, RunSummary } from "./AutoresearchPanel";
+import { IterationsTable } from "./IterationsTable";
+
+const STARTED_AT = Date.parse("2026-07-10T14:00:00Z");
+const run: AutoresearchRun = {
+  id: "run-results",
+  config: {
+    taskId: "task-1",
+    direction: "minimize",
+    targetValue: 300,
+    maxIterations: 3,
+    implementModel: null,
+    measureModel: null,
+    implementEffort: null,
+    measureEffort: null,
+    instructions: "Reduce dashboard loading time.",
+  },
+  status: "completed",
+  metricName: "dashboard bundle",
+  metricUnit: "KiB",
+  phase: null,
+  originalModel: null,
+  originalEffort: null,
+  researchFindings: [],
+  iterations: [
+    {
+      index: 1,
+      value: 3850.7,
+      bestValue: 3850.7,
+      delta: null,
+      summary: "Established the baseline",
+      hypothesis: "The eager graph defines the current cost",
+      plan: "Measure the marginal dashboard bundle",
+      approach: "baseline",
+      at: STARTED_AT + 5 * 60_000,
+    },
+    {
+      index: 2,
+      value: 3320.4,
+      bestValue: 3320.4,
+      delta: -530.3,
+      summary: "Lazy loaded dashboard modals",
+      hypothesis: "Modal imports dominate the eager route",
+      plan: "Split modal imports and remeasure",
+      approach: "code splitting",
+      at: STARTED_AT + 15 * 60_000,
+    },
+    {
+      index: 3,
+      value: 3208.1,
+      bestValue: 3208.1,
+      delta: -112.3,
+      summary: "Deferred the insight editor",
+      hypothesis: "The editor is unused during initial dashboard render",
+      plan: "Load the editor when add insight opens",
+      approach: "lazy loading",
+      at: STARTED_AT + 25 * 60_000,
+    },
+  ],
+  startedAt: STARTED_AT,
+  endedAt: STARTED_AT + 26 * 60_000,
+  endReason: "max-iterations",
+  interruptedReason: null,
+  lastError: null,
+};
+
+function Results({ run }: { run: AutoresearchRun }) {
+  return (
+    <Flex direction="column" gap="4">
+      <RunStats run={run} />
+      <IterationsTable
+        iterations={run.iterations}
+        direction={run.config.direction}
+        unit={run.metricUnit}
+      />
+      <RunSummary run={run} />
+    </Flex>
+  );
+}
+
+const meta: Meta<typeof Results> = {
+  title: "Autoresearch/Results and Summary",
+  component: Results,
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-[760px] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Results>;
+
+export const CompletedRun: Story = { args: { run } };
+
+export const BaselineJustRecorded: Story = {
+  args: {
+    run: {
+      ...run,
+      status: "running",
+      endedAt: null,
+      iterations: [run.iterations[0]],
+    },
+  },
+};

--- a/packages/ui/src/features/autoresearch/AutoresearchRuntimeStats.stories.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchRuntimeStats.stories.tsx
@@ -1,0 +1,55 @@
+import type { AutoresearchRun } from "@posthog/core/autoresearch/schemas";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AutoresearchRuntimeStats } from "./AutoresearchRuntimeStats";
+
+const STARTED_AT = Date.parse("2026-07-10T14:00:00Z");
+const run: AutoresearchRun = {
+  id: "run-runtime",
+  config: {
+    taskId: "task-1",
+    direction: "minimize",
+    targetValue: null,
+    maxIterations: 10,
+    implementModel: null,
+    measureModel: null,
+    implementEffort: null,
+    measureEffort: null,
+    instructions: "Reduce dashboard loading time.",
+  },
+  status: "completed",
+  metricName: null,
+  metricUnit: null,
+  phase: null,
+  originalModel: null,
+  originalEffort: null,
+  researchFindings: [],
+  iterations: [],
+  startedAt: STARTED_AT,
+  endedAt: STARTED_AT + 26 * 60_000 + 17_000,
+  endReason: "max-iterations",
+  interruptedReason: null,
+  lastError: null,
+};
+
+const meta: Meta<typeof AutoresearchRuntimeStats> = {
+  title: "Autoresearch/Runtime Stats",
+  component: AutoresearchRuntimeStats,
+};
+
+export default meta;
+type Story = StoryObj<typeof AutoresearchRuntimeStats>;
+
+export const WithContextUsage: Story = {
+  args: {
+    run,
+    usage: {
+      used: 175_000,
+      size: 1_000_000,
+      percentage: 18,
+      cost: null,
+      breakdown: null,
+    },
+  },
+};
+
+export const BeforeUsageUpdate: Story = { args: { run, usage: null } };

--- a/packages/ui/src/features/autoresearch/AutoresearchRuntimeStats.test.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchRuntimeStats.test.tsx
@@ -1,0 +1,75 @@
+import type { AutoresearchRun } from "@posthog/core/autoresearch/schemas";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AutoresearchRuntimeStats } from "./AutoresearchRuntimeStats";
+
+function makeRun(overrides: Partial<AutoresearchRun> = {}): AutoresearchRun {
+  return {
+    id: "run-1",
+    config: {
+      taskId: "task-1",
+      direction: "minimize",
+      targetValue: null,
+      maxIterations: 10,
+      implementModel: null,
+      measureModel: null,
+      implementEffort: null,
+      measureEffort: null,
+      instructions: "Reduce memory usage.",
+    },
+    status: "running",
+    metricName: null,
+    metricUnit: null,
+    phase: null,
+    originalModel: null,
+    originalEffort: null,
+    researchFindings: [],
+    iterations: [],
+    startedAt: 1_000,
+    endedAt: null,
+    endReason: null,
+    interruptedReason: null,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+function renderStats(
+  run: AutoresearchRun,
+  usage: React.ComponentProps<typeof AutoresearchRuntimeStats>["usage"],
+) {
+  return render(
+    <Theme>
+      <AutoresearchRuntimeStats run={run} usage={usage} />
+    </Theme>,
+  );
+}
+
+describe("AutoresearchRuntimeStats", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("shows elapsed time and live usage reported by the runtime", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(66_000);
+    renderStats(makeRun(), {
+      used: 42_800,
+      size: 200_000,
+      percentage: 21,
+      cost: { amount: 1.284, currency: "USD" },
+      breakdown: null,
+    });
+
+    expect(screen.getByText("1m 05s")).toBeVisible();
+    expect(screen.getByText("43K / 200K")).toBeVisible();
+    expect(screen.getByText("21% of current window")).toBeVisible();
+  });
+
+  it("uses the end time and explains unavailable usage", () => {
+    renderStats(makeRun({ endedAt: 31_000, status: "completed" }), null);
+
+    expect(screen.getByText("30s")).toBeVisible();
+    expect(screen.getByText("Waiting")).toBeVisible();
+    expect(screen.getByText("Total run time")).toBeVisible();
+  });
+});

--- a/packages/ui/src/features/autoresearch/AutoresearchRuntimeStats.tsx
+++ b/packages/ui/src/features/autoresearch/AutoresearchRuntimeStats.tsx
@@ -1,0 +1,88 @@
+import { Clock, Gauge } from "@phosphor-icons/react";
+import type { AutoresearchRun } from "@posthog/core/autoresearch/schemas";
+import type { ContextUsage } from "@posthog/core/sessions/contextUsage";
+import { Text } from "@radix-ui/themes";
+import { useEffect, useState } from "react";
+import { formatDuration } from "../sessions/components/GeneratingIndicator";
+import { formatTokensCompact } from "../sessions/contextColors";
+
+export function AutoresearchRuntimeStats({
+  run,
+  usage,
+}: {
+  run: AutoresearchRun;
+  usage: ContextUsage | null;
+}) {
+  const elapsed = useRunElapsed(run);
+  const contextValue = usage
+    ? usage.size > 0
+      ? `${formatTokensCompact(usage.used)} / ${formatTokensCompact(usage.size)}`
+      : formatTokensCompact(usage.used)
+    : "Waiting";
+  const contextDetail = usage
+    ? usage.size > 0
+      ? `${usage.percentage}% of current window`
+      : "Current context"
+    : "No usage update yet";
+  return (
+    <section
+      className="grid grid-cols-1 gap-2 sm:grid-cols-2"
+      aria-label="Autoresearch runtime metrics"
+    >
+      <RuntimeMetric
+        icon={<Clock size={15} />}
+        label="Elapsed"
+        value={formatDuration(elapsed, 0)}
+        detail={
+          run.endedAt === null ? "Since this run started" : "Total run time"
+        }
+      />
+      <RuntimeMetric
+        icon={<Gauge size={15} />}
+        label="Context tokens"
+        value={contextValue}
+        detail={contextDetail}
+      />
+    </section>
+  );
+}
+
+function RuntimeMetric({
+  icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-md border border-gray-5 bg-gray-1 px-3 py-2.5">
+      <div className="flex items-center gap-1.5 text-gray-10">
+        {icon}
+        <Text size="1">{label}</Text>
+      </div>
+      <Text as="div" size="3" weight="medium" className="mt-1 tabular-nums">
+        {value}
+      </Text>
+      <Text as="div" size="1" color="gray" className="mt-0.5">
+        {detail}
+      </Text>
+    </div>
+  );
+}
+
+function useRunElapsed(run: AutoresearchRun): number {
+  const [now, setNow] = useState(() => Date.now());
+  const live = run.endedAt === null;
+
+  useEffect(() => {
+    if (!live) return;
+    const interval = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(interval);
+  }, [live]);
+
+  return Math.max(0, (run.endedAt ?? now) - run.startedAt);
+}

--- a/packages/ui/src/features/autoresearch/IterationsTable.tsx
+++ b/packages/ui/src/features/autoresearch/IterationsTable.tsx
@@ -87,13 +87,20 @@ export function IterationsTable({
               </Text>
             </Table.Cell>
             <Table.Cell className="max-w-[320px]">
-              <Text
-                size="1"
-                className="block truncate"
-                title={iteration.summary ?? undefined}
-              >
-                {iteration.summary ?? "—"}
-              </Text>
+              <div className="flex min-w-0 items-center gap-2">
+                {iteration.approach && (
+                  <Badge color="gray" size="1" variant="soft">
+                    {iteration.approach}
+                  </Badge>
+                )}
+                <Text
+                  size="1"
+                  className="block truncate"
+                  title={iteration.summary ?? undefined}
+                >
+                  {iteration.summary ?? "None"}
+                </Text>
+              </div>
             </Table.Cell>
             <Table.Cell>
               <Text size="1" color="gray">

--- a/packages/ui/src/features/autoresearch/MetricChart.tsx
+++ b/packages/ui/src/features/autoresearch/MetricChart.tsx
@@ -21,7 +21,7 @@ interface MetricChartProps {
 }
 
 /**
- * Metric value per iteration (solid, with dots) plus the best-so-far
+ * Metric value per iteration, shown as a solid line with dots, plus the best
  * frontier (dashed) and the optional target line.
  */
 export function MetricChart({
@@ -32,7 +32,7 @@ export function MetricChart({
   unit,
 }: MetricChartProps) {
   const theme = useChartTheme();
-  // Canvas colors must be concrete — `var(--…)` strings don't paint. The
+  // Canvas colors must be concrete because CSS variable strings do not paint. The
   // theme's palette is already resolved from CSS variables.
   const valueColor = theme.colors[0] ?? "#1d4aff";
   const bestColor = theme.axisColor ?? "#8b8d98";
@@ -89,7 +89,7 @@ export function MetricChart({
             showCrosshair: true,
             yTickFormatter: (value) =>
               withMetricUnit(formatChartValue(value), unit),
-            // Keep an off-scale target visible instead of clipping it.
+            // Keep a target outside the current scale visible instead of clipping it.
             valueDomain:
               targetValue === null ? undefined : { include: [targetValue] },
           }}

--- a/packages/ui/src/features/autoresearch/PreBaselineState.stories.tsx
+++ b/packages/ui/src/features/autoresearch/PreBaselineState.stories.tsx
@@ -1,0 +1,79 @@
+import type { AutoresearchRun } from "@posthog/core/autoresearch/schemas";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PreBaselineState } from "./PreBaselineState";
+
+const run: AutoresearchRun = {
+  id: "run-research",
+  config: {
+    taskId: "task-1",
+    direction: "minimize",
+    targetValue: null,
+    maxIterations: 10,
+    implementModel: null,
+    measureModel: null,
+    implementEffort: null,
+    measureEffort: null,
+    instructions: "Reduce dashboard loading time.",
+  },
+  status: "running",
+  metricName: null,
+  metricUnit: null,
+  phase: null,
+  originalModel: null,
+  originalEffort: null,
+  researchFindings: [
+    {
+      index: 1,
+      area: "build",
+      summary: "Located the production bundle measurement",
+      finding:
+        "The dashboard marginal bundle can be isolated from esbuild metadata.",
+      nextStep: "Establish the baseline bundle size",
+      at: 1,
+    },
+    {
+      index: 2,
+      area: "frontend",
+      summary: "Mapped eager dashboard imports",
+      finding: "Dashboard modals load before users open them.",
+      nextStep: "Inspect modal boundaries",
+      at: 2,
+    },
+  ],
+  iterations: [],
+  startedAt: Date.parse("2026-07-10T14:00:00Z"),
+  endedAt: null,
+  endReason: null,
+  interruptedReason: null,
+  lastError: null,
+};
+
+const meta: Meta<typeof PreBaselineState> = {
+  title: "Autoresearch/Research Map",
+  component: PreBaselineState,
+};
+
+export default meta;
+type Story = StoryObj<typeof PreBaselineState>;
+
+export const FindingsByCodeArea: Story = {
+  args: {
+    run,
+    sessionActivity: {
+      status: "connected",
+      isPromptPending: true,
+      isCompacting: false,
+    },
+  },
+};
+
+export const EstablishingBaseline: Story = {
+  args: {
+    run: { ...run, researchFindings: [] },
+    sessionActivity: {
+      status: "connected",
+      isPromptPending: true,
+      isCompacting: false,
+    },
+  },
+};

--- a/packages/ui/src/features/autoresearch/PreBaselineState.tsx
+++ b/packages/ui/src/features/autoresearch/PreBaselineState.tsx
@@ -1,0 +1,224 @@
+import { MagnifyingGlass } from "@phosphor-icons/react";
+import type { AutoresearchRun } from "@posthog/core/autoresearch/schemas";
+import { Badge, Skeleton, Spinner, Text } from "@radix-ui/themes";
+
+export interface SessionActivity {
+  status: "connecting" | "connected" | "disconnected" | "error";
+  isPromptPending: boolean;
+  isCompacting: boolean;
+}
+
+export function PreBaselineState({
+  run,
+  sessionActivity,
+}: {
+  run: AutoresearchRun;
+  sessionActivity: SessionActivity | null;
+}) {
+  const live = run.status === "running" || run.status === "interrupted";
+  const activity = baselineActivity(run, sessionActivity);
+
+  return (
+    <div className="flex flex-col gap-4" aria-live="polite">
+      <div className="flex items-start gap-3 rounded-md border border-blue-6 bg-blue-2 px-3 py-3">
+        {live && <Spinner size="2" className="mt-0.5 shrink-0" />}
+        <div>
+          <Text as="div" size="2" weight="medium">
+            {activity.title}
+          </Text>
+          <Text as="p" size="1" color="gray" className="mt-0.5 leading-4">
+            {activity.description}
+          </Text>
+        </div>
+      </div>
+
+      {live ? (
+        <BaselineDashboardSkeleton maxIterations={run.config.maxIterations} />
+      ) : (
+        <div className="rounded-md border border-gray-5 bg-gray-2 px-3 py-4 text-center">
+          <Text size="1" color="gray">
+            No metric report was recorded for this run.
+          </Text>
+        </div>
+      )}
+
+      {run.researchFindings.length > 0 && <ResearchFindings run={run} />}
+    </div>
+  );
+}
+
+function baselineActivity(
+  run: AutoresearchRun,
+  session: SessionActivity | null,
+): { title: string; description: string } {
+  if (run.status === "paused") {
+    return {
+      title: "Baseline measurement paused",
+      description: "Resume the run to collect the first metric value.",
+    };
+  }
+  if (run.status === "interrupted") {
+    return {
+      title: "Reconnecting before baseline measurement",
+      description:
+        "Autoresearch will resume automatically when the agent is available.",
+    };
+  }
+  if (run.status !== "running") {
+    return {
+      title: "Run ended before the baseline was reported",
+      description: run.lastError ?? "The agent did not return a metric value.",
+    };
+  }
+  if (!session || session.status === "connecting") {
+    return {
+      title: "Connecting to the agent",
+      description:
+        "The baseline measurement starts when the task session is ready.",
+    };
+  }
+  if (session.isCompacting) {
+    return {
+      title: "Preparing agent context",
+      description:
+        "The baseline measurement will continue after context compaction.",
+    };
+  }
+  if (session.isPromptPending) {
+    if (run.researchFindings.length > 0) {
+      const latest = run.researchFindings[run.researchFindings.length - 1];
+      return {
+        title: "Researching the codebase",
+        description:
+          latest?.nextStep ??
+          "The agent is continuing its investigation before measuring the baseline.",
+      };
+    }
+    return {
+      title: "Establishing the baseline",
+      description:
+        "The agent is running the measurement defined in the task prompt.",
+    };
+  }
+  return {
+    title: "Waiting for the first metric report",
+    description:
+      "The dashboard will populate when the agent reports the baseline value.",
+  };
+}
+
+function ResearchFindings({ run }: { run: AutoresearchRun }) {
+  const groups = Map.groupBy(
+    run.researchFindings,
+    (finding) => finding.area ?? "General",
+  );
+  return (
+    <section className="rounded-md border border-gray-5">
+      <div className="flex items-center gap-2 border-gray-5 border-b px-3 py-2">
+        <MagnifyingGlass size={14} className="text-gray-10" />
+        <Text size="2" weight="medium">
+          Codebase research
+        </Text>
+        <Text size="1" color="gray">
+          {run.researchFindings.length}{" "}
+          {run.researchFindings.length === 1 ? "finding" : "findings"}
+        </Text>
+      </div>
+      <div className="grid gap-2 p-2 sm:grid-cols-2">
+        {Array.from(groups.entries()).map(([area, findings]) => (
+          <section
+            key={area}
+            className="rounded-sm border border-gray-5 bg-gray-1"
+          >
+            <div className="flex items-center justify-between gap-2 border-gray-5 border-b px-2.5 py-2">
+              <Badge color="gray" size="1" variant="soft">
+                {area}
+              </Badge>
+              <Text size="1" color="gray">
+                {findings.length}
+              </Text>
+            </div>
+            <ol className="divide-y divide-gray-5">
+              {findings.map((finding) => (
+                <li key={finding.index} className="px-2.5 py-2">
+                  <Text size="1" weight="medium">
+                    {finding.summary}
+                  </Text>
+                  <Text as="p" size="1" color="gray" className="mt-1 leading-4">
+                    {finding.finding}
+                  </Text>
+                  {finding.nextStep && (
+                    <Text
+                      as="p"
+                      size="1"
+                      className="mt-1 text-blue-11 leading-4"
+                    >
+                      Next: {finding.nextStep}
+                    </Text>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </section>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function BaselineDashboardSkeleton({
+  maxIterations,
+}: {
+  maxIterations: number;
+}) {
+  return (
+    <output
+      className="flex flex-col gap-4"
+      aria-label="Loading autoresearch metrics"
+    >
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {[
+          ["Best", "w-16"],
+          ["Last", "w-16"],
+          ["Iterations", "w-12"],
+          ["Target", "w-14"],
+        ].map(([title, width]) => (
+          <div key={title} className="rounded-md border border-gray-5 p-3">
+            <Text as="div" size="1" color="gray">
+              {title}
+            </Text>
+            {title === "Iterations" ? (
+              <Text as="div" size="4" weight="medium" className="mt-1">
+                0 / {maxIterations}
+              </Text>
+            ) : (
+              <Skeleton className={`mt-2 h-6 ${width}`} />
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex h-[220px] flex-col justify-between rounded-md border border-gray-5 bg-gray-2 p-3">
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-5/6" />
+          <Skeleton className="h-3 w-2/3" />
+        </div>
+        <div className="flex items-end gap-2">
+          {["h-8", "h-12", "h-16", "h-20", "h-24"].map((height) => (
+            <Skeleton key={height} className={`w-full ${height}`} />
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-md border border-gray-5 p-3">
+        <div className="flex items-center justify-between gap-4">
+          <Skeleton className="h-3 w-8" />
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-3 w-12" />
+          <Skeleton className="h-3 w-40" />
+        </div>
+      </div>
+    </output>
+  );
+}

--- a/packages/ui/src/features/autoresearch/autoresearchActivity.test.ts
+++ b/packages/ui/src/features/autoresearch/autoresearchActivity.test.ts
@@ -67,4 +67,33 @@ describe("analyzeAutoresearchActivity", () => {
       measurement: 3_000,
     });
   });
+
+  it("excludes activity after a historical run ended", () => {
+    const events = [
+      updateEvent(2_000, {
+        sessionUpdate: "tool_call",
+        title: "Run benchmark",
+        kind: "execute",
+        status: "completed",
+      }),
+      updateEvent(6_000, {
+        sessionUpdate: "tool_call",
+        title: "Later manual edit",
+        kind: "edit",
+        status: "completed",
+      }),
+    ];
+
+    const result = analyzeAutoresearchActivity(events, 1_000, 4_000, 10_000);
+
+    expect(result.items).toEqual([
+      expect.objectContaining({ label: "Run benchmark" }),
+    ]);
+    expect(result.timeByKind).toEqual({
+      reasoning: 1_000,
+      research: 0,
+      implementation: 0,
+      measurement: 2_000,
+    });
+  });
 });

--- a/packages/ui/src/features/autoresearch/autoresearchActivity.test.ts
+++ b/packages/ui/src/features/autoresearch/autoresearchActivity.test.ts
@@ -1,0 +1,70 @@
+import type { AcpMessage } from "@posthog/shared";
+import { describe, expect, it } from "vitest";
+import { analyzeAutoresearchActivity } from "./autoresearchActivity";
+
+function updateEvent(ts: number, update: Record<string, unknown>): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: { update },
+    },
+  } as AcpMessage;
+}
+
+describe("analyzeAutoresearchActivity", () => {
+  it("extracts the current plan and classifies observable work", () => {
+    const events = [
+      updateEvent(2_000, {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "```autoresearch\ntype: plan\nhypothesis: selectors cause rerenders\nplan: memoize selectors and benchmark\napproach: rendering\n```",
+        },
+      }),
+      updateEvent(3_000, {
+        sessionUpdate: "tool_call",
+        title: "Search for selectors",
+        kind: "search",
+        status: "completed",
+      }),
+      updateEvent(5_000, {
+        sessionUpdate: "tool_call",
+        title: "Edit selector module",
+        kind: "edit",
+        status: "completed",
+      }),
+      updateEvent(8_000, {
+        sessionUpdate: "tool_call",
+        title: "Run benchmark",
+        kind: "execute",
+        status: "in_progress",
+      }),
+    ];
+
+    const result = analyzeAutoresearchActivity(events, 1_000, null, 11_000);
+
+    expect(result.currentPlan).toEqual({
+      hypothesis: "selectors cause rerenders",
+      plan: "memoize selectors and benchmark",
+      approach: "rendering",
+    });
+    expect(result.items.map((item) => item.kind)).toEqual([
+      "measurement",
+      "implementation",
+      "research",
+    ]);
+    expect(result.items[0]).toMatchObject({
+      label: "Run benchmark",
+      active: true,
+    });
+    expect(result.timeByKind).toEqual({
+      reasoning: 2_000,
+      research: 2_000,
+      implementation: 3_000,
+      measurement: 3_000,
+    });
+  });
+});

--- a/packages/ui/src/features/autoresearch/autoresearchActivity.ts
+++ b/packages/ui/src/features/autoresearch/autoresearchActivity.ts
@@ -1,0 +1,112 @@
+import { parsePlanReport } from "@posthog/core/autoresearch/prompts";
+import type { AcpMessage } from "@posthog/shared";
+
+export type AutoresearchActivityKind =
+  | "research"
+  | "implementation"
+  | "measurement"
+  | "reasoning";
+
+export interface AutoresearchActivityItem {
+  id: string;
+  kind: AutoresearchActivityKind;
+  label: string;
+  at: number;
+  active: boolean;
+}
+
+export interface AutoresearchActivitySnapshot {
+  currentPlan: ReturnType<typeof parsePlanReport>;
+  items: AutoresearchActivityItem[];
+  timeByKind: Record<AutoresearchActivityKind, number>;
+}
+
+export function analyzeAutoresearchActivity(
+  events: AcpMessage[],
+  startedAt: number,
+  endedAt: number | null,
+  now: number,
+): AutoresearchActivitySnapshot {
+  const relevant = events.filter((event) => event.ts >= startedAt);
+  const items: AutoresearchActivityItem[] = [];
+  const agentText: string[] = [];
+
+  for (const event of relevant) {
+    const message = event.message;
+    if (!("method" in message) || message.method !== "session/update") continue;
+    const params = message.params as
+      | {
+          update?: {
+            sessionUpdate?: string;
+            title?: string;
+            kind?: string | null;
+            status?: string | null;
+            content?: { type?: string; text?: string };
+          };
+        }
+      | undefined;
+    const update = params?.update;
+    if (!update) continue;
+
+    if (
+      update.sessionUpdate === "agent_message_chunk" &&
+      update.content?.type === "text" &&
+      update.content.text
+    ) {
+      agentText.push(update.content.text);
+      continue;
+    }
+
+    if (update.sessionUpdate !== "tool_call") continue;
+    const kind = activityKindForTool(update.kind);
+    items.push({
+      id: `${event.ts}:${update.title ?? "tool"}`,
+      kind,
+      label: update.title || activityLabel(kind),
+      at: event.ts,
+      active: update.status === "in_progress" || update.status === "pending",
+    });
+  }
+
+  const currentPlan = parsePlanReport(agentText.join(""));
+  const end = endedAt ?? now;
+  const boundaries = items.map((item) => ({ at: item.at, kind: item.kind }));
+  const timeByKind: Record<AutoresearchActivityKind, number> = {
+    research: 0,
+    implementation: 0,
+    measurement: 0,
+    reasoning: 0,
+  };
+  let cursor = startedAt;
+  let kind: AutoresearchActivityKind = "reasoning";
+  for (const boundary of boundaries) {
+    timeByKind[kind] += Math.max(0, boundary.at - cursor);
+    cursor = boundary.at;
+    kind = boundary.kind;
+  }
+  timeByKind[kind] += Math.max(0, end - cursor);
+
+  return {
+    currentPlan,
+    items: items.slice(-8).reverse(),
+    timeByKind,
+  };
+}
+
+function activityKindForTool(kind?: string | null): AutoresearchActivityKind {
+  if (kind === "edit" || kind === "delete" || kind === "move") {
+    return "implementation";
+  }
+  if (kind === "execute") return "measurement";
+  if (kind === "read" || kind === "search" || kind === "fetch") {
+    return "research";
+  }
+  return "reasoning";
+}
+
+function activityLabel(kind: AutoresearchActivityKind): string {
+  if (kind === "implementation") return "Editing code";
+  if (kind === "measurement") return "Running a command";
+  if (kind === "research") return "Inspecting the codebase";
+  return "Working";
+}

--- a/packages/ui/src/features/autoresearch/autoresearchActivity.ts
+++ b/packages/ui/src/features/autoresearch/autoresearchActivity.ts
@@ -27,7 +27,10 @@ export function analyzeAutoresearchActivity(
   endedAt: number | null,
   now: number,
 ): AutoresearchActivitySnapshot {
-  const relevant = events.filter((event) => event.ts >= startedAt);
+  const relevant = events.filter(
+    (event) =>
+      event.ts >= startedAt && (endedAt === null || event.ts <= endedAt),
+  );
   const items: AutoresearchActivityItem[] = [];
   const agentText: string[] = [];
 

--- a/packages/ui/src/features/autoresearch/autoresearchDraftStore.ts
+++ b/packages/ui/src/features/autoresearch/autoresearchDraftStore.ts
@@ -2,7 +2,7 @@ import type { AutoresearchDraftConfig } from "@posthog/core/autoresearch/schemas
 import { create } from "zustand";
 
 /**
- * Autoresearch mode armed on a new-task composer, keyed by the composer's
+ * Autoresearch mode armed on a new task composer, keyed by the composer
  * draft session id. Submitting the composer turns the draft into a run.
  */
 interface AutoresearchDraftState {

--- a/packages/ui/src/features/autoresearch/metricFormat.test.ts
+++ b/packages/ui/src/features/autoresearch/metricFormat.test.ts
@@ -16,7 +16,7 @@ describe("deltaTone", () => {
 
 describe("formatMetricDelta", () => {
   it.each([
-    [null, "kB", "—"],
+    [null, "kB", "Baseline"],
     [10.5, "kB", "+10.5 kB"],
     [-3, null, "-3"],
     [2, "%", "+2%"],

--- a/packages/ui/src/features/autoresearch/metricFormat.ts
+++ b/packages/ui/src/features/autoresearch/metricFormat.ts
@@ -45,12 +45,12 @@ export function deltaTone(
   return isImprovement(delta, 0, direction) ? "improved" : "worsened";
 }
 
-/** Signed delta with unit ("+1.5 kB"); "—" for the baseline iteration. */
+/** Signed delta with unit ("+1.5 kB"); "Baseline" for the first iteration. */
 export function formatMetricDelta(
   delta: number | null,
   unit: string | null,
 ): string {
-  if (delta === null) return "—";
+  if (delta === null) return "Baseline";
   return withMetricUnit(
     `${delta > 0 ? "+" : ""}${metricNumberFormat.format(delta)}`,
     unit,

--- a/packages/ui/src/features/autoresearch/stageModels.tsx
+++ b/packages/ui/src/features/autoresearch/stageModels.tsx
@@ -10,7 +10,7 @@ export interface AutoresearchModelOption {
 }
 
 /**
- * Sentinel for "no stage model" — Radix `Select.Item` cannot have an empty
+ * Sentinel for "no stage model" because Radix `Select.Item` cannot have an empty
  * value, so the "leave the session model alone" choice needs a placeholder.
  * Shared so the composer strip and the dashboard dialog can't drift onto
  * different sentinels.
@@ -18,7 +18,7 @@ export interface AutoresearchModelOption {
 export const NO_STAGE_MODEL = "__no_stage_model__";
 
 /**
- * Derive stage select options from a session config option — works for the
+ * Derive stage select options from a session config option. This works for the
  * `model` option and the `thought_level` (effort) option alike.
  */
 export function toStageSelectOptions(

--- a/packages/ui/src/features/message-editor/components/ModeSelector.tsx
+++ b/packages/ui/src/features/message-editor/components/ModeSelector.tsx
@@ -136,7 +136,7 @@ export function ModeSelector({
                 setOpen(false);
               }}
             >
-              <span className="text-violet-11">
+              <span className="text-muted-foreground">
                 <ChartLineUp size={12} />
               </span>
               <span className="whitespace-nowrap">Autoresearch</span>

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -732,12 +732,9 @@ export function TaskInput({
       implementEffort: currentReasoningLevel ?? null,
       measureEffort: currentReasoningLevel ?? null,
     });
-    // The loop iterates unattended, so a permission prompt would stall it.
-    // Default to the most hands-off mode available: bypass when the user has
-    // enabled it, otherwise accept-edits.
-    const autonomousMode = allowBypassPermissions
-      ? "bypassPermissions"
-      : "acceptEdits";
+    // Autoresearch needs to apply edits without stopping for each change, but
+    // it should not silently inherit the broader bypass-permissions mode.
+    const autonomousMode = "acceptEdits";
     if (modeOption && isValidConfigValue(modeOption, autonomousMode)) {
       setConfigOption(modeOption.id, autonomousMode);
     }
@@ -749,7 +746,6 @@ export function TaskInput({
     sessionId,
     currentModel,
     currentReasoningLevel,
-    allowBypassPermissions,
     modeOption,
     setConfigOption,
     workspaceMode,
@@ -1194,7 +1190,7 @@ export function TaskInput({
 
               <Flex direction="column" gap="0">
                 {autoresearchDraft && (
-                  <div className="mb-2 rounded-md border border-violet-6 bg-violet-2 px-2.5 py-1.5">
+                  <div className="mb-3 rounded-md border border-gray-6 bg-gray-2 px-3.5 py-3">
                     <AutoresearchComposerControls
                       draft={autoresearchDraft}
                       modelOptions={autoresearchModelOptions}
@@ -1218,7 +1214,7 @@ export function TaskInput({
                   sessionId={promptSessionId}
                   placeholder={
                     autoresearchDraft
-                      ? "What should the agent optimize? Describe the goal, how to measure it, and any constraints — it measures a baseline, then iterates."
+                      ? "Example: Reduce memory usage measured by `pnpm bench:memory` without changing behavior."
                       : `What do you want to ship? ${hints}`
                   }
                   editorHeight="large"

--- a/packages/workspace-server/src/db/repositories/autoresearch-run-repository.ts
+++ b/packages/workspace-server/src/db/repositories/autoresearch-run-repository.ts
@@ -20,7 +20,7 @@ export interface AutoresearchRunUpsert {
 /**
  * Persisted autoresearch runs. The run itself is an opaque JSON blob owned
  * by @posthog/core; this repository only stores it and answers the two
- * queries the app needs — a task's history, and the still-open runs worth
+ * queries the app needs: a task history and the open runs worth
  * resuming after a restart.
  */
 export interface IAutoresearchRunRepository {


### PR DESCRIPTION
## Summary

- redesign the Autoresearch setup input with clearer metric direction, examples, help content, feedback contact, and accept edits defaults
- surface streamed research findings, hypotheses, iteration plans, approach labels, live activity, context usage, time breakdowns, and completed run summaries
- record completed metric reports while the agent is still working, including composer runs whose initial prompt is already active
- prioritize iteration metrics and results in the dashboard hierarchy
- add dedicated and configurable Storybook coverage for the full dashboard and individual states
- 
<img width="1493" height="1091" alt="Screenshot 2026-07-10 at 16 44 11" src="https://github.com/user-attachments/assets/60b1a09f-245d-4762-b6d4-4495d1f1a47d" />

<img width="1493" height="1091" alt="Screenshot 2026-07-10 at 16 44 17" src="https://github.com/user-attachments/assets/13123fd8-c144-40b4-9b88-e1c9efc32b57" />

<img width="1493" height="1091" alt="Screenshot 2026-07-10 at 16 32 43" src="https://github.com/user-attachments/assets/793160dc-4f9c-48c0-a1a6-7a095f93792b" />

<img width="1493" height="1091" alt="Screenshot 2026-07-10 at 16 32 25" src="https://github.com/user-attachments/assets/c64d6221-e74c-48ce-b966-5b6c558d0100" />

<img width="1493" height="1091" alt="Screenshot 2026-07-10 at 16 02 03" src="https://github.com/user-attachments/assets/9452a822-17fc-470b-9c84-5c89e5877772" />


## Validation

- 155 core Autoresearch tests
- 25 UI Autoresearch tests
- core and UI typechecks
- static Storybook build
- Biome and diff checks

Created with Autoresearch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*