### PR TITLE
refactor(data-warehouse): render Linear inbox setup via DynamicSourceSetup

### DIFF
--- a/packages/ui/src/features/inbox/components/DataSourceSetup.tsx
+++ b/packages/ui/src/features/inbox/components/DataSourceSetup.tsx
@@ -1,4 +1,3 @@
-import { useHostTRPC } from "@posthog/host-router/react";
 import { Button } from "@posthog/quill";
 import { useAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -14,8 +13,7 @@ import {
 } from "@posthog/ui/features/integrations/useIntegrations";
 import { toast } from "@posthog/ui/primitives/toast";
 import { Box, Flex, Text, TextField } from "@radix-ui/themes";
-import { useMutation } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 type DataSourceType = "github" | "linear" | "jira" | "zendesk" | "pganalyze";
 
@@ -53,7 +51,15 @@ export function DataSourceSetup({
     case "github":
       return <GitHubSetup onComplete={onComplete} onCancel={onCancel} />;
     case "linear":
-      return <LinearSetup onComplete={onComplete} onCancel={onCancel} />;
+      return (
+        <DynamicSourceSetup
+          sourceType="Linear"
+          title="Connect Linear"
+          schemas={schemasPayload("linear")}
+          onComplete={onComplete}
+          onCancel={onCancel}
+        />
+      );
     case "jira":
       return (
         <DynamicSourceSetup
@@ -263,142 +269,6 @@ function GitHubSetup({ onComplete, onCancel }: SetupFormProps) {
             size="sm"
             onClick={handleSubmit}
             disabled={!repo || !selectedIntegrationId || loading}
-          >
-            {loading ? "Creating..." : "Create source"}
-          </Button>
-        </Flex>
-      </Flex>
-    </SetupFormContainer>
-  );
-}
-
-const POLL_INTERVAL_MS = 3_000;
-const POLL_TIMEOUT_MS = 5 * 60 * 1000;
-
-function LinearSetup({ onComplete }: SetupFormProps) {
-  const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
-  const projectId = useAuthStateValue((state) => state.currentProjectId);
-  const client = useAuthenticatedClient();
-  const trpc = useHostTRPC();
-  const [loading, setLoading] = useState(false);
-  const [oauthConnected, setOauthConnected] = useState(false);
-  const [linearIntegrationId, setLinearIntegrationId] = useState<
-    number | string | null
-  >(null);
-  const [pollError, setPollError] = useState<string | null>(null);
-  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const stopPolling = useCallback(() => {
-    if (pollTimerRef.current) {
-      clearInterval(pollTimerRef.current);
-      pollTimerRef.current = null;
-    }
-    if (pollTimeoutRef.current) {
-      clearTimeout(pollTimeoutRef.current);
-      pollTimeoutRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => stopPolling, [stopPolling]);
-
-  const startLinearFlow = useMutation(
-    trpc.linearIntegration.startFlow.mutationOptions(),
-  );
-
-  const handleOAuthConnect = useCallback(async () => {
-    if (!cloudRegion || !projectId || !client) return;
-    setLoading(true);
-    setPollError(null);
-    try {
-      await startLinearFlow.mutateAsync({
-        region: cloudRegion,
-        projectId,
-      });
-
-      pollTimerRef.current = setInterval(async () => {
-        try {
-          const integrations =
-            await client.getIntegrationsForProject(projectId);
-          const linearIntegration = integrations.find(
-            (i: { kind: string }) => i.kind === "linear",
-          ) as { id: number | string } | undefined;
-          if (linearIntegration) {
-            stopPolling();
-            setLoading(false);
-            setOauthConnected(true);
-            setLinearIntegrationId(linearIntegration.id);
-            toast.success("Linear connected");
-          }
-        } catch {
-          // Ignore individual poll failures
-        }
-      }, POLL_INTERVAL_MS);
-
-      pollTimeoutRef.current = setTimeout(() => {
-        stopPolling();
-        setLoading(false);
-        setPollError("Connection timed out. Please try again.");
-      }, POLL_TIMEOUT_MS);
-    } catch (error) {
-      setLoading(false);
-      toast.error(
-        error instanceof Error ? error.message : "Failed to connect Linear",
-      );
-    }
-  }, [cloudRegion, projectId, client, stopPolling, startLinearFlow]);
-
-  const handleSubmit = useCallback(async () => {
-    if (!projectId || !client || !linearIntegrationId) return;
-
-    setLoading(true);
-    try {
-      await client.createExternalDataSource(projectId, {
-        source_type: "Linear",
-        payload: {
-          linear_integration_id: linearIntegrationId,
-          schemas: schemasPayload("linear"),
-        },
-      });
-      toast.success("Linear data source created");
-      onComplete();
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to create data source",
-      );
-    } finally {
-      setLoading(false);
-    }
-  }, [projectId, client, linearIntegrationId, onComplete]);
-
-  return (
-    <SetupFormContainer title="Connect Linear">
-      <Flex direction="column" gap="3">
-        <Button
-          type="button"
-          variant="primary"
-          size="sm"
-          onClick={handleOAuthConnect}
-          disabled={loading || oauthConnected}
-        >
-          {oauthConnected
-            ? "Linear connected"
-            : loading
-              ? "Waiting for authorization..."
-              : "Log into Linear to continue"}
-        </Button>
-
-        {pollError && (
-          <Text className="text-(--red-11) text-sm">{pollError}</Text>
-        )}
-
-        <Flex gap="2" justify="end">
-          <Button
-            type="button"
-            variant="primary"
-            size="sm"
-            onClick={handleSubmit}
-            disabled={!oauthConnected || loading}
           >
             {loading ? "Creating..." : "Create source"}
           </Button>

--- a/packages/ui/src/features/inbox/components/DynamicSourceSetup.tsx
+++ b/packages/ui/src/features/inbox/components/DynamicSourceSetup.tsx
@@ -2,7 +2,9 @@ import type {
   SourceConfig,
   SourceFieldConfig,
   SourceFieldInputConfig,
+  SourceFieldOauthConfig,
 } from "@posthog/api-client/posthog-client";
+import { useHostTRPC } from "@posthog/host-router/react";
 import { Button } from "@posthog/quill";
 import { useAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
@@ -17,7 +19,8 @@ import {
   TextArea,
   TextField,
 } from "@radix-ui/themes";
-import { useCallback, useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface SchemaPayload {
   name: string;
@@ -35,7 +38,12 @@ interface DynamicSourceSetupProps {
   onCancel: () => void;
 }
 
-type FieldValues = Record<string, string | boolean>;
+type FieldValue = string | number | boolean;
+type FieldValues = Record<string, FieldValue>;
+
+/** Poll cadence/ceiling for discovering the integration created by an OAuth grant. */
+const POLL_INTERVAL_MS = 3_000;
+const POLL_TIMEOUT_MS = 5 * 60 * 1000;
 
 const INPUT_TYPES = new Set([
   "text",
@@ -56,15 +64,11 @@ function isInputField(
 }
 
 /**
- * A field type the generic renderer cannot handle inline (OAuth grants, SSH
- * tunnels, file uploads). Sources requiring these still need a bespoke form.
+ * A field type the generic renderer cannot handle inline (SSH tunnels, file
+ * uploads). Sources requiring these still need a bespoke form.
  */
 function isUnsupportedField(field: SourceFieldConfig): boolean {
-  return (
-    field.type === "oauth" ||
-    field.type === "ssh-tunnel" ||
-    field.type === "file-upload"
-  );
+  return field.type === "ssh-tunnel" || field.type === "file-upload";
 }
 
 /**
@@ -90,6 +94,10 @@ function missingRequiredFields(
         }
         const option = field.options.find((o) => o.value === selected);
         if (option?.fields) walk(option.fields);
+      } else if (field.type === "oauth") {
+        if (field.required && !values[field.name]) {
+          missing.push(field.name);
+        }
       } else if (isInputField(field) && field.required) {
         const value = values[field.name];
         if (typeof value !== "string" || value.trim().length === 0) {
@@ -123,6 +131,9 @@ function buildPayload(
           selection: selected,
           ...(option?.fields ? collect(option.fields) : {}),
         };
+      } else if (field.type === "oauth") {
+        const value = values[field.name];
+        if (value !== undefined && value !== "") out[field.name] = value;
       } else if (isInputField(field)) {
         const value = values[field.name];
         if (typeof value === "string") out[field.name] = value.trim();
@@ -146,7 +157,7 @@ export function DynamicSourceSetup({
   const [values, setValues] = useState<FieldValues>({});
   const [submitting, setSubmitting] = useState(false);
 
-  const setValue = useCallback((name: string, value: string | boolean) => {
+  const setValue = useCallback((name: string, value: FieldValue) => {
     setValues((prev) => ({ ...prev, [name]: value }));
   }, []);
 
@@ -207,6 +218,7 @@ export function DynamicSourceSetup({
               field={field}
               values={values}
               setValue={setValue}
+              providerName={title.replace(/^Connect\s+/i, "")}
             />
           ))}
           {hasUnsupportedField && (
@@ -244,10 +256,12 @@ function SourceField({
   field,
   values,
   setValue,
+  providerName,
 }: {
   field: SourceFieldConfig;
   values: FieldValues;
-  setValue: (name: string, value: string | boolean) => void;
+  setValue: (name: string, value: FieldValue) => void;
+  providerName: string;
 }) {
   if (field.type === "switch-group") {
     const enabled = !!values[field.name];
@@ -270,9 +284,21 @@ function SourceField({
               field={nested}
               values={values}
               setValue={setValue}
+              providerName={providerName}
             />
           ))}
       </Flex>
+    );
+  }
+
+  if (field.type === "oauth") {
+    return (
+      <OAuthSourceField
+        field={field}
+        value={values[field.name]}
+        setValue={setValue}
+        providerName={providerName}
+      />
     );
   }
 
@@ -301,6 +327,7 @@ function SourceField({
             field={nested}
             values={values}
             setValue={setValue}
+            providerName={providerName}
           />
         ))}
       </Flex>
@@ -335,6 +362,126 @@ function SourceField({
   }
 
   return null;
+}
+
+/**
+ * Renders an `oauth` config field: a connect button that launches the provider's
+ * OAuth flow, polls for the resulting integration, and writes its id into the
+ * form. Mirrors the previous bespoke Linear setup. Only providers with a wired
+ * flow starter (currently `linear`) can be connected here; others surface a
+ * message.
+ */
+function OAuthSourceField({
+  field,
+  value,
+  setValue,
+  providerName,
+}: {
+  field: SourceFieldOauthConfig;
+  value: FieldValue | undefined;
+  setValue: (name: string, value: FieldValue) => void;
+  providerName: string;
+}) {
+  const region = useAuthStateValue((state) => state.cloudRegion);
+  const projectId = useAuthStateValue((state) => state.currentProjectId);
+  const client = useAuthenticatedClient();
+  const trpc = useHostTRPC();
+  const startLinearFlow = useMutation(
+    trpc.linearIntegration.startFlow.mutationOptions(),
+  );
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollTimer.current) {
+      clearInterval(pollTimer.current);
+      pollTimer.current = null;
+    }
+    if (pollTimeout.current) {
+      clearTimeout(pollTimeout.current);
+      pollTimeout.current = null;
+    }
+  }, []);
+  useEffect(() => stopPolling, [stopPolling]);
+
+  const connected = value !== undefined && value !== "";
+
+  const startFlow = useCallback(async () => {
+    if (field.kind === "linear") {
+      if (!region || !projectId) throw new Error("Missing project context");
+      await startLinearFlow.mutateAsync({ region, projectId });
+      return;
+    }
+    throw new Error(`Connecting ${providerName} isn't supported here yet.`);
+  }, [field.kind, region, projectId, startLinearFlow, providerName]);
+
+  const handleConnect = useCallback(async () => {
+    if (!projectId || !client) return;
+    setConnecting(true);
+    setError(null);
+    try {
+      await startFlow();
+      pollTimer.current = setInterval(async () => {
+        try {
+          const integrations =
+            await client.getIntegrationsForProject(projectId);
+          const match = integrations.find(
+            (i: { kind: string }) => i.kind === field.kind,
+          ) as { id: number | string } | undefined;
+          if (match) {
+            stopPolling();
+            setConnecting(false);
+            setValue(field.name, match.id);
+            toast.success(`${providerName} connected`);
+          }
+        } catch {
+          // Ignore individual poll failures; the timeout below bounds the wait.
+        }
+      }, POLL_INTERVAL_MS);
+      pollTimeout.current = setTimeout(() => {
+        stopPolling();
+        setConnecting(false);
+        setError("Connection timed out. Please try again.");
+      }, POLL_TIMEOUT_MS);
+    } catch (err) {
+      setConnecting(false);
+      setError(
+        err instanceof Error
+          ? err.message
+          : `Failed to connect ${providerName}`,
+      );
+    }
+  }, [
+    projectId,
+    client,
+    startFlow,
+    field.kind,
+    field.name,
+    setValue,
+    providerName,
+    stopPolling,
+  ]);
+
+  return (
+    <Flex direction="column" gap="2">
+      <Button
+        type="button"
+        variant="primary"
+        size="sm"
+        onClick={handleConnect}
+        disabled={connecting || connected}
+      >
+        {connected
+          ? `${providerName} connected`
+          : connecting
+            ? "Waiting for authorization..."
+            : `Log into ${providerName} to continue`}
+      </Button>
+      {error && <Text className="text-(--red-11) text-sm">{error}</Text>}
+    </Flex>
+  );
 }
 
 function SetupFormContainer({


### PR DESCRIPTION
## Problem

The Linear inbox source-setup form was a ~130-line bespoke component (`LinearSetup`) duplicating connect-and-poll logic that the generic `DynamicSourceSetup` (added in #3306) could own. Linear's warehouse config is a single `oauth` field, so it can render from the `wizard` endpoint like the credential sources already do.

## Changes

- Extend `DynamicSourceSetup` to handle `oauth` config fields: a connect button launches the provider's OAuth flow, polls for the resulting integration, and writes its id into the form value (generalising the old Linear-specific poll).
- Route the `linear` case through `DynamicSourceSetup` and delete `LinearSetup`.

Linear's config is exactly one oauth field (`kind=linear` → `linear_integration_id`), so the connect flow, button microcopy, and create payload (`{ linear_integration_id, schemas }`) are unchanged. The only visible difference is a Cancel button, consistent with the other sources.

**GitHub is intentionally not included.** Its config exposes an auth-method select (OAuth/PAT) and a `repository` field, but the current Code UI deliberately omits the auth-method/PAT UI and uses a bespoke searchable repo picker that isn't config-driven anywhere (PostHog's own web wizard special-cases it too). Rendering GitHub purely from config would change its UI and add no real simplification, so it stays bespoke.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` — clean for the changed files (remaining errors are pre-existing stale cross-package dists).
- Biome lint/format clean.
- Not verified in the running app (no CDP session available): the live Linear OAuth connect + source creation. The connect/poll logic and the create payload are a faithful port of the previous `LinearSetup`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
