### PR TITLE
chore(ci): tighten stale PR timings

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
-          days-before-pr-stale: 30
-          days-before-pr-close: 7
+          days-before-pr-stale: 20
+          days-before-pr-close: 5
           days-before-issue-stale: -1
           days-before-issue-close: -1
           stale-pr-label: stale
-          stale-pr-message: "This PR has had no activity for 30 days and has been marked stale. It will be closed in 7 days if no further activity occurs."
+          stale-pr-message: "This PR has had no activity for 20 days and has been marked stale. It will be closed in 5 days if no further activity occurs."
           close-pr-message: "Closing this PR due to inactivity. Feel free to reopen if you'd like to continue the work."
           exempt-pr-labels: "no stale,security"
           exempt-draft-pr: false


### PR DESCRIPTION
## Problem

Stale PRs linger too long before being cleaned up.

## Changes

Tightened the stale workflow: PRs are marked stale after 20 days of inactivity (was 30) and closed 5 days later (was 7). Updated the stale comment to match.

## How did you test this?

Config-only change to the stale action's day thresholds, no tests run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
