### PR TITLE
fix(git): keep handoff packs on the repository filesystem

### DIFF
--- a/packages/agent/src/handoff-checkpoint.test.ts
+++ b/packages/agent/src/handoff-checkpoint.test.ts
@@ -1,3 +1,5 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   decodeHandoffArtifact,
@@ -222,6 +224,18 @@ describe("HandoffCheckpointTracker", () => {
     expect(checkpoint).not.toBeNull();
     if (!checkpoint) return;
     expect(Object.keys(store.artifacts).length).toBeGreaterThan(0);
+    const gitCommonDirRaw = await cloudRepo.git([
+      "rev-parse",
+      "--git-common-dir",
+    ]);
+    const gitCommonDir = path.isAbsolute(gitCommonDirRaw)
+      ? gitCommonDirRaw
+      : path.resolve(cloudRepo.path, gitCommonDirRaw);
+    expect(
+      (await readdir(gitCommonDir)).filter((entry) =>
+        entry.startsWith("posthog-code-handoff-"),
+      ),
+    ).toEqual([]);
 
     const applyTracker = createTracker(localRepo.path, apiClient);
     await applyTracker.applyFromHandoff(checkpoint);

--- a/packages/agent/src/handoff-checkpoint.ts
+++ b/packages/agent/src/handoff-checkpoint.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import {
   type GitHandoffBranchDivergence,
   type GitHandoffCheckpoint,
@@ -149,12 +149,10 @@ export class HandoffCheckpointTracker {
         indexArtifactPath: uploads.index?.storagePath,
       };
     } finally {
-      const tempDir = capture.headPack?.path
-        ? dirname(capture.headPack.path)
-        : dirname(capture.indexFile.path);
-      await this.removeIfPresent(capture.headPack?.path);
-      await this.removeIfPresent(capture.indexFile.path);
-      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      await rm(capture.artifactDirectory, {
+        recursive: true,
+        force: true,
+      }).catch(() => {});
     }
   }
 

--- a/packages/git/src/handoff.test.ts
+++ b/packages/git/src/handoff.test.ts
@@ -103,10 +103,9 @@ async function makeCloudChanges(
 }
 
 async function cleanupCapture(capture: GitHandoffCaptureResult): Promise<void> {
-  if (capture.headPack?.path) {
-    await rm(capture.headPack.path, { force: true }).catch(() => {});
-  }
-  await rm(capture.indexFile.path, { force: true }).catch(() => {});
+  await rm(capture.artifactDirectory, { recursive: true, force: true }).catch(
+    () => {},
+  );
 }
 
 async function captureAndApply(
@@ -145,6 +144,41 @@ async function captureAndApply(
 }
 
 describe("GitHandoffTracker", () => {
+  it("stores capture artifacts beside the git object store", async () => {
+    await withRepos(async (repos) => {
+      await makeCloudChanges(repos.cloudRepo, repos.cloudGit);
+
+      const captureTracker = new GitHandoffTracker({
+        repositoryPath: repos.cloudRepo,
+      });
+      const capture = await captureTracker.captureForHandoff(
+        repos.localGitState,
+      );
+      const gitCommonDir = (
+        await repos.cloudGit.raw([
+          "rev-parse",
+          "--path-format=absolute",
+          "--git-common-dir",
+        ])
+      ).trim();
+
+      try {
+        expect(path.dirname(capture.artifactDirectory)).toBe(gitCommonDir);
+        expect(path.dirname(path.dirname(capture.indexFile.path))).toBe(
+          gitCommonDir,
+        );
+        if (!capture.headPack) {
+          throw new Error("Expected handoff capture to include a pack file");
+        }
+        expect(path.dirname(path.dirname(capture.headPack.path))).toBe(
+          gitCommonDir,
+        );
+      } finally {
+        await cleanupCapture(capture);
+      }
+    });
+  }, 15000);
+
   it("captures and reapplies head, worktree, and index state from local files", async () => {
     await withRepos(async (repos) => {
       await makeCloudChanges(repos.cloudRepo, repos.cloudGit);

--- a/packages/git/src/handoff.ts
+++ b/packages/git/src/handoff.ts
@@ -1,6 +1,5 @@
 import { spawn } from "node:child_process";
 import { copyFile, mkdtemp, readFile, rm, stat } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import type {
   GitHandoffCheckpoint,
@@ -26,6 +25,7 @@ export interface GitHandoffArtifactFile {
 
 export interface GitHandoffCaptureResult {
   checkpoint: GitHandoffCheckpoint;
+  artifactDirectory: string;
   headPack?: GitHandoffArtifactFile;
   indexFile: GitHandoffArtifactFile;
   totalBytes: number;
@@ -92,7 +92,7 @@ export class GitHandoffTracker {
 
     const checkpoint = result.data;
     const git = createGitClient(this.repositoryPath);
-    const tempDir = await this.createTempDir(checkpoint.checkpointId);
+    const tempDir = await this.createTempDir(git, checkpoint.checkpointId);
     const checkpointRef = `${CHECKPOINT_REF_PREFIX}${checkpoint.checkpointId}`;
 
     try {
@@ -139,10 +139,14 @@ export class GitHandoffTracker {
           upstreamMergeRef: tracking.upstreamMergeRef,
           remoteUrl: tracking.remoteUrl,
         },
+        artifactDirectory: tempDir,
         headPack,
         indexFile,
         totalBytes: (headPack?.rawBytes ?? 0) + indexFile.rawBytes,
       };
+    } catch (error) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+      throw error;
     } finally {
       await deleteCheckpoint(git, checkpoint.checkpointId).catch(() => {});
     }
@@ -590,8 +594,27 @@ export class GitHandoffTracker {
     return exitCode === 0;
   }
 
-  private async createTempDir(checkpointId: string): Promise<string> {
-    return mkdtemp(joinTempPrefix(checkpointId));
+  private async createTempDir(
+    git: GitClient,
+    checkpointId: string,
+  ): Promise<string> {
+    // Git stages packs in the object store, so the destination must share its filesystem.
+    const gitCommonDir = await this.resolveGitCommonDir(git);
+    return mkdtemp(
+      path.join(gitCommonDir, `posthog-code-handoff-${checkpointId}-`),
+    );
+  }
+
+  private async resolveGitCommonDir(git: GitClient): Promise<string> {
+    const raw = await git.raw([
+      "rev-parse",
+      "--path-format=absolute",
+      "--git-common-dir",
+    ]);
+    const resolved = raw.trim() || ".git";
+    return path.isAbsolute(resolved)
+      ? resolved
+      : path.resolve(this.repositoryPath, resolved);
   }
 
   private async getGitPath(git: GitClient, gitPath: string): Promise<string> {
@@ -713,10 +736,6 @@ export class GitHandoffTracker {
       child.stdin.end(input);
     });
   }
-}
-
-function joinTempPrefix(checkpointId: string): string {
-  return path.join(tmpdir(), `posthog-code-handoff-${checkpointId}-`);
 }
 
 export async function readHandoffLocalGitState(


### PR DESCRIPTION
## Problem

Cloud handoff checkpoint capture writes pack output under the operating system temp directory. When that directory and the repository object store are on different filesystems, Git cannot rename the staged pack and the handoff state is not captured.

follow-up to #3393 

## Changes

- Create handoff temp directories inside the Git common directory so pack creation stays on the object store filesystem, including for linked worktrees
- Add regression coverage for the capture artifact location

