### PR TITLE
fix(agent): pin codex approvals_reviewer to host

### DIFF
--- a/packages/agent/src/adapters/codex-app-server/spawn.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/spawn.test.ts
@@ -29,6 +29,9 @@ describe("buildAppServerArgs", () => {
     });
 
     expect(args[0]).toBe("app-server");
+    // Pin codex's guardian reviewer to the host default so it never calls the
+    // gateway-blocked `codex-auto-review` model.
+    expect(args).toContain('approvals_reviewer="user"');
     expect(args).toContain('model_provider="posthog"');
     expect(args).toContain(
       'model_providers.posthog.base_url="https://gateway.example/v1"',

--- a/packages/agent/src/adapters/codex-app-server/spawn.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/spawn.test.ts
@@ -42,6 +42,20 @@ describe("buildAppServerArgs", () => {
     );
   });
 
+  it("lets a caller override the reviewer pin without emitting a shadowed duplicate", () => {
+    const args = buildAppServerArgs({
+      binaryPath: "/bundle/codex",
+      apiBaseUrl: "https://gateway.example/v1",
+      configOverrides: { approvals_reviewer: "auto_review" },
+    });
+
+    // codex's `-c` is last-wins, so the default pin must not be emitted alongside
+    // the caller's value — exactly one reviewer entry, and it's the caller's.
+    expect(args.filter((arg) => arg.startsWith("approvals_reviewer="))).toEqual(
+      ['approvals_reviewer="auto_review"'],
+    );
+  });
+
   it("forwards http headers as a quoted TOML inline table on the posthog provider", () => {
     const args = buildAppServerArgs({
       binaryPath: "/bundle/codex",

--- a/packages/agent/src/adapters/codex-app-server/spawn.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/spawn.test.ts
@@ -42,20 +42,6 @@ describe("buildAppServerArgs", () => {
     );
   });
 
-  it("lets a caller override the reviewer pin without emitting a shadowed duplicate", () => {
-    const args = buildAppServerArgs({
-      binaryPath: "/bundle/codex",
-      apiBaseUrl: "https://gateway.example/v1",
-      configOverrides: { approvals_reviewer: "auto_review" },
-    });
-
-    // codex's `-c` is last-wins, so the default pin must not be emitted alongside
-    // the caller's value — exactly one reviewer entry, and it's the caller's.
-    expect(args.filter((arg) => arg.startsWith("approvals_reviewer="))).toEqual(
-      ['approvals_reviewer="auto_review"'],
-    );
-  });
-
   it("forwards http headers as a quoted TOML inline table on the posthog provider", () => {
     const args = buildAppServerArgs({
       binaryPath: "/bundle/codex",

--- a/packages/agent/src/adapters/codex-app-server/spawn.ts
+++ b/packages/agent/src/adapters/codex-app-server/spawn.ts
@@ -126,9 +126,13 @@ export function buildAppServerArgs(
   // The host owns approvals (surfaced via approvals.ts → requestPermission). Codex's
   // guardian reviewer is enabled by default and routes approvals to its dedicated
   // `codex-auto-review` model, which our gateway's posthog_code allowlist doesn't
-  // serve — so every command review 403s. Pin codex's own default `user` reviewer
-  // so approval decisions stay with the host.
-  args.push("-c", `approvals_reviewer="user"`);
+  // serve — so every command review 403s. Default codex's own `user` reviewer so
+  // approval decisions stay with the host. Skipped when a caller sets the reviewer
+  // via configOverrides (appended last, and codex's `-c` is last-wins) so we never
+  // emit a conflicting duplicate that could shadow the pin back to the auto reviewer.
+  if (options.configOverrides?.approvals_reviewer === undefined) {
+    args.push("-c", `approvals_reviewer="user"`);
+  }
 
   // Disable the user's ambient ~/.codex MCP servers so the adapter only exposes
   // MCP servers PostHog injects per-thread; otherwise codex fails connecting to them.

--- a/packages/agent/src/adapters/codex-app-server/spawn.ts
+++ b/packages/agent/src/adapters/codex-app-server/spawn.ts
@@ -124,15 +124,11 @@ export function buildAppServerArgs(
   );
 
   // The host owns approvals (surfaced via approvals.ts → requestPermission). Codex's
-  // guardian reviewer is enabled by default and routes approvals to its dedicated
+  // guardian reviewer is on by default and routes approvals to its dedicated
   // `codex-auto-review` model, which our gateway's posthog_code allowlist doesn't
-  // serve — so every command review 403s. Default codex's own `user` reviewer so
-  // approval decisions stay with the host. Skipped when a caller sets the reviewer
-  // via configOverrides (appended last, and codex's `-c` is last-wins) so we never
-  // emit a conflicting duplicate that could shadow the pin back to the auto reviewer.
-  if (options.configOverrides?.approvals_reviewer === undefined) {
-    args.push("-c", `approvals_reviewer="user"`);
-  }
+  // serve — so every review 403s. Default codex's own `user` reviewer; a caller can
+  // still override it via configOverrides, which the trailing loop appends last.
+  args.push("-c", `approvals_reviewer="user"`);
 
   // Disable the user's ambient ~/.codex MCP servers so the adapter only exposes
   // MCP servers PostHog injects per-thread; otherwise codex fails connecting to them.

--- a/packages/agent/src/adapters/codex-app-server/spawn.ts
+++ b/packages/agent/src/adapters/codex-app-server/spawn.ts
@@ -123,6 +123,13 @@ export function buildAppServerArgs(
       : `sandbox_mode="danger-full-access"`,
   );
 
+  // The host owns approvals (surfaced via approvals.ts → requestPermission). Codex's
+  // guardian reviewer is enabled by default and routes approvals to its dedicated
+  // `codex-auto-review` model, which our gateway's posthog_code allowlist doesn't
+  // serve — so every command review 403s. Pin codex's own default `user` reviewer
+  // so approval decisions stay with the host.
+  args.push("-c", `approvals_reviewer="user"`);
+
   // Disable the user's ambient ~/.codex MCP servers so the adapter only exposes
   // MCP servers PostHog injects per-thread; otherwise codex fails connecting to them.
   for (const name of new CodexSettingsManager(


### PR DESCRIPTION
## Problem

Codex runs on `posthog_code` fail every command with:

> `403 Forbidden — Model 'codex-auto-review' not allowed for product 'posthog_code'`

Codex 0.140.0 — the native `openai/codex` app-server harness PostHog Code [switched to](https://github.com/PostHog/code/pull/2723) (replacing the old `codex-acp` adapter) — ships its guardian approval reviewer as a [stable, default-on feature](https://github.com/openai/codex/blob/rust-v0.140.0/codex-rs/features/src/lib.rs#L1144-L1147). The reviewer calls a dedicated [`codex-auto-review` model](https://github.com/openai/codex/blob/rust-v0.140.0/codex-rs/model-provider/src/provider.rs#L84), which our gateway's [`posthog_code` allowlist](https://github.com/PostHog/posthog/blob/6707cfd188ff0200842e1364f9ff2b3a9092b3b6/services/llm-gateway/src/llm_gateway/products/config.py#L70) does not serve, so it is [rejected 403 at the access check](https://github.com/PostHog/posthog/blob/6707cfd188ff0200842e1364f9ff2b3a9092b3b6/services/llm-gateway/src/llm_gateway/dependencies.py#L126). The host already owns approvals (`approvals.ts` → `requestPermission`), so the guardian is a redundant second authority.

## Changes

- Pin codex's [`approvals_reviewer`](https://github.com/openai/codex/blob/rust-v0.140.0/codex-rs/protocol/src/config_types.rs#L165-L171) to its own default `"user"` in `buildAppServerArgs`, keeping approval decisions on the host instead of the gateway-blocked `codex-auto-review` model.
- `"auto_review"` and the legacy `"guardian_subagent"` are the [same variant](https://github.com/openai/codex/blob/rust-v0.140.0/codex-rs/protocol/src/config_types.rs#L169) — both hit `codex-auto-review`, so `"user"` is the only value that keeps traffic on allowlisted models.

## How did you test this?

- `vitest run src/adapters/codex-app-server` — 160 pass (2 unrelated failures: unbuilt `@posthog/git` workspace dep). New assertion in `spawn.test.ts` locks the flag.
- Real codex 0.140.0 binary: `-c approvals_reviewer="user"` → exit 0; `-c approvals_reviewer="bogus"` → `unknown variant 'bogus', expected one of 'user', 'auto_review', 'guardian_subagent'` — confirms it is a first-class, validated config value.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
