### PR TITLE
feat(message-editor): double paste to undo chip auto-conversion

### DIFF
--- a/packages/core/src/message-editor/paste.test.ts
+++ b/packages/core/src/message-editor/paste.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { type AutoConvertedPaste, isRepeatOfAutoConvertedPaste } from "./paste";
+
+const lastPaste: AutoConvertedPaste = {
+  clipboardText: "https://github.com/posthog/code/issues/42",
+  insertText: "https://github.com/posthog/code/issues/42",
+  chipId: "chip-1",
+};
+
+describe("isRepeatOfAutoConvertedPaste", () => {
+  it.each([
+    {
+      name: "same clipboard text as the last conversion",
+      last: lastPaste,
+      clipboardText: lastPaste.clipboardText,
+      expected: true,
+    },
+    {
+      name: "no prior conversion",
+      last: null,
+      clipboardText: lastPaste.clipboardText,
+      expected: false,
+    },
+    {
+      name: "different clipboard text",
+      last: lastPaste,
+      clipboardText: "something else",
+      expected: false,
+    },
+    {
+      name: "clipboard text differing only by whitespace",
+      last: lastPaste,
+      clipboardText: `${lastPaste.clipboardText} `,
+      expected: false,
+    },
+    {
+      name: "empty clipboard text",
+      last: lastPaste,
+      clipboardText: "",
+      expected: false,
+    },
+    {
+      name: "undefined clipboard text",
+      last: lastPaste,
+      clipboardText: undefined,
+      expected: false,
+    },
+  ])("returns $expected for $name", ({ last, clipboardText, expected }) => {
+    expect(isRepeatOfAutoConvertedPaste(last, clipboardText)).toBe(expected);
+  });
+});

--- a/packages/core/src/message-editor/paste.ts
+++ b/packages/core/src/message-editor/paste.ts
@@ -29,3 +29,18 @@ export function buildPastedTextLabel(
 ): string {
   return `Pasted text #${pasteNumber} (${lineCount} lines)`;
 }
+
+export interface AutoConvertedPaste {
+  clipboardText: string;
+  insertText: string;
+  chipId: string;
+}
+
+export function isRepeatOfAutoConvertedPaste(
+  last: AutoConvertedPaste | null,
+  clipboardText: string | null | undefined,
+): last is AutoConvertedPaste {
+  return (
+    last !== null && !!clipboardText && clipboardText === last.clipboardText
+  );
+}

--- a/packages/ui/src/features/message-editor/hostApi.ts
+++ b/packages/ui/src/features/message-editor/hostApi.ts
@@ -72,12 +72,6 @@ export function getGhStatus(): Promise<GhStatus> {
   return hostClient().git.getGhStatus.query();
 }
 
-export function readAbsoluteFile(input: {
-  filePath: string;
-}): Promise<string | null> {
-  return hostClient().fs.readAbsoluteFile.query(input);
-}
-
 export function selectDirectory(): Promise<string | null> {
   return hostClient().os.selectDirectory.query();
 }

--- a/packages/ui/src/features/message-editor/pasteUndoStore.ts
+++ b/packages/ui/src/features/message-editor/pasteUndoStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface PasteUndoState {
+  undoableChipId: string | null;
+  setUndoableChipId: (chipId: string | null) => void;
+}
+
+export const usePasteUndoStore = create<PasteUndoState>((set) => ({
+  undoableChipId: null,
+  setUndoableChipId: (chipId) => set({ undoableChipId: chipId }),
+}));

--- a/packages/ui/src/features/message-editor/tiptap/MentionChipNode.ts
+++ b/packages/ui/src/features/message-editor/tiptap/MentionChipNode.ts
@@ -1,6 +1,7 @@
 import type { UploadableSkillSource } from "@posthog/shared";
 import { mergeAttributes, Node } from "@tiptap/core";
 import { ReactNodeViewRenderer } from "@tiptap/react";
+import { findChipRangeById } from "./chipRange";
 import { MentionChipView } from "./MentionChipView";
 
 export type ChipType =
@@ -103,39 +104,22 @@ export const MentionChipNode = Node.create({
       replaceMentionChipById:
         (chipId: string, attrs: Partial<MentionChipAttrs>) =>
         ({ tr, state, dispatch }) => {
-          let found = false;
-          state.doc.descendants((node, pos) => {
-            if (found) return false;
-            if (node.type.name !== "mentionChip") return;
-            if (node.attrs.chipId !== chipId) return;
-            found = true;
-            tr.setNodeMarkup(pos, undefined, { ...node.attrs, ...attrs });
-            return false;
-          });
-          if (found && dispatch) dispatch(tr);
-          return found;
+          const range = findChipRangeById(state.doc, chipId);
+          if (!range) return false;
+          const node = state.doc.nodeAt(range.from);
+          if (!node) return false;
+          tr.setNodeMarkup(range.from, undefined, { ...node.attrs, ...attrs });
+          if (dispatch) dispatch(tr);
+          return true;
         },
       removeMentionChipById:
         (chipId: string) =>
         ({ tr, state, dispatch }) => {
-          let found = false;
-          state.doc.descendants((node, pos) => {
-            if (found) return false;
-            if (node.type.name !== "mentionChip") return;
-            if (node.attrs.chipId !== chipId) return;
-            found = true;
-            const from = pos;
-            const to = pos + node.nodeSize;
-            // Also swallow a trailing single space the suggestion adds.
-            const after = state.doc.textBetween(
-              to,
-              Math.min(to + 1, state.doc.content.size),
-            );
-            tr.delete(from, after === " " ? to + 1 : to);
-            return false;
-          });
-          if (found && dispatch) dispatch(tr);
-          return found;
+          const range = findChipRangeById(state.doc, chipId);
+          if (!range) return false;
+          tr.delete(range.from, range.to);
+          if (dispatch) dispatch(tr);
+          return true;
         },
     };
   },

--- a/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
+++ b/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
@@ -64,12 +64,14 @@ function DefaultChip({
   type,
   id,
   label,
+  pastedText,
   selected,
   onRemove,
 }: {
   type: string;
   id: string;
   label: string;
+  pastedText: boolean;
   selected: boolean;
   onRemove: () => void;
 }) {
@@ -97,7 +99,11 @@ function DefaultChip({
   );
 
   if (isFile || isFolder) {
-    return <Tooltip content={id}>{chipContent}</Tooltip>;
+    return (
+      <Tooltip content={pastedText ? "Paste again to expand as text" : id}>
+        {chipContent}
+      </Tooltip>
+    );
   }
 
   return chipContent;
@@ -109,7 +115,7 @@ export function MentionChipView({
   editor,
   selected,
 }: NodeViewProps) {
-  const { type, id, label } = node.attrs as MentionChipAttrs;
+  const { type, id, label, pastedText } = node.attrs as MentionChipAttrs;
 
   const handleRemove = () => {
     const pos = getPos();
@@ -127,6 +133,7 @@ export function MentionChipView({
         type={type}
         id={id}
         label={label}
+        pastedText={pastedText}
         selected={selected}
         onRemove={handleRemove}
       />

--- a/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
+++ b/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
@@ -13,6 +13,7 @@ import {
 import { Chip } from "@posthog/quill";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { usePasteUndoStore } from "../pasteUndoStore";
 import type { ChipType, MentionChipAttrs } from "./MentionChipNode";
 
 const chipBase = "group/chip relative top-px active:translate-y-0 pl-1";
@@ -64,6 +65,7 @@ function DefaultChip({
   type,
   id,
   label,
+  chipId,
   pastedText,
   selected,
   onRemove,
@@ -71,10 +73,14 @@ function DefaultChip({
   type: string;
   id: string;
   label: string;
+  chipId: string | null;
   pastedText: boolean;
   selected: boolean;
   onRemove: () => void;
 }) {
+  const undoableChipId = usePasteUndoStore((state) => state.undoableChipId);
+  const canUndoPaste =
+    pastedText && chipId !== null && chipId === undoableChipId;
   const isCommand = type === "command";
   const prefix = isCommand ? "/" : "@";
   const isFile = type === "file";
@@ -100,7 +106,7 @@ function DefaultChip({
 
   if (isFile || isFolder) {
     return (
-      <Tooltip content={pastedText ? "Paste again to expand as text" : id}>
+      <Tooltip content={canUndoPaste ? "Paste again to expand as text" : id}>
         {chipContent}
       </Tooltip>
     );
@@ -115,7 +121,8 @@ export function MentionChipView({
   editor,
   selected,
 }: NodeViewProps) {
-  const { type, id, label, pastedText } = node.attrs as MentionChipAttrs;
+  const { type, id, label, pastedText, chipId } =
+    node.attrs as MentionChipAttrs;
 
   const handleRemove = () => {
     const pos = getPos();
@@ -133,6 +140,7 @@ export function MentionChipView({
         type={type}
         id={id}
         label={label}
+        chipId={chipId ?? null}
         pastedText={pastedText}
         selected={selected}
         onRemove={handleRemove}

--- a/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
+++ b/packages/ui/src/features/message-editor/tiptap/MentionChipView.tsx
@@ -11,12 +11,8 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { Chip } from "@posthog/quill";
-import { useSettingsStore as useFeatureSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
-import type { Node as PmNode } from "@tiptap/pm/model";
-import type { Editor } from "@tiptap/react";
 import { type NodeViewProps, NodeViewWrapper } from "@tiptap/react";
-import { readAbsoluteFile } from "../hostApi";
 import type { ChipType, MentionChipAttrs } from "./MentionChipNode";
 
 const chipBase = "group/chip relative top-px active:translate-y-0 pl-1";
@@ -107,63 +103,13 @@ function DefaultChip({
   return chipContent;
 }
 
-function PastedTextChip({
-  label,
-  filePath,
-  editor,
-  node,
-  getPos,
-  selected,
-  onRemove,
-}: {
-  label: string;
-  filePath: string;
-  editor: Editor;
-  node: PmNode;
-  getPos: () => number | undefined;
-  selected: boolean;
-  onRemove: () => void;
-}) {
-  const handleClick = async () => {
-    useFeatureSettingsStore.getState().markHintLearned("paste-as-file");
-
-    const content = await readAbsoluteFile({
-      filePath,
-    });
-    if (!content) return;
-
-    const pos = getPos();
-    if (pos == null) return;
-
-    editor
-      .chain()
-      .focus()
-      .deleteRange({ from: pos, to: pos + node.nodeSize })
-      .insertContentAt(pos, content)
-      .run();
-  };
-
-  return (
-    <Tooltip content="Click to paste as text instead">
-      <Chip
-        size="xs"
-        contentEditable={false}
-        onClick={handleClick}
-        className={`${chipBase} cli-file-mention cursor-pointer! ${selected ? selectedRing : ""}`}
-      >
-        <IconCloseButton type="file" onRemove={onRemove} />@{label}
-      </Chip>
-    </Tooltip>
-  );
-}
-
 export function MentionChipView({
   node,
   getPos,
   editor,
   selected,
 }: NodeViewProps) {
-  const { type, id, label, pastedText } = node.attrs as MentionChipAttrs;
+  const { type, id, label } = node.attrs as MentionChipAttrs;
 
   const handleRemove = () => {
     const pos = getPos();
@@ -177,25 +123,13 @@ export function MentionChipView({
 
   return (
     <NodeViewWrapper as="span" className="inline">
-      {pastedText ? (
-        <PastedTextChip
-          label={label}
-          filePath={id}
-          editor={editor}
-          node={node}
-          getPos={getPos}
-          selected={selected}
-          onRemove={handleRemove}
-        />
-      ) : (
-        <DefaultChip
-          type={type}
-          id={id}
-          label={label}
-          selected={selected}
-          onRemove={handleRemove}
-        />
-      )}
+      <DefaultChip
+        type={type}
+        id={id}
+        label={label}
+        selected={selected}
+        onRemove={handleRemove}
+      />
     </NodeViewWrapper>
   );
 }

--- a/packages/ui/src/features/message-editor/tiptap/chipRange.test.ts
+++ b/packages/ui/src/features/message-editor/tiptap/chipRange.test.ts
@@ -1,0 +1,75 @@
+import { getSchema } from "@tiptap/core";
+import { Node as PmNode } from "@tiptap/pm/model";
+import StarterKit from "@tiptap/starter-kit";
+import { describe, expect, it } from "vitest";
+import { findChipRangeById } from "./chipRange";
+import { MentionChipNode } from "./MentionChipNode";
+
+const schema = getSchema([StarterKit, MentionChipNode]);
+
+function chip(chipId: string | null) {
+  return {
+    type: "mentionChip",
+    attrs: {
+      type: "file",
+      id: "/tmp/pasted.txt",
+      label: "Pasted text #1 (2 lines)",
+      pastedText: true,
+      chipId,
+    },
+  };
+}
+
+function text(value: string) {
+  return { type: "text", text: value };
+}
+
+function docOf(...content: object[]): PmNode {
+  return PmNode.fromJSON(schema, {
+    type: "doc",
+    content: [{ type: "paragraph", content }],
+  });
+}
+
+describe("findChipRangeById", () => {
+  it.each([
+    {
+      name: "chip followed by a trailing space swallows the space",
+      doc: docOf(chip("a"), text(" tail")),
+      chipId: "a",
+      expected: { from: 1, to: 3 },
+    },
+    {
+      name: "chip at the end of the doc",
+      doc: docOf(text("hi "), chip("a")),
+      chipId: "a",
+      expected: { from: 4, to: 5 },
+    },
+    {
+      name: "chip followed by non-space text",
+      doc: docOf(chip("a"), text("x")),
+      chipId: "a",
+      expected: { from: 1, to: 2 },
+    },
+    {
+      name: "matching chip among several",
+      doc: docOf(chip("a"), text(" "), chip("b"), text(" ")),
+      chipId: "b",
+      expected: { from: 3, to: 5 },
+    },
+    {
+      name: "no chip with the requested id",
+      doc: docOf(chip("a"), text(" ")),
+      chipId: "missing",
+      expected: null,
+    },
+    {
+      name: "chip without a chipId attribute",
+      doc: docOf(chip(null), text(" ")),
+      chipId: "a",
+      expected: null,
+    },
+  ])("$name", ({ doc, chipId, expected }) => {
+    expect(findChipRangeById(doc, chipId)).toEqual(expected);
+  });
+});

--- a/packages/ui/src/features/message-editor/tiptap/chipRange.ts
+++ b/packages/ui/src/features/message-editor/tiptap/chipRange.ts
@@ -1,0 +1,27 @@
+import type { Node as PmNode } from "@tiptap/pm/model";
+
+export interface ChipRange {
+  from: number;
+  to: number;
+}
+
+export function findChipRangeById(
+  doc: PmNode,
+  chipId: string,
+): ChipRange | null {
+  let range: ChipRange | null = null;
+  doc.descendants((node, pos) => {
+    if (range) return false;
+    if (node.type.name !== "mentionChip") return;
+    if (node.attrs.chipId !== chipId) return;
+    const nodeEnd = pos + node.nodeSize;
+    // Also swallow the trailing space the chip insertion added.
+    const after = doc.textBetween(
+      nodeEnd,
+      Math.min(nodeEnd + 1, doc.content.size),
+    );
+    range = { from: pos, to: after === " " ? nodeEnd + 1 : nodeEnd };
+    return false;
+  });
+  return range;
+}

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -11,10 +11,12 @@ import {
   parseGithubIssueUrl,
 } from "@posthog/core/message-editor/githubIssueUrl";
 import {
+  type AutoConvertedPaste,
   buildMarkdownLink,
   buildPastedTextLabel,
   extractBashCommand,
   isBashModeText,
+  isRepeatOfAutoConvertedPaste,
   isUrlOnly,
   shouldAutoConvertLongText,
 } from "@posthog/core/message-editor/paste";
@@ -69,6 +71,11 @@ export interface UseTiptapEditorOptions {
 const EDITOR_CLASS =
   "cli-editor min-h-[1.5em] w-full break-words border-none bg-transparent pr-2 text-[14px] text-[var(--gray-12)] outline-none [overflow-wrap:break-word] [white-space:pre-wrap] [word-break:break-word]";
 
+interface TrackedAutoConvertedPaste extends AutoConvertedPaste {
+  chipInserted: boolean;
+  canceled: boolean;
+}
+
 function insertChipWithTrailingSpace(
   view: EditorView,
   attrs: {
@@ -76,6 +83,7 @@ function insertChipWithTrailingSpace(
     id: string;
     label: string;
     pastedText?: boolean;
+    chipId?: string;
   },
 ): void {
   const chipNode = view.state.schema.nodes.mentionChip.create({
@@ -92,8 +100,14 @@ async function pasteTextAsFile(
   view: EditorView,
   text: string,
   pasteCountRef: React.MutableRefObject<number>,
+  tracked?: TrackedAutoConvertedPaste,
 ): Promise<void> {
   const result = await persistTextContent(text);
+  if (tracked?.canceled) {
+    view.dispatch(view.state.tr.insertText(text));
+    view.focus();
+    return;
+  }
   pasteCountRef.current += 1;
   const lineCount = text.split("\n").length;
   insertChipWithTrailingSpace(view, {
@@ -101,15 +115,51 @@ async function pasteTextAsFile(
     id: result.path,
     label: buildPastedTextLabel(pasteCountRef.current, lineCount),
     pastedText: true,
+    chipId: tracked?.chipId,
   });
+  if (tracked) tracked.chipInserted = true;
   view.focus();
 }
 
 function insertGithubRefPlaceholder(
   view: EditorView,
   parsed: ParsedGithubIssueUrl,
+  chipId: string,
 ): void {
-  insertChipWithTrailingSpace(view, buildGithubRefPlaceholderChip(parsed));
+  insertChipWithTrailingSpace(view, {
+    ...buildGithubRefPlaceholderChip(parsed),
+    chipId,
+  });
+}
+
+function replaceChipWithText(
+  view: EditorView,
+  chipId: string,
+  text: string,
+): boolean {
+  const { doc, selection } = view.state;
+  let chipFrom = -1;
+  let chipTo = -1;
+  doc.descendants((node, pos) => {
+    if (chipFrom >= 0) return false;
+    if (node.type.name !== "mentionChip") return;
+    if (node.attrs.chipId !== chipId) return;
+    const nodeEnd = pos + node.nodeSize;
+    // Also swallow the trailing space the chip insertion added.
+    const after = doc.textBetween(
+      nodeEnd,
+      Math.min(nodeEnd + 1, doc.content.size),
+    );
+    chipFrom = pos;
+    chipTo = after === " " ? nodeEnd + 1 : nodeEnd;
+    return false;
+  });
+  if (chipFrom < 0) return false;
+  // Only treat it as a double paste while the caret still follows the chip.
+  if (selection.from !== chipTo && selection.from !== chipTo - 1) return false;
+  view.dispatch(view.state.tr.insertText(text, chipFrom, chipTo));
+  view.focus();
+  return true;
 }
 
 async function fetchGithubRefTitle(
@@ -234,6 +284,9 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
   const draftRef = useRef<ReturnType<typeof useDraftSync> | null>(null);
 
   const pasteCountRef = useRef(0);
+  const lastAutoConvertedPasteRef = useRef<TrackedAutoConvertedPaste | null>(
+    null,
+  );
   const historyActions = usePromptHistoryStore.getState();
   const [isEmptyState, setIsEmptyState] = useState(true);
   const [isReady, setIsReady] = useState(false);
@@ -376,6 +429,10 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
           const clipboardText = event.clipboardData?.getData("text/plain");
           const trimmedClipboardText = clipboardText?.trim();
 
+          // Only the immediately-following paste can undo an auto-conversion.
+          const lastConverted = lastAutoConvertedPasteRef.current;
+          lastAutoConvertedPasteRef.current = null;
+
           // Auto-wrap selected text as markdown link when pasting a URL
           if (
             from !== to &&
@@ -398,12 +455,42 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
             return true;
           }
 
+          // Pasting the same clipboard again undoes the chip auto-conversion
+          if (
+            from === to &&
+            isRepeatOfAutoConvertedPaste(lastConverted, clipboardText)
+          ) {
+            if (
+              replaceChipWithText(
+                view,
+                lastConverted.chipId,
+                lastConverted.insertText,
+              )
+            ) {
+              event.preventDefault();
+              return true;
+            }
+            if (!lastConverted.chipInserted) {
+              event.preventDefault();
+              lastConverted.canceled = true;
+              return true;
+            }
+          }
+
           // Auto-convert a pasted GitHub issue or PR URL into a chip
-          if (from === to && trimmedClipboardText) {
+          if (from === to && clipboardText && trimmedClipboardText) {
             const parsedRef = parseGithubIssueUrl(trimmedClipboardText);
             if (parsedRef) {
               event.preventDefault();
-              insertGithubRefPlaceholder(view, parsedRef);
+              const chipId = crypto.randomUUID();
+              insertGithubRefPlaceholder(view, parsedRef, chipId);
+              lastAutoConvertedPasteRef.current = {
+                clipboardText,
+                insertText: clipboardText,
+                chipId,
+                chipInserted: true,
+                canceled: false,
+              };
               void resolveGithubRefChip(view, parsedRef);
               return true;
             }
@@ -458,13 +545,29 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
           ) {
             event.preventDefault();
 
+            const tracked: TrackedAutoConvertedPaste = {
+              clipboardText: clipboardText || effectiveText,
+              insertText: effectiveText,
+              chipId: crypto.randomUUID(),
+              chipInserted: false,
+              canceled: false,
+            };
+            lastAutoConvertedPasteRef.current = tracked;
+
             (async () => {
               try {
-                await pasteTextAsFile(view, effectiveText, pasteCountRef);
-                showPasteHint(
-                  "Pasted as file attachment",
-                  "Click the chip to convert back to text.",
+                await pasteTextAsFile(
+                  view,
+                  effectiveText,
+                  pasteCountRef,
+                  tracked,
                 );
+                if (!tracked.canceled) {
+                  showPasteHint(
+                    "Pasted as file attachment",
+                    "Paste again or click the chip to convert back to text.",
+                  );
+                }
               } catch (_error) {
                 toast.error("Failed to convert pasted text to attachment");
               }

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -103,11 +103,7 @@ async function pasteTextAsFile(
   tracked?: TrackedAutoConvertedPaste,
 ): Promise<void> {
   const result = await persistTextContent(text);
-  if (tracked?.canceled) {
-    view.dispatch(view.state.tr.insertText(text));
-    view.focus();
-    return;
-  }
+  if (tracked?.canceled) return;
   pasteCountRef.current += 1;
   const lineCount = text.split("\n").length;
   insertChipWithTrailingSpace(view, {
@@ -468,11 +464,18 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
               )
             ) {
               event.preventDefault();
+              useFeatureSettingsStore
+                .getState()
+                .markHintLearned("paste-as-file");
               return true;
             }
             if (!lastConverted.chipInserted) {
               event.preventDefault();
               lastConverted.canceled = true;
+              useFeatureSettingsStore
+                .getState()
+                .markHintLearned("paste-as-file");
+              view.dispatch(view.state.tr.insertText(lastConverted.insertText));
               return true;
             }
           }
@@ -565,11 +568,13 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
                 if (!tracked.canceled) {
                   showPasteHint(
                     "Pasted as file attachment",
-                    "Paste again or click the chip to convert back to text.",
+                    "Paste again to convert back to text.",
                   );
                 }
               } catch (_error) {
-                toast.error("Failed to convert pasted text to attachment");
+                if (!tracked.canceled) {
+                  toast.error("Failed to convert pasted text to attachment");
+                }
               }
             })();
 

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -72,6 +72,7 @@ const EDITOR_CLASS =
   "cli-editor min-h-[1.5em] w-full break-words border-none bg-transparent pr-2 text-[14px] text-[var(--gray-12)] outline-none [overflow-wrap:break-word] [white-space:pre-wrap] [word-break:break-word]";
 
 interface TrackedAutoConvertedPaste extends AutoConvertedPaste {
+  kind: "file" | "github-ref";
   chipInserted: boolean;
   canceled: boolean;
 }
@@ -467,9 +468,11 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
               )
             ) {
               event.preventDefault();
-              useFeatureSettingsStore
-                .getState()
-                .markHintLearned("paste-as-file");
+              if (lastConverted.kind === "file") {
+                useFeatureSettingsStore
+                  .getState()
+                  .markHintLearned("paste-as-file");
+              }
               return true;
             }
             if (!lastConverted.chipInserted) {
@@ -494,6 +497,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
                 clipboardText,
                 insertText: clipboardText,
                 chipId,
+                kind: "github-ref",
                 chipInserted: true,
                 canceled: false,
               };
@@ -555,6 +559,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
               clipboardText: clipboardText || effectiveText,
               insertText: effectiveText,
               chipId: crypto.randomUUID(),
+              kind: "file",
               chipInserted: false,
               canceled: false,
             };

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -169,35 +169,25 @@ async function fetchGithubRefTitle(
 async function resolveGithubRefChip(
   view: EditorView,
   parsed: ParsedGithubIssueUrl,
+  chipId: string,
 ): Promise<void> {
-  const chipType = parsed.kind === "pr" ? "github_pr" : "github_issue";
-  const placeholderLabel = `#${parsed.number} - Loading...`;
   const title = await fetchGithubRefTitle(parsed);
   const resolvedLabel =
     title !== null ? `#${parsed.number} - ${title}` : `#${parsed.number}`;
 
   if (view.isDestroyed) return;
 
-  const { doc, tr } = view.state;
-  let updated = false;
-  doc.descendants((node, pos) => {
-    if (
-      node.type.name !== "mentionChip" ||
-      node.attrs.type !== chipType ||
-      node.attrs.id !== parsed.normalizedUrl ||
-      node.attrs.label !== placeholderLabel
-    ) {
-      return true;
-    }
-    tr.setNodeMarkup(pos, undefined, {
+  const { doc } = view.state;
+  const range = findChipRangeById(doc, chipId);
+  if (!range) return;
+  const node = doc.nodeAt(range.from);
+  if (!node) return;
+  view.dispatch(
+    view.state.tr.setNodeMarkup(range.from, undefined, {
       ...node.attrs,
       label: resolvedLabel,
-    });
-    updated = true;
-    return false;
-  });
-
-  if (updated) view.dispatch(tr);
+    }),
+  );
 }
 
 function showPasteHint(message: string, description: string): void {
@@ -487,7 +477,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
                 kind: "github-ref",
                 status: "inserted",
               };
-              void resolveGithubRefChip(view, parsedRef);
+              void resolveGithubRefChip(view, parsedRef, chipId);
               return true;
             }
           }

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -29,6 +29,7 @@ import { useEditor } from "@tiptap/react";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getGithubIssue, getGithubPullRequest } from "../hostApi";
+import { usePasteUndoStore } from "../pasteUndoStore";
 import { usePromptHistoryStore } from "../promptHistoryStore";
 import { findChipRangeById } from "../tiptap/chipRange";
 import { getEditorExtensions } from "../tiptap/extensions";
@@ -264,6 +265,13 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
   const lastAutoConvertedPasteRef = useRef<TrackedAutoConvertedPaste | null>(
     null,
   );
+  useEffect(() => {
+    return () => {
+      if (lastAutoConvertedPasteRef.current) {
+        usePasteUndoStore.getState().setUndoableChipId(null);
+      }
+    };
+  }, []);
   const historyActions = usePromptHistoryStore.getState();
   const [isEmptyState, setIsEmptyState] = useState(true);
   const [isReady, setIsReady] = useState(false);
@@ -409,6 +417,9 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
           // Only the immediately-following paste can undo an auto-conversion.
           const lastConverted = lastAutoConvertedPasteRef.current;
           lastAutoConvertedPasteRef.current = null;
+          if (lastConverted) {
+            usePasteUndoStore.getState().setUndoableChipId(null);
+          }
 
           // Auto-wrap selected text as markdown link when pasting a URL
           if (
@@ -539,6 +550,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
               status: "pending",
             };
             lastAutoConvertedPasteRef.current = tracked;
+            usePasteUndoStore.getState().setUndoableChipId(tracked.chipId);
 
             (async () => {
               try {

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -568,7 +568,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
                 if (!tracked.canceled) {
                   showPasteHint(
                     "Pasted as file attachment",
-                    "Paste again to convert back to text.",
+                    "Paste again to expand as text.",
                   );
                 }
               } catch (_error) {

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -73,8 +73,7 @@ const EDITOR_CLASS =
 
 interface TrackedAutoConvertedPaste extends AutoConvertedPaste {
   kind: "file" | "github-ref";
-  chipInserted: boolean;
-  canceled: boolean;
+  status: "pending" | "inserted" | "canceled";
 }
 
 function insertChipWithTrailingSpace(
@@ -104,7 +103,7 @@ async function pasteTextAsFile(
   tracked?: TrackedAutoConvertedPaste,
 ): Promise<void> {
   const result = await persistTextContent(text);
-  if (tracked?.canceled) return;
+  if (tracked?.status === "canceled") return;
   pasteCountRef.current += 1;
   const lineCount = text.split("\n").length;
   insertChipWithTrailingSpace(view, {
@@ -114,7 +113,7 @@ async function pasteTextAsFile(
     pastedText: true,
     chipId: tracked?.chipId,
   });
-  if (tracked) tracked.chipInserted = true;
+  if (tracked) tracked.status = "inserted";
   view.focus();
 }
 
@@ -475,9 +474,9 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
               }
               return true;
             }
-            if (!lastConverted.chipInserted) {
+            if (lastConverted.status === "pending") {
               event.preventDefault();
-              lastConverted.canceled = true;
+              lastConverted.status = "canceled";
               useFeatureSettingsStore
                 .getState()
                 .markHintLearned("paste-as-file");
@@ -498,8 +497,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
                 insertText: clipboardText,
                 chipId,
                 kind: "github-ref",
-                chipInserted: true,
-                canceled: false,
+                status: "inserted",
               };
               void resolveGithubRefChip(view, parsedRef);
               return true;
@@ -560,8 +558,7 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
               insertText: effectiveText,
               chipId: crypto.randomUUID(),
               kind: "file",
-              chipInserted: false,
-              canceled: false,
+              status: "pending",
             };
             lastAutoConvertedPasteRef.current = tracked;
 
@@ -573,14 +570,14 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
                   pasteCountRef,
                   tracked,
                 );
-                if (!tracked.canceled) {
+                if (tracked.status !== "canceled") {
                   showPasteHint(
                     "Pasted as file attachment",
                     "Paste again to expand as text.",
                   );
                 }
               } catch (_error) {
-                if (!tracked.canceled) {
+                if (tracked.status !== "canceled") {
                   toast.error("Failed to convert pasted text to attachment");
                 }
               }

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -218,7 +218,10 @@ function showPasteHint(message: string, description: string): void {
     message === "Pasted as file attachment" ? "paste-as-file" : "paste-inline";
   if (!store.shouldShowHint(key)) return;
   store.recordHintShown(key);
-  toast.info(message, description);
+  toast.info(message, {
+    description,
+    action: { label: "Got it", onClick: () => store.markHintLearned(key) },
+  });
 }
 
 export function useTiptapEditor(options: UseTiptapEditorOptions) {

--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -30,6 +30,7 @@ import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getGithubIssue, getGithubPullRequest } from "../hostApi";
 import { usePromptHistoryStore } from "../promptHistoryStore";
+import { findChipRangeById } from "../tiptap/chipRange";
 import { getEditorExtensions } from "../tiptap/extensions";
 import {
   type DraftContext,
@@ -134,26 +135,13 @@ function replaceChipWithText(
   text: string,
 ): boolean {
   const { doc, selection } = view.state;
-  let chipFrom = -1;
-  let chipTo = -1;
-  doc.descendants((node, pos) => {
-    if (chipFrom >= 0) return false;
-    if (node.type.name !== "mentionChip") return;
-    if (node.attrs.chipId !== chipId) return;
-    const nodeEnd = pos + node.nodeSize;
-    // Also swallow the trailing space the chip insertion added.
-    const after = doc.textBetween(
-      nodeEnd,
-      Math.min(nodeEnd + 1, doc.content.size),
-    );
-    chipFrom = pos;
-    chipTo = after === " " ? nodeEnd + 1 : nodeEnd;
-    return false;
-  });
-  if (chipFrom < 0) return false;
+  const range = findChipRangeById(doc, chipId);
+  if (!range) return false;
   // Only treat it as a double paste while the caret still follows the chip.
-  if (selection.from !== chipTo && selection.from !== chipTo - 1) return false;
-  view.dispatch(view.state.tr.insertText(text, chipFrom, chipTo));
+  if (selection.from !== range.to && selection.from !== range.to - 1) {
+    return false;
+  }
+  view.dispatch(view.state.tr.insertText(text, range.from, range.to));
   view.focus();
   return true;
 }


### PR DESCRIPTION
## Problem

Pasting a GitHub issue/PR URL or long text into the composer auto-converts it to a chip. When you wanted the raw text instead, undoing that means knowing about Cmd+Shift+V ahead of time.

## Changes

Pasting the same clipboard again right after an auto-conversion now replaces the chip with the plain text. Covers GitHub ref chips and long-text attachment chips. A repeat paste that lands before the text finishes persisting inserts the text immediately at the paste position instead of waiting on the file write. It only fires while the caret still follows the chip, so typing or moving the caret between pastes keeps normal paste behavior.

Double paste is now the only un-convert path: the click-to-convert behavior on pasted-text chips is removed and their tooltip says "Paste again to expand as text".

![Pasted text chip with tooltip](https://gist.githubusercontent.com/charlesvien/70c9e4ab892bcc4e480b3d5f0c648ea0/raw/pr-chip-tooltip.png)

The first-time hint toast teaches the gesture and can be acknowledged with "Got it" to never show again (it also stops once the user double-pastes, or after 3 showings):

![Paste hint toast with Got it action](https://gist.githubusercontent.com/charlesvien/70c9e4ab892bcc4e480b3d5f0c648ea0/raw/pr-toast-hint.png)

After pasting the same clipboard again, the chip expands back to the raw text:

![Expanded text after double paste](https://gist.githubusercontent.com/charlesvien/70c9e4ab892bcc4e480b3d5f0c648ea0/raw/pr-expanded-state.png)

## How did you test this?

- Drove the dev app over CDP: pasted a GitHub issue URL twice (chip, then plain URL), long text twice (chip, then inline text), a zero-delay double paste (text appears immediately, single copy, no orphaned chip), typed between pastes (two chips, no un-convert), clicked a pasted-text chip (inert, no conversion), hovered the chip (tooltip shows "Paste again to expand as text") and triggered the paste hint toast (renders with a working "Got it" action).
- Unit tests for the repeat-paste predicate in `@posthog/core` (`paste.test.ts`).
- `pnpm typecheck` and `biome lint packages/core` (zero `noRestrictedImports`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?