### PR TITLE
fix(usage): clarify spend summary window

### DIFF
--- a/packages/ui/src/features/usage/components/SpendKpiStrip.tsx
+++ b/packages/ui/src/features/usage/components/SpendKpiStrip.tsx
@@ -1,5 +1,6 @@
 import {
   formatUsd,
+  formatWindow,
   type SpendAnalysisFilledDay,
   windowDays,
 } from "@posthog/core/billing/spendAnalysisFormat";
@@ -41,6 +42,7 @@ export function SpendKpiStrip({ data, filledDays }: SpendKpiStripProps) {
   const costSeries = filledDays?.map((d) => Math.max(0, d.cost_usd));
   const eventSeries = filledDays?.map((d) => d.event_count);
   const latestDay = filledDays?.at(-1);
+  const windowLabel = formatWindow(summary.date_from, summary.date_to);
 
   return (
     <Flex className="overflow-hidden rounded-(--radius-3) border border-(--gray-5) bg-(--color-panel-solid)">
@@ -64,6 +66,7 @@ export function SpendKpiStrip({ data, filledDays }: SpendKpiStripProps) {
           formatValue={formatUsd}
           change={null}
           subtitle={costSeries ? undefined : `${codeShare}% of total`}
+          restingSubtitle={windowLabel}
           sparklineHeight={28}
         />
       </KpiCell>
@@ -76,6 +79,7 @@ export function SpendKpiStrip({ data, filledDays }: SpendKpiStripProps) {
           theme={theme}
           formatValue={(v) => v.toLocaleString()}
           change={null}
+          restingSubtitle={windowLabel}
           sparklineHeight={28}
         />
       </KpiCell>

--- a/packages/ui/src/features/usage/components/SpendKpiStrip.tsx
+++ b/packages/ui/src/features/usage/components/SpendKpiStrip.tsx
@@ -34,10 +34,6 @@ interface SpendKpiStripProps {
 export function SpendKpiStrip({ data, filledDays }: SpendKpiStripProps) {
   const theme = useChartTheme();
   const { summary } = data;
-  const codeShare =
-    summary.total_cost_usd > 0
-      ? Math.round((summary.scoped_cost_usd / summary.total_cost_usd) * 100)
-      : 0;
   const labels = filledDays?.map((d) => spendDayLabel(d.day));
   const costSeries = filledDays?.map((d) => Math.max(0, d.cost_usd));
   const eventSeries = filledDays?.map((d) => d.event_count);
@@ -65,7 +61,6 @@ export function SpendKpiStrip({ data, filledDays }: SpendKpiStripProps) {
           theme={theme}
           formatValue={formatUsd}
           change={null}
-          subtitle={costSeries ? undefined : `${codeShare}% of total`}
           restingSubtitle={windowLabel}
           sparklineHeight={28}
         />


### PR DESCRIPTION
## Problem

Spend totals on the Plan & usage dashboard looked like single-day values because the cards showed the latest sparkline date beneath the selected-window total.

## Changes

Show the selected spend window under the PostHog Code and Generations totals at rest. Hovering the sparkline still switches the caption to the hovered day.