### PR TITLE
fix(shared): transliterate x-posthog-property header values to ASCII

### DIFF
--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -12,6 +12,7 @@ import type {
 } from "@anthropic-ai/claude-agent-sdk";
 import type { FileEnrichmentDeps } from "../../../enrichment/file-enricher";
 import { IS_ROOT } from "../../../utils/common";
+import { buildGatewayPropertyHeaders } from "../../../utils/gateway";
 import type { Logger } from "../../../utils/logger";
 import type { TaskState } from "../conversion/task-state";
 import {
@@ -163,7 +164,7 @@ function buildEnvironment(gateway?: GatewayEnv): Record<string, string> {
   // get_llm_client(team_id=...).
   const projectId = gateway?.posthogProjectId ?? process.env.POSTHOG_PROJECT_ID;
   if (projectId) {
-    headerLines.push(`x-posthog-property-team_id: ${projectId}`);
+    headerLines.push(buildGatewayPropertyHeaders({ team_id: projectId }));
   }
   // Route to AWS Bedrock as a fallback when Anthropic returns 5xx
   headerLines.push("x-posthog-use-bedrock-fallback: true");

--- a/packages/core/src/llm-gateway/llm-gateway.test.ts
+++ b/packages/core/src/llm-gateway/llm-gateway.test.ts
@@ -114,8 +114,8 @@ describe("LlmGatewayService.prompt", () => {
         // literal "null" strings on the captured event.
         unused: null,
         skipped: undefined,
-        // Newlines and non-latin1 bytes are sanitized so an undici-backed
-        // fetch doesn't reject the request before it's sent.
+        // Newlines and non-ASCII characters are sanitized so no HTTP client
+        // (undici, Bun's fetch) rejects the request before it's sent.
         rich: "line one\nline two — done 🎉",
       },
     });

--- a/packages/shared/src/posthog-property-headers.test.ts
+++ b/packages/shared/src/posthog-property-headers.test.ts
@@ -57,11 +57,21 @@ describe("buildPosthogPropertyHeaderRecord", () => {
     ).toEqual({ "x-posthog-property-task_title": "dontship" });
   });
 
-  it("keeps latin1 characters such as accents", () => {
-    expect(buildPosthogPropertyHeaderRecord({ task_title: "café" })).toEqual({
-      "x-posthog-property-task_title": "café",
-    });
-  });
+  it.each([
+    { title: "café", expected: "cafe" },
+    {
+      title: "sono più di 48 ore, è tardi",
+      expected: "sono piu di 48 ore, e tardi",
+    },
+    { title: "Ærøskøbing–東京", expected: "rskbing" },
+  ])(
+    "transliterates accents to ASCII and drops what has no base letter ($title)",
+    ({ title, expected }) => {
+      expect(buildPosthogPropertyHeaderRecord({ task_title: title })).toEqual({
+        "x-posthog-property-task_title": expected,
+      });
+    },
+  );
 });
 
 describe("buildPosthogPropertyHeaderLines", () => {

--- a/packages/shared/src/posthog-property-headers.test.ts
+++ b/packages/shared/src/posthog-property-headers.test.ts
@@ -58,12 +58,11 @@ describe("buildPosthogPropertyHeaderRecord", () => {
   });
 
   it.each([
-    { title: "café", expected: "cafe" },
     {
       title: "sono più di 48 ore, è tardi",
       expected: "sono piu di 48 ore, e tardi",
     },
-    { title: "Ærøskøbing–東京", expected: "rskbing" },
+    { title: "Ærøskøbing", expected: "rskbing" },
   ])(
     "transliterates accents to ASCII and drops what has no base letter ($title)",
     ({ title, expected }) => {

--- a/packages/shared/src/posthog-property-headers.test.ts
+++ b/packages/shared/src/posthog-property-headers.test.ts
@@ -59,16 +59,53 @@ describe("buildPosthogPropertyHeaderRecord", () => {
 
   it.each([
     {
+      case: "precomposed accents (the incident title)",
       title: "sono più di 48 ore, è tardi",
       expected: "sono piu di 48 ore, e tardi",
     },
-    { title: "Ærøskøbing", expected: "rskbing" },
+    {
+      case: "combining marks already decomposed in the input",
+      title: "cafe\u0301 al volo",
+      expected: "cafe al volo",
+    },
+    {
+      case: "NFKD compatibility forms (ligature, unit, fullwidth)",
+      title: "ﬁle ㎏ Ｆｕｌｌ",
+      expected: "file kg Full",
+    },
+    {
+      case: "letters with no ASCII decomposition are dropped",
+      title: "Ærøskøbing Straße",
+      expected: "rskbing Strae",
+    },
+    {
+      case: "fully non-Latin titles collapse to an empty value",
+      title: "東京🎉",
+      expected: "",
+    },
+  ])("$case", ({ title, expected }) => {
+    expect(buildPosthogPropertyHeaderRecord({ task_title: title })).toEqual({
+      "x-posthog-property-task_title": expected,
+    });
+  });
+
+  // The regression class from the incident: any non-ASCII byte in the value
+  // makes Bun's fetch (the Claude Code CLI) reject the whole request with
+  // "Header 'x-posthog-property-task_title' has invalid value".
+  it.each([
+    "sono più di 48 ore che non tracciamo trace in AI observability",
+    "perché non funziona più? è rotto da ieri",
+    "Größenänderung prüfen — Umlaute überall",
+    "vérifier l'intégration après déploiement",
+    "corrigir a validação do título",
+    "проверить трассировку в проде",
+    "タイトルのバグを修正する 🚀",
+    "mixed ‘smart’ quotes – dashes … and​zero-width",
   ])(
-    "transliterates accents to ASCII and drops what has no base letter ($title)",
-    ({ title, expected }) => {
-      expect(buildPosthogPropertyHeaderRecord({ task_title: title })).toEqual({
-        "x-posthog-property-task_title": expected,
-      });
+    "emits only printable ASCII a strict HTTP client accepts (%s)",
+    (title) => {
+      const record = buildPosthogPropertyHeaderRecord({ task_title: title });
+      expect(record["x-posthog-property-task_title"]).toMatch(/^[\x20-\x7e]*$/);
     },
   );
 });

--- a/packages/shared/src/posthog-property-headers.ts
+++ b/packages/shared/src/posthog-property-headers.ts
@@ -3,14 +3,13 @@ export type PosthogPropertyValue = string | number | boolean | null | undefined;
 export type PosthogProperties = Record<string, PosthogPropertyValue>;
 
 /**
- * Make a value safe to embed in an HTTP header value. Collapses newlines to
- * spaces (the header block is newline-delimited), transliterates accented
- * letters to their ASCII base (`più` → `piu`), and drops everything else
- * outside printable ASCII (emoji, smart quotes, CJK). Latin1 bytes are valid
- * per RFC 9110 and undici accepts them, but Bun's fetch — which the Claude
- * Code CLI uses to send headers wired through `ANTHROPIC_CUSTOM_HEADERS` —
- * rejects any non-ASCII header value, so printable ASCII is the only range
- * every consumer accepts.
+ * Make a value safe to embed in an HTTP header value. Only printable ASCII
+ * survives: latin1 is valid per RFC 9110 and undici accepts it, but Bun's
+ * fetch — which the Claude Code CLI uses for `ANTHROPIC_CUSTOM_HEADERS` —
+ * rejects any non-ASCII header value. NFKD plus the final strip is what
+ * transliterates accented letters to their ASCII base (`più` → `piu`); the
+ * combining-mark pass just keeps a stray mark from splitting a newline run
+ * before it is collapsed to a single space.
  */
 function sanitizeHeaderValue(value: string): string {
   return value

--- a/packages/shared/src/posthog-property-headers.ts
+++ b/packages/shared/src/posthog-property-headers.ts
@@ -4,13 +4,20 @@ export type PosthogProperties = Record<string, PosthogPropertyValue>;
 
 /**
  * Make a value safe to embed in an HTTP header value. Collapses newlines to
- * spaces (the header block is newline-delimited) and drops characters outside
- * the valid header-byte range — control chars and code points above latin1
- * (emoji, smart quotes) — which an HTTP client (e.g. undici) would otherwise
- * reject before sending. ASCII is preserved.
+ * spaces (the header block is newline-delimited), transliterates accented
+ * letters to their ASCII base (`più` → `piu`), and drops everything else
+ * outside printable ASCII (emoji, smart quotes, CJK). Latin1 bytes are valid
+ * per RFC 9110 and undici accepts them, but Bun's fetch — which the Claude
+ * Code CLI uses to send headers wired through `ANTHROPIC_CUSTOM_HEADERS` —
+ * rejects any non-ASCII header value, so printable ASCII is the only range
+ * every consumer accepts.
  */
 function sanitizeHeaderValue(value: string): string {
-  return value.replace(/[\r\n]+/g, " ").replace(/[^\x20-\x7e\x80-\xff]/g, "");
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[\r\n]+/g, " ")
+    .replace(/[^\x20-\x7e]/g, "");
 }
 
 function buildEntries(properties: PosthogProperties): Array<[string, string]> {


### PR DESCRIPTION
## Problem

Slack-originated task runs fail whenever the task title contains an accented character (Zendesk ticket [#62236](https://posthoghelp.zendesk.com/agent/tickets/62236), internal link):

```
API Error: Header 'x-posthog-property-task_title' has invalid value: 'sono più di 48 ore…'
```

Task metadata is forwarded to the LLM gateway as `x-posthog-property-*` headers via `ANTHROPIC_CUSTOM_HEADERS`. The sanitizer kept latin-1 characters (fine for undici), but the Claude Code CLI is a Bun binary and Bun's fetch rejects any non-ASCII header value — so the request dies client-side and `retry` hits the same wall.

## Changes

- `sanitizeHeaderValue` transliterates accents to their ASCII base via NFKD (`più` → `piu`) and drops everything else outside printable ASCII — the only range every HTTP client accepts.
- The hand-built `team_id` header line in the Claude session builder now goes through the shared builder too.
- Tests: parameterized transliteration cases per input class, plus an invariant test asserting emitted values are always printable ASCII for a battery of non-ASCII titles.

## How did you test this?

- `pnpm vitest run` in `packages/shared` and the llm-gateway tests in `packages/core` — all pass.
- `pnpm typecheck` in `packages/shared` and `packages/agent`.
- Root cause verified by inspection: the error template is baked into the Claude CLI binary (Bun's Headers validation). Standalone repro with bun installed: `bun -e 'new Headers({"x": "più"})'`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
