### PR TITLE
fix(sidebar): reveal collapsed nav by edge proximity, close only on directional exit

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -51,14 +51,7 @@ export function ChannelsSidebar() {
     setOpenAuto(hasCompletedOnboarding || Object.keys(workspaces).length > 0);
   }, [workspacesFetched, workspaces, hasCompletedOnboarding, setOpenAuto]);
 
-  // Hover-reveal while collapsed (see the pointer gesture below). Any open
-  // (click, Cmd+B) makes the peek redundant — drop it so the overlay state
-  // can't linger.
   const peek = useSidebarPeekStore((s) => s.peek);
-  // Pointer-position hover gesture (Dia-style): approaching the left edge peeks
-  // the nav out, and once out it stays until the pointer crosses decisively
-  // into the content (past the panel's right edge + margin). Leaving to the
-  // left / off-window keeps it open. Off while docked or mid-resize.
   useSidebarEdgeHoverPeek({
     enabled: !open && !isResizing,
     peeked: peek,

--- a/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsSidebar.tsx
@@ -18,6 +18,7 @@ import {
 } from "@posthog/ui/features/sidebar/sidebarPeekStore";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
+import { useSidebarEdgeHoverPeek } from "@posthog/ui/primitives/hooks/useSidebarEdgeHoverPeek";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import { navigateToArchived } from "@posthog/ui/router/navigationBridge";
 import { Box, Flex } from "@radix-ui/themes";
@@ -50,10 +51,22 @@ export function ChannelsSidebar() {
     setOpenAuto(hasCompletedOnboarding || Object.keys(workspaces).length > 0);
   }, [workspacesFetched, workspaces, hasCompletedOnboarding, setOpenAuto]);
 
-  // Hover-reveal while collapsed: the left gutter / title-bar toggle set peek,
-  // and the panel keeps it alive under the pointer. Any open (click, Cmd+B)
-  // makes the peek redundant — drop it so the overlay state can't linger.
+  // Hover-reveal while collapsed (see the pointer gesture below). Any open
+  // (click, Cmd+B) makes the peek redundant — drop it so the overlay state
+  // can't linger.
   const peek = useSidebarPeekStore((s) => s.peek);
+  // Pointer-position hover gesture (Dia-style): approaching the left edge peeks
+  // the nav out, and once out it stays until the pointer crosses decisively
+  // into the content (past the panel's right edge + margin). Leaving to the
+  // left / off-window keeps it open. Off while docked or mid-resize.
+  useSidebarEdgeHoverPeek({
+    enabled: !open && !isResizing,
+    peeked: peek,
+    side: "left",
+    width,
+    onReveal: beginSidebarPeek,
+    onClose: () => endSidebarPeek(),
+  });
   useEffect(() => {
     if (open) cancelSidebarPeek();
   }, [open]);

--- a/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -1,4 +1,5 @@
 import { SIDEBAR_MIN_WIDTH } from "@posthog/ui/features/sidebar/constants";
+import { PEEK_CLOSE_MARGIN } from "@posthog/ui/primitives/hooks/useSidebarEdgeHoverPeek";
 import { Box, Flex } from "@radix-ui/themes";
 import React from "react";
 
@@ -146,13 +147,13 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
       if (dragEndedClosedRef.current) {
         setWidth(dragStartWidthRef.current);
       }
-      // A floating-panel drag suppresses the panel's mouseleave (the pointer
-      // can travel anywhere mid-drag), so when it ends off-panel, schedule the
-      // hide the leave would have scheduled.
+      // A floating-panel drag lets the pointer travel anywhere mid-drag, so
+      // when it ends decisively in the content (past the panel edge + the
+      // same directional-close margin the hover gesture uses), hide the peek.
       if (!open && peek) {
         const pointer =
           side === "left" ? e.clientX : window.innerWidth - e.clientX;
-        if (pointer > width) onPeekLeave?.();
+        if (pointer > width + PEEK_CLOSE_MARGIN) onPeekLeave?.();
       }
     };
 
@@ -227,10 +228,6 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
     >
       <Flex
         direction="column"
-        onMouseEnter={isOverlay ? onPeekEnter : undefined}
-        onMouseLeave={
-          isOverlay && !isResizing ? () => onPeekLeave?.() : undefined
-        }
         style={{
           width: `${width}px`,
           ...(isOverlay

--- a/packages/ui/src/primitives/ResizableSidebar.tsx
+++ b/packages/ui/src/primitives/ResizableSidebar.tsx
@@ -147,9 +147,6 @@ export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
       if (dragEndedClosedRef.current) {
         setWidth(dragStartWidthRef.current);
       }
-      // A floating-panel drag lets the pointer travel anywhere mid-drag, so
-      // when it ends decisively in the content (past the panel edge + the
-      // same directional-close margin the hover gesture uses), hide the peek.
       if (!open && peek) {
         const pointer =
           side === "left" ? e.clientX : window.innerWidth - e.clientX;

--- a/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.test.ts
+++ b/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.test.ts
@@ -1,0 +1,44 @@
+import {
+  PEEK_CLOSE_MARGIN,
+  PEEK_REVEAL_THRESHOLD,
+  shouldCloseOnExit,
+  shouldRevealOnEdge,
+} from "@posthog/ui/primitives/hooks/useSidebarEdgeHoverPeek";
+import { describe, expect, it } from "vitest";
+
+describe("shouldRevealOnEdge", () => {
+  const threshold = PEEK_REVEAL_THRESHOLD;
+
+  it.each([
+    // [name, pointer, wasInside, expected]
+    ["crosses into the zone from outside", 10, false, true],
+    ["already inside the zone (no re-trigger)", 10, true, false],
+    ["outside the zone", 100, false, false],
+    ["flick from outside straight to the edge in one sample", 0, false, true],
+    ["exactly on the threshold, crossing in", threshold, false, true],
+    ["just past the threshold", threshold + 1, false, false],
+  ])("%s", (_name, pointer, wasInside, expected) => {
+    expect(shouldRevealOnEdge({ pointer, wasInside, threshold })).toBe(
+      expected,
+    );
+  });
+});
+
+describe("shouldCloseOnExit", () => {
+  const margin = PEEK_CLOSE_MARGIN;
+
+  it.each([
+    // [name, pointer, width, expected]
+    ["inside the panel", 100, 240, false],
+    ["between the panel edge and the margin", 280, 240, false],
+    ["exactly on the far edge (right edge)", 240, 240, false],
+    ["exactly on the close boundary", 240 + margin, 240, false],
+    ["past the close boundary into content", 240 + margin + 1, 240, true],
+    ["stays open at the left edge / off-window", 0, 240, false],
+    // Wider panel: the boundary tracks the live width.
+    ["wide panel still open before its boundary", 400 + margin, 400, false],
+    ["wide panel closes past its boundary", 400 + margin + 1, 400, true],
+  ])("%s", (_name, pointer, width, expected) => {
+    expect(shouldCloseOnExit({ pointer, width, margin })).toBe(expected);
+  });
+});

--- a/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.test.ts
+++ b/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.test.ts
@@ -10,7 +10,6 @@ describe("shouldRevealOnEdge", () => {
   const threshold = PEEK_REVEAL_THRESHOLD;
 
   it.each([
-    // [name, pointer, wasInside, expected]
     ["crosses into the zone from outside", 10, false, true],
     ["already inside the zone (no re-trigger)", 10, true, false],
     ["outside the zone", 100, false, false],
@@ -28,14 +27,12 @@ describe("shouldCloseOnExit", () => {
   const margin = PEEK_CLOSE_MARGIN;
 
   it.each([
-    // [name, pointer, width, expected]
     ["inside the panel", 100, 240, false],
     ["between the panel edge and the margin", 280, 240, false],
     ["exactly on the far edge (right edge)", 240, 240, false],
     ["exactly on the close boundary", 240 + margin, 240, false],
     ["past the close boundary into content", 240 + margin + 1, 240, true],
     ["stays open at the left edge / off-window", 0, 240, false],
-    // Wider panel: the boundary tracks the live width.
     ["wide panel still open before its boundary", 400 + margin, 400, false],
     ["wide panel closes past its boundary", 400 + margin + 1, 400, true],
   ])("%s", (_name, pointer, width, expected) => {

--- a/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.ts
+++ b/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.ts
@@ -1,20 +1,8 @@
 import { useEffect, useRef } from "react";
 
-// Dia-style hover-peek gesture for the collapsed sidebar. Two pointer-position
-// rules replace the old fixed 8px hover strip + mouseleave close:
-//  - Reveal: crossing within PEEK_REVEAL_THRESHOLD px of the sidebar's window
-//    edge peeks it out — proximity, not a pixel-perfect strip.
-//  - Close: once peeked, only crossing past (sidebar far edge + PEEK_CLOSE_MARGIN)
-//    into the content closes it. Leaving in any other direction — left, up,
-//    down, off-window — keeps it open.
-// Both thresholds are distance from the sidebar's own window edge, so the same
-// math works for a left or right sidebar. Tunable.
 export const PEEK_REVEAL_THRESHOLD = 24;
 export const PEEK_CLOSE_MARGIN = 64;
 
-// Only fires on the crossing from outside → inside the threshold, so a cursor
-// already parked in the zone (e.g. right after a drag-to-close that released
-// near the edge) can't re-trigger until it leaves and comes back.
 export function shouldRevealOnEdge({
   pointer,
   wasInside,
@@ -27,8 +15,6 @@ export function shouldRevealOnEdge({
   return pointer <= threshold && !wasInside;
 }
 
-// Directional close: only when the pointer moves decisively into the content,
-// past the sidebar's far edge plus the margin.
 export function shouldCloseOnExit({
   pointer,
   width,
@@ -42,14 +28,9 @@ export function shouldCloseOnExit({
 }
 
 interface UseSidebarEdgeHoverPeekOptions {
-  // Active only while the sidebar is collapsed and not being dragged.
   enabled: boolean;
-  // Whether the peek overlay is currently shown — switches the listener from
-  // "watch for reveal" to "watch for directional close".
   peeked: boolean;
   side: "left" | "right";
-  // Current sidebar width; the close threshold is measured against it live so
-  // resizing the panel keeps the gesture correct.
   width: number;
   onReveal: () => void;
   onClose: () => void;
@@ -63,22 +44,16 @@ export function useSidebarEdgeHoverPeek({
   onReveal,
   onClose,
 }: UseSidebarEdgeHoverPeekOptions): void {
-  // Read the latest props/callbacks inside the listener without re-subscribing
-  // on every render (mirrors the ref pattern the drag lifecycle uses).
   const stateRef = useRef({ peeked, side, width, onReveal, onClose });
   stateRef.current = { peeked, side, width, onReveal, onClose };
 
   useEffect(() => {
     if (!enabled) return;
 
-    // Assume "inside" on arm so an already-parked cursor must exit the reveal
-    // zone once before it can peek — prevents an instant re-peek after a
-    // drag-to-close that released near the edge.
     let wasInside = true;
 
     const handleMouseMove = (e: MouseEvent) => {
       const state = stateRef.current;
-      // Distance from the sidebar's own window edge, regardless of side.
       const pointer =
         state.side === "left" ? e.clientX : window.innerWidth - e.clientX;
 

--- a/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.ts
+++ b/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.ts
@@ -44,37 +44,37 @@ export function useSidebarEdgeHoverPeek({
   onReveal,
   onClose,
 }: UseSidebarEdgeHoverPeekOptions): void {
-  const stateRef = useRef({ peeked, side, width, onReveal, onClose });
-  stateRef.current = { peeked, side, width, onReveal, onClose };
+  const stateRef = useRef({ enabled, peeked, side, width, onReveal, onClose });
+  stateRef.current = { enabled, peeked, side, width, onReveal, onClose };
 
   useEffect(() => {
-    if (!enabled) return;
-
-    let wasInside = true;
+    let wasInside = false;
 
     const handleMouseMove = (e: MouseEvent) => {
       const state = stateRef.current;
       const pointer =
         state.side === "left" ? e.clientX : window.innerWidth - e.clientX;
 
-      if (state.peeked) {
-        if (
-          shouldCloseOnExit({
+      if (state.enabled) {
+        if (state.peeked) {
+          if (
+            shouldCloseOnExit({
+              pointer,
+              width: state.width,
+              margin: PEEK_CLOSE_MARGIN,
+            })
+          ) {
+            state.onClose();
+          }
+        } else if (
+          shouldRevealOnEdge({
             pointer,
-            width: state.width,
-            margin: PEEK_CLOSE_MARGIN,
+            wasInside,
+            threshold: PEEK_REVEAL_THRESHOLD,
           })
         ) {
-          state.onClose();
+          state.onReveal();
         }
-      } else if (
-        shouldRevealOnEdge({
-          pointer,
-          wasInside,
-          threshold: PEEK_REVEAL_THRESHOLD,
-        })
-      ) {
-        state.onReveal();
       }
 
       wasInside = pointer <= PEEK_REVEAL_THRESHOLD;
@@ -82,5 +82,5 @@ export function useSidebarEdgeHoverPeek({
 
     document.addEventListener("mousemove", handleMouseMove);
     return () => document.removeEventListener("mousemove", handleMouseMove);
-  }, [enabled]);
+  }, []);
 }

--- a/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.ts
+++ b/packages/ui/src/primitives/hooks/useSidebarEdgeHoverPeek.ts
@@ -1,0 +1,111 @@
+import { useEffect, useRef } from "react";
+
+// Dia-style hover-peek gesture for the collapsed sidebar. Two pointer-position
+// rules replace the old fixed 8px hover strip + mouseleave close:
+//  - Reveal: crossing within PEEK_REVEAL_THRESHOLD px of the sidebar's window
+//    edge peeks it out — proximity, not a pixel-perfect strip.
+//  - Close: once peeked, only crossing past (sidebar far edge + PEEK_CLOSE_MARGIN)
+//    into the content closes it. Leaving in any other direction — left, up,
+//    down, off-window — keeps it open.
+// Both thresholds are distance from the sidebar's own window edge, so the same
+// math works for a left or right sidebar. Tunable.
+export const PEEK_REVEAL_THRESHOLD = 24;
+export const PEEK_CLOSE_MARGIN = 64;
+
+// Only fires on the crossing from outside → inside the threshold, so a cursor
+// already parked in the zone (e.g. right after a drag-to-close that released
+// near the edge) can't re-trigger until it leaves and comes back.
+export function shouldRevealOnEdge({
+  pointer,
+  wasInside,
+  threshold,
+}: {
+  pointer: number;
+  wasInside: boolean;
+  threshold: number;
+}): boolean {
+  return pointer <= threshold && !wasInside;
+}
+
+// Directional close: only when the pointer moves decisively into the content,
+// past the sidebar's far edge plus the margin.
+export function shouldCloseOnExit({
+  pointer,
+  width,
+  margin,
+}: {
+  pointer: number;
+  width: number;
+  margin: number;
+}): boolean {
+  return pointer > width + margin;
+}
+
+interface UseSidebarEdgeHoverPeekOptions {
+  // Active only while the sidebar is collapsed and not being dragged.
+  enabled: boolean;
+  // Whether the peek overlay is currently shown — switches the listener from
+  // "watch for reveal" to "watch for directional close".
+  peeked: boolean;
+  side: "left" | "right";
+  // Current sidebar width; the close threshold is measured against it live so
+  // resizing the panel keeps the gesture correct.
+  width: number;
+  onReveal: () => void;
+  onClose: () => void;
+}
+
+export function useSidebarEdgeHoverPeek({
+  enabled,
+  peeked,
+  side,
+  width,
+  onReveal,
+  onClose,
+}: UseSidebarEdgeHoverPeekOptions): void {
+  // Read the latest props/callbacks inside the listener without re-subscribing
+  // on every render (mirrors the ref pattern the drag lifecycle uses).
+  const stateRef = useRef({ peeked, side, width, onReveal, onClose });
+  stateRef.current = { peeked, side, width, onReveal, onClose };
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    // Assume "inside" on arm so an already-parked cursor must exit the reveal
+    // zone once before it can peek — prevents an instant re-peek after a
+    // drag-to-close that released near the edge.
+    let wasInside = true;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const state = stateRef.current;
+      // Distance from the sidebar's own window edge, regardless of side.
+      const pointer =
+        state.side === "left" ? e.clientX : window.innerWidth - e.clientX;
+
+      if (state.peeked) {
+        if (
+          shouldCloseOnExit({
+            pointer,
+            width: state.width,
+            margin: PEEK_CLOSE_MARGIN,
+          })
+        ) {
+          state.onClose();
+        }
+      } else if (
+        shouldRevealOnEdge({
+          pointer,
+          wasInside,
+          threshold: PEEK_REVEAL_THRESHOLD,
+        })
+      ) {
+        state.onReveal();
+      }
+
+      wasInside = pointer <= PEEK_REVEAL_THRESHOLD;
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    return () => document.removeEventListener("mousemove", handleMouseMove);
+  }, [enabled]);
+}

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -45,7 +45,6 @@ import { useSetupDiscovery } from "@posthog/ui/features/setup/useSetupDiscovery"
 import {
   beginSidebarPeek,
   cancelSidebarPeek,
-  endSidebarPeek,
   useSidebarPeekStore,
 } from "@posthog/ui/features/sidebar/sidebarPeekStore";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
@@ -372,13 +371,10 @@ function RootLayout() {
                 aria-label="Toggle sidebar"
                 onClick={handleToggleSidebar}
                 onMouseEnter={() => {
+                  // Hovering the toggle is a secondary reveal affordance; the
+                  // directional-close gesture (see useSidebarEdgeHoverPeek)
+                  // owns hiding it again.
                   if (!sidebarOpen) beginSidebarPeek();
-                }}
-                onMouseLeave={() => {
-                  // Grace only here: the pointer needs time to travel from
-                  // the title-bar button down into the nav. Leaving the nav
-                  // itself hides immediately.
-                  if (!sidebarOpen) endSidebarPeek(300);
                 }}
               >
                 {sidebarOpen ? (
@@ -438,21 +434,9 @@ function RootLayout() {
         </Flex>
         <ConnectivityBanner />
         <Flex flexGrow="1" overflow="hidden" className="relative">
-          {/* Invisible hover gutter: while the sidebar is collapsed, resting
-              the pointer on the window's left edge peeks the sidebar out as an
-              overlay. The panel (z-50) slides over this strip, so its own
-              hover handlers take over keeping the peek alive. */}
-          {!sidebarOpen && (
-            <Box
-              className="absolute inset-y-0 left-0 z-40 w-2"
-              onMouseEnter={() => {
-                // A drag-to-close sweeps the pointer through this strip —
-                // peeking then would fight the drag.
-                if (!sidebarIsResizing) beginSidebarPeek();
-              }}
-              onMouseLeave={() => endSidebarPeek()}
-            />
-          )}
+          {/* The collapsed-sidebar hover-reveal is driven by pointer position
+              (see useSidebarEdgeHoverPeek in ChannelsSidebar), not a fixed hit
+              strip — approaching the left edge peeks it out. */}
           {/* Scrim under the peeked nav: dims the content while the overlay is
               out. Purely visual (pointer-transparent) and paired with the
               panel's slide — same 200ms ease-out — so they read as one unit. */}

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -371,9 +371,6 @@ function RootLayout() {
                 aria-label="Toggle sidebar"
                 onClick={handleToggleSidebar}
                 onMouseEnter={() => {
-                  // Hovering the toggle is a secondary reveal affordance; the
-                  // directional-close gesture (see useSidebarEdgeHoverPeek)
-                  // owns hiding it again.
                   if (!sidebarOpen) beginSidebarPeek();
                 }}
               >
@@ -434,9 +431,6 @@ function RootLayout() {
         </Flex>
         <ConnectivityBanner />
         <Flex flexGrow="1" overflow="hidden" className="relative">
-          {/* The collapsed-sidebar hover-reveal is driven by pointer position
-              (see useSidebarEdgeHoverPeek in ChannelsSidebar), not a fixed hit
-              strip — approaching the left edge peeks it out. */}
           {/* Scrim under the peeked nav: dims the content while the overlay is
               out. Purely visual (pointer-transparent) and paired with the
               panel's slide — same 200ms ease-out — so they read as one unit. */}


### PR DESCRIPTION
## Problem

Closes #3366

The collapsed-sidebar hover-peek (#3361) was fiddly: the reveal trigger was an
8px invisible strip at the window edge (`onMouseEnter`), so it took pixel-perfect
aim to open. And it closed on *any* `mouseleave`, so sliding to the edge and
continuing left or off-window dismissed the nav in your face.

## Changes

Replace the DOM hover triggers with pointer-position rules (Dia-style), in a new
`useSidebarEdgeHoverPeek` hook (one document `mousemove` listener, active only
while collapsed and not resizing):

- **Reveal** when the cursor crosses within `24px` of the left edge (proximity,
  and only on the crossing, so it can't re-trigger right after a drag-to-close).
- **Directional close**: once peeked, close only when the cursor crosses past
  `sidebar width + 64px` into the content. Leaving left, up, down, or off-window
  keeps it open.

Removes the fixed 8px hit strip and the title-bar button's 300ms leave grace,
and aligns the drag-to-close end margin with the same 64px. Thresholds are named
constants (`PEEK_REVEAL_THRESHOLD`, `PEEK_CLOSE_MARGIN`).

## Before / after

https://github.com/user-attachments/assets/17f558a1-c82b-421f-a57a-446ab099d9c4

## How did you test this?

- Unit tests for the two pure helpers (`shouldRevealOnEdge`, `shouldCloseOnExit`),
  14 cases, `pnpm --filter @posthog/ui test`.
- `pnpm typecheck` and Biome pass.
- Manually in the dev app: reveal from various distances and speeds; slide to the
  edge and continue off-window (stays open); leave without entering the content
  (stays open); cross into the content past the margin (closes); drag-to-close
  near the edge (no re-peek).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*