### PR TITLE
Fix "undefined · ~NaNK tokens" in codex compaction boundary

### DIFF
--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -2818,8 +2818,7 @@ describe("CodexAppServerAgent", () => {
       _meta: {},
     } as unknown as NewSessionRequest);
 
-    // A token-usage update precedes auto-compaction (the window fills mid-turn);
-    // its counts feed the boundary's preTokens/contextSize so the UI isn't NaN.
+    // The last usage reading before compaction feeds the boundary's preTokens/contextSize.
     stub.emit("thread/tokenUsage/updated", {
       tokenUsage: {
         last: { inputTokens: 180000, outputTokens: 5000, totalTokens: 185000 },
@@ -2835,8 +2834,7 @@ describe("CodexAppServerAgent", () => {
       item: { type: "contextCompaction", id: "c1", summary: "…" },
     });
 
-    // compact_boundary clears isCompacting + drains the host queue, and carries the
-    // trigger/token fields the CompactBoundaryView needs.
+    // compact_boundary clears isCompacting + drains the host queue.
     expect(
       extNotifications.find((n) => n.method === "_posthog/compact_boundary")
         ?.params,

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -2818,6 +2818,15 @@ describe("CodexAppServerAgent", () => {
       _meta: {},
     } as unknown as NewSessionRequest);
 
+    // A token-usage update precedes auto-compaction (the window fills mid-turn);
+    // its counts feed the boundary's preTokens/contextSize so the UI isn't NaN.
+    stub.emit("thread/tokenUsage/updated", {
+      tokenUsage: {
+        last: { inputTokens: 180000, outputTokens: 5000, totalTokens: 185000 },
+        modelContextWindow: 200000,
+      },
+    });
+
     // The compaction item brackets it: started → in progress, completed → boundary.
     stub.emit("item/started", {
       item: { type: "contextCompaction", id: "c1" },
@@ -2826,11 +2835,17 @@ describe("CodexAppServerAgent", () => {
       item: { type: "contextCompaction", id: "c1", summary: "…" },
     });
 
-    // compact_boundary clears isCompacting + drains the host queue.
+    // compact_boundary clears isCompacting + drains the host queue, and carries the
+    // trigger/token fields the CompactBoundaryView needs.
     expect(
       extNotifications.find((n) => n.method === "_posthog/compact_boundary")
         ?.params,
-    ).toMatchObject({ sessionId: "t" });
+    ).toMatchObject({
+      sessionId: "t",
+      trigger: "auto",
+      preTokens: 185000,
+      contextSize: 200000,
+    });
     // ...and a user-visible marker lands in the transcript.
     expect(sessionUpdates).toContainEqual({
       sessionId: "t",

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -1749,7 +1749,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
         sessionId: this.sessionId,
         // codex only auto-compacts; there's no manual /compact.
         trigger: "auto",
-        preTokens: this.usage.contextTokens() ?? 0,
+        preTokens: this.usage.contextTokens(),
         contextSize: this.usage.contextSize(),
       })
       .catch(() => undefined);

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -1747,6 +1747,10 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     void this.client
       .extNotification(POSTHOG_NOTIFICATIONS.COMPACT_BOUNDARY, {
         sessionId: this.sessionId,
+        // codex only auto-compacts; there's no manual /compact.
+        trigger: "auto",
+        preTokens: this.usage.contextTokens() ?? 0,
+        contextSize: this.usage.contextSize(),
       })
       .catch(() => undefined);
     void this.client

--- a/packages/agent/src/adapters/codex-app-server/usage-tracker.ts
+++ b/packages/agent/src/adapters/codex-app-server/usage-tracker.ts
@@ -27,6 +27,8 @@ export class UsageTracker {
   private baseline: ContextBreakdownBaseline = emptyBaseline();
   private lastTurn?: Usage;
   private contextUsed?: number;
+  // Model context window is a constant, so it survives resetForTurn.
+  private contextWindow?: number;
 
   setBaseline(baseline: ContextBreakdownBaseline): void {
     this.baseline = baseline;
@@ -48,6 +50,7 @@ export class UsageTracker {
     const { context, used, size } = reading;
     // Drives the per-source breakdown's "conversation" bucket on turn complete.
     this.contextUsed = used;
+    if (size != null) this.contextWindow = size;
     const inputTokens = context.inputTokens ?? 0;
     const outputTokens = context.outputTokens ?? 0;
     const cachedReadTokens = context.cachedInputTokens ?? 0;
@@ -80,5 +83,10 @@ export class UsageTracker {
   /** Live context occupancy (same derivation as the renderer gauge), or undefined pre-usage. */
   contextTokens(): number | undefined {
     return this.contextUsed;
+  }
+
+  /** Model context window last reported by codex, or undefined pre-usage. */
+  contextSize(): number | undefined {
+    return this.contextWindow;
   }
 }


### PR DESCRIPTION
## Problem

A user on `gpt-5.6-sol` saw the transcript render **"Conversation compacted · undefined · ~NaNK tokens"** after an auto-compaction.

The codex-app-server adapter emitted the `_posthog/compact_boundary` notification with only `sessionId`, whereas the Claude adapter includes `trigger`, `preTokens`, and `contextSize`. With those fields missing, `CompactBoundaryView` rendered `${trigger}` as `"undefined"` and `Math.round(undefined / 1000)` as `NaN`.

## Changes

- `UsageTracker` retains the model context window and exposes `contextSize()`.
- The codex compaction boundary now sends `trigger: "auto"` (codex only auto-compacts), `preTokens` from live context occupancy, and `contextSize`.
- `CompactBoundaryView` (and its type chain) treat `trigger`/`preTokens` as optional and omit each segment when absent — so a missing value can never render as `undefined`/`NaN` again.

## Why

Reported by a user; the compaction marker was showing garbage text on codex models.

## How did you test this?

- Extended the existing codex agent test to emit a token-usage update before compaction and assert the boundary carries `trigger: "auto"`, `preTokens: 185000`, `contextSize: 200000`. All 75 codex agent tests pass.
- `pnpm --filter @posthog/ui typecheck` and `@posthog/agent` build pass; Biome lint clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*