### PR TITLE
feat(code-review): add custom PR comment chat

### DIFF
--- a/packages/core/src/code-review/reviewPrompts.test.ts
+++ b/packages/core/src/code-review/reviewPrompts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildAskAboutPrCommentPrompt,
   buildBatchedInlineCommentsPrompt,
+  buildChatAboutPrCommentPrompt,
   buildFixPrCommentPrompt,
   buildInlineCommentPrompt,
 } from "./reviewPrompts";
@@ -65,7 +66,7 @@ describe("buildBatchedInlineCommentsPrompt", () => {
   });
 });
 
-describe("buildFixPrCommentPrompt / buildAskAboutPrCommentPrompt", () => {
+describe("PR comment prompts", () => {
   it("includes the thread body and side", () => {
     const out = buildFixPrCommentPrompt("a.ts", 4, "new", [
       makeComment("please rename"),
@@ -80,5 +81,20 @@ describe("buildFixPrCommentPrompt / buildAskAboutPrCommentPrompt", () => {
       makeComment("why?"),
     ]);
     expect(out).toContain("Do not make any changes");
+  });
+
+  it("chat prompt includes the thread and custom message", () => {
+    const out = buildChatAboutPrCommentPrompt(
+      'src/a".ts',
+      8,
+      "new",
+      [makeComment("consider extracting this", "reviewer")],
+      "Is there already a helper for this?",
+    );
+    expect(out).toContain('<file path="src/a&quot;.ts" />');
+    expect(out).toContain("line 8 (new)");
+    expect(out).toContain("@reviewer");
+    expect(out).toContain("consider extracting this");
+    expect(out.endsWith("Is there already a helper for this?")).toBe(true);
   });
 });

--- a/packages/core/src/code-review/reviewPrompts.ts
+++ b/packages/core/src/code-review/reviewPrompts.ts
@@ -15,6 +15,17 @@ function formatThreadForPrompt(comments: PrReviewComment[]): string {
   return comments.map((c) => `@${c.user.login}:\n> ${c.body}`).join("\n\n");
 }
 
+function formatPrCommentPromptContext(
+  filePath: string,
+  line: number,
+  side: "old" | "new",
+  comments: PrReviewComment[],
+): string {
+  const escapedPath = escapeXmlAttr(filePath);
+  const thread = formatThreadForPrompt(comments);
+  return `<file path="${escapedPath}" />, line ${line} (${side}):\n\n${thread}`;
+}
+
 function formatLineRef(startLine: number, endLine: number): string {
   return startLine === endLine
     ? `line ${startLine}`
@@ -85,9 +96,8 @@ export function buildFixPrCommentPrompt(
   side: "old" | "new",
   comments: PrReviewComment[],
 ): string {
-  const escapedPath = escapeXmlAttr(filePath);
-  const thread = formatThreadForPrompt(comments);
-  return `Fix this PR review comment on <file path="${escapedPath}" />, line ${line} (${side}):\n\n${thread}`;
+  const context = formatPrCommentPromptContext(filePath, line, side, comments);
+  return `Fix this PR review comment on ${context}`;
 }
 
 export function buildAskAboutPrCommentPrompt(
@@ -96,7 +106,17 @@ export function buildAskAboutPrCommentPrompt(
   side: "old" | "new",
   comments: PrReviewComment[],
 ): string {
-  const escapedPath = escapeXmlAttr(filePath);
-  const thread = formatThreadForPrompt(comments);
-  return `Help me understand this PR review comment on <file path="${escapedPath}" />, line ${line} (${side}):\n\n${thread}\n\nWhat is this comment asking for and how should I address it? Do not make any changes, your job is simply to chat with me about this comment. If I need further changes, I'll ask.`;
+  const context = formatPrCommentPromptContext(filePath, line, side, comments);
+  return `Help me understand this PR review comment on ${context}\n\nWhat is this comment asking for and how should I address it? Do not make any changes, your job is simply to chat with me about this comment. If I need further changes, I'll ask.`;
+}
+
+export function buildChatAboutPrCommentPrompt(
+  filePath: string,
+  line: number,
+  side: "old" | "new",
+  comments: PrReviewComment[],
+  message: string,
+): string {
+  const context = formatPrCommentPromptContext(filePath, line, side, comments);
+  return `Regarding this PR review comment on ${context}\n\n${message}`;
 }

--- a/packages/ui/src/features/code-review/components/PrCommentThread.test.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.test.tsx
@@ -111,6 +111,35 @@ describe("PrCommentThread", () => {
     );
   });
 
+  it("keeps a reply composer opened while a chat message is sending", async () => {
+    let resolveSend: ((success: boolean) => void) | undefined;
+    sendPromptToAgent.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveSend = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    renderThread();
+
+    await user.click(screen.getByRole("button", { name: "Chat" }));
+    await user.type(
+      screen.getByPlaceholderText("Ask the agent about this comment..."),
+      "Check this",
+    );
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    await user.click(screen.getByRole("button", { name: "Close composer" }));
+    await user.click(screen.getByRole("button", { name: "Reply" }));
+    await user.type(screen.getByPlaceholderText("Write a reply..."), "Keep me");
+
+    resolveSend?.(true);
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText("Write a reply...")).toHaveValue(
+        "Keep me",
+      ),
+    );
+  });
+
   it("still posts replies without sending them to chat", async () => {
     const user = userEvent.setup();
     renderThread();

--- a/packages/ui/src/features/code-review/components/PrCommentThread.test.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.test.tsx
@@ -1,0 +1,125 @@
+import type { PrReviewComment } from "@posthog/shared";
+import { Theme } from "@radix-ui/themes";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrCommentMetadata } from "../types";
+import { PrCommentThread } from "./PrCommentThread";
+
+const { reply, resolve, sendPromptToAgent } = vi.hoisted(() => ({
+  reply: vi.fn(),
+  resolve: vi.fn(),
+  sendPromptToAgent: vi.fn(),
+}));
+
+vi.mock("../hooks/usePrCommentActions", () => ({
+  usePrCommentActions: () => ({ reply, resolve }),
+}));
+
+vi.mock("../../sessions/sendPromptToAgent", () => ({ sendPromptToAgent }));
+
+function makeComment(): PrReviewComment {
+  return {
+    id: 42,
+    body: "Could this use the shared helper?",
+    created_at: "2026-07-14T12:00:00Z",
+    user: {
+      login: "reviewer",
+      avatar_url: "",
+    },
+  } as PrReviewComment;
+}
+
+function makeMetadata(): PrCommentMetadata {
+  return {
+    kind: "pr-comment",
+    threadId: 42,
+    nodeId: "thread-node",
+    isResolved: false,
+    comments: [makeComment()],
+    isOutdated: false,
+    isFileLevel: false,
+    startLine: 8,
+    endLine: 8,
+    side: "additions",
+  };
+}
+
+function renderThread() {
+  return render(
+    <Theme>
+      <PrCommentThread
+        taskId="task-1"
+        prUrl="https://github.com/PostHog/posthog/pull/1"
+        filePath="src/example.ts"
+        metadata={makeMetadata()}
+      />
+    </Theme>,
+  );
+}
+
+describe("PrCommentThread", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reply.mockResolvedValue(true);
+    resolve.mockResolvedValue(true);
+    sendPromptToAgent.mockResolvedValue(true);
+  });
+
+  it("sends a custom chat message with the review context", async () => {
+    const user = userEvent.setup();
+    renderThread();
+
+    await user.click(screen.getByRole("button", { name: "Chat" }));
+    await user.type(
+      screen.getByPlaceholderText("Ask the agent about this comment..."),
+      "Check whether this helper already exists",
+    );
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(sendPromptToAgent).toHaveBeenCalledWith(
+      "task-1",
+      expect.stringContaining("Could this use the shared helper?"),
+    );
+    expect(sendPromptToAgent).toHaveBeenCalledWith(
+      "task-1",
+      expect.stringContaining("Check whether this helper already exists"),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByPlaceholderText("Ask the agent about this comment..."),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("keeps the custom message available when sending fails", async () => {
+    sendPromptToAgent.mockResolvedValue(false);
+    const user = userEvent.setup();
+    renderThread();
+
+    await user.click(screen.getByRole("button", { name: "Chat" }));
+    const textarea = screen.getByPlaceholderText(
+      "Ask the agent about this comment...",
+    );
+    await user.type(textarea, "Keep this draft");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByPlaceholderText("Ask the agent about this comment..."),
+      ).toHaveValue("Keep this draft"),
+    );
+  });
+
+  it("still posts replies without sending them to chat", async () => {
+    const user = userEvent.setup();
+    renderThread();
+
+    await user.click(screen.getByRole("button", { name: "Reply" }));
+    await user.type(screen.getByPlaceholderText("Write a reply..."), "Done");
+    await user.click(screen.getByRole("button", { name: "Reply" }));
+
+    expect(reply).toHaveBeenCalledWith(42, "Done");
+    expect(sendPromptToAgent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/features/code-review/components/PrCommentThread.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.tsx
@@ -12,6 +12,7 @@ import {
 } from "@phosphor-icons/react";
 import {
   buildAskAboutPrCommentPrompt,
+  buildChatAboutPrCommentPrompt,
   buildFixPrCommentPrompt,
 } from "@posthog/core/code-review/reviewPrompts";
 import { Button } from "@posthog/quill";
@@ -40,6 +41,7 @@ const ghRehypePlugins: PluggableList = [
 ];
 
 const MAX_COMMENT_HEIGHT = 120;
+type ComposerMode = "reply" | "chat";
 
 /** Strip markdown noise to a single-line preview for the collapsed header. */
 function toPreview(body: string): string {
@@ -61,11 +63,12 @@ interface ThreadActionBarProps {
   comments: PrReviewComment[];
   isResolved: boolean;
   onResolveToggle: () => void;
-  showReplyBox: boolean;
+  composerMode: ComposerMode | null;
   pendingReply: string | null;
-  onShowReplyBox: () => void;
-  onHideReplyBox: () => void;
-  onSubmitReply: () => void;
+  isSendingChat: boolean;
+  onShowComposer: (mode: ComposerMode) => void;
+  onHideComposer: () => void;
+  onSubmitComposer: () => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
   textareaRefCallback: (el: HTMLTextAreaElement | null) => void;
 }
@@ -79,20 +82,26 @@ function ThreadActionBar({
   comments,
   isResolved,
   onResolveToggle,
-  showReplyBox,
+  composerMode,
   pendingReply,
-  onShowReplyBox,
-  onHideReplyBox,
-  onSubmitReply,
+  isSendingChat,
+  onShowComposer,
+  onHideComposer,
+  onSubmitComposer,
   onKeyDown,
   textareaRefCallback,
 }: ThreadActionBarProps) {
-  if (showReplyBox) {
+  if (composerMode) {
+    const isReply = composerMode === "reply";
+    const isSending = isSendingChat || (isReply && !!pendingReply);
+    const submitLabel = isSending ? "Sending..." : isReply ? "Reply" : "Send";
     return (
       <div className="mt-1.5 border-[var(--gray-4)] border-t pt-1.5">
         <textarea
           ref={textareaRefCallback}
-          placeholder="Write a reply..."
+          placeholder={
+            isReply ? "Write a reply..." : "Ask the agent about this comment..."
+          }
           onKeyDown={onKeyDown}
           className="min-h-[48px] w-full resize-none rounded border border-[var(--gray-6)] bg-[var(--color-background)] p-1.5 text-[13px] text-[var(--gray-12)] leading-normal outline-none"
         />
@@ -100,13 +109,13 @@ function ThreadActionBar({
           <Button
             variant="primary"
             size="sm"
-            onClick={onSubmitReply}
-            disabled={!!pendingReply}
+            onClick={onSubmitComposer}
+            disabled={isSending}
           >
-            <ChatCircle />
-            {pendingReply ? "Sending..." : "Reply"}
+            {isReply ? <ChatCircle /> : <Robot />}
+            {submitLabel}
           </Button>
-          <Button size="icon-sm" onClick={onHideReplyBox}>
+          <Button size="icon-sm" onClick={onHideComposer}>
             <X />
           </Button>
         </Flex>
@@ -121,7 +130,7 @@ function ThreadActionBar({
       className="mt-1 border-[var(--gray-4)] border-t pt-1.5"
     >
       {prUrl && (
-        <Button size="sm" onClick={onShowReplyBox}>
+        <Button size="sm" onClick={() => onShowComposer("reply")}>
           <ChatCircle />
           Reply
         </Button>
@@ -167,6 +176,11 @@ function ThreadActionBar({
       >
         <Robot />
         Ask
+      </Button>
+
+      <Button size="sm" onClick={() => onShowComposer("chat")}>
+        <Robot />
+        Chat
       </Button>
     </Flex>
   );
@@ -296,8 +310,9 @@ export function PrCommentThread({
   } = metadata;
   const side = annotationSide === "deletions" ? "old" : "new";
   const { reply, resolve } = usePrCommentActions(prUrl);
-  const [showReplyBox, setShowReplyBox] = useState(false);
+  const [composerMode, setComposerMode] = useState<ComposerMode | null>(null);
   const [pendingReply, setPendingReply] = useState<string | null>(null);
+  const [isSendingChat, setIsSendingChat] = useState(false);
   const [isResolved, setIsResolved] = useState(initialIsResolved);
   // Resolved/outdated threads add up — start them collapsed.
   const [isCollapsed, setIsCollapsed] = useState(
@@ -319,30 +334,50 @@ export function PrCommentThread({
     prevLastCommentIdRef.current = lastCommentId;
   }, [lastCommentId, pendingReply]);
 
-  const handleReplySubmit = useCallback(async () => {
+  const handleComposerSubmit = useCallback(async () => {
     const text = textareaRef.current?.value?.trim();
-    if (text) {
-      setPendingReply(text);
-      setShowReplyBox(false);
-      const success = await reply(threadId, text);
-      if (!success) {
-        setPendingReply(null);
-      }
+    if (!text || !composerMode) return;
+
+    if (composerMode === "chat") {
+      setIsSendingChat(true);
+      const success = await sendPromptToAgent(
+        taskId,
+        buildChatAboutPrCommentPrompt(filePath, endLine, side, comments, text),
+      );
+      setIsSendingChat(false);
+      if (success) setComposerMode(null);
+      return;
     }
-  }, [reply, threadId]);
+
+    setPendingReply(text);
+    setComposerMode(null);
+    const success = await reply(threadId, text);
+    if (!success) {
+      setPendingReply(null);
+    }
+  }, [
+    comments,
+    composerMode,
+    endLine,
+    filePath,
+    reply,
+    side,
+    taskId,
+    threadId,
+  ]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (isSendMessageSubmitKey(e)) {
         e.preventDefault();
-        handleReplySubmit();
+        handleComposerSubmit();
       }
       if (e.key === "Escape") {
         e.preventDefault();
-        setShowReplyBox(false);
+        setComposerMode(null);
       }
     },
-    [handleReplySubmit],
+    [handleComposerSubmit],
   );
 
   const setTextareaRefCallback = useCallback(
@@ -497,11 +532,12 @@ export function PrCommentThread({
                   comments={comments}
                   isResolved={isResolved}
                   onResolveToggle={handleResolveToggle}
-                  showReplyBox={showReplyBox}
+                  composerMode={composerMode}
                   pendingReply={pendingReply}
-                  onShowReplyBox={() => setShowReplyBox(true)}
-                  onHideReplyBox={() => setShowReplyBox(false)}
-                  onSubmitReply={handleReplySubmit}
+                  isSendingChat={isSendingChat}
+                  onShowComposer={setComposerMode}
+                  onHideComposer={() => setComposerMode(null)}
+                  onSubmitComposer={handleComposerSubmit}
                   onKeyDown={handleKeyDown}
                   textareaRefCallback={setTextareaRefCallback}
                 />

--- a/packages/ui/src/features/code-review/components/PrCommentThread.tsx
+++ b/packages/ui/src/features/code-review/components/PrCommentThread.tsx
@@ -115,7 +115,11 @@ function ThreadActionBar({
             {isReply ? <ChatCircle /> : <Robot />}
             {submitLabel}
           </Button>
-          <Button size="icon-sm" onClick={onHideComposer}>
+          <Button
+            size="icon-sm"
+            aria-label="Close composer"
+            onClick={onHideComposer}
+          >
             <X />
           </Button>
         </Flex>
@@ -345,7 +349,11 @@ export function PrCommentThread({
         buildChatAboutPrCommentPrompt(filePath, endLine, side, comments, text),
       );
       setIsSendingChat(false);
-      if (success) setComposerMode(null);
+      if (success) {
+        setComposerMode((currentMode) =>
+          currentMode === "chat" ? null : currentMode,
+        );
+      }
       return;
     }
 

--- a/packages/ui/src/features/sessions/sendPromptToAgent.test.ts
+++ b/packages/ui/src/features/sessions/sendPromptToAgent.test.ts
@@ -69,27 +69,22 @@ describe("sendPromptToAgent", () => {
     async (rejection, expectedMessage) => {
       mockSender.mockRejectedValueOnce(rejection);
 
-      sendPromptToAgent("task-1", "hello");
+      const success = await sendPromptToAgent("task-1", "hello");
 
-      await vi.waitFor(() =>
-        expect(toast.error).toHaveBeenCalledWith(expectedMessage),
-      );
+      expect(success).toBe(false);
+      expect(toast.error).toHaveBeenCalledWith(expectedMessage);
     },
   );
 
   it("does not toast when the send resolves", async () => {
     mockSender.mockResolvedValueOnce(undefined);
 
-    sendPromptToAgent("task-1", "hello");
+    const success = await sendPromptToAgent("task-1", "hello");
 
-    // Await the exact promise the sender returned rather than guessing how many
-    // microtasks the catch chain takes to settle.
-    await mockSender.mock.results[0]?.value;
+    expect(success).toBe(true);
     expect(toast.error).not.toHaveBeenCalled();
   });
 
-  // The send is fire-and-forget, so the panel/review side effects must run
-  // regardless of whether it ultimately resolves or rejects.
   it.each([
     ["resolves", () => mockSender.mockResolvedValueOnce(undefined)],
     ["rejects", () => mockSender.mockRejectedValueOnce(new Error("nope"))],

--- a/packages/ui/src/features/sessions/sendPromptToAgent.ts
+++ b/packages/ui/src/features/sessions/sendPromptToAgent.ts
@@ -17,20 +17,20 @@ import {
 export function sendPromptToAgent(
   taskId: string,
   prompt: string | ContentBlock[],
-): void {
-  // Button/review/skill-initiated prompts are fire-and-forget, but a rejected
-  // send (auth failure, sandbox unreachable, agent process died) must still be
-  // surfaced, or the turn just shows "Generated in Xs" with no reply.
-  void resolveService<AgentPromptSender>(AGENT_PROMPT_SENDER)(
+): Promise<boolean> {
+  const sendPromise = resolveService<AgentPromptSender>(AGENT_PROMPT_SENDER)(
     taskId,
     prompt,
-  ).catch((error: unknown) => {
-    toast.error(
-      error instanceof Error
-        ? error.message
-        : "Failed to send your message to the agent. Please try again.",
-    );
-  });
+  )
+    .then(() => true)
+    .catch((error: unknown) => {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to send your message to the agent. Please try again.",
+      );
+      return false;
+    });
 
   const { getReviewMode, setReviewMode } = useReviewNavigationStore.getState();
   if (getReviewMode(taskId) === "expanded") {
@@ -45,4 +45,6 @@ export function sendPromptToAgent(
       setActiveTab(taskId, result.panelId, DEFAULT_TAB_IDS.LOGS);
     }
   }
+
+  return sendPromise;
 }


### PR DESCRIPTION
## Problem

PR review comments can only be sent to the agent through fixed Fix or Ask prompts.

Sometimes I know what i want to say, and the buttons available didn't let me do it

## Changes

https://github.com/user-attachments/assets/4d5a16c3-f543-496b-8824-19daa076b5bd


- Add a Chat action with an inline custom prompt.
- Include the full review thread and code location as agent context.
- Keep the draft available when sending fails.
- Add focused prompt, sender, and component tests.

## How did you test this?

- `pnpm --filter @posthog/core exec vitest run src/code-review/reviewPrompts.test.ts`
- `pnpm --filter @posthog/ui exec vitest run src/features/sessions/sendPromptToAgent.test.ts src/features/code-review/components/PrCommentThread.test.tsx`
- `pnpm --filter @posthog/core typecheck`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm exec biome lint packages/core`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
