### PR TITLE
fix(harness): stabilize OAuth callback tests

### DIFF
--- a/packages/harness/src/extensions/posthog-provider/oauth.test.ts
+++ b/packages/harness/src/extensions/posthog-provider/oauth.test.ts
@@ -251,7 +251,7 @@ describe("loginPosthog region selection", () => {
   });
 });
 
-describe("loginPosthog", () => {
+describe("loginPosthog", { timeout: 15_000 }, () => {
   const originalPort = process.env.HARNESS_OAUTH_PORT;
   let fetchSpy: MockInstance<typeof fetch>;
   let port: number;


### PR DESCRIPTION
## Problem

The harness OAuth callback tests use real loopback HTTP servers and can exceed Vitest's default 5-second timeout when CI is under load
