### PR TITLE
fix(models): offer max reasoning for gpt-5.6

### DIFF
--- a/packages/agent/src/adapters/codex-app-server/models.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/models.test.ts
@@ -4,6 +4,7 @@ import {
   formatCodexModelName,
   getReasoningEffortOptions,
   modelIdFromConfigOptions,
+  supportsMaxEffort,
   supportsXhighEffort,
 } from "./models";
 
@@ -30,8 +31,8 @@ describe("getReasoningEffortOptions", () => {
     "gpt-5.6-luna",
     "openai/gpt-5.6-sol",
     "GPT-5.6-SOL",
-  ])("offers Extra High for the gpt-5.6 family (%s)", (modelId) => {
-    expect(values(modelId)).toEqual(["low", "medium", "high", "xhigh"]);
+  ])("offers Max for the gpt-5.6 family (%s)", (modelId) => {
+    expect(values(modelId)).toEqual(["low", "medium", "high", "xhigh", "max"]);
   });
 
   it.each(["gpt-5.3-codex", "gpt-5.1", "o3"])(
@@ -54,6 +55,14 @@ describe("supportsXhighEffort", () => {
     expect(supportsXhighEffort("gpt-5.5-codex")).toBe(true);
     expect(supportsXhighEffort("GPT-5.5")).toBe(true);
     expect(supportsXhighEffort("gpt-5.3-codex")).toBe(false);
+  });
+});
+
+describe("supportsMaxEffort", () => {
+  it("is true only for the gpt-5.6 family", () => {
+    expect(supportsMaxEffort("gpt-5.6-sol")).toBe(true);
+    expect(supportsMaxEffort("GPT-5.6-LUNA")).toBe(true);
+    expect(supportsMaxEffort("gpt-5.5")).toBe(false);
   });
 });
 

--- a/packages/agent/src/adapters/codex-app-server/models.ts
+++ b/packages/agent/src/adapters/codex-app-server/models.ts
@@ -15,12 +15,16 @@ const CODEX_REASONING_EFFORT_OPTIONS: ReasoningEffortOption[] = [
   { value: "high", name: "High" },
 ];
 
-// OpenAI's `reasoning_effort` exposes an "extra high" tier only on the gpt-5.5
-// and gpt-5.6 families, matching what the Codex app offers. Older models top
-// out at "high".
+// OpenAI's `reasoning_effort` exposes an "extra high" tier on the gpt-5.5 and
+// gpt-5.6 families. GPT-5.6 also supports the "max" tier. Older models top out
+// at "high".
 export function supportsXhighEffort(modelId: string): boolean {
   const id = modelId.toLowerCase();
   return id.includes("gpt-5.5") || id.includes("gpt-5.6");
+}
+
+export function supportsMaxEffort(modelId: string): boolean {
+  return modelId.toLowerCase().includes("gpt-5.6");
 }
 
 export function getReasoningEffortOptions(
@@ -29,6 +33,9 @@ export function getReasoningEffortOptions(
   const options = [...CODEX_REASONING_EFFORT_OPTIONS];
   if (supportsXhighEffort(modelId)) {
     options.push({ value: "xhigh", name: "Extra High" });
+  }
+  if (supportsMaxEffort(modelId)) {
+    options.push({ value: "max", name: "Max" });
   }
   return options;
 }

--- a/packages/agent/src/adapters/reasoning-effort.test.ts
+++ b/packages/agent/src/adapters/reasoning-effort.test.ts
@@ -15,12 +15,12 @@ describe("isSupportedReasoningEffort", () => {
     );
   });
 
-  it("accepts xhigh but not max for the codex gpt-5.6 family", () => {
+  it("accepts xhigh and max for the codex gpt-5.6 family", () => {
     expect(isSupportedReasoningEffort("codex", "gpt-5.6-luna", "xhigh")).toBe(
       true,
     );
     expect(isSupportedReasoningEffort("codex", "gpt-5.6-sol", "max")).toBe(
-      false,
+      true,
     );
   });
 


### PR DESCRIPTION
## Problem

GPT-5.6 supports the `max` reasoning level, but PostHog Code only exposed options through `xhigh`. This made the model picker and runtime validation reject a supported configuration. The companion task API change is https://github.com/PostHog/posthog/pull/70351