### PR TITLE
chore(phrocs): Auto-update phrocs binary on pnpm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cp .env.example .env
 
 ### Running in Development
 
-By default, `pnpm dev` uses phrocs (our custom process runner) to run the agent and code app in parallel. phrocs auto-installs and keeps itself up to date: on every `pnpm dev` the local binary is checked against the latest `phrocs-latest` release checksums and re-downloaded if it differs (skipped when offline). It reads the `mprocs.yaml` config file. The binary lives at `bin/phrocs` and is git-ignored.
+By default, `pnpm dev` uses phrocs (our custom process runner) to run the agent and code app in parallel. phrocs auto-installs and keeps itself up to date: on every `pnpm install` the local binary is checked against the latest `phrocs-latest` release checksums and re-downloaded if it differs (skipped when offline or in CI). `pnpm dev` only downloads it if it is missing entirely. It reads the `mprocs.yaml` config file. The binary lives at `bin/phrocs` and is git-ignored.
 
 ```bash
 # Run both agent (watch mode) and code app in parallel
@@ -44,8 +44,6 @@ pnpm dev
 pnpm dev:agent  # Run agent in watch mode
 pnpm dev:code   # Run code app
 
-# Force a fresh phrocs download (normally not needed, pnpm dev auto-updates)
-pnpm update:phrocs
 
 # Use mprocs instead of phrocs
 pnpm dev:mprocs

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cp .env.example .env
 
 ### Running in Development
 
-By default, `pnpm dev` uses phrocs (our custom process runner) to run the agent and code app in parallel. phrocs auto-installs on first run and reads the `mprocs.yaml` config file. The binary is downloaded to `bin/phrocs` and is git-ignored.
+By default, `pnpm dev` uses phrocs (our custom process runner) to run the agent and code app in parallel. phrocs auto-installs and keeps itself up to date: on every `pnpm dev` the local binary is checked against the latest `phrocs-latest` release checksums and re-downloaded if it differs (skipped when offline). It reads the `mprocs.yaml` config file. The binary lives at `bin/phrocs` and is git-ignored.
 
 ```bash
 # Run both agent (watch mode) and code app in parallel
@@ -44,7 +44,7 @@ pnpm dev
 pnpm dev:agent  # Run agent in watch mode
 pnpm dev:code   # Run code app
 
-# Manually update phrocs to the latest version
+# Force a fresh phrocs download (normally not needed, pnpm dev auto-updates)
 pnpm update:phrocs
 
 # Use mprocs instead of phrocs

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b",
   "scripts": {
     "preinstall": "node scripts/enforce-pnpm.mjs",
+    "postinstall": "bash scripts/ensure-phrocs.sh --update",
     "setup": "bash apps/code/bin/setup",
     "prepare": "husky",
     "dev": "pnpm build:deps && bash scripts/ensure-phrocs.sh && bin/phrocs --config mprocs.yaml",
@@ -34,8 +35,7 @@
     "format": "biome format --write",
     "clean": "pnpm -r clean",
     "knip": "knip",
-    "skills:pull": "node scripts/pull-skills.mjs",
-    "update:phrocs": "rm -f bin/phrocs && bash scripts/ensure-phrocs.sh"
+    "skills:pull": "node scripts/pull-skills.mjs"
   },
   "keywords": [
     "posthog",

--- a/scripts/ensure-phrocs.sh
+++ b/scripts/ensure-phrocs.sh
@@ -4,6 +4,17 @@ set -euo pipefail
 PHROCS_BIN="bin/phrocs"
 RELEASE_URL="https://github.com/PostHog/posthog/releases/download/phrocs-latest"
 
+MODE="ensure"
+[ "${1:-}" = "--update" ] && MODE="update"
+
+if [ "$MODE" = "update" ] && [ -n "${CI:-}" ]; then
+  exit 0
+fi
+
+if [ "$MODE" = "ensure" ] && [ -x "$PHROCS_BIN" ]; then
+  exit 0
+fi
+
 ARCH=$(uname -m)
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
@@ -28,12 +39,16 @@ sha256() {
   fi
 }
 
-keep_existing() {
+bail() {
   if [ -x "$PHROCS_BIN" ]; then
     echo "phrocs: $1, keeping existing binary" >&2
     exit 0
   fi
   echo "phrocs: $1 and no local binary exists" >&2
+  if [ "$MODE" = "update" ]; then
+    echo "phrocs: will retry on next pnpm install or pnpm dev" >&2
+    exit 0
+  fi
   exit 1
 }
 
@@ -41,22 +56,22 @@ TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 curl -fsSL --max-time 10 "${RELEASE_URL}/checksums.txt" -o "$TMP_DIR/checksums.txt" \
-  || keep_existing "could not fetch checksums to check for updates"
+  || bail "could not fetch checksums"
 
 EXPECTED=$(awk -v bin="$BINARY" '{name = $2; sub(/^\*/, "", name); if (name == bin) {print $1; exit}}' "$TMP_DIR/checksums.txt")
-[ -n "$EXPECTED" ] || keep_existing "no checksum for ${BINARY} in latest release"
+[ -n "$EXPECTED" ] || bail "no checksum for ${BINARY} in latest release"
 
 if [ -x "$PHROCS_BIN" ] && [ "$(sha256 "$PHROCS_BIN")" = "$EXPECTED" ]; then
   exit 0
 fi
 
 echo "phrocs: downloading latest release..."
-curl -fSL --max-time 120 "${RELEASE_URL}/${BINARY}" -o "$TMP_DIR/phrocs" \
-  || keep_existing "download failed"
+curl -fsSL --max-time 120 "${RELEASE_URL}/${BINARY}" -o "$TMP_DIR/phrocs" \
+  || bail "download failed"
 
 ACTUAL=$(sha256 "$TMP_DIR/phrocs")
 if [ "$ACTUAL" != "$EXPECTED" ]; then
-  keep_existing "checksum mismatch on download (expected ${EXPECTED}, got ${ACTUAL})"
+  bail "checksum mismatch on download (expected ${EXPECTED}, got ${ACTUAL})"
 fi
 
 mkdir -p bin

--- a/scripts/ensure-phrocs.sh
+++ b/scripts/ensure-phrocs.sh
@@ -43,7 +43,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 curl -fsSL --max-time 10 "${RELEASE_URL}/checksums.txt" -o "$TMP_DIR/checksums.txt" \
   || keep_existing "could not fetch checksums to check for updates"
 
-EXPECTED=$(awk -v bin="$BINARY" '$2 == bin {print $1}' "$TMP_DIR/checksums.txt")
+EXPECTED=$(awk -v bin="$BINARY" '{name = $2; sub(/^\*/, "", name); if (name == bin) {print $1; exit}}' "$TMP_DIR/checksums.txt")
 [ -n "$EXPECTED" ] || keep_existing "no checksum for ${BINARY} in latest release"
 
 if [ -x "$PHROCS_BIN" ] && [ "$(sha256 "$PHROCS_BIN")" = "$EXPECTED" ]; then

--- a/scripts/ensure-phrocs.sh
+++ b/scripts/ensure-phrocs.sh
@@ -2,12 +2,7 @@
 set -euo pipefail
 
 PHROCS_BIN="bin/phrocs"
-
-if [ -x "$PHROCS_BIN" ]; then
-  exit 0
-fi
-
-echo "phrocs not found, downloading..."
+RELEASE_URL="https://github.com/PostHog/posthog/releases/download/phrocs-latest"
 
 ARCH=$(uname -m)
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -24,10 +19,47 @@ case "$OS" in
 esac
 
 BINARY="phrocs-${OS}-${ARCH}"
-URL="https://github.com/PostHog/posthog/releases/download/phrocs-latest/${BINARY}"
+
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+keep_existing() {
+  if [ -x "$PHROCS_BIN" ]; then
+    echo "phrocs: $1, keeping existing binary" >&2
+    exit 0
+  fi
+  echo "phrocs: $1 and no local binary exists" >&2
+  exit 1
+}
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+curl -fsSL --max-time 10 "${RELEASE_URL}/checksums.txt" -o "$TMP_DIR/checksums.txt" \
+  || keep_existing "could not fetch checksums to check for updates"
+
+EXPECTED=$(awk -v bin="$BINARY" '$2 == bin {print $1}' "$TMP_DIR/checksums.txt")
+[ -n "$EXPECTED" ] || keep_existing "no checksum for ${BINARY} in latest release"
+
+if [ -x "$PHROCS_BIN" ] && [ "$(sha256 "$PHROCS_BIN")" = "$EXPECTED" ]; then
+  exit 0
+fi
+
+echo "phrocs: downloading latest release..."
+curl -fSL --max-time 120 "${RELEASE_URL}/${BINARY}" -o "$TMP_DIR/phrocs" \
+  || keep_existing "download failed"
+
+ACTUAL=$(sha256 "$TMP_DIR/phrocs")
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+  keep_existing "checksum mismatch on download (expected ${EXPECTED}, got ${ACTUAL})"
+fi
 
 mkdir -p bin
-curl -fSL "$URL" -o "$PHROCS_BIN"
-chmod +x "$PHROCS_BIN"
-
-echo "phrocs installed to $PHROCS_BIN"
+chmod +x "$TMP_DIR/phrocs"
+mv "$TMP_DIR/phrocs" "$PHROCS_BIN"
+echo "phrocs: updated to latest (${PHROCS_BIN})"


### PR DESCRIPTION
## Problem

`scripts/ensure-phrocs.sh` only downloads `bin/phrocs` when it is missing, so the binary drifts behind the rolling `phrocs-latest` release until someone remembers to run `pnpm update:phrocs`.

## Changes

A `postinstall` hook now runs `ensure-phrocs.sh --update` on every `pnpm install`: it fetches the release's `checksums.txt`, compares it against the local binary's sha256 and re-downloads on mismatch, with checksum verification (which the old script skipped). It never breaks `pnpm install`: network failures warn and keep the existing binary, and CI skips the check entirely. `pnpm dev` keeps a fast offline presence check that only downloads when the binary is missing. `pnpm update:phrocs` is removed since installs now keep the binary fresh.

## How did you test this?

Ran both modes through all paths: ensure mode is instant with a binary present and downloads when missing, update mode is a no-op when checksums match, re-downloads a stale binary, skips under `CI=1`, and offline it exits 0 (keeping any existing binary) while ensure mode without a binary exits 1. shellcheck is clean and package.json parses.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?