### PR TITLE
Ux/rename threads to contexts

### DIFF
--- a/packages/ui/src/features/browser-tabs/BrowserTabStrip.tsx
+++ b/packages/ui/src/features/browser-tabs/BrowserTabStrip.tsx
@@ -1,6 +1,5 @@
 import {
   BrainIcon,
-  HashIcon,
   HouseIcon,
   PlugsConnectedIcon,
   RobotIcon,
@@ -50,6 +49,7 @@ import {
   useRouter,
   useRouterState,
 } from "@tanstack/react-router";
+import { SquircleDashed } from "lucide-react";
 import { type ReactNode, useEffect, useMemo } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import {
@@ -519,8 +519,8 @@ export function BrowserTabStrip() {
           const meta = channelSectionFor(section);
           return {
             id: t.id,
-            label: meta?.label ?? channel ?? "Channel",
-            icon: <HashIcon size={14} />,
+            label: meta?.label ?? channel ?? "Context",
+            icon: <SquircleDashed size={14} />,
             channelName: channel,
             // No section meta → the channel's index page.
             isChannelHome: !meta,

--- a/packages/ui/src/features/browser-tabs/TabStrip.tsx
+++ b/packages/ui/src/features/browser-tabs/TabStrip.tsx
@@ -231,7 +231,7 @@ function SortableTabPill({
               repeat the channel-home name already shown above. */}
           {tab.channelName ? (
             <div className="text-muted">
-              #{tab.channelName}
+              {tab.channelName}
               {tab.isChannelHome ? " / home" : null}
             </div>
           ) : null}

--- a/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -89,7 +89,7 @@ function ActivityRow({
                 <>
                   {" in "}
                   <Text as="span" size="1" weight="medium">
-                    #{item.channelName}
+                    {item.channelName}
                   </Text>
                 </>
               )}
@@ -176,7 +176,7 @@ export function ActivityView() {
           Activity
         </Text>
         <Text size="2" className="block text-muted-foreground">
-          Mentions of you across channel threads.
+          Mentions of you across contexts.
         </Text>
         <div className="mt-4">
           {isLoading && items.length === 0 ? (

--- a/packages/ui/src/features/canvas/components/ChannelBreadcrumb.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelBreadcrumb.tsx
@@ -1,4 +1,3 @@
-import { HashIcon } from "@phosphor-icons/react";
 import {
   Button,
   Tooltip,
@@ -8,6 +7,7 @@ import {
 import { HeaderTitleEditor } from "@posthog/ui/features/task-detail/HeaderTitleEditor";
 import { Flex, Text } from "@radix-ui/themes";
 import { useNavigate } from "@tanstack/react-router";
+import { SquircleDashed } from "lucide-react";
 import { type ReactNode, useState } from "react";
 
 interface ChannelBreadcrumbProps {
@@ -48,7 +48,10 @@ export function ChannelBreadcrumb({
 
   const channelSegment = (
     <>
-      <HashIcon size={12} className="mt-px shrink-0 text-muted-foreground/80" />
+      <SquircleDashed
+        size={12}
+        className="mt-px shrink-0 text-muted-foreground/80"
+      />
       <Text
         className="min-w-0 truncate whitespace-nowrap font-medium text-[13px]"
         title={channelName}

--- a/packages/ui/src/features/canvas/components/ChannelContextPanel.test.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelContextPanel.test.tsx
@@ -34,7 +34,7 @@ describe("ChannelContextPanel", () => {
   it.each([
     {
       channelName: "project-bluebird",
-      expectedTitle: "#project-bluebird CONTEXT.md",
+      expectedTitle: "project-bluebird CONTEXT.md",
     },
     { channelName: undefined, expectedTitle: "CONTEXT.md" },
   ])(

--- a/packages/ui/src/features/canvas/components/ChannelContextPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelContextPanel.tsx
@@ -29,7 +29,7 @@ export function ChannelContextPanel({
           weight="medium"
           className="min-w-0 truncate text-gray-12"
         >
-          {channelName ? `#${channelName} ` : ""}CONTEXT.md
+          {channelName ? `${channelName} ` : ""}CONTEXT.md
         </Text>
         <Tooltip content="Close">
           <button

--- a/packages/ui/src/features/canvas/components/ChannelHeader.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHeader.tsx
@@ -1,9 +1,9 @@
-import { HashIcon } from "@phosphor-icons/react";
 import { Button, cn } from "@posthog/quill";
 import { ChannelTabs } from "@posthog/ui/features/canvas/components/ChannelTabs";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { Text } from "@radix-ui/themes";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { SquircleDashed } from "lucide-react";
 
 // The shared channel header: a clickable "# channel" that doubles as the Home
 // item — it routes to the channel home (`/website/$channelId`, like the sidebar
@@ -29,15 +29,12 @@ export function ChannelHeader({ channelId }: { channelId: string }) {
         size="sm"
         className={cn("min-w-0", isHome ? "bg-fill-selected" : "")}
       >
-        <HashIcon
-          size={12}
-          className="mt-px shrink-0 text-muted-foreground/80"
+        <SquircleDashed
+          size={20}
+          className="shrink-0 text-muted-foreground/80"
         />
-        <Text
-          className="min-w-0 truncate font-medium text-[13px]"
-          title={channelName}
-        >
-          {channelName ?? "Channel"}
+        <Text className="min-w-0 truncate font-medium" title={channelName}>
+          {channelName ?? "Context"}
         </Text>
       </Button>
       <ChannelTabs channelId={channelId} />

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -2,7 +2,6 @@ import {
   ChartBarIcon,
   DotsThreeIcon,
   FileTextIcon,
-  HashIcon,
   LinkIcon,
   LockSimpleIcon,
   PencilSimpleIcon,
@@ -60,6 +59,7 @@ import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { SquircleDashed } from "lucide-react";
 import { Fragment, type ReactNode, useEffect, useRef, useState } from "react";
 import { hostClient } from "../hostClient";
 
@@ -138,7 +138,7 @@ function useChannelActions(channel: Channel): {
         channel_id: channel.id,
         success: false,
       });
-      toast.error("Couldn't delete channel", {
+      toast.error("Couldn't delete context", {
         description: error instanceof Error ? error.message : String(error),
       });
       return false;
@@ -148,7 +148,7 @@ function useChannelActions(channel: Channel): {
   const actions: ChannelActionItem[] = [
     {
       key: "star",
-      label: isStarred ? "Unstar channel" : "Star channel",
+      label: isStarred ? "Unstar context" : "Star context",
       icon: <StarIcon size={14} weight={isStarred ? "fill" : "regular"} />,
       onSelect: () => {
         track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
@@ -167,14 +167,14 @@ function useChannelActions(channel: Channel): {
     },
     {
       key: "rename",
-      label: "Rename channel…",
+      label: "Rename context…",
       icon: <PencilSimpleIcon size={14} />,
       separatorBefore: true,
       onSelect: () => setRenameOpen(true),
     },
     {
       key: "delete",
-      label: "Delete channel…",
+      label: "Delete context…",
       icon: <TrashIcon size={14} />,
       variant: "destructive",
       onSelect: () => setConfirmDeleteOpen(true),
@@ -334,7 +334,7 @@ function ChannelSection({ channel }: { channel: Channel }) {
               }}
               className="w-full min-w-0 justify-start gap-2 data-selected:bg-fill-selected data-selected:text-gray-12"
             >
-              <HashIcon size={14} className="shrink-0 text-gray-9" />
+              <SquircleDashed size={14} className="shrink-0 text-gray-9" />
               <span
                 className={cn(
                   "truncate font-medium text-[13px] text-gray-12 group-hover/chan:pr-8",
@@ -439,19 +439,19 @@ function ChannelSection({ channel }: { channel: Channel }) {
       >
         <AlertDialogContent className="max-w-md">
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete #{channel.name}?</AlertDialogTitle>
+            <AlertDialogTitle>Delete {channel.name}?</AlertDialogTitle>
             <AlertDialogDescription>
-              This permanently deletes the channel and can’t be undone.
+              This permanently deletes the context and can’t be undone.
               <ul className="list-disc ps-4">
                 <li>
-                  The channel and its{" "}
+                  The context and its{" "}
                   <span className="font-medium">CONTEXT.md</span> are deleted.
                 </li>
                 <li>
-                  Every canvas saved in this channel is permanently deleted.
+                  Every canvas saved in this context is permanently deleted.
                 </li>
                 <li>
-                  Filed tasks are removed from the channel, but the tasks
+                  Filed tasks are removed from the context, but the tasks
                   themselves are not deleted.
                 </li>
               </ul>
@@ -470,7 +470,7 @@ function ChannelSection({ channel }: { channel: Channel }) {
                 })
               }
             >
-              Delete channel
+              Delete context
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -505,7 +505,7 @@ function PersonalChannelRow() {
         params: { channelId: folder.id },
       });
     } catch (error) {
-      toast.error("Couldn't open #me", {
+      toast.error("Couldn't open me", {
         description: error instanceof Error ? error.message : String(error),
       });
     }
@@ -521,7 +521,7 @@ function PersonalChannelRow() {
       onClick={() => void open()}
       className="w-full min-w-0 justify-start gap-2 data-selected:bg-fill-selected data-selected:text-gray-12"
     >
-      <HashIcon size={14} className="shrink-0 text-gray-9" />
+      <SquircleDashed size={14} className="shrink-0 text-gray-9" />
       <span className="truncate font-medium text-[13px] text-gray-12">
         {PERSONAL_CHANNEL_NAME}
       </span>
@@ -583,8 +583,8 @@ export function ChannelsList() {
         <Box className={cn(starred.length > 0 && "mt-3")}>
           <MenuLabel className="group flex items-center justify-between uppercase">
             <span className="flex items-center gap-2">
-              <HashIcon size={14} className="text-gray-9" />
-              Channels
+              <SquircleDashed size={14} className="text-gray-9" />
+              Contexts
             </span>
             <Button
               variant="outline"
@@ -599,7 +599,7 @@ export function ChannelsList() {
 
         {!isLoading && channels.length === 0 && (
           <Text size="1" className="px-2 text-gray-9">
-            No channels yet. Create one to get started.
+            No contexts yet. Create one to get started.
           </Text>
         )}
 

--- a/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -1,4 +1,4 @@
-import { HashIcon, XIcon } from "@phosphor-icons/react";
+import { XIcon } from "@phosphor-icons/react";
 import { validateChannelName } from "@posthog/core/canvas/channelName";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -7,6 +7,7 @@ import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Dialog, Flex, IconButton, Text, TextField } from "@radix-ui/themes";
 import { useNavigate } from "@tanstack/react-router";
+import { SquircleDashed } from "lucide-react";
 import { useState } from "react";
 
 // Matches Slack's "Create a channel" naming constraint.
@@ -55,7 +56,7 @@ export function CreateChannelModal({
         surface: "sidebar",
         success: false,
       });
-      toast.error("Couldn't create channel", {
+      toast.error("Couldn't create context", {
         description: error instanceof Error ? error.message : String(error),
       });
       return;
@@ -78,7 +79,7 @@ export function CreateChannelModal({
       <Dialog.Content maxWidth="560px">
         <Flex align="start" justify="between" gap="3">
           <Dialog.Title>
-            <Text className="font-bold text-lg">Create a channel</Text>
+            <Text className="font-bold text-lg">Create a context</Text>
           </Dialog.Title>
           <Dialog.Close>
             <IconButton
@@ -118,7 +119,7 @@ export function CreateChannelModal({
             }}
           >
             <TextField.Slot>
-              <HashIcon size={16} className="text-gray-10" />
+              <SquircleDashed size={16} className="text-gray-10" />
             </TextField.Slot>
             <TextField.Slot side="right">
               <Text className="text-gray-9 text-sm tabular-nums">
@@ -132,7 +133,7 @@ export function CreateChannelModal({
             </Text>
           )}
           <Text className="text-gray-10 text-sm">
-            Each channel gets its own dashboards, tasks, and settings. Use a
+            Each context gets its own dashboards, tasks, and settings. Use a
             name that's easy to find.
           </Text>
         </Flex>

--- a/packages/ui/src/features/canvas/components/RenameChannelModal.tsx
+++ b/packages/ui/src/features/canvas/components/RenameChannelModal.tsx
@@ -1,4 +1,4 @@
-import { HashIcon, XIcon } from "@phosphor-icons/react";
+import { XIcon } from "@phosphor-icons/react";
 import { validateChannelName } from "@posthog/core/canvas/channelName";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -7,6 +7,7 @@ import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChanne
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Dialog, Flex, IconButton, Text, TextField } from "@radix-ui/themes";
+import { SquircleDashed } from "lucide-react";
 import { useEffect, useState } from "react";
 
 // Matches the create-channel naming constraint.
@@ -54,7 +55,7 @@ export function RenameChannelModal({
         channel_id: channel.id,
         success: false,
       });
-      toast.error("Couldn't rename channel", {
+      toast.error("Couldn't rename context", {
         description: error instanceof Error ? error.message : String(error),
       });
     }
@@ -70,7 +71,7 @@ export function RenameChannelModal({
       <Dialog.Content maxWidth="560px">
         <Flex align="start" justify="between" gap="3">
           <Dialog.Title>
-            <Text className="font-bold text-lg">Rename channel</Text>
+            <Text className="font-bold text-lg">Rename context</Text>
           </Dialog.Title>
           <Dialog.Close>
             <IconButton
@@ -110,7 +111,7 @@ export function RenameChannelModal({
             }}
           >
             <TextField.Slot>
-              <HashIcon size={16} className="text-gray-10" />
+              <SquircleDashed size={16} className="text-gray-10" />
             </TextField.Slot>
             <TextField.Slot side="right">
               <Text className="text-gray-9 text-sm tabular-nums">

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -15,14 +15,17 @@ import {
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useFolderInstructions } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
-import { useBackendChannel } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
+import {
+  PERSONAL_CHANNEL_NAME,
+  useBackendChannel,
+} from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
 import { SuggestedPromptCard } from "@posthog/ui/features/task-detail/components/SuggestedPromptCard";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
-import { Text } from "@radix-ui/themes";
+import { Heading, Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef } from "react";
@@ -100,7 +103,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
             task_id: task.id,
             success: false,
           });
-          toast.error("Couldn't file task to channel", {
+          toast.error("Couldn't file task to context", {
             description: error instanceof Error ? error.message : String(error),
           });
         });
@@ -131,12 +134,17 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
 
   const emptyState = (
     <div className="mx-auto flex min-h-full w-full max-w-[680px] flex-col justify-center gap-6 px-4 py-10">
-      <div className="text-center">
-        <h1 className="font-semibold text-2xl text-gray-12 tracking-tight">
-          {channelName ? `Welcome to #${channelName}` : "Welcome"}
-        </h1>
-        <Text className="mt-2 block text-[13px] text-gray-10">
-          Every message kicks off a task the whole channel can follow.
+      <div className="flex flex-col items-center gap-2 text-center">
+        <Heading className="font-bold text-2xl">
+          {channelName === PERSONAL_CHANNEL_NAME
+            ? "Welcome to your own personal context"
+            : channelName
+              ? `Welcome to ${channelName}`
+              : "Welcome"}
+        </Heading>
+        <Text>
+          Contexts are for areas of work. Context.md is self-updating, so start
+          some work and the context file will update itself.
         </Text>
       </div>
       <div className="flex flex-col gap-2">

--- a/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -415,7 +415,7 @@ function EmptyState({
         <EmptyTitle>No CONTEXT.md yet</EmptyTitle>
         <EmptyDescription>
           CONTEXT.md tells agents the specific details they need to know when
-          working in <strong>#{channelName}</strong> — conventions, gotchas, key
+          working in <strong>{channelName}</strong> — conventions, gotchas, key
           files, and anything else that isn't obvious from the code.
         </EmptyDescription>
       </EmptyHeader>

--- a/packages/ui/src/features/canvas/components/WebsiteNewTask.test.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteNewTask.test.tsx
@@ -73,14 +73,12 @@ describe("WebsiteNewTask context panel", () => {
 
     // Panel starts closed.
     expect(
-      screen.queryByText("#project-bluebird CONTEXT.md"),
+      screen.queryByText("project-bluebird CONTEXT.md"),
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "context-chip" }));
 
-    expect(
-      screen.getByText("#project-bluebird CONTEXT.md"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("project-bluebird CONTEXT.md")).toBeInTheDocument();
     const viewContextCalls = () =>
       track.mock.calls.filter(
         ([, props]) => props?.action_type === "view_context",
@@ -97,7 +95,7 @@ describe("WebsiteNewTask context panel", () => {
     // Clicking again closes the panel and must NOT re-track view_context.
     await user.click(screen.getByRole("button", { name: "context-chip" }));
     expect(
-      screen.queryByText("#project-bluebird CONTEXT.md"),
+      screen.queryByText("project-bluebird CONTEXT.md"),
     ).not.toBeInTheDocument();
     expect(viewContextCalls()).toHaveLength(1);
   });

--- a/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
@@ -91,7 +91,7 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
             task_id: task.id,
             success: false,
           });
-          toast.error("Couldn't file task to channel", {
+          toast.error("Couldn't file task to context", {
             description: error instanceof Error ? error.message : String(error),
           });
         });

--- a/packages/ui/src/features/canvas/hooks/useDashboards.ts
+++ b/packages/ui/src/features/canvas/hooks/useDashboards.ts
@@ -193,7 +193,7 @@ export function useOpenHomeCanvas(): (channel: {
         });
       } catch (error) {
         log.error("Failed to open home canvas", { error });
-        toast.error("Couldn't open channel home", {
+        toast.error("Couldn't open context home", {
           description: error instanceof Error ? error.message : String(error),
         });
       }

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -3,7 +3,6 @@ import {
   CaretRightIcon,
   ChartLine,
   EnvelopeSimple,
-  HashIcon,
 } from "@phosphor-icons/react";
 import { resolveService } from "@posthog/di/container";
 import {
@@ -76,6 +75,7 @@ import {
   ZoomInIcon,
   ZoomOutIcon,
 } from "@radix-ui/react-icons";
+import { SquircleDashed } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface CommandMenuProps {
@@ -483,12 +483,12 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     if (channels.length === 0) return [];
     return [
       {
-        label: "Channels",
+        label: "Contexts",
         items: channels.map((channel) => ({
           id: `channel-${channel.id}`,
           label: channel.name,
-          keywords: "channel",
-          icon: <HashIcon size={12} className="text-gray-11" />,
+          keywords: "context",
+          icon: <SquircleDashed size={12} className="text-gray-11" />,
           action: "open-channel" as CommandMenuAction,
           channelId: channel.id,
           onRun: () => {

--- a/packages/ui/src/features/sidebar/components/SidebarNavSection.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarNavSection.tsx
@@ -1,4 +1,3 @@
-import { HashIcon } from "@phosphor-icons/react";
 import { Badge, Switch } from "@posthog/quill";
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -29,6 +28,7 @@ import { track } from "@posthog/ui/shell/analytics";
 import { useCommandMenuStore } from "@posthog/ui/shell/commandMenuStore";
 import { Box, Flex } from "@radix-ui/themes";
 import { useRouterState } from "@tanstack/react-router";
+import { SquircleDashed } from "lucide-react";
 import { ActivityItem } from "./items/ActivityItem";
 import { AgentsItem } from "./items/AgentsItem";
 import { CommandCenterItem } from "./items/CommandCenterItem";
@@ -199,9 +199,9 @@ export function SidebarNavSection({
           className="group flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-[13px] leading-snug transition-colors hover:bg-fill-secondary"
         >
           <span className="flex shrink-0 items-center opacity-80">
-            <HashIcon size={16} />
+            <SquircleDashed size={14} />
           </span>
-          <span className="min-w-0 truncate font-medium">Channels</span>
+          <span className="min-w-0 truncate font-medium">Contexts</span>
           <Badge variant="info">Alpha</Badge>
           <Switch
             id="channels-toggle"

--- a/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -1335,7 +1335,7 @@ export function TaskInput({
                         <button
                           type="button"
                           onClick={() => setChannelContextDismissed(true)}
-                          aria-label="Remove channel context from prompt"
+                          aria-label="Remove context from prompt"
                           className="ml-0.5 inline-flex size-3.5 items-center justify-center rounded text-gray-10 hover:bg-gray-5 hover:text-gray-12"
                         >
                           <X size={12} />

--- a/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -124,7 +124,7 @@ export function useTaskContextMenu() {
             try {
               await fileTask(intent.channelId, task.id, task.title);
             } catch (error) {
-              toast.error("Couldn't file task to channel", {
+              toast.error("Couldn't file task to context", {
                 description:
                   error instanceof Error ? error.message : String(error),
               });


### PR DESCRIPTION
## Problem
Name channels is confusing

## Changes
Surface level rename from Channels => Contexts

<img width="1119" height="946" alt="image" src="https://github.com/user-attachments/assets/da2c3f71-fc98-405e-985c-73963787bfaa" />


## How did you test this?
locally
