### PR TITLE
fix(sidebar): Use blue alpha badge on Home

### DIFF
--- a/packages/ui/src/features/sidebar/components/items/HomeItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/HomeItem.tsx
@@ -29,7 +29,7 @@ export function HomeItem({
       }
       isActive={isActive}
       onClick={onClick}
-      endContent={<Badge variant="warning">Alpha</Badge>}
+      endContent={<Badge variant="info">Alpha</Badge>}
     />
   );
 }


### PR DESCRIPTION
## Problem

Alpha badges in the sidebar are blue (info variant) but the Home item's Alpha badge rendered yellow (warning), clashing with the other Alpha badges and matching the Beta badge instead.

## Changes

Switched the Home item's Alpha badge from `variant="warning"` to `variant="info"` so it renders blue like the other Alpha badges. Beta stays yellow.

## How did you test this?

Ran Biome and `pnpm --filter @posthog/ui typecheck` on the change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?