### PR TITLE
fix(browser-tabs): hide the new-tab button on cloud runs

### DIFF
--- a/packages/ui/src/features/browser-tabs/BrowserTabStrip.tsx
+++ b/packages/ui/src/features/browser-tabs/BrowserTabStrip.tsx
@@ -41,6 +41,7 @@ import { getLeafPanel } from "@posthog/ui/features/panels/panelStoreHelpers";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
+import { useIsWorkspaceCloudRun } from "@posthog/ui/features/workspace/useWorkspace";
 import { useAppView } from "@posthog/ui/router/useAppView";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
@@ -196,6 +197,11 @@ export function BrowserTabStrip() {
   );
   const channelsEnabled =
     useSidebarStore((s) => s.channelsEnabled) && bluebirdEnabled;
+
+  // A cloud run is read-only, so opening a new tab there makes no sense — hide
+  // the new-tab button and disable its Cmd/Ctrl+T shortcut. Off a task route
+  // params.taskId is undefined, so this is false and the button stays.
+  const isCloudRun = useIsWorkspaceCloudRun(params.taskId);
 
   // The active channel sub-section (artifacts/history/context) is the
   // route segment after the channelId. Null when on the channel home or a
@@ -812,7 +818,11 @@ export function BrowserTabStrip() {
       e.preventDefault();
       handleNewTab();
     },
-    { enableOnFormTags: true, enableOnContentEditable: true },
+    {
+      enableOnFormTags: true,
+      enableOnContentEditable: true,
+      enabled: !isCloudRun,
+    },
   );
 
   // Cmd/Ctrl+W closes the active browser tab. Always preventDefault so Electron
@@ -861,7 +871,7 @@ export function BrowserTabStrip() {
       onCloseOthers={handleCloseOthers}
       onCloseToRight={handleCloseToRight}
       onCloseToLeft={handleCloseToLeft}
-      onNewTab={handleNewTab}
+      onNewTab={isCloudRun ? undefined : handleNewTab}
     />
   );
 }

--- a/packages/ui/src/features/browser-tabs/TabStrip.test.tsx
+++ b/packages/ui/src/features/browser-tabs/TabStrip.test.tsx
@@ -72,6 +72,11 @@ describe("TabStrip", () => {
     expect(props.onNewTab).toHaveBeenCalledTimes(1);
   });
 
+  it("hides the new-tab button when onNewTab is omitted", () => {
+    setup({ onNewTab: undefined });
+    expect(screen.queryByLabelText("New tab")).toBeNull();
+  });
+
   it("collapses a pinned tab to an icon-only pill without a close affordance", () => {
     setup({
       tabs: [{ ...tabs[0], pinned: true }, tabs[1]],

--- a/packages/ui/src/features/browser-tabs/TabStrip.tsx
+++ b/packages/ui/src/features/browser-tabs/TabStrip.tsx
@@ -42,7 +42,9 @@ export interface TabStripProps {
   activeTabId: string | null;
   onSelect: (tabId: string) => void;
   onClose: (tabId: string) => void;
-  onNewTab: () => void;
+  /** When omitted, the trailing new-tab button is hidden (e.g. on read-only
+   * cloud runs, where opening a tab makes no sense). */
+  onNewTab?: () => void;
   onTogglePin: (tabId: string) => void;
   onCloseOthers: (tabId: string) => void;
   onCloseToRight: (tabId: string) => void;
@@ -110,21 +112,23 @@ export function TabStrip({
             onCloseToLeft={onCloseToLeft}
           />
         ))}
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                size="icon-sm"
-                aria-label="New tab"
-                className="no-drag shrink-0"
-                onClick={onNewTab}
-              >
-                <PlusIcon size={14} />
-              </Button>
-            }
-          />
-          <TooltipContent side="bottom">New tab</TooltipContent>
-        </Tooltip>
+        {onNewTab && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  size="icon-sm"
+                  aria-label="New tab"
+                  className="no-drag shrink-0"
+                  onClick={onNewTab}
+                >
+                  <PlusIcon size={14} />
+                </Button>
+              }
+            />
+            <TooltipContent side="bottom">New tab</TooltipContent>
+          </Tooltip>
+        )}
       </Flex>
     </TooltipProvider>
   );


### PR DESCRIPTION
## Problem

On a cloud run, the title-bar new-tab **+** button (and its `Cmd/Ctrl+T` shortcut) is still shown even though it makes no sense there — cloud runs are read-only. Reported from the Channels/Code experience when not opted into the channels surface.

The button is rendered by `BrowserTabStrip`, which is mounted on every route in `__root.tsx` and had no awareness of whether the current run is a cloud run. So it showed regardless. The panel "New terminal" button was already hidden on cloud (via `LeafNodeRenderer` + `useIsWorkspaceCloudRun`); this closes the same gap for the title-bar new-tab button.

## Changes

- `TabStrip`: `onNewTab` is now optional; when it's omitted the trailing new-tab button isn't rendered.
- `BrowserTabStrip`: compute `useIsWorkspaceCloudRun(params.taskId)` and, on a cloud run, pass `onNewTab={undefined}` and disable the `Cmd/Ctrl+T` hotkey. Off a task route `params.taskId` is undefined, so behavior is unchanged there.

Reuses the existing `useIsWorkspaceCloudRun` gate rather than a new signal, matching how the panel terminal button is already gated.

## How did you test this?

Automated (I'm the PostHog Slack app; I did not manually drive the app):
- Added a `TabStrip` test asserting the new-tab button is absent when `onNewTab` is omitted. It fails on the pre-change component (button rendered unconditionally) and passes after — that's the regression guard.
- `pnpm exec vitest run` on `TabStrip.test.tsx` — 12/12 pass.
- `turbo typecheck --filter=@posthog/ui` passes; Biome check clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1783933949246609?thread_ts=1783933949.246609&cid=C09G8Q32R6F)*
