### PR TITLE
fix(canvas): name the canvas before creating its generation task

### DIFF
--- a/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateFreeformCanvas.ts
@@ -115,6 +115,17 @@ export function useGenerateFreeformCanvas(args: {
       } = opts;
       setIsStarting(true);
       try {
+        // Auto-name a still-unnamed canvas from its generation prompt BEFORE
+        // creating the task: the name feeds the task title, the backend task
+        // description (which doubles as the optimistic first-message bubble on
+        // cloud runs), and the generation prompt's header — naming afterwards
+        // would leave all three reading `Untitled canvas`. Runs concurrently
+        // with model resolution below, so the common path adds no latency.
+        // Best-effort: on failure the placeholder name is kept, as before.
+        const namePromise = isPlaceholderCanvasName(name)
+          ? titleGenerator.generateCanvasName(instruction).catch(() => null)
+          : Promise.resolve(null);
+
         // A cloud run requires an explicit adapter + model (the API rejects a
         // cloud runtime without a model). Resolve the caller's pick — or the
         // adapter's server default when none — the same way the inbox one-click
@@ -137,18 +148,26 @@ export function useGenerateFreeformCanvas(args: {
           }
         }
 
+        const generatedName = (await namePromise)?.trim();
+        const canvasName = generatedName || name;
+        if (generatedName) {
+          // Rename fire-and-forget: a failure shouldn't block the run, and the
+          // task carries the real name regardless.
+          void renameDashboard(dashboardId, canvasName).catch(() => {});
+        }
+
         const result = await taskService.createTask(
           {
             content: buildFreeformGenerationPrompt({
               dashboardId,
-              name,
+              name: canvasName,
               channelName,
               templateId,
               instruction,
               currentCode,
               useStarter,
             }),
-            taskDescription: `Generate canvas "${name}"`,
+            taskDescription: `Generate canvas "${canvasName}"`,
             // Unattended generation: run in auto mode so it doesn't stall on edit-approval prompts.
             executionMode: "auto" as const,
             workspaceMode,
@@ -180,31 +199,12 @@ export function useGenerateFreeformCanvas(args: {
         // finishes, even after the user navigates to another canvas.
         useCanvasGenerationTrackerStore
           .getState()
-          .track({ taskId: task.id, dashboardId, channelId, name });
+          .track({ taskId: task.id, dashboardId, channelId, name: canvasName });
         // Refresh the workspace cache so the new cloud workspace row appears and
         // the task view resolves the cloud run instead of the repo-picker prompt.
         void queryClient.invalidateQueries({
           queryKey: trpc.workspace.getAll.queryKey(),
         });
-        // Auto-name a still-unnamed canvas from its generation prompt, using the
-        // same helper model that names tasks. Best-effort: a failure (or a user
-        // who already named the canvas) leaves the existing title untouched.
-        if (isPlaceholderCanvasName(name)) {
-          void titleGenerator
-            .generateCanvasName(instruction)
-            .then(async (generated) => {
-              const title = generated?.trim();
-              if (title) {
-                await renameDashboard(dashboardId, title);
-                // Keep the tracked generation's name in sync so its completion
-                // toast reads the real title, not "Untitled canvas".
-                useCanvasGenerationTrackerStore
-                  .getState()
-                  .updateName(task.id, title);
-              }
-            })
-            .catch(() => {});
-        }
         return task.id;
       } finally {
         setIsStarting(false);

--- a/packages/ui/src/features/canvas/stores/canvasGenerationTrackerStore.ts
+++ b/packages/ui/src/features/canvas/stores/canvasGenerationTrackerStore.ts
@@ -16,9 +16,6 @@ interface CanvasGenerationTrackerState {
   // Keyed by taskId.
   tracked: Record<string, TrackedCanvasGeneration>;
   track: (entry: TrackedCanvasGeneration) => void;
-  // Keep the display name fresh when a freshly-created canvas is auto-renamed
-  // from its prompt after generation has already started.
-  updateName: (taskId: string, name: string) => void;
   untrack: (taskId: string) => void;
 }
 
@@ -27,17 +24,6 @@ export const useCanvasGenerationTrackerStore =
     tracked: {},
     track: (entry) =>
       set((s) => ({ tracked: { ...s.tracked, [entry.taskId]: entry } })),
-    updateName: (taskId, name) =>
-      set((s) =>
-        s.tracked[taskId]
-          ? {
-              tracked: {
-                ...s.tracked,
-                [taskId]: { ...s.tracked[taskId], name },
-              },
-            }
-          : s,
-      ),
     untrack: (taskId) =>
       set((s) => {
         if (!s.tracked[taskId]) return s;


### PR DESCRIPTION
## Problem

Every canvas generation task kicked off from the channel composer's Canvas mode (#3348) gets the title `Generate canvas "Untitled canvas"`, and that placeholder also shows as the first prompt bubble before the agent starts. The composer creates the dashboard with the placeholder name at submit time, and auto-naming only ran *after* the task was created — renaming the dashboard but never the task, its backend description, or the generation prompt's header.

## Changes

- `useGenerateFreeformCanvas`: for a still-unnamed canvas, generate the name from the instruction **before** creating the task (concurrently with model resolution, so the common path adds no latency). The real name now feeds the task title/description, the prompt header, the channel filing, and the completion toast; the dashboard rename is fired best-effort. Falls back to the placeholder if name generation fails, as before.
- Removed the now-unused post-task rename block and the tracker store's `updateName`.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` — clean
- `biome check` on the changed files — clean
- `pnpm --filter @posthog/ui test` — 164 files / 1458 tests passed

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*