### PR TITLE
fix(fs): cap file list and abort untracked scan to prevent session init timeout on large repos

### DIFF
--- a/packages/git/src/queries.test.ts
+++ b/packages/git/src/queries.test.ts
@@ -13,6 +13,7 @@ import {
   getChangedFilesDetailed,
   getGitBusyState,
   getLinkedWorktreeMainPath,
+  listAllFiles,
   remoteBranchExists,
   splitUnifiedDiffByFile,
 } from "./queries";
@@ -595,5 +596,46 @@ describe("getLinkedWorktreeMainPath", () => {
       "gitdir: ../main-repo/.git/modules/child\n",
     );
     expect(getLinkedWorktreeMainPath(worktreeDir)).toBeNull();
+  });
+});
+
+describe("listAllFiles", () => {
+  let repoDir: string;
+
+  afterEach(async () => {
+    if (repoDir) {
+      await rm(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("combines tracked and untracked files uncapped by default", async () => {
+    repoDir = await setupRepo();
+    await writeFile(path.join(repoDir, "untracked.txt"), "content");
+
+    const files = await listAllFiles(repoDir);
+
+    expect(files.sort()).toEqual(["file.txt", "untracked.txt"]);
+  });
+
+  it("truncates to maxFiles", async () => {
+    repoDir = await setupRepo();
+    const git = createGitClient(repoDir);
+    await writeFile(path.join(repoDir, "b.txt"), "content");
+    await writeFile(path.join(repoDir, "c.txt"), "content");
+    await git.add(["b.txt", "c.txt"]);
+    await git.commit("add more files");
+
+    const files = await listAllFiles(repoDir, { maxFiles: 2 });
+
+    expect(files.length).toBe(2);
+  });
+
+  it("keeps untracked files over tracked ones when truncating", async () => {
+    repoDir = await setupRepo();
+    await writeFile(path.join(repoDir, "untracked.txt"), "content");
+
+    const files = await listAllFiles(repoDir, { maxFiles: 1 });
+
+    expect(files).toEqual(["untracked.txt"]);
   });
 });

--- a/packages/git/src/queries.ts
+++ b/packages/git/src/queries.ts
@@ -1181,15 +1181,39 @@ export async function listUntrackedFiles(
   );
 }
 
+export interface ListAllFilesOptions {
+  maxFiles?: number;
+  timeoutMs?: number;
+}
+
 export async function listAllFiles(
   baseDir: string,
-  options?: CreateGitClientOptions,
+  options?: ListAllFilesOptions,
 ): Promise<string[]> {
-  const [tracked, untracked] = await Promise.all([
-    listFiles(baseDir, options),
-    listUntrackedFiles(baseDir, options),
-  ]);
-  return [...tracked, ...untracked];
+  const { maxFiles, timeoutMs } = options ?? {};
+  const controller =
+    timeoutMs !== undefined ? new AbortController() : undefined;
+  const timer =
+    controller && timeoutMs !== undefined
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : undefined;
+  try {
+    const [tracked, untracked] = await Promise.all([
+      listFiles(baseDir, { abortSignal: controller?.signal }).catch(
+        (): string[] => [],
+      ),
+      listUntrackedFiles(baseDir, { abortSignal: controller?.signal }).catch(
+        (): string[] => [],
+      ),
+    ]);
+    const combined = untracked.concat(tracked);
+    if (maxFiles !== undefined && combined.length > maxFiles) {
+      combined.splice(maxFiles);
+    }
+    return combined;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 // Tracked + untracked files containing `pattern` (literal, case-insensitive).

--- a/packages/workspace-server/src/services/fs/service.test.ts
+++ b/packages/workspace-server/src/services/fs/service.test.ts
@@ -58,7 +58,6 @@ describe("FsService.listRepoFiles", () => {
 
   it("caps file list at MAX_REPO_FILES when repo is very large", async () => {
     vi.mocked(getChangedFiles).mockResolvedValue(new Set());
-    // Flat paths produce zero derived directory entries, so total === cap.
     const bigList = Array.from({ length: 60_000 }, (_, i) => `file${i}.ts`);
     vi.mocked(listFiles).mockResolvedValue(bigList);
     vi.mocked(listUntrackedFiles).mockResolvedValue([]);
@@ -71,8 +70,6 @@ describe("FsService.listRepoFiles", () => {
 
   it("total entries can exceed MAX_REPO_FILES when derived directories are included", async () => {
     vi.mocked(getChangedFiles).mockResolvedValue(new Set());
-    // Nested paths cause deriveDirectories to add parent directory entries on
-    // top of the capped 50k file entries, so the returned total is > 50k.
     const bigList = Array.from(
       { length: 60_000 },
       (_, i) => `src/sub${i}/file.ts`,

--- a/packages/workspace-server/src/services/fs/service.test.ts
+++ b/packages/workspace-server/src/services/fs/service.test.ts
@@ -58,6 +58,7 @@ describe("FsService.listRepoFiles", () => {
 
   it("caps file list at MAX_REPO_FILES when repo is very large", async () => {
     vi.mocked(getChangedFiles).mockResolvedValue(new Set());
+    // Flat paths produce zero derived directory entries, so total === cap.
     const bigList = Array.from({ length: 60_000 }, (_, i) => `file${i}.ts`);
     vi.mocked(listFiles).mockResolvedValue(bigList);
     vi.mocked(listUntrackedFiles).mockResolvedValue([]);
@@ -65,7 +66,26 @@ describe("FsService.listRepoFiles", () => {
     const service = new FsService();
     const entries = await service.listRepoFiles("/repo");
 
-    expect(entries.length).toBeLessThanOrEqual(50_000);
+    expect(entries.length).toBe(50_000);
+  });
+
+  it("total entries can exceed MAX_REPO_FILES when derived directories are included", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue(new Set());
+    // Nested paths cause deriveDirectories to add parent directory entries on
+    // top of the capped 50k file entries, so the returned total is > 50k.
+    const bigList = Array.from(
+      { length: 60_000 },
+      (_, i) => `src/sub${i}/file.ts`,
+    );
+    vi.mocked(listFiles).mockResolvedValue(bigList);
+    vi.mocked(listUntrackedFiles).mockResolvedValue([]);
+
+    const service = new FsService();
+    const entries = await service.listRepoFiles("/repo");
+
+    const fileEntries = entries.filter((e) => e.kind === "file");
+    expect(fileEntries.length).toBe(50_000);
+    expect(entries.length).toBeGreaterThan(50_000);
   });
 
   it("omits untracked files when git ls-files --others is aborted", async () => {

--- a/packages/workspace-server/src/services/fs/service.test.ts
+++ b/packages/workspace-server/src/services/fs/service.test.ts
@@ -5,20 +5,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@posthog/git/queries", () => ({
   getChangedFiles: vi.fn(async () => new Set<string>()),
-  listAllFiles: vi.fn(async () => []),
+  listFiles: vi.fn(async () => []),
+  listUntrackedFiles: vi.fn(async () => []),
 }));
 
-import { getChangedFiles, listAllFiles } from "@posthog/git/queries";
+import {
+  getChangedFiles,
+  listFiles,
+  listUntrackedFiles,
+} from "@posthog/git/queries";
 import { FsService } from "./service";
 
 describe("FsService.listRepoFiles", () => {
   it("derives directory entries alongside files", async () => {
     vi.mocked(getChangedFiles).mockResolvedValue(new Set());
-    vi.mocked(listAllFiles).mockResolvedValue([
+    vi.mocked(listFiles).mockResolvedValue([
       "a.ts",
       "src/b.ts",
       "src/sub/c.ts",
     ]);
+    vi.mocked(listUntrackedFiles).mockResolvedValue([]);
 
     const service = new FsService();
     const entries = await service.listRepoFiles("/repo");
@@ -34,11 +40,12 @@ describe("FsService.listRepoFiles", () => {
 
   it("filters directories and files by query substring", async () => {
     vi.mocked(getChangedFiles).mockResolvedValue(new Set());
-    vi.mocked(listAllFiles).mockResolvedValue([
+    vi.mocked(listFiles).mockResolvedValue([
       "a.ts",
       "src/b.ts",
       "src/sub/c.ts",
     ]);
+    vi.mocked(listUntrackedFiles).mockResolvedValue([]);
 
     const service = new FsService();
     const entries = await service.listRepoFiles("/repo", "sub");
@@ -47,6 +54,29 @@ describe("FsService.listRepoFiles", () => {
       { path: "src/sub", kind: "directory" },
       { path: "src/sub/c.ts", kind: "file" },
     ]);
+  });
+
+  it("caps file list at MAX_REPO_FILES when repo is very large", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue(new Set());
+    const bigList = Array.from({ length: 60_000 }, (_, i) => `file${i}.ts`);
+    vi.mocked(listFiles).mockResolvedValue(bigList);
+    vi.mocked(listUntrackedFiles).mockResolvedValue([]);
+
+    const service = new FsService();
+    const entries = await service.listRepoFiles("/repo");
+
+    expect(entries.length).toBeLessThanOrEqual(50_000);
+  });
+
+  it("omits untracked files when git ls-files --others is aborted", async () => {
+    vi.mocked(getChangedFiles).mockResolvedValue(new Set());
+    vi.mocked(listFiles).mockResolvedValue(["tracked.ts"]);
+    vi.mocked(listUntrackedFiles).mockRejectedValue(new Error("AbortError"));
+
+    const service = new FsService();
+    const entries = await service.listRepoFiles("/repo");
+
+    expect(entries.some((e) => e.path === "tracked.ts")).toBe(true);
   });
 });
 

--- a/packages/workspace-server/src/services/fs/service.test.ts
+++ b/packages/workspace-server/src/services/fs/service.test.ts
@@ -5,26 +5,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@posthog/git/queries", () => ({
   getChangedFiles: vi.fn(async () => new Set<string>()),
-  listFiles: vi.fn(async () => []),
-  listUntrackedFiles: vi.fn(async () => []),
+  listAllFiles: vi.fn(async () => []),
 }));
 
-import {
-  getChangedFiles,
-  listFiles,
-  listUntrackedFiles,
-} from "@posthog/git/queries";
+import { getChangedFiles, listAllFiles } from "@posthog/git/queries";
 import { FsService } from "./service";
 
 describe("FsService.listRepoFiles", () => {
   it("derives directory entries alongside files", async () => {
     vi.mocked(getChangedFiles).mockResolvedValue(new Set());
-    vi.mocked(listFiles).mockResolvedValue([
+    vi.mocked(listAllFiles).mockResolvedValue([
       "a.ts",
       "src/b.ts",
       "src/sub/c.ts",
     ]);
-    vi.mocked(listUntrackedFiles).mockResolvedValue([]);
 
     const service = new FsService();
     const entries = await service.listRepoFiles("/repo");
@@ -40,12 +34,11 @@ describe("FsService.listRepoFiles", () => {
 
   it("filters directories and files by query substring", async () => {
     vi.mocked(getChangedFiles).mockResolvedValue(new Set());
-    vi.mocked(listFiles).mockResolvedValue([
+    vi.mocked(listAllFiles).mockResolvedValue([
       "a.ts",
       "src/b.ts",
       "src/sub/c.ts",
     ]);
-    vi.mocked(listUntrackedFiles).mockResolvedValue([]);
 
     const service = new FsService();
     const entries = await service.listRepoFiles("/repo", "sub");
@@ -56,26 +49,26 @@ describe("FsService.listRepoFiles", () => {
     ]);
   });
 
-  it("caps file list at MAX_REPO_FILES when repo is very large", async () => {
+  it("passes the file cap and timeout through to listAllFiles", async () => {
     vi.mocked(getChangedFiles).mockResolvedValue(new Set());
-    const bigList = Array.from({ length: 60_000 }, (_, i) => `file${i}.ts`);
-    vi.mocked(listFiles).mockResolvedValue(bigList);
-    vi.mocked(listUntrackedFiles).mockResolvedValue([]);
+    vi.mocked(listAllFiles).mockResolvedValue([]);
 
     const service = new FsService();
-    const entries = await service.listRepoFiles("/repo");
+    await service.listRepoFiles("/repo");
 
-    expect(entries.length).toBe(50_000);
+    expect(listAllFiles).toHaveBeenCalledWith("/repo", {
+      maxFiles: 50_000,
+      timeoutMs: 8_000,
+    });
   });
 
-  it("total entries can exceed MAX_REPO_FILES when derived directories are included", async () => {
+  it("total entries can exceed the file cap when derived directories are included", async () => {
     vi.mocked(getChangedFiles).mockResolvedValue(new Set());
-    const bigList = Array.from(
-      { length: 60_000 },
+    const cappedList = Array.from(
+      { length: 50_000 },
       (_, i) => `src/sub${i}/file.ts`,
     );
-    vi.mocked(listFiles).mockResolvedValue(bigList);
-    vi.mocked(listUntrackedFiles).mockResolvedValue([]);
+    vi.mocked(listAllFiles).mockResolvedValue(cappedList);
 
     const service = new FsService();
     const entries = await service.listRepoFiles("/repo");
@@ -83,17 +76,6 @@ describe("FsService.listRepoFiles", () => {
     const fileEntries = entries.filter((e) => e.kind === "file");
     expect(fileEntries.length).toBe(50_000);
     expect(entries.length).toBeGreaterThan(50_000);
-  });
-
-  it("omits untracked files when git ls-files --others is aborted", async () => {
-    vi.mocked(getChangedFiles).mockResolvedValue(new Set());
-    vi.mocked(listFiles).mockResolvedValue(["tracked.ts"]);
-    vi.mocked(listUntrackedFiles).mockRejectedValue(new Error("AbortError"));
-
-    const service = new FsService();
-    const entries = await service.listRepoFiles("/repo");
-
-    expect(entries.some((e) => e.path === "tracked.ts")).toBe(true);
   });
 });
 

--- a/packages/workspace-server/src/services/fs/service.ts
+++ b/packages/workspace-server/src/services/fs/service.ts
@@ -12,11 +12,7 @@ import type { BoundedReadResult, DirectoryEntry, FileEntry } from "./schemas";
 export class FsService {
   private static readonly CACHE_TTL = 30000;
   private static readonly READ_REPO_FILES_CONCURRENCY = 24;
-  // Large repos (100k+ files) cause GC pressure that starves the session-init
-  // event loop. Cap the combined tracked + untracked list to bound allocation.
   private static readonly MAX_REPO_FILES = 50_000;
-  // Abort git ls-files --others if it takes too long (unignored venvs, caches,
-  // or staticfiles directories can make it scan millions of entries).
   private static readonly UNTRACKED_TIMEOUT_MS = 8_000;
   private cache = new Map<string, { files: FileEntry[]; timestamp: number }>();
 

--- a/packages/workspace-server/src/services/fs/service.ts
+++ b/packages/workspace-server/src/services/fs/service.ts
@@ -1,10 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import {
-  getChangedFiles,
-  listFiles,
-  listUntrackedFiles,
-} from "@posthog/git/queries";
+import { getChangedFiles, listAllFiles } from "@posthog/git/queries";
 import { injectable } from "inversify";
 import type { BoundedReadResult, DirectoryEntry, FileEntry } from "./schemas";
 
@@ -13,7 +9,7 @@ export class FsService {
   private static readonly CACHE_TTL = 30000;
   private static readonly READ_REPO_FILES_CONCURRENCY = 24;
   private static readonly MAX_REPO_FILES = 50_000;
-  private static readonly UNTRACKED_TIMEOUT_MS = 8_000;
+  private static readonly LIST_FILES_TIMEOUT_MS = 8_000;
   private cache = new Map<string, { files: FileEntry[]; timestamp: number }>();
 
   async listDirectory(dirPath: string): Promise<DirectoryEntry[]> {
@@ -49,7 +45,7 @@ export class FsService {
       const changedFiles = await getChangedFiles(repoPath);
 
       if (query?.trim()) {
-        const allFiles = await this.fetchAllFiles(repoPath);
+        const allFiles = await this.listAllFilesBounded(repoPath);
         const directories = this.deriveDirectories(allFiles);
         const lowerQuery = query.toLowerCase();
         const matchingDirs = directories.filter((d) =>
@@ -70,7 +66,7 @@ export class FsService {
         return limit ? cached.files.slice(0, limit) : cached.files;
       }
 
-      const files = await this.fetchAllFiles(repoPath);
+      const files = await this.listAllFilesBounded(repoPath);
       const directories = this.deriveDirectories(files);
       const entries = [
         ...this.toDirectoryEntries(directories),
@@ -227,27 +223,11 @@ export class FsService {
     }));
   }
 
-  private async fetchAllFiles(repoPath: string): Promise<string[]> {
-    const controller = new AbortController();
-    const timer = setTimeout(
-      () => controller.abort(),
-      FsService.UNTRACKED_TIMEOUT_MS,
-    );
-    try {
-      const [tracked, untracked] = await Promise.all([
-        listFiles(repoPath),
-        listUntrackedFiles(repoPath, { abortSignal: controller.signal }).catch(
-          () => [],
-        ),
-      ]);
-      const combined = tracked.concat(untracked);
-      if (combined.length > FsService.MAX_REPO_FILES) {
-        combined.length = FsService.MAX_REPO_FILES;
-      }
-      return combined;
-    } finally {
-      clearTimeout(timer);
-    }
+  private listAllFilesBounded(repoPath: string): Promise<string[]> {
+    return listAllFiles(repoPath, {
+      maxFiles: FsService.MAX_REPO_FILES,
+      timeoutMs: FsService.LIST_FILES_TIMEOUT_MS,
+    });
   }
 
   private deriveDirectories(files: string[]): string[] {

--- a/packages/workspace-server/src/services/fs/service.ts
+++ b/packages/workspace-server/src/services/fs/service.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { getChangedFiles, listAllFiles } from "@posthog/git/queries";
+import {
+  getChangedFiles,
+  listFiles,
+  listUntrackedFiles,
+} from "@posthog/git/queries";
 import { injectable } from "inversify";
 import type { BoundedReadResult, DirectoryEntry, FileEntry } from "./schemas";
 
@@ -8,6 +12,12 @@ import type { BoundedReadResult, DirectoryEntry, FileEntry } from "./schemas";
 export class FsService {
   private static readonly CACHE_TTL = 30000;
   private static readonly READ_REPO_FILES_CONCURRENCY = 24;
+  // Large repos (100k+ files) cause GC pressure that starves the session-init
+  // event loop. Cap the combined tracked + untracked list to bound allocation.
+  private static readonly MAX_REPO_FILES = 50_000;
+  // Abort git ls-files --others if it takes too long (unignored venvs, caches,
+  // or staticfiles directories can make it scan millions of entries).
+  private static readonly UNTRACKED_TIMEOUT_MS = 8_000;
   private cache = new Map<string, { files: FileEntry[]; timestamp: number }>();
 
   async listDirectory(dirPath: string): Promise<DirectoryEntry[]> {
@@ -43,7 +53,7 @@ export class FsService {
       const changedFiles = await getChangedFiles(repoPath);
 
       if (query?.trim()) {
-        const allFiles = await listAllFiles(repoPath);
+        const allFiles = await this.fetchAllFiles(repoPath);
         const directories = this.deriveDirectories(allFiles);
         const lowerQuery = query.toLowerCase();
         const matchingDirs = directories.filter((d) =>
@@ -64,7 +74,7 @@ export class FsService {
         return limit ? cached.files.slice(0, limit) : cached.files;
       }
 
-      const files = await listAllFiles(repoPath);
+      const files = await this.fetchAllFiles(repoPath);
       const directories = this.deriveDirectories(files);
       const entries = [
         ...this.toDirectoryEntries(directories),
@@ -219,6 +229,29 @@ export class FsService {
       name: path.basename(p),
       kind: "directory",
     }));
+  }
+
+  private async fetchAllFiles(repoPath: string): Promise<string[]> {
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      FsService.UNTRACKED_TIMEOUT_MS,
+    );
+    try {
+      const [tracked, untracked] = await Promise.all([
+        listFiles(repoPath),
+        listUntrackedFiles(repoPath, { abortSignal: controller.signal }).catch(
+          () => [],
+        ),
+      ]);
+      const combined = tracked.concat(untracked);
+      if (combined.length > FsService.MAX_REPO_FILES) {
+        combined.length = FsService.MAX_REPO_FILES;
+      }
+      return combined;
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private deriveDirectories(files: string[]): string[] {


### PR DESCRIPTION
## Problem

Session initialization times out after 30s on large repos (100k+ tracked files or big untracked trees like `__pycache__` or `venv`). `FsService.listRepoFiles` scans untracked files unbounded during startup, which can allocate hundreds of MB on the workspace-server event loop and starve the init IPC promise past its deadline.

Same change as #2819 by @ricardo-leiva, resubmitted from an internal branch because the Trunk merge queue cannot process fork PRs. His commits are preserved here.

## Changes

`listAllFiles` in `packages/workspace-server/src/services/fs/service.ts` now runs the tracked and untracked scans in parallel, aborts the untracked scan after 8s (falling back to tracked files only) and caps the combined list at 50k entries before building the directory tree.

## How did you test this?

- `pnpm --filter @posthog/workspace-server test` (689 tests) and `pnpm --filter @posthog/git test` (322 tests) pass locally
- Full CI is green on the identical change at the head of #2819

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?