### PR TITLE
fix(command-center): question prompt no longer blocks thread scroll

### DIFF
--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -137,7 +137,13 @@ function ComposerSlot({
   children: React.ReactNode;
 }) {
   return (
-    <Box className="min-h-0 shrink-0 overflow-y-auto">
+    <Box
+      className={
+        compact
+          ? "max-h-[50%] min-h-0 overflow-y-auto"
+          : "min-h-0 shrink-0 overflow-y-auto"
+      }
+    >
       <ComposerWidth compact={compact}>{children}</ComposerWidth>
     </Box>
   );


### PR DESCRIPTION
## Summary

Fixes #2510.

When a question/permission prompt appeared in a Command Center cell, the `ComposerSlot` wrapper had `shrink-0`, preventing the flex layout from yielding space to the `ThreadView` above. Combined with `ActionSelector`'s `max-h-[80vh]` (80% of the *viewport*, not the cell), the question card could consume the entire visible area in a compact command-center cell, making it impossible to scroll up to read past messages.

## Root cause

```
Flex column (height: 100% of cell)
|-- ThreadView   -> min-h-0 flex-1 (scrollable)  <- got crushed to 0
`-- ComposerSlot -> shrink-0 [x] + ActionSelector max-h-[80vh] [x]
```

## Changes

**`packages/ui/src/features/sessions/components/SessionView.tsx`**

In `ComposerSlot`, drop `shrink-0` and add `max-h-[50%]` in compact mode so the question card never consumes more than half the cell height. The thread above remains scrollable. Non-compact (full task view) behavior is unchanged.

## Testing

- Open the Command Center with a task that triggers a question prompt (multi-step `question` tool call)
- - Confirm the conversation thread is still visible and scrollable above the question card
- - Confirm the question card itself scrolls if content is taller than 50% of the cell
- - Confirm full task view (non-compact) works exactly as before