### PR TITLE
fix(sidebar): Move Alpha and Beta badges next to labels

### DIFF
--- a/packages/ui/src/features/sidebar/components/SidebarItem.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarItem.tsx
@@ -25,11 +25,19 @@ interface SidebarItemProps {
   onDoubleClick?: () => void;
   onContextMenu?: (e: React.MouseEvent) => void;
   action?: SidebarItemAction;
+  /** Hugs the label but never truncates with it; pushes endContent right. */
+  badge?: React.ReactNode;
   endContent?: React.ReactNode;
   disabled?: boolean;
 }
 
-function SidebarItemLabel({ label }: { label: React.ReactNode }) {
+function SidebarItemLabel({
+  label,
+  grow,
+}: {
+  label: React.ReactNode;
+  grow: boolean;
+}) {
   const canTooltip = typeof label === "string" || typeof label === "number";
 
   const measureRef = useCallback((el: HTMLSpanElement | null) => {
@@ -44,7 +52,7 @@ function SidebarItemLabel({ label }: { label: React.ReactNode }) {
   }, []);
 
   const span = (
-    <span ref={measureRef} className="min-w-0 flex-1 truncate">
+    <span ref={measureRef} className={cn("min-w-0 truncate", grow && "flex-1")}>
       {label}
     </span>
   );
@@ -76,6 +84,7 @@ export function SidebarItem({
   onClick,
   onDoubleClick,
   onContextMenu,
+  badge,
   endContent,
   disabled,
 }: SidebarItemProps) {
@@ -108,7 +117,12 @@ export function SidebarItem({
       ) : null}
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="flex min-h-[18px] items-center gap-1">
-          <SidebarItemLabel label={label} />
+          <SidebarItemLabel label={label} grow={!badge} />
+          {badge ? (
+            <span className="mr-auto ml-1 flex shrink-0 items-center">
+              {badge}
+            </span>
+          ) : null}
           {endContent}
         </span>
         {subtitle ? (

--- a/packages/ui/src/features/sidebar/components/items/HomeItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/HomeItem.tsx
@@ -21,15 +21,13 @@ export function HomeItem({
       label={
         <>
           Home
-          <Badge variant="info" className="ml-2">
-            Alpha
-          </Badge>
           <SidebarCountBadge
             count={attentionCount}
             title={`${attentionCount} item${attentionCount === 1 ? "" : "s"} needing attention`}
           />
         </>
       }
+      badge={<Badge variant="info">Alpha</Badge>}
       isActive={isActive}
       onClick={onClick}
     />

--- a/packages/ui/src/features/sidebar/components/items/HomeItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/HomeItem.tsx
@@ -21,6 +21,9 @@ export function HomeItem({
       label={
         <>
           Home
+          <Badge variant="info" className="ml-2">
+            Alpha
+          </Badge>
           <SidebarCountBadge
             count={attentionCount}
             title={`${attentionCount} item${attentionCount === 1 ? "" : "s"} needing attention`}
@@ -29,7 +32,6 @@ export function HomeItem({
       }
       isActive={isActive}
       onClick={onClick}
-      endContent={<Badge variant="info">Alpha</Badge>}
     />
   );
 }

--- a/packages/ui/src/features/sidebar/components/items/InboxItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/InboxItem.tsx
@@ -35,6 +35,9 @@ export function InboxItem({
           label={
             <>
               Inbox
+              <Badge variant="warning" className="ml-2">
+                Beta
+              </Badge>
               <SidebarCountBadge
                 count={pullRequestCount}
                 title={`${pullRequestCount} pull requests to review`}
@@ -43,12 +46,7 @@ export function InboxItem({
           }
           isActive={isActive}
           onClick={onClick}
-          endContent={
-            <>
-              <Badge variant="warning">Beta</Badge>
-              <SidebarKbdHint keys={SHORTCUTS.INBOX} />
-            </>
-          }
+          endContent={<SidebarKbdHint keys={SHORTCUTS.INBOX} />}
         />
       </div>
     </Tooltip>

--- a/packages/ui/src/features/sidebar/components/items/InboxItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/InboxItem.tsx
@@ -35,15 +35,13 @@ export function InboxItem({
           label={
             <>
               Inbox
-              <Badge variant="warning" className="ml-2">
-                Beta
-              </Badge>
               <SidebarCountBadge
                 count={pullRequestCount}
                 title={`${pullRequestCount} pull requests to review`}
               />
             </>
           }
+          badge={<Badge variant="warning">Beta</Badge>}
           isActive={isActive}
           onClick={onClick}
           endContent={<SidebarKbdHint keys={SHORTCUTS.INBOX} />}


### PR DESCRIPTION
## Problem

The Alpha and Beta badges on the Home and Inbox nav items were pinned to the right edge of the sidebar while Contexts renders its badge next to the label, so the nav looked out of sync.

## Changes

Added a `badge` slot to `SidebarItem` that sits next to the label without truncating with it, and moved the Home and Inbox badges into it. Shortcut hints stay right-aligned.

<img src="https://raw.githubusercontent.com/PostHog/code/c1fc1d1bba34b07224cb86b6fe392953a2dee6cc/sidebar-badges.png" width="300" alt="Sidebar with stage badges next to labels" />

Home is behind the home-tab flag and not visible here; it uses the same slot as Inbox.

## How did you test this?

`pnpm --filter @posthog/ui typecheck`, Biome on the changed files and verified in the running dev app (screenshot above).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?