### PR TITLE
fix(sessions): keep auto task titles pinned to the original prompt

### DIFF
--- a/packages/core/src/sessions/chatTitle.test.ts
+++ b/packages/core/src/sessions/chatTitle.test.ts
@@ -1,6 +1,7 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
 import {
+  canApplyTitleFromPrompts,
   decideTitleGeneration,
   formatPromptsForTitleInput,
   getFallbackTaskTitle,
@@ -180,6 +181,32 @@ describe("decideTitleGeneration", () => {
       expect(decision.shouldGenerateFromPrompts).toBe(expected);
     },
   );
+});
+
+describe("canApplyTitleFromPrompts", () => {
+  it("allows the first-prompt fire to write the title", () => {
+    expect(
+      canApplyTitleFromPrompts(1, { title: "Custom", description: "d" }),
+    ).toBe(true);
+  });
+
+  it("blocks later fires from rewriting a real title", () => {
+    expect(
+      canApplyTitleFromPrompts(1 + REGENERATE_INTERVAL, {
+        title: "Fix login bug",
+        description: "the login page 500s",
+      }),
+    ).toBe(false);
+  });
+
+  it("allows later fires to replace a placeholder title", () => {
+    expect(
+      canApplyTitleFromPrompts(1 + REGENERATE_INTERVAL, {
+        title: "Fix login",
+        description: "Fix login",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("selectPromptsForTitle", () => {

--- a/packages/core/src/sessions/chatTitle.ts
+++ b/packages/core/src/sessions/chatTitle.ts
@@ -77,6 +77,18 @@ export function decideTitleGeneration(input: {
   return { shouldGenerateFromPrompts, shouldGenerateFromTaskDescription };
 }
 
+// Prompt-window fires past the first prompt describe the recent conversation,
+// not the task, so the title must stay pinned to the original prompt context.
+// Later fires may only fill in a title that is still the raw-description
+// placeholder (e.g. an earlier generation failed); the summary always
+// refreshes regardless.
+export function canApplyTitleFromPrompts(
+  promptCount: number,
+  task: Pick<Task, "title" | "description">,
+): boolean {
+  return promptCount <= 1 || isPlaceholderTaskTitle(task);
+}
+
 export function selectPromptsForTitle(
   prompts: string[],
   promptCount: number,

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -449,6 +449,54 @@ describe("useChatTitleGenerator", () => {
     expect(mockGenerateTitle).toHaveBeenCalledTimes(1);
   });
 
+  it("does not rewrite an unlocked real title from later prompts, but still refreshes the summary", async () => {
+    // Auto-generated at creation: real title, title_manually_set false.
+    const unlockedTask = createTask({
+      title: "Fix login bug",
+      description: "the login page 500s for SSO users",
+    });
+    cacheTask(unlockedTask);
+    mockGenerateTitle.mockResolvedValue({
+      title: "Discuss deploy schedule",
+      summary: "User is coordinating a deploy",
+    });
+    mockPrompts.value = Array.from({ length: 8 }, (_, i) => `prompt ${i}`);
+
+    renderHook(() => useChatTitleGenerator(unlockedTask));
+
+    await waitFor(() => {
+      expect(mockGenerateTitle).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(mockSessionStoreSetters.updateSession).toHaveBeenCalledWith(
+        "run-1",
+        { conversationSummary: "User is coordinating a deploy" },
+      );
+    });
+    expect(mockUpdateTask).not.toHaveBeenCalled();
+  });
+
+  it("replaces a placeholder title from later prompts", async () => {
+    const placeholderTask = createTask({
+      title: "Attached files: pasted-text.txt",
+      description: "Attached files: pasted-text.txt",
+    });
+    cacheTask(placeholderTask);
+    mockGenerateTitle.mockResolvedValue({
+      title: "Refactor auth flow",
+      summary: "",
+    });
+    mockPrompts.value = Array.from({ length: 8 }, (_, i) => `prompt ${i}`);
+
+    renderHook(() => useChatTitleGenerator(placeholderTask));
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(TASK_ID, {
+        title: "Refactor auth flow",
+      });
+    });
+  });
+
   it("skips catch-up generation when the title is locked and a summary exists", async () => {
     const lockedTask = createTask({
       title: "Custom auth title",

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
@@ -1,5 +1,6 @@
 import type { Schemas } from "@posthog/api-client";
 import {
+  canApplyTitleFromPrompts,
   decideTitleGeneration,
   formatPromptsForTitleInput,
   isAutoTitleLocked,
@@ -120,6 +121,17 @@ export function useChatTitleGenerator(task: Task): void {
 
           if (title && isTitleLocked()) {
             log.debug("Skipping auto-title, user renamed task", { taskId });
+          } else if (
+            title &&
+            !canApplyTitleFromPrompts(
+              promptCount,
+              getCachedTask(queryClient, taskId) ?? task,
+            )
+          ) {
+            log.debug("Skipping auto-title, keeping original-context title", {
+              taskId,
+              promptCount,
+            });
           } else if (title) {
             if (client) {
               await client.updateTask(taskId, { title });


### PR DESCRIPTION
## Problem

Tasks sometimes get renamed based on the most recent messages in the conversation instead of keeping the name generated from the original prompt.

The only writer that rewrites a task title after creation is `useChatTitleGenerator`: its interval and catch-up fires (`REGENERATE_INTERVAL`) generate from the last 7 prompts and write the result as the task title whenever the title isn't locked (`title_manually_set`). Tasks created server-side (cloud creation, warm-run activation, Slack-origin tasks) get an auto-generated title with `title_manually_set = false`, so they are exactly the ones exposed. #3315 removed the remount-driven refires, but any surviving prompt-window fire still renames these tasks. Task `description` is never rewritten anywhere; the rename is the whole symptom.

## Changes

- Add `canApplyTitleFromPrompts` in `chatTitle.ts`: prompt-based fires past the first prompt may no longer write the title, unless the current title is still the raw-description placeholder (so the retry path for failed initial generations keeps working).
- Gate the title write in `useChatTitleGenerator` with it; summary generation is unchanged, so conversation summaries (used for commit/PR context) still refresh at every interval.

## How did you test this?

Red-green: added a failing test reproducing the rename (unlocked task with a real title at prompt count 8 gets retitled from recent prompts), then implemented the gate and confirmed it passes. Also added coverage for the placeholder-retry path. Ran the full sessions suites in `@posthog/core` (274 tests) and `@posthog/ui` (365 tests), `biome lint`, and `tsc --noEmit` on both packages — all green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*