### PR TITLE
fix(canvas): send model when generating CONTEXT.md with agent

### DIFF
--- a/packages/ui/src/features/canvas/hooks/useGenerateContext.ts
+++ b/packages/ui/src/features/canvas/hooks/useGenerateContext.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_GATEWAY_MODEL } from "@posthog/agent/gateway-models";
 import {
   TASK_SERVICE,
   type TaskService,
@@ -42,6 +43,11 @@ export function useGenerateContext(channelId: string, channelName: string) {
             // test a local build of these features before merging.
             workspaceMode,
             allowNoRepo: true,
+            // A cloud run pairs a runtime adapter with a model, and the API
+            // rejects one without the other. Since this flow lets the agent pick
+            // its repo at runtime, it never surfaces a model picker, so pin the
+            // default gateway model here to match the adapter the saga defaults to.
+            model: DEFAULT_GATEWAY_MODEL,
           },
           (output) => invalidateTasks(output.task),
         );


### PR DESCRIPTION
## Problem

Using **Generate with agent** to create a channel's CONTEXT.md in PostHog Code desktop fails immediately with a validation error and generation never starts:

```
{"type":"validation_error","code":"invalid_input","detail":"This field is required when selecting a cloud runtime.","attr":"model"}
```

**Why:** this flow was reported from the desktop app as broken — clicking the button to generate a CONTEXT.md returns the error above instead of kicking off a run.

The generate flow starts a cloud run but never picks a model (the agent chooses its repo at runtime, so no model picker is shown). The cloud-create path in the task-creation saga defaults the runtime adapter to `claude` but leaves the model unset, and the task-run bootstrap API requires a runtime adapter and model together — a runtime adapter without a model is rejected.

## Changes

Pin the default gateway model in `useGenerateContext` so the adapter/model pair the API requires is always complete, matching the adapter the saga already defaults to. This mirrors how the other programmatic cloud-run entry points (inbox, workstream actions) resolve a model before starting a run.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` — passes
- `biome check` on the changed file — clean
- Traced the request path end to end against the backend serializer that raises the error to confirm the missing `model` is the cause.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B73C8480P/p1783944116517239?thread_ts=1783944116.517239&cid=C0B73C8480P)*