### PR TITLE
fix: compact boundary marker showing "undefined · ~NaNK tokens" on codex sessions

### DIFF
--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -1810,6 +1810,9 @@ describe("CodexAppServerAgent", () => {
     } as unknown as NewSessionRequest);
 
     // The compaction item brackets it: started → in progress, completed → boundary.
+    stub.emit("thread/tokenUsage/updated", {
+      tokenUsage: { last: { inputTokens: 90000, totalTokens: 120000 } },
+    });
     stub.emit("item/started", {
       item: { type: "contextCompaction", id: "c1" },
     });
@@ -1817,11 +1820,12 @@ describe("CodexAppServerAgent", () => {
       item: { type: "contextCompaction", id: "c1", summary: "…" },
     });
 
-    // compact_boundary clears isCompacting + drains the host queue.
+    // compact_boundary clears isCompacting + drains the host queue; trigger/preTokens
+    // feed the renderer's boundary marker.
     expect(
       extNotifications.find((n) => n.method === "_posthog/compact_boundary")
         ?.params,
-    ).toMatchObject({ sessionId: "t" });
+    ).toMatchObject({ sessionId: "t", trigger: "auto", preTokens: 120000 });
     // ...and a user-visible marker lands in the transcript.
     expect(sessionUpdates).toContainEqual({
       sessionId: "t",

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -1091,6 +1091,10 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     void this.client
       .extNotification(POSTHOG_NOTIFICATIONS.COMPACT_BOUNDARY, {
         sessionId: this.sessionId,
+        // codex only compacts on its own (contextCompaction items); preTokens is the last
+        // context occupancy reading, omitted when no usage arrived yet.
+        trigger: "auto",
+        preTokens: this.usage.contextTokens(),
       })
       .catch(() => undefined);
     void this.client

--- a/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -541,9 +541,10 @@ function handleNotification(
 
   if (isNotification(msg.method, POSTHOG_NOTIFICATIONS.COMPACT_BOUNDARY)) {
     ensureImplicitTurn(b, ts);
+    // trigger/preTokens are adapter-dependent: the claude adapter sends both, codex sends neither.
     const params = msg.params as {
-      trigger: "manual" | "auto";
-      preTokens: number;
+      trigger?: "manual" | "auto";
+      preTokens?: number;
       contextSize?: number;
     };
     markCompactingStatusComplete(b);

--- a/packages/ui/src/features/sessions/components/session-update/CompactBoundaryView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/CompactBoundaryView.tsx
@@ -4,8 +4,9 @@ import { Badge, Box, Flex, Text } from "@radix-ui/themes";
 import { useChatThreadChrome } from "../chat-thread/chatThreadChrome";
 
 interface CompactBoundaryViewProps {
-  trigger: "manual" | "auto";
-  preTokens: number;
+  // Both optional — the codex adapter reports a boundary without metadata.
+  trigger?: "manual" | "auto";
+  preTokens?: number;
   contextSize?: number;
 }
 
@@ -14,9 +15,10 @@ export function CompactBoundaryView({
   preTokens,
   contextSize,
 }: CompactBoundaryViewProps) {
-  const tokensK = Math.round(preTokens / 1000);
+  const hasTokens = typeof preTokens === "number" && Number.isFinite(preTokens);
+  const tokensK = hasTokens ? Math.round(preTokens / 1000) : null;
   const percent =
-    contextSize && contextSize > 0
+    hasTokens && contextSize && contextSize > 0
       ? Math.round((preTokens / contextSize) * 100)
       : null;
   // New thread renders the boundary as a centered separator marker; the legacy thread keeps its
@@ -24,13 +26,13 @@ export function CompactBoundaryView({
   const chatChrome = useChatThreadChrome();
 
   if (chatChrome) {
+    const markerParts = ["Conversation compacted"];
+    if (trigger) markerParts.push(trigger);
+    if (percent !== null) markerParts.push(`${percent}% of context`);
+    else if (tokensK !== null) markerParts.push(`~${tokensK}K tokens`);
     return (
       <ChatMarker variant="separator">
-        <ChatMarkerContent>
-          {`Conversation compacted · ${trigger} · ${
-            percent !== null ? `${percent}% of context` : `~${tokensK}K tokens`
-          }`}
-        </ChatMarkerContent>
+        <ChatMarkerContent>{markerParts.join(" · ")}</ChatMarkerContent>
       </ChatMarker>
     );
   }
@@ -40,18 +42,22 @@ export function CompactBoundaryView({
       <Flex align="center" gap="2">
         <Lightning size={14} weight="fill" className="text-blue-9" />
         <Text className="text-[13px] text-gray-11">Conversation compacted</Text>
-        <Badge
-          size="1"
-          color={trigger === "auto" ? "orange" : "blue"}
-          variant="soft"
-        >
-          {trigger}
-        </Badge>
-        <Text className="text-[13px] text-gray-9">
-          {percent !== null
-            ? `(${percent}% of context · ~${tokensK}K tokens summarized)`
-            : `(~${tokensK}K tokens summarized)`}
-        </Text>
+        {trigger && (
+          <Badge
+            size="1"
+            color={trigger === "auto" ? "orange" : "blue"}
+            variant="soft"
+          >
+            {trigger}
+          </Badge>
+        )}
+        {tokensK !== null && (
+          <Text className="text-[13px] text-gray-9">
+            {percent !== null
+              ? `(${percent}% of context · ~${tokensK}K tokens summarized)`
+              : `(~${tokensK}K tokens summarized)`}
+          </Text>
+        )}
       </Flex>
     </Box>
   );

--- a/packages/ui/src/features/sessions/components/session-update/SessionUpdateView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/SessionUpdateView.tsx
@@ -25,8 +25,8 @@ export type RenderItem =
     }
   | {
       sessionUpdate: "compact_boundary";
-      trigger: "manual" | "auto";
-      preTokens: number;
+      trigger?: "manual" | "auto";
+      preTokens?: number;
       contextSize?: number;
     }
   | {


### PR DESCRIPTION
## Problem

A user on a codex model (gpt-5.6-sol) saw the compaction marker render as **"Conversation compacted · undefined · ~NaNK tokens"**. The codex app-server adapter emits `_posthog/compact_boundary` with only `sessionId`, but the UI assumed `trigger` and `preTokens` (which only the Claude adapter sends) were always present, so it interpolated `undefined` and `NaN` straight into the marker.

## Why

Codex sessions compact regularly, so every codex user hitting auto-compaction sees this broken marker in the transcript.

## Changes

- `CompactBoundaryView` (and the item types feeding it) now treat `trigger`/`preTokens` as optional and drop the missing segments instead of rendering `undefined`/`NaN`.
- The codex adapter now reports `trigger: "auto"` (codex only self-compacts) and `preTokens` from its usage tracker's last context-occupancy reading, so the marker shows real data going forward.

## How did you test this?

- `vitest run codex-app-server-agent` in `packages/agent` (75 passed), including an updated boundary test asserting `trigger`/`preTokens`.
- `vitest run buildConversationItems` in `packages/ui` (32 passed).
- `tsc --noEmit` on `@posthog/agent` and `@posthog/ui`; biome check on changed files (only pre-existing warnings).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*