### PR TITLE
fix(channels): canvas mode model/effort pickers + task card in feed

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -1,6 +1,7 @@
 import { isValidConfigValue } from "@posthog/core/task-detail/configOptions";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import {
   forwardRef,
@@ -32,6 +33,7 @@ import { usePreviewConfig } from "../../task-detail/hooks/usePreviewConfig";
 import { useTaskCreation } from "../../task-detail/hooks/useTaskCreation";
 import { resolveWorkspaceModePreference } from "../../task-detail/hooks/workspaceModePreference";
 import { trackAndCreateCanvas } from "../createCanvasAnalytics";
+import { channelFeedQueryKey } from "../hooks/useChannelFeed";
 import {
   UNTITLED_CANVAS_NAME,
   useDashboardMutations,
@@ -98,39 +100,6 @@ export const ChannelHomeComposer = forwardRef<
     setCanvasArmed(!canvasArmed);
   }, [channelId, canvasArmed]);
 
-  const handleCanvasSubmit = useCallback(async () => {
-    const instruction = editorRef.current?.getText().trim();
-    if (!instruction || isStartingCanvas) return;
-    let record: { id: string; name: string };
-    try {
-      record = await trackAndCreateCanvas(
-        channelId,
-        "freeform",
-        "channel_home",
-        () => createDashboard(channelId, UNTITLED_CANVAS_NAME, "freeform"),
-      );
-    } catch (error) {
-      toastError("Couldn't create canvas", error);
-      return;
-    }
-    // generate() surfaces its own failure toasts; on success it files the task
-    // to the channel and tracks completion for the finished-generation toast.
-    const taskId = await generateCanvas({
-      dashboardId: record.id,
-      name: record.name,
-      templateId: "freeform",
-      instruction,
-      useStarter: true,
-    });
-    if (!taskId) return;
-    editorRef.current?.clear();
-    setCanvasArmed(false);
-    void navigate({
-      to: "/website/$channelId/dashboards/$dashboardId",
-      params: { channelId, dashboardId: record.id },
-    });
-  }, [channelId, createDashboard, generateCanvas, isStartingCanvas, navigate]);
-
   const {
     lastUsedAdapter,
     setLastUsedAdapter,
@@ -192,6 +161,61 @@ export const ChannelHomeComposer = forwardRef<
     modeFallback;
   const currentReasoningLevel =
     thoughtOption?.type === "select" ? thoughtOption.currentValue : undefined;
+
+  const queryClient = useQueryClient();
+  const handleCanvasSubmit = useCallback(async () => {
+    const instruction = editorRef.current?.getText().trim();
+    if (!instruction || isStartingCanvas) return;
+    let record: { id: string; name: string };
+    try {
+      record = await trackAndCreateCanvas(
+        channelId,
+        "freeform",
+        "channel_home",
+        () => createDashboard(channelId, UNTITLED_CANVAS_NAME, "freeform"),
+      );
+    } catch (error) {
+      toastError("Couldn't create canvas", error);
+      return;
+    }
+    // generate() surfaces its own failure toasts; on success it files the task
+    // to the channel and tracks completion for the finished-generation toast.
+    const taskId = await generateCanvas({
+      dashboardId: record.id,
+      name: record.name,
+      templateId: "freeform",
+      instruction,
+      // Owned by the backend channel so the run shows as a card in the feed,
+      // like a plain composer submit.
+      backendChannelId,
+      adapter: adapter ?? "claude",
+      model: currentModel,
+      reasoningLevel: currentReasoningLevel,
+      useStarter: true,
+    });
+    if (!taskId) return;
+    // Surface the new card without waiting for the feed's next poll.
+    void queryClient.invalidateQueries({
+      queryKey: channelFeedQueryKey(backendChannelId),
+    });
+    editorRef.current?.clear();
+    setCanvasArmed(false);
+    void navigate({
+      to: "/website/$channelId/dashboards/$dashboardId",
+      params: { channelId, dashboardId: record.id },
+    });
+  }, [
+    channelId,
+    backendChannelId,
+    adapter,
+    currentModel,
+    currentReasoningLevel,
+    createDashboard,
+    generateCanvas,
+    isStartingCanvas,
+    navigate,
+    queryClient,
+  ]);
 
   const { isCreatingTask, canSubmit, handleSubmit } = useTaskCreation({
     editorRef,
@@ -303,21 +327,17 @@ export const ChannelHomeComposer = forwardRef<
         enableCommands
         enableBashMode={false}
         modelSelector={
-          // Canvas generation resolves the adapter's default model itself.
-          canvasArmed ? null : (
-            <UnifiedModelSelector
-              modelOption={modelOption}
-              adapter={adapter ?? "claude"}
-              onAdapterChange={setAdapter}
-              disabled={isBusy}
-              isConnecting={isLoading}
-              onModelChange={handleModelChange}
-            />
-          )
+          <UnifiedModelSelector
+            modelOption={modelOption}
+            adapter={adapter ?? "claude"}
+            onAdapterChange={setAdapter}
+            disabled={isBusy}
+            isConnecting={isLoading}
+            onModelChange={handleModelChange}
+          />
         }
         reasoningSelector={
-          !isLoading &&
-          !canvasArmed && (
+          !isLoading && (
             <ReasoningLevelSelector
               thoughtOption={thoughtOption}
               adapter={adapter}

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 import { useConnectivity } from "../../../hooks/useConnectivity";
 import { track } from "../../../shell/analytics";
+import { useOptionalAuthenticatedClient } from "../../auth/authClient";
 import { useUserRepositoryIntegration } from "../../integrations/useIntegrations";
 import { PromptInput } from "../../message-editor/components/PromptInput";
 import { useDraftStore } from "../../message-editor/draftStore";
@@ -39,6 +40,10 @@ import {
   useDashboardMutations,
 } from "../hooks/useDashboards";
 import { useGenerateFreeformCanvas } from "../hooks/useGenerateFreeformCanvas";
+import {
+  normalizeChannelName,
+  PERSONAL_CHANNEL_NAME,
+} from "../hooks/useTaskChannels";
 
 export interface ChannelHomeComposerHandle {
   /** Drop a starter prompt into the editor and apply its mode, if any. */
@@ -163,9 +168,27 @@ export const ChannelHomeComposer = forwardRef<
     thoughtOption?.type === "select" ? thoughtOption.currentValue : undefined;
 
   const queryClient = useQueryClient();
+  const apiClient = useOptionalAuthenticatedClient();
   const handleCanvasSubmit = useCallback(async () => {
     const instruction = editorRef.current?.getText().trim();
     if (!instruction || isStartingCanvas) return;
+    // The folder→backend channel mapping can still be resolving when the user
+    // submits (fresh channel, cold channels list). Resolve it here rather than
+    // silently creating a run the feed will never show. The personal channel
+    // can't be resolved by name; it only arrives via the channels list.
+    let feedChannelId = backendChannelId;
+    const normalizedName = channelName ? normalizeChannelName(channelName) : "";
+    if (
+      !feedChannelId &&
+      apiClient &&
+      normalizedName &&
+      normalizedName !== PERSONAL_CHANNEL_NAME
+    ) {
+      feedChannelId = await apiClient
+        .resolveTaskChannel(normalizedName)
+        .then((c) => c.id)
+        .catch(() => undefined);
+    }
     let record: { id: string; name: string };
     try {
       record = await trackAndCreateCanvas(
@@ -187,7 +210,7 @@ export const ChannelHomeComposer = forwardRef<
       instruction,
       // Owned by the backend channel so the run shows as a card in the feed,
       // like a plain composer submit.
-      backendChannelId,
+      backendChannelId: feedChannelId,
       adapter: adapter ?? "claude",
       model: currentModel,
       reasoningLevel: currentReasoningLevel,
@@ -196,7 +219,7 @@ export const ChannelHomeComposer = forwardRef<
     if (!taskId) return;
     // Surface the new card without waiting for the feed's next poll.
     void queryClient.invalidateQueries({
-      queryKey: channelFeedQueryKey(backendChannelId),
+      queryKey: channelFeedQueryKey(feedChannelId),
     });
     editorRef.current?.clear();
     setCanvasArmed(false);
@@ -206,7 +229,9 @@ export const ChannelHomeComposer = forwardRef<
     });
   }, [
     channelId,
+    channelName,
     backendChannelId,
+    apiClient,
     adapter,
     currentModel,
     currentReasoningLevel,

--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -10,7 +10,11 @@ import {
 } from "@posthog/core/task-detail/taskService";
 import { useService } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
-import { getCloudUrlFromRegion, type WorkspaceMode } from "@posthog/shared";
+import {
+  type Adapter,
+  getCloudUrlFromRegion,
+  type WorkspaceMode,
+} from "@posthog/shared";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { buildFreeformGenerationPrompt } from "@posthog/ui/features/canvas/freeformPrompt";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
@@ -77,6 +81,15 @@ export function useGenerateFreeformCanvas(args: {
       templateId?: string;
       instruction: string;
       currentCode?: string;
+      // Backend channel UUID that owns the created task, so it lands in the
+      // channel's task feed like a plain composer submit.
+      backendChannelId?: string;
+      // The composer's picks, when the surface exposes model/effort selectors.
+      // The model is validated against the gateway (falling back to the
+      // adapter's default) so a stale id can't 403 the run.
+      adapter?: Adapter;
+      model?: string;
+      reasoningLevel?: string;
       // Default on (opt out in the bar): seed the starter scaffold on first build.
       useStarter?: boolean;
       // Dev-only override (the bar exposes a local/cloud picker in dev so a
@@ -90,6 +103,9 @@ export function useGenerateFreeformCanvas(args: {
         templateId,
         instruction,
         currentCode,
+        backendChannelId,
+        adapter = "claude",
+        reasoningLevel,
         useStarter,
         // Defaults to a cloud run — canvas generation should never tie up (or
         // depend on) the local machine, and it's never the sticky last-used
@@ -100,16 +116,17 @@ export function useGenerateFreeformCanvas(args: {
       setIsStarting(true);
       try {
         // A cloud run requires an explicit adapter + model (the API rejects a
-        // cloud runtime without a model). Canvas has no model picker, so resolve
-        // the adapter's server default the same way the inbox one-click flows do
-        // — the resolver validates against the gateway, so a stale id can't slip
-        // through and 403 the run.
-        let model: string | undefined;
+        // cloud runtime without a model). Resolve the caller's pick — or the
+        // adapter's server default when none — the same way the inbox one-click
+        // flows do; the resolver validates against the gateway, so a stale id
+        // can't slip through and 403 the run.
+        let model: string | undefined = opts.model;
         if (workspaceMode === "cloud") {
           model = cloudRegion
             ? await modelResolver.resolveDefaultModel(
                 getCloudUrlFromRegion(cloudRegion),
-                "claude",
+                adapter,
+                opts.model,
               )
             : undefined;
           if (!model) {
@@ -135,11 +152,13 @@ export function useGenerateFreeformCanvas(args: {
             // Unattended generation: run in auto mode so it doesn't stall on edit-approval prompts.
             executionMode: "auto" as const,
             workspaceMode,
-            adapter: "claude",
+            adapter,
             model,
+            reasoningLevel,
             allowNoRepo: true,
             channelContext,
             channelName,
+            channelId: backendChannelId,
           },
           (output) => invalidateTasks(output.task),
         );
@@ -151,9 +170,12 @@ export function useGenerateFreeformCanvas(args: {
 
         const task = result.data.task;
         // File into the channel + record as the canvas's generation task. Both
-        // are best-effort: a failure here shouldn't undo a started task.
+        // are best-effort: a failure here shouldn't undo a started task. The
+        // generation-task write is awaited so a caller that navigates to the
+        // canvas right after generate() lands on the generating view (with the
+        // run in the side panel), not the empty hero.
         void fileTask(channelId, task.id, task.title).catch(() => {});
-        void setGenerationTask(dashboardId, task.id).catch(() => {});
+        await setGenerationTask(dashboardId, task.id).catch(() => {});
         // Track this run so a toast (with a link back here) fires when it
         // finishes, even after the user navigates to another canvas.
         useCanvasGenerationTrackerStore


### PR DESCRIPTION
## Problem

Follow-up fixes to canvas mode in the channel composer, from testing feedback:
- The model and reasoning-effort selectors were hidden while canvas mode was armed, so the generation always ran on the adapter's default model.
- The generation task didn't appear as a card in the channel feed, and navigating to the canvas after submit could land on the empty hero instead of the generating view with the run in the right side panel.

## Changes

- Keep the model + effort selectors visible in canvas mode and pass the picks into `generate()` — the model is validated against the gateway with the adapter default as fallback, so a stale id can't 403 the run.
- Create the generation task owned by the backend channel (`channelId`) so it shows in the channel feed like a plain composer submit, and invalidate the feed on submit.
- Await the generation-task write before navigating so the canvas opens straight into the generating view with the task in the side panel.

## How did you test this?

- `@posthog/ui` typecheck and Biome lint clean.
- Canvas + message-editor vitest suites (123 tests) pass.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*