### PR TITLE
chore(dev): Group dev processes into phrocs categories

### DIFF
--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -1,5 +1,5 @@
 procs:
-  1-code:
+  code:
     shell: 'node scripts/wait-for-electron-exit.mjs && node scripts/pnpm-run.mjs --filter code run start'
     env:
       DEBUG: "false"
@@ -8,26 +8,48 @@ procs:
       - git
       - enricher
       - platform
+    groups:
+      layer: Application
 
-  2-agent:
+  agent:
     shell: 'node scripts/pnpm-run.mjs --filter agent run dev'
+    groups:
+      layer: Packages
 
-  3-git:
+  git:
     shell: 'node scripts/pnpm-run.mjs --filter @posthog/git run dev'
+    groups:
+      layer: Packages
 
   platform:
     shell: 'node scripts/pnpm-run.mjs --filter @posthog/platform run dev'
+    groups:
+      layer: Packages
 
-  4-enricher:
+  enricher:
     shell: 'node scripts/pnpm-run.mjs --filter @posthog/enricher run dev'
+    groups:
+      layer: Packages
 
-  5-storybook:
+  storybook:
     shell: 'node scripts/pnpm-run.mjs --filter code run storybook'
     autostart: false
+    groups:
+      layer: Tools
 
-  6-mobile-ios:
+  mobile-ios:
     shell: 'node scripts/pnpm-run.mjs --filter @posthog/mobile run ios'
     autostart: false
+    groups:
+      layer: Application
 
-  7-chromium-log:
+  chromium-log:
     shell: 'tail -F ~/.posthog-code/logs-dev/chromium.log'
+    groups:
+      layer: Tools
+
+# Grouping dimension the sidebar starts grouped by (press `g` to cycle/disable).
+default_group: layer
+
+group_order:
+  layer: [Application, Packages, Tools]


### PR DESCRIPTION
## Problem

The phrocs sidebar shows all dev processes as one flat list, ordered by numeric name prefixes (`1-code`, `2-agent`). The posthog repo groups its processes into categories, which reads much better as the process count grows.

## Changes

Adds `groups.layer` to each process plus `default_group` and `group_order`, so the phrocs sidebar groups processes into Application, Packages and Tools. Drops the numeric name prefixes since grouping replaces them for ordering, which also makes `code`'s `depends_on` entries match real process names. Stock mprocs (`pnpm dev:mprocs`) ignores the new keys, so the fallback keeps working.

## How did you test this?

Ran both `phrocs --config mprocs.yaml` and `mprocs --config mprocs.yaml` headless: both parse the new config cleanly and fail only on the missing TTY.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?