### PR TITLE
fix(agent): unbreak the codex local-tools MCP server ESM bundle

### DIFF
--- a/packages/agent/build/verify-local-tools-mcp-server.mjs
+++ b/packages/agent/build/verify-local-tools-mcp-server.mjs
@@ -1,0 +1,104 @@
+// Post-build smoke check: boot the bundled local-tools MCP server exactly the
+// way Codex spawns it in a cloud sandbox (a bare `node dist/...js` process) and
+// assert it answers `tools/list`. Catches bundling regressions — e.g. inlined
+// CJS deps whose dynamic `require()` throws in ESM output — that unit tests
+// running from src can never see, and that otherwise fail silently in cloud
+// runs (Codex drops a failed MCP server and the signed-git tools just vanish).
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const script = resolve(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "../dist/adapters/codex-app-server/local-tools-mcp-server.js",
+);
+
+const ctx = Buffer.from(
+  JSON.stringify({ cwd: "/tmp", taskId: "smoke", token: "smoke-token" }),
+).toString("base64");
+
+const child = spawn(process.execPath, [script], {
+  env: {
+    ...process.env,
+    // Mirror the production Codex spawn: if this ever runs from an
+    // Electron-hosted process, execPath is the app binary, not node.
+    ELECTRON_RUN_AS_NODE: "1",
+    POSTHOG_LOCAL_TOOLS_CTX: ctx,
+    POSTHOG_LOCAL_TOOLS_ENABLED:
+      "git_signed_commit,git_signed_merge,git_signed_rewrite",
+  },
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+let stderr = "";
+child.stderr.on("data", (d) => {
+  stderr += d.toString();
+});
+
+const timeout = setTimeout(() => {
+  fail(`timed out waiting for tools/list response\nstderr: ${stderr}`);
+}, 15_000);
+
+function fail(message) {
+  console.error(`[verify-local-tools-mcp-server] FAIL: ${message}`);
+  child.kill();
+  process.exit(1);
+}
+
+child.on("exit", (code) => {
+  if (code !== null && code !== 0) {
+    fail(
+      `server exited with code ${code} before responding\nstderr: ${stderr}`,
+    );
+  }
+});
+
+child.stdin.write(
+  `${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "smoke", version: "0.0.0" },
+    },
+  })}\n`,
+);
+child.stdin.write(
+  `${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`,
+);
+child.stdin.write(
+  `${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" })}\n`,
+);
+
+let buffer = "";
+child.stdout.on("data", (chunk) => {
+  buffer += chunk.toString();
+  let newline = buffer.indexOf("\n");
+  while (newline >= 0) {
+    const line = buffer.slice(0, newline).trim();
+    buffer = buffer.slice(newline + 1);
+    newline = buffer.indexOf("\n");
+    if (!line) continue;
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (message.id !== 2) continue;
+    const names = (message.result?.tools ?? []).map((t) => t.name);
+    if (!names.includes("git_signed_commit")) {
+      fail(
+        `tools/list missing git_signed_commit, got: ${JSON.stringify(names)}`,
+      );
+    }
+    console.log(
+      `[verify-local-tools-mcp-server] OK: dist server boots and lists ${names.length} tools`,
+    );
+    clearTimeout(timeout);
+    child.kill();
+    process.exit(0);
+  }
+});

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -104,7 +104,7 @@
   "author": "PostHog",
   "license": "MIT",
   "scripts": {
-    "build": "node ../../scripts/rimraf.mjs dist && tsup",
+    "build": "node ../../scripts/rimraf.mjs dist && tsup && node build/verify-local-tools-mcp-server.mjs",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -969,6 +969,20 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       void this.finalizeTurn(mapTurnStopReason(turn?.status));
     }
 
+    if (method === APP_SERVER_NOTIFICATIONS.MCP_STARTUP_STATUS) {
+      const startup = params as {
+        name?: string;
+        status?: string;
+        error?: string | null;
+      };
+      if (startup?.status === "failed") {
+        this.logger.warn("MCP server failed to start; its tools are absent", {
+          server: startup.name,
+          error: startup.error,
+        });
+      }
+    }
+
     if (method === APP_SERVER_NOTIFICATIONS.ERROR) {
       // A non-retried fatal error: resolve the turn so prompt() returns rather than hangs.
       const willRetry = (params as { willRetry?: boolean })?.willRetry;

--- a/packages/agent/src/adapters/codex-app-server/protocol.ts
+++ b/packages/agent/src/adapters/codex-app-server/protocol.ts
@@ -40,6 +40,9 @@ export const APP_SERVER_NOTIFICATIONS = {
   // codex auto-compacted the thread; mirrors Claude's compact_boundary so the host's context indicator + queue drain fire.
   CONTEXT_COMPACTED: "thread/compacted",
   COMMAND_OUTPUT_DELTA: "item/commandExecution/outputDelta",
+  // Per-server MCP startup progress. `status: "failed"` is the only signal codex
+  // emits when a configured server dies at launch — its tools silently never appear.
+  MCP_STARTUP_STATUS: "mcpServer/startupStatus/updated",
   // PTY-level stdin echoed back for an interactive terminal command.
   TERMINAL_INTERACTION: "item/commandExecution/terminalInteraction",
   FILE_CHANGE_PATCH_UPDATED: "item/fileChange/patchUpdated",

--- a/packages/agent/tsup.config.ts
+++ b/packages/agent/tsup.config.ts
@@ -131,6 +131,13 @@ export default defineConfig([
     format: ["esm"],
     dts: true,
     clean: false,
+    // noExternal inlines CJS deps (e.g. simple-git via @posthog/git) whose
+    // dynamic `require(...)` calls throw in ESM output unless a real require
+    // exists. Entries spawned directly by node (local-tools-mcp-server.js)
+    // crash at import time without this shim.
+    banner: {
+      js: 'import { createRequire as __createRequire } from "node:module"; const require = __createRequire(import.meta.url);',
+    },
     ...sharedOptions,
     onSuccess: async () => {
       copyAssets();


### PR DESCRIPTION
## Problem

Cloud tasks running on a Codex model cannot commit or open PRs: the model reports that `git_signed_commit` is not available, even though the session config injects the `posthog-code-tools` MCP server and the agent-server logs `hasLocalTools: true`.

Root cause: the bundled `dist/adapters/codex-app-server/local-tools-mcp-server.js` crashes at import time with `Dynamic require of "fs" is not supported`. `noExternal` inlines `@posthog/git`'s CJS dependencies (`simple-git` → `@kwsites/file-exists`) into the ESM bundle, where esbuild's `require` shim throws. Codex spawns the server, the process dies before answering `initialize`, codex emits `mcpServer/startupStatus/updated {status: "failed"}` (which the adapter ignored), and the signed-git tools silently never reach the model. The Claude adapter is unaffected because it registers these tools in-process; only the Codex path uses this standalone bundle.

## Changes

- Add a `createRequire` banner to the ESM tsup config so inlined CJS `require(...)` calls resolve when an entry runs directly under node.
- Add a post-build smoke check (`build/verify-local-tools-mcp-server.mjs`, wired into `pnpm build`) that boots the dist server exactly like codex does and asserts `tools/list` includes the signed-git tools — this fails the build on any future bundling regression.
- Log a warning when codex reports an MCP server startup failure instead of dropping the notification, so this class of failure is diagnosable from agent logs.
