### PR TITLE
ci(trunk): upload impacted targets with fork-aware auth so fork PRs can enter the merge queue

### DIFF
--- a/.github/workflows/trunk-impacted-targets.yml
+++ b/.github/workflows/trunk-impacted-targets.yml
@@ -22,8 +22,12 @@ on:
 
 concurrency:
   # Supersede in-flight uploads when the PR head moves; the last upload per head
-  # SHA wins on Trunk's side anyway.
-  group: trunk-impacted-targets-${{ github.head_ref || github.ref }}
+  # SHA wins on Trunk's side anyway. Key on the PR number, not head_ref: fork
+  # PRs frequently share a source branch name (many are opened from `main`), and
+  # keying on head_ref would put two such PRs in one group where one cancels the
+  # other's upload — leaving that head SHA without the upload it needs to enter
+  # the queue.
+  group: trunk-impacted-targets-${{ github.event.pull_request.number || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/trunk-impacted-targets.yml
+++ b/.github/workflows/trunk-impacted-targets.yml
@@ -1,0 +1,83 @@
+# Uploads this PR's impacted targets to Trunk so the parallel merge queue can
+# schedule it. Trunk needs an impacted-targets upload to place a PR into a lane;
+# without one, fork PRs never enter the queue and have to be merged by hand (see
+# PR #2819).
+#
+# The upload authenticates with the org API token (x-api-token) on internal PRs.
+# Fork PR workflow runs do NOT receive repo secrets — GitHub withholds them from
+# `pull_request` runs originating in a fork — so for forks we authenticate with
+# the workflow run id instead (x-forked-workflow-run-id). Trunk verifies the run
+# id belongs to a live fork-PR workflow whose head SHA matches the payload.
+# Ref: https://docs.trunk.io/merge-queue/optimizations/parallel-queues/api#handling-forked-pull-requests
+#
+# SECURITY: this MUST stay on the `pull_request` trigger, never
+# `pull_request_target`. `pull_request_target` would hand repo secrets to code
+# from untrusted forks ("pwn request"). The fork path deliberately needs no
+# secret, so the plain `pull_request` trigger is sufficient and safe.
+name: Trunk Impacted Targets
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  # Supersede in-flight uploads when the PR head moves; the last upload per head
+  # SHA wins on Trunk's side anyway.
+  group: trunk-impacted-targets-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    # Reads only the event payload and talks out to Trunk — no repo write or PR
+    # API access needed.
+    permissions:
+      contents: read
+    env:
+      IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+      RUN_ID: ${{ github.run_id }}
+      REPO_OWNER: ${{ github.repository_owner }}
+      REPO_NAME: ${{ github.event.repository.name }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      # Head SHA (not the synthetic merge commit): it matches the workflow run's
+      # head_sha, which is what Trunk checks when verifying a fork upload.
+      PR_SHA: ${{ github.event.pull_request.head.sha }}
+      TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+    steps:
+      - name: Upload impacted targets to Trunk
+        # Not continue-on-error: a silent failure here is exactly what kept fork
+        # PRs out of the queue, so surface upload problems loudly. --retry rides
+        # out transient Trunk/network blips.
+        run: |
+          set -euo pipefail
+
+          # We report "ALL" — every target — which is always correct: it can
+          # never under-report and let the queue merge conflicting PRs in
+          # parallel. It yields no parallelism benefit, but it gets every PR
+          # (forks included) into the queue. To actually parallelise, replace
+          # "ALL" with a computed target-name list (e.g. derived from the
+          # dorny/paths-filter outputs in test.yml) once the queue's target
+          # names are defined; see the Trunk bazel-action reference impl.
+          payload="$(jq -n \
+            --arg host "github.com" \
+            --arg owner "$REPO_OWNER" \
+            --arg name "$REPO_NAME" \
+            --argjson number "$PR_NUMBER" \
+            --arg sha "$PR_SHA" \
+            --arg targetBranch "$TARGET_BRANCH" \
+            '{repo: {host: $host, owner: $owner, name: $name}, pr: {number: $number, sha: $sha}, targetBranch: $targetBranch, impactedTargets: "ALL"}')"
+
+          if [ "$IS_FORK" = "true" ]; then
+            echo "Fork PR — authenticating with x-forked-workflow-run-id ($RUN_ID)"
+            auth_header="x-forked-workflow-run-id: $RUN_ID"
+          else
+            echo "Internal PR — authenticating with x-api-token"
+            auth_header="x-api-token: $TRUNK_API_TOKEN"
+          fi
+
+          curl --fail --silent --show-error --retry 3 --retry-all-errors \
+            -X POST "https://api.trunk.io/v1/setImpactedTargets" \
+            -H "Content-Type: application/json" \
+            -H "$auth_header" \
+            --data "$payload"


### PR DESCRIPTION
## Problem

Fork PRs can't be merged through the Trunk parallel merge queue and have to be merged by hand — e.g. [#2819](https://github.com/PostHog/code/pull/2819), which Trunk logged as "😎 Merged manually" and landed via GitHub auto-squash, with no `Trunk Merge Queue` check ever running.

Trunk needs an **impacted-targets upload** to place a PR into a queue lane. That upload authenticates with the org API token (`x-api-token` = `secrets.TRUNK_API_TOKEN`), but **GitHub withholds repo secrets from `pull_request` runs originating in a fork**, so fork PRs can never make that call. The repo had *no* impacted-targets upload at all (only the flaky-test `analytics-uploader`).

Per the Trunk team: *"add a `x-forked-workflow-run-id` header to the request to upload impacted targets for your parallel queue from forked PRs."*

## Change

New workflow `.github/workflows/trunk-impacted-targets.yml` that POSTs to `/v1/setImpactedTargets` on every PR:

- **Internal PRs** → `x-api-token: ${{ secrets.TRUNK_API_TOKEN }}`
- **Fork PRs** → `x-forked-workflow-run-id: ${{ github.run_id }}` (no secret required)

Details:
- Fork detection reuses the same expression as the existing `e2e` job (`head.repo.full_name != github.repository`).
- Request body matches Trunk's schema (`repo{host,owner,name}`, `pr{number,sha}`, `targetBranch`, `impactedTargets`), built with `jq` from env-passed context (no untrusted PR data interpolated into the shell). Uses the PR **head** SHA so it matches the run's `head_sha` for Trunk's fork verification.
- Reports `impactedTargets: "ALL"` — always correct (never under-reports), gets forks into the queue; a computed target list for real parallelism is left as a documented TODO in the file.
- **Fails loudly** (no `continue-on-error`) with retries — a silent upload failure is exactly what kept fork PRs out of the queue.
- Stays on the `pull_request` trigger, **never** `pull_request_target`, so no secret is exposed to fork code ("pwn request").

Ref: https://docs.trunk.io/merge-queue/optimizations/parallel-queues/api#handling-forked-pull-requests

## Verification

- YAML parses; `on`/`jobs`/`concurrency`/`permissions` as intended.
- Smoke-tested the shell block with sample values: `jq` payload is schema-correct (`pr.number` is a JSON number) and the auth header switches correctly between fork/internal.
- Server-side acceptance of a fork upload can only be observed once a real fork PR runs this workflow — suggest watching the next fork PR to confirm it now enters the queue.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*