### PR TITLE
fix(permissions): cap permission prompt height and scroll long content

### DIFF
--- a/packages/ui/src/primitives/action-selector/ActionSelector.tsx
+++ b/packages/ui/src/primitives/action-selector/ActionSelector.tsx
@@ -227,9 +227,9 @@ export function ActionSelector({
       style={{
         outline: "none",
       }}
-      className="rounded-(--radius-3) border border-(--gray-6) bg-(--gray-1)"
+      className="flex max-h-[80vh] flex-col rounded-(--radius-3) border border-(--gray-6) bg-(--gray-1)"
     >
-      <Flex direction="column" gap="2">
+      <Flex direction="column" gap="2" className="min-h-0 flex-1">
         {hasSteps && steps && (
           <StepTabs
             steps={steps}
@@ -253,13 +253,20 @@ export function ActionSelector({
             </Text>
           ))}
 
-        {pendingAction && <Box>{pendingAction}</Box>}
+        {(pendingAction || question) && (
+          <Box className="min-h-0 flex-1 overflow-y-auto">
+            {pendingAction && (
+              <Box mb={question ? "2" : "0"}>{pendingAction}</Box>
+            )}
+            {question && (
+              <Text as="p" className="text-[13px]">
+                {question}
+              </Text>
+            )}
+          </Box>
+        )}
 
         <Box>
-          <Text mb="2" as="p" className="text-[13px]">
-            {question}
-          </Text>
-
           <Flex direction="column" gap="1" px="2">
             {allOptions.map((option, index) => {
               if (isSubmitOption(option.id) || isCancelOption(option.id)) {


### PR DESCRIPTION
## Problem

When a permission request is very long (e.g. a large shell command or a big MCP tool input, common with the codex adapter on worktree/local tasks), the approval card could grow taller than the visible area and push the Allow/Deny buttons off-screen. Because the card itself didn't scroll, users had no way to reach the buttons short of zooming the whole app out.

## Changes

Cap the shared `ActionSelector` permission card at `80vh` and make the pending-action + question region scroll internally (`min-h-0 flex-1 overflow-y-auto`), while the option rows and Allow/Deny buttons stay pinned and always visible. Fixing it in the shared primitive covers every permission kind and both the session view and the canvas permission dialog.

## How did you test this?

- `pnpm build` (all packages)
- `pnpm --filter @posthog/ui typecheck` — clean
- Biome check on the changed file — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1784024637473999?thread_ts=1784024637.473999&cid=C09G8Q32R6F)*
