### PR TITLE
feat(sidebar): hover-peek collapsed nav with drag-to-close

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -10,6 +10,12 @@ import { ProjectSwitcher } from "@posthog/ui/features/sidebar/components/Project
 import { SidebarMenu } from "@posthog/ui/features/sidebar/components/SidebarMenu";
 import { SidebarNavSection } from "@posthog/ui/features/sidebar/components/SidebarNavSection";
 import { UpdateBanner } from "@posthog/ui/features/sidebar/components/UpdateBanner";
+import {
+  beginSidebarPeek,
+  cancelSidebarPeek,
+  endSidebarPeek,
+  useSidebarPeekStore,
+} from "@posthog/ui/features/sidebar/sidebarPeekStore";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
@@ -32,6 +38,7 @@ export function ChannelsSidebar() {
   // finished onboarding or has any workspace, matching the retired MainSidebar —
   // so a brand-new user sees the welcome screen without the sidebar beside it.
   const open = useSidebarStore((s) => s.open);
+  const setOpen = useSidebarStore((s) => s.setOpen);
   const setOpenAuto = useSidebarStore((s) => s.setOpenAuto);
   const hasCompletedOnboarding = useOnboardingStore(
     (s) => s.hasCompletedOnboarding,
@@ -42,6 +49,14 @@ export function ChannelsSidebar() {
     if (!workspacesFetched) return;
     setOpenAuto(hasCompletedOnboarding || Object.keys(workspaces).length > 0);
   }, [workspacesFetched, workspaces, hasCompletedOnboarding, setOpenAuto]);
+
+  // Hover-reveal while collapsed: the left gutter / title-bar toggle set peek,
+  // and the panel keeps it alive under the pointer. Any open (click, Cmd+B)
+  // makes the peek redundant — drop it so the overlay state can't linger.
+  const peek = useSidebarPeekStore((s) => s.peek);
+  useEffect(() => {
+    if (open) cancelSidebarPeek();
+  }, [open]);
 
   // Channels stay behind project-bluebird: the toggle only appears where the
   // canvas backend is wired, and a persisted "on" is ignored when the flag is
@@ -69,6 +84,11 @@ export function ChannelsSidebar() {
       isResizing={isResizing}
       setIsResizing={setIsResizing}
       side="left"
+      setOpen={setOpen}
+      peek={peek}
+      onPeekEnter={beginSidebarPeek}
+      onPeekLeave={() => endSidebarPeek()}
+      onPeekDismiss={cancelSidebarPeek}
     >
       <Flex direction="column" className="h-full bg-chrome">
         {/* The nav owns the "Enable channels" toggle + Canvas rows (gated by

--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -57,6 +57,9 @@ export function ChannelsSidebar() {
   useEffect(() => {
     if (open) cancelSidebarPeek();
   }, [open]);
+  // The peek store is a module-level singleton — if this sidebar unmounts
+  // while peeked (route without it), a stale peek would greet the remount.
+  useEffect(() => () => cancelSidebarPeek(), []);
 
   // Channels stay behind project-bluebird: the toggle only appears where the
   // canvas backend is wired, and a persisted "on" is ignored when the flag is

--- a/packages/ui/src/features/sidebar/sidebarPeekStore.ts
+++ b/packages/ui/src/features/sidebar/sidebarPeekStore.ts
@@ -1,0 +1,44 @@
+import { create } from "zustand";
+
+// Ephemeral hover-peek state for the collapsed sidebar: hovering the left
+// gutter or the title-bar toggle slides the sidebar out as an overlay, and
+// leaving hides it. Re-entering any trigger before the hide fires keeps the
+// peek alive. Not persisted.
+interface SidebarPeekStore {
+  peek: boolean;
+  setPeek: (peek: boolean) => void;
+}
+
+export const useSidebarPeekStore = create<SidebarPeekStore>()((set) => ({
+  peek: false,
+  setPeek: (peek) => set({ peek }),
+}));
+
+// The hide timer is shared across every trigger (gutter, toggle button, the
+// panel itself) so re-entering any of them keeps the peek alive.
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+const clearHideTimer = (): void => {
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+};
+
+export function beginSidebarPeek(): void {
+  clearHideTimer();
+  useSidebarPeekStore.getState().setPeek(true);
+}
+
+export function endSidebarPeek(delayMs = 0): void {
+  clearHideTimer();
+  hideTimer = setTimeout(() => {
+    hideTimer = null;
+    useSidebarPeekStore.getState().setPeek(false);
+  }, delayMs);
+}
+
+export function cancelSidebarPeek(): void {
+  clearHideTimer();
+  useSidebarPeekStore.getState().setPeek(false);
+}

--- a/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -2,6 +2,20 @@ import { SIDEBAR_MIN_WIDTH } from "@posthog/ui/features/sidebar/constants";
 import { Box, Flex } from "@radix-ui/themes";
 import React from "react";
 
+// Linear-style drag-to-close: dragging the handle clamps at SIDEBAR_MIN_WIDTH,
+// but pulling well past it toward the edge collapses the sidebar. While the
+// button is still held, dragging back out pops it open again. The reopen line
+// sits slightly outside the collapse line so the boundary can't jitter.
+const DRAG_COLLAPSE_AT = SIDEBAR_MIN_WIDTH * 0.5;
+const DRAG_REOPEN_AT = DRAG_COLLAPSE_AT + 16;
+
+// Every moving part of the open/close choreography — the box width, the
+// panel's translateX, and the title bar in __root — must share this exact
+// curve (Tailwind's ease-out) and duration, or the panel's edge drifts ahead
+// of the content edge mid-animation and the layers visibly overlap.
+const SLIDE_EASING = "cubic-bezier(0, 0, 0.2, 1)";
+const SLIDE_WIDTH_TRANSITION = `width 0.2s ${SLIDE_EASING}, min-width 0.2s ${SLIDE_EASING}, max-width 0.2s ${SLIDE_EASING}`;
+
 interface ResizableSidebarProps {
   children: React.ReactNode;
   open: boolean;
@@ -10,6 +24,16 @@ interface ResizableSidebarProps {
   isResizing: boolean;
   setIsResizing: (isResizing: boolean) => void;
   side: "left" | "right";
+  // Enables drag-to-close/reopen. Without it, dragging just clamps at min.
+  setOpen?: (open: boolean) => void;
+  // While closed, the panel can "peek" — slide out over the content as a
+  // floating overlay (hover-reveal). The enter/leave handlers let the caller
+  // keep the peek alive while the pointer is over the panel itself; dismiss
+  // hides it immediately (drag-to-close of the floating panel).
+  peek?: boolean;
+  onPeekEnter?: () => void;
+  onPeekLeave?: () => void;
+  onPeekDismiss?: () => void;
 }
 
 export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
@@ -20,34 +44,106 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
   isResizing,
   setIsResizing,
   side,
+  setOpen,
+  peek = false,
+  onPeekEnter,
+  onPeekLeave,
+  onPeekDismiss,
 }) => {
+  // Whether the active drag started on the docked sidebar or the floating
+  // (peek) one — dragging back out must restore the same mode it closed from.
+  const dragOriginRef = React.useRef<"docked" | "overlay">("docked");
+  // Width when the drag began: a drag-to-close clamps the store width down to
+  // SIDEBAR_MIN_WIDTH on the way to the edge, so if the drag ends closed we
+  // put this back — the next open should restore the user's chosen width.
+  const dragStartWidthRef = React.useRef(width);
+
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
+    dragOriginRef.current = open ? "docked" : "overlay";
+    dragStartWidthRef.current = width;
     setIsResizing(true);
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
   };
 
+  // If the component unmounts mid-drag (e.g. a route swap while holding the
+  // handle), no mouseup will ever fire — reset the drag's global side effects
+  // or the app is left with a col-resize cursor, text selection disabled, and
+  // a stuck isResizing that makes the next mount resize on bare mousemove.
+  const unmountResetRef = React.useRef({ isResizing, setIsResizing });
+  unmountResetRef.current = { isResizing, setIsResizing };
+  React.useEffect(
+    () => () => {
+      const { isResizing: active, setIsResizing: reset } =
+        unmountResetRef.current;
+      if (active) {
+        reset(false);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      }
+    },
+    [],
+  );
+
   React.useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
       if (!isResizing) return;
 
+      // Distance from the sidebar's window edge, regardless of side.
+      const pointer =
+        side === "left" ? e.clientX : window.innerWidth - e.clientX;
       const maxWidth = window.innerWidth * 0.5;
-      const newWidth =
-        side === "left"
-          ? Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxWidth, e.clientX))
-          : Math.max(
-              SIDEBAR_MIN_WIDTH,
-              Math.min(maxWidth, window.innerWidth - e.clientX),
-            );
-      setWidth(newWidth);
+      const clamped = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxWidth, pointer));
+
+      if (open) {
+        if (pointer < DRAG_COLLAPSE_AT && setOpen) {
+          setOpen(false);
+          return;
+        }
+        setWidth(clamped);
+        return;
+      }
+
+      if (peek) {
+        if (pointer < DRAG_COLLAPSE_AT) {
+          onPeekDismiss?.();
+          return;
+        }
+        setWidth(clamped);
+        return;
+      }
+
+      // Closed mid-drag and still holding: dragging back out pops it open in
+      // whichever mode the drag started from.
+      if (pointer >= DRAG_REOPEN_AT) {
+        if (dragOriginRef.current === "docked" && setOpen) {
+          setOpen(true);
+        } else {
+          onPeekEnter?.();
+        }
+        setWidth(clamped);
+      }
     };
 
-    const handleMouseUp = () => {
-      if (isResizing) {
-        setIsResizing(false);
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
+    const handleMouseUp = (e: MouseEvent) => {
+      if (!isResizing) return;
+      setIsResizing(false);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      // Drag ended closed (drag-to-close or peek dismiss): the collapse walk
+      // clamped the store width to min on the way down — restore the pre-drag
+      // width so the next open comes back at the user's chosen size.
+      if (!open && !peek) {
+        setWidth(dragStartWidthRef.current);
+      }
+      // A floating-panel drag suppresses the panel's mouseleave (the pointer
+      // can travel anywhere mid-drag), so when it ends off-panel, schedule the
+      // hide the leave would have scheduled.
+      if (!open && peek) {
+        const pointer =
+          side === "left" ? e.clientX : window.innerWidth - e.clientX;
+        if (pointer > width) onPeekLeave?.();
       }
     };
 
@@ -58,9 +154,44 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [setWidth, isResizing, setIsResizing, side]);
+  }, [
+    setWidth,
+    isResizing,
+    setIsResizing,
+    side,
+    open,
+    peek,
+    width,
+    setOpen,
+    onPeekEnter,
+    onPeekLeave,
+    onPeekDismiss,
+  ]);
 
   const isLeft = side === "left";
+  // Closed = overlay mode: the box collapses to 0 width but the panel stays
+  // mounted as an absolutely positioned layer that peek slides in and out.
+  const isOverlay = !open;
+  const overlayVisible = isOverlay && peek;
+
+  // While the panel slides, the resize handle sweeps under a stationary
+  // pointer and picks up a stale :hover (browsers only recompute hover on
+  // pointer moves) — the primary line would stick on. Disarm the handle for
+  // the duration of any slide; a grab in progress keeps it live.
+  const [handleArmed, setHandleArmed] = React.useState(true);
+  const skipFirstArmCycle = React.useRef(true);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: open/overlayVisible are pure triggers — any open/peek flip starts a slide and must disarm the handle
+  React.useEffect(() => {
+    if (skipFirstArmCycle.current) {
+      skipFirstArmCycle.current = false;
+      return;
+    }
+    setHandleArmed(false);
+    // Slightly past the 200ms slide; timer-based so reduced-motion (no
+    // transitionend) can't leave the handle disarmed.
+    const timer = setTimeout(() => setHandleArmed(true), 250);
+    return () => clearTimeout(timer);
+  }, [open, overlayVisible]);
 
   return (
     <Box
@@ -68,8 +199,12 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
         width: open ? `${width}px` : "0",
         minWidth: open ? `${width}px` : "0",
         maxWidth: open ? `${width}px` : "0",
-        overflow: open ? "visible" : "hidden",
-        transition: isResizing ? "none" : "width 0.2s ease-in-out",
+        // Suppress only while dragging the docked sidebar so it tracks the
+        // pointer frame-for-frame; a drag-to-close (open flips false mid-drag)
+        // re-enables it so the collapse animates instead of jump-cutting.
+        // min/max-width must animate too — they clamp the rendered width, so
+        // left un-transitioned they snap the box to 0 and the content jumps.
+        transition: isResizing && open ? "none" : SLIDE_WIDTH_TRANSITION,
         borderLeft: !isLeft && open ? "1px solid var(--border)" : "none",
         borderRight: isLeft && open ? "1px solid var(--border)" : "none",
       }}
@@ -77,25 +212,77 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
     >
       <Flex
         direction="column"
+        onMouseEnter={isOverlay ? onPeekEnter : undefined}
+        onMouseLeave={
+          isOverlay && !isResizing ? () => onPeekLeave?.() : undefined
+        }
         style={{
           width: `${width}px`,
+          ...(isOverlay
+            ? {
+                transform: overlayVisible
+                  ? "translateX(0)"
+                  : isLeft
+                    ? "translateX(-100%)"
+                    : "translateX(100%)",
+                pointerEvents: overlayVisible ? "auto" : "none",
+                willChange: "transform",
+                // Track the pointer frame-for-frame while resizing the
+                // floating panel, but let a drag-to-dismiss (peek flips off
+                // mid-drag) fall through to the slide-out transition.
+                transition: isResizing && overlayVisible ? "none" : undefined,
+              }
+            : // Docked keeps the same animated transform so the open flip
+              // continues the slide (-100% → 0) in lockstep with the box
+              // width — without it the panel snaps in ahead of the content.
+              { transform: "translateX(0)" }),
         }}
-        className="h-full min-w-0"
+        className={
+          isOverlay
+            ? `absolute inset-y-0 z-50 h-full min-w-0 border-border bg-chrome transition-transform duration-200 ease-out motion-reduce:transition-none ${
+                isLeft ? "left-0 border-r" : "right-0 border-l"
+              } ${
+                // Shadow only while shown — at translateX(-100%) the panel's
+                // edge sits exactly on x=0 and an always-on shadow would paint
+                // a sliver over the content.
+                overlayVisible ? "shadow-lg" : ""
+              }`
+            : "relative h-full min-w-0 transition-transform duration-200 ease-out motion-reduce:transition-none"
+        }
       >
         {children}
+        {/* Resize handle lives inside the panel so it rides along in both the
+            docked and floating states. */}
+        {(open || overlayVisible) && (
+          <Box
+            onMouseDown={handleMouseDown}
+            className={`no-drag group absolute top-0 bottom-0 flex w-2 cursor-col-resize justify-center bg-transparent ${
+              handleArmed || isResizing ? "" : "pointer-events-none"
+            }`}
+            style={{
+              left: isLeft ? undefined : -5,
+              right: isLeft ? -5 : undefined,
+              zIndex: 100,
+            }}
+          >
+            <span
+              className={`h-full w-px transition-colors duration-150 ease-out ${
+                isResizing
+                  ? "bg-primary"
+                  : handleArmed
+                    ? "bg-transparent delay-100 group-hover:bg-primary"
+                    : "bg-transparent"
+              }`}
+            />
+          </Box>
+        )}
       </Flex>
-      {open && (
-        <Box
-          onMouseDown={handleMouseDown}
-          className="no-drag group absolute top-0 bottom-0 flex w-2 cursor-col-resize justify-center bg-transparent"
-          style={{
-            left: isLeft ? undefined : -5,
-            right: isLeft ? -5 : undefined,
-            zIndex: 100,
-          }}
-        >
-          <span className="h-full w-px bg-transparent transition-colors delay-100 duration-150 ease-out group-hover:bg-primary" />
-        </Box>
+      {/* Full-screen shield while dragging: keeps the col-resize cursor no
+          matter what the pointer crosses (content sets its own cursors, and
+          webview tabs would swallow the drag entirely). Outside the panel so
+          the panel's pointer-events:none while drag-closed can't disable it. */}
+      {isResizing && (
+        <Box className="fixed inset-0 z-[200] cursor-col-resize" />
       )}
     </Box>
   );

--- a/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -57,11 +57,17 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
   // SIDEBAR_MIN_WIDTH on the way to the edge, so if the drag ends closed we
   // put this back — the next open should restore the user's chosen width.
   const dragStartWidthRef = React.useRef(width);
+  // Whether the drag has closed the sidebar. Tracked in a ref, synchronously
+  // with the mousemove that closes it — mouseup can fire before React
+  // re-registers the listeners with the post-close open/peek values, so the
+  // closure state can't be trusted for the width restore.
+  const dragEndedClosedRef = React.useRef(false);
 
   const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
     dragOriginRef.current = open ? "docked" : "overlay";
     dragStartWidthRef.current = width;
+    dragEndedClosedRef.current = false;
     setIsResizing(true);
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
@@ -99,6 +105,7 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
       if (open) {
         if (pointer < DRAG_COLLAPSE_AT && setOpen) {
           setOpen(false);
+          dragEndedClosedRef.current = true;
           return;
         }
         setWidth(clamped);
@@ -108,6 +115,7 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
       if (peek) {
         if (pointer < DRAG_COLLAPSE_AT) {
           onPeekDismiss?.();
+          dragEndedClosedRef.current = true;
           return;
         }
         setWidth(clamped);
@@ -122,6 +130,7 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
         } else {
           onPeekEnter?.();
         }
+        dragEndedClosedRef.current = false;
         setWidth(clamped);
       }
     };
@@ -134,7 +143,7 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
       // Drag ended closed (drag-to-close or peek dismiss): the collapse walk
       // clamped the store width to min on the way down — restore the pre-drag
       // width so the next open comes back at the user's chosen size.
-      if (!open && !peek) {
+      if (dragEndedClosedRef.current) {
         setWidth(dragStartWidthRef.current);
       }
       // A floating-panel drag suppresses the panel's mouseleave (the pointer
@@ -176,22 +185,28 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
 
   // While the panel slides, the resize handle sweeps under a stationary
   // pointer and picks up a stale :hover (browsers only recompute hover on
-  // pointer moves) — the primary line would stick on. Disarm the handle for
-  // the duration of any slide; a grab in progress keeps it live.
+  // pointer moves) — the primary line would stick on. Any open/peek flip
+  // starts a slide, so disarm the handle inline during that same render (a
+  // grab in progress keeps it live), then re-arm once the slide is over.
   const [handleArmed, setHandleArmed] = React.useState(true);
-  const skipFirstArmCycle = React.useRef(true);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: open/overlayVisible are pure triggers — any open/peek flip starts a slide and must disarm the handle
-  React.useEffect(() => {
-    if (skipFirstArmCycle.current) {
-      skipFirstArmCycle.current = false;
-      return;
-    }
+  const [prevSlideState, setPrevSlideState] = React.useState({
+    open,
+    overlayVisible,
+  });
+  if (
+    prevSlideState.open !== open ||
+    prevSlideState.overlayVisible !== overlayVisible
+  ) {
+    setPrevSlideState({ open, overlayVisible });
     setHandleArmed(false);
+  }
+  React.useEffect(() => {
+    if (handleArmed) return;
     // Slightly past the 200ms slide; timer-based so reduced-motion (no
     // transitionend) can't leave the handle disarmed.
     const timer = setTimeout(() => setHandleArmed(true), 250);
     return () => clearTimeout(timer);
-  }, [open, overlayVisible]);
+  }, [handleArmed]);
 
   return (
     <Box

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -4,7 +4,7 @@ import {
   CaretRightIcon,
 } from "@phosphor-icons/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
-import { Button } from "@posthog/quill";
+import { Button, ButtonGroup } from "@posthog/quill";
 import {
   BILLING_FLAG,
   HOME_TAB_FLAG,
@@ -42,6 +42,12 @@ import { useInboxDeepLink } from "@posthog/ui/features/inbox/hooks/useInboxDeepL
 import { useIntegrations } from "@posthog/ui/features/integrations/useIntegrations";
 import { useScoutDeepLink } from "@posthog/ui/features/scouts/hooks/useScoutDeepLink";
 import { useSetupDiscovery } from "@posthog/ui/features/setup/useSetupDiscovery";
+import {
+  beginSidebarPeek,
+  cancelSidebarPeek,
+  endSidebarPeek,
+  useSidebarPeekStore,
+} from "@posthog/ui/features/sidebar/sidebarPeekStore";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useSidebarData } from "@posthog/ui/features/sidebar/useSidebarData";
 import { useVisualTaskOrder } from "@posthog/ui/features/sidebar/useVisualTaskOrder";
@@ -76,6 +82,7 @@ import {
   useRouter,
   useRouterState,
 } from "@tanstack/react-router";
+import { SidebarClose, SidebarOpen } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 // The router devtools render their genuine floating overlay, mounted by the
@@ -185,6 +192,14 @@ function RootLayout() {
   // When the sidebar is collapsed (Cmd+B) the title bar's left block shrinks to
   // fit its own controls so the tab strip flushes left with the content pane.
   const sidebarOpen = useSidebarStore((s) => s.open);
+  const toggleSidebar = useSidebarStore((s) => s.toggle);
+  const sidebarPeek = useSidebarPeekStore((s) => s.peek);
+  // Toggling makes any hover-peek redundant (opening replaces the overlay;
+  // closing must not leave it lingering under the pointer).
+  const handleToggleSidebar = (): void => {
+    cancelSidebarPeek();
+    toggleSidebar();
+  };
 
   const sidebarData = useSidebarData({ activeView: view });
   const visualTaskOrder = useVisualTaskOrder(sidebarData);
@@ -340,33 +355,60 @@ function RootLayout() {
             className="shrink-0 pr-2 pl-[78px]"
             style={{
               width: sidebarOpen ? channelsSidebarWidth : undefined,
-              transition: sidebarIsResizing ? "none" : "width 0.2s ease-in-out",
+              // Same curve/duration as ResizableSidebar's SLIDE_EASING so the
+              // title bar tracks the sidebar edge.
+              transition: sidebarIsResizing
+                ? "none"
+                : "width 0.2s cubic-bezier(0, 0, 0.2, 1)",
             }}
           >
             <Flex align="center" gap="2" className="no-drag">
               <Box className="h-[14px] w-[30px] overflow-hidden [&>svg]:h-[14px] [&>svg]:w-auto">
                 <LogosLandscape code={false} />
               </Box>
+              <Button
+                variant="outline"
+                size="icon-sm"
+                aria-label="Toggle sidebar"
+                onClick={handleToggleSidebar}
+                onMouseEnter={() => {
+                  if (!sidebarOpen) beginSidebarPeek();
+                }}
+                onMouseLeave={() => {
+                  // Grace only here: the pointer needs time to travel from
+                  // the title-bar button down into the nav. Leaving the nav
+                  // itself hides immediately.
+                  if (!sidebarOpen) endSidebarPeek(300);
+                }}
+              >
+                {sidebarOpen ? (
+                  <SidebarClose size={10} />
+                ) : (
+                  <SidebarOpen size={10} />
+                )}
+              </Button>
             </Flex>
             <Flex align="center" gap="2" className="no-drag">
-              <Button
-                variant="outline"
-                size="icon-sm"
-                aria-label="Back"
-                disabled={!canGoBack}
-                onClick={() => router.history.back()}
-              >
-                <CaretLeftIcon size={14} />
-              </Button>
-              <Button
-                variant="outline"
-                size="icon-sm"
-                aria-label="Forward"
-                disabled={!canGoForward}
-                onClick={() => router.history.forward()}
-              >
-                <CaretRightIcon size={14} />
-              </Button>
+              <ButtonGroup className="no-drag">
+                <Button
+                  variant="outline"
+                  size="icon-sm"
+                  aria-label="Back"
+                  disabled={!canGoBack}
+                  onClick={() => router.history.back()}
+                >
+                  <CaretLeftIcon size={14} />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="icon-sm"
+                  aria-label="Forward"
+                  disabled={!canGoForward}
+                  onClick={() => router.history.forward()}
+                >
+                  <CaretRightIcon size={14} />
+                </Button>
+              </ButtonGroup>
             </Flex>
           </Flex>
           {/* Tabs work in both spaces: channel tabs under /website and plain
@@ -395,12 +437,45 @@ function RootLayout() {
           )}
         </Flex>
         <ConnectivityBanner />
-        <Flex flexGrow="1" overflow="hidden">
+        <Flex flexGrow="1" overflow="hidden" className="relative">
+          {/* Invisible hover gutter: while the sidebar is collapsed, resting
+              the pointer on the window's left edge peeks the sidebar out as an
+              overlay. The panel (z-50) slides over this strip, so its own
+              hover handlers take over keeping the peek alive. */}
+          {!sidebarOpen && (
+            <Box
+              className="absolute inset-y-0 left-0 z-40 w-2"
+              onMouseEnter={() => {
+                // A drag-to-close sweeps the pointer through this strip —
+                // peeking then would fight the drag.
+                if (!sidebarIsResizing) beginSidebarPeek();
+              }}
+              onMouseLeave={() => endSidebarPeek()}
+            />
+          )}
+          {/* Scrim under the peeked nav: dims the content while the overlay is
+              out. Purely visual (pointer-transparent) and paired with the
+              panel's slide — same 200ms ease-out — so they read as one unit. */}
+          {!sidebarOpen && (
+            <Box
+              aria-hidden
+              // The radix preset replaces Tailwind's palette, so plain
+              // `bg-black/*` doesn't exist — use the radix black-alpha scale
+              // (--black-a2 = 10%, --black-a5 = 30%).
+              className={`pointer-events-none absolute inset-0 z-40 bg-blackA-2 transition-opacity duration-200 ease-out motion-reduce:transition-none dark:bg-blackA-5 ${
+                sidebarPeek ? "opacity-100" : "opacity-0"
+              }`}
+            />
+          )}
           <ChannelsSidebar />
           {/* Content sits in a bordered, rounded card inset from the window
               edges — the framed pane from the design. */}
           <Box flexGrow="1" className="overflow-hidden">
-            <Box className="h-full overflow-hidden rounded-tl-sm border-border border-t border-l bg-background">
+            <Box
+              className={`h-full overflow-hidden border-border border-t border-l bg-background ${
+                sidebarOpen ? "rounded-tl-sm" : ""
+              }`}
+            >
               <Flex direction="column" height="100%">
                 {/* The /website space renders its own header (WebsiteLayout);
                       everywhere else the shared header carries the view title


### PR DESCRIPTION
## Problems

* Lost collapse nav button, shortcut-only (cmd b)

<img width="1262" height="1022" alt="2026-07-11 00 31 19" src="https://github.com/user-attachments/assets/43a99048-9f2b-43bc-9e7b-06ccf0187522" />


## Changes

- **Hover-peek**: when the nav is collapsed, hovering an invisible gutter on the window's left edge (or the title-bar toggle) slides the nav out as a floating overlay over the content with a subtle dimming scrim; mouse off and it slides back. The floating panel is resizable too.
- **Drag-to-close**: dragging the resize handle clamps at min width, but pulling past half the min width collapses the sidebar; keep holding and drag back out and it pops open again (16px hysteresis so the boundary can't jitter). Works on both the docked and floating panel. The pre-drag width is restored on close so reopening comes back at your chosen size.
- **Synced animation**: the container width (incl. min/max-width, which otherwise clamp and jump-cut), the panel translateX, and the title bar all animate on one shared 200ms curve so the content edge and nav edge track each other frame-for-frame in both directions.
- The title-bar button now toggles collapse (was history-back, duplicating the button next to it), with the icon reflecting state.
- Resize polish: the handle's primary line stays lit while grabbing, a full-screen shield keeps the col-resize cursor during drags, and the handle disarms briefly during slides so it can't pick up a stale :hover.
- Collapsed content pane drops its top-left border radius (flush with the window edge).
- Unmount mid-drag resets body cursor/user-select and the isResizing flag.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` and biome clean.
- Manual in the dev app: peek in/out via gutter and button, drag-to-close/reopen from docked and floating states, resize while floating, scrim fade, animation sync when toggling open/closed (verified scrim styles via CDP against the running app — the radix Tailwind preset has no `bg-black/*`, hence the `bg-blackA-*` scale).
- Verified the other ResizableSidebar consumers (right-side panels: skills, marketplace, canvas, new-task context) are unaffected: all sit inside overflow-hidden ancestors and none use peek.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

🤖 Generated with [Claude Code](https://claude.com/claude-code)