### PR TITLE
fix(agent): Gate spoken narration on the user setting

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -75,7 +75,7 @@ import { Logger } from "../../utils/logger";
 import { Pushable } from "../../utils/streams";
 import { BaseAcpAgent } from "../base-acp-agent";
 import { LOCAL_TOOLS_MCP_NAME } from "../local-tools";
-import { resolveTaskId } from "../session-meta";
+import { resolveSpokenNarration, resolveTaskId } from "../session-meta";
 import {
   buildBreakdown,
   emptyBaseline,
@@ -1891,7 +1891,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     // needs so the session doesn't pin the whole meta object.
     const baseBranch = meta?.baseBranch;
     const environment = meta?.environment;
-    const spokenNarration = meta?.spokenNarration ?? environment === "cloud";
+    const spokenNarration = resolveSpokenNarration(meta);
     const buildInProcessMcpServers = (): Record<
       string,
       McpSdkServerConfigWithInstance

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1891,6 +1891,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
     // needs so the session doesn't pin the whole meta object.
     const baseBranch = meta?.baseBranch;
     const environment = meta?.environment;
+    const spokenNarration = meta?.spokenNarration ?? environment === "cloud";
     const buildInProcessMcpServers = (): Record<
       string,
       McpSdkServerConfigWithInstance
@@ -1903,7 +1904,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           taskRunId: meta?.taskRunId,
           baseBranch,
         },
-        { environment },
+        { environment, spokenNarration },
       );
       return server ? { [LOCAL_TOOLS_MCP_NAME]: server } : {};
     };
@@ -1923,7 +1924,9 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       ...initialInProcess,
     };
 
-    const systemPrompt = buildSystemPrompt(meta?.systemPrompt);
+    const systemPrompt = buildSystemPrompt(meta?.systemPrompt, {
+      spokenNarration,
+    });
 
     if (meta?.mcpToolApprovals) {
       setMcpToolApprovalStates(meta.mcpToolApprovals);

--- a/packages/agent/src/adapters/claude/mcp/local-tools.test.ts
+++ b/packages/agent/src/adapters/claude/mcp/local-tools.test.ts
@@ -20,10 +20,10 @@ describe("createLocalToolsMcpServer", () => {
     }
   });
 
-  it("exposes only the always-on tools on a desktop run (no cloud-only tools)", async () => {
+  it("exposes speak on a desktop run with narration on (no cloud-only tools)", async () => {
     const server = createLocalToolsMcpServer(
       { cwd: "/repo", token: "ghs_x" },
-      undefined,
+      { environment: "local", spokenNarration: true },
     );
     if (!server) {
       throw new Error("expected the local-tools server to be registered");
@@ -37,12 +37,19 @@ describe("createLocalToolsMcpServer", () => {
 
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name);
-    // `speak` is always on (narration works on desktop and cloud alike).
     expect(names).toContain("speak");
     // Signed-git tools are cloud-only and must not leak into a desktop run.
     expect(names).not.toContain("git_signed_commit");
 
     await client.close();
+  });
+
+  it("registers no server on a desktop run with narration off (no tools pass their gate)", () => {
+    const server = createLocalToolsMcpServer(
+      { cwd: "/repo", token: "ghs_x" },
+      undefined,
+    );
+    expect(server).toBeUndefined();
   });
 
   it("exposes git_signed_commit over MCP in a cloud run with a token", async () => {
@@ -66,6 +73,9 @@ describe("createLocalToolsMcpServer", () => {
     expect(names).toContain("git_signed_commit");
     expect(names).toContain("git_signed_merge");
     expect(names).toContain("git_signed_rewrite");
+    // The adapter resolves spokenNarration before building the server; without
+    // an explicit true here the speak tool stays gated off.
+    expect(names).not.toContain("speak");
 
     await client.close();
   });

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
@@ -108,6 +108,16 @@ describe("canUseTool MCP approval enforcement", () => {
     expect(context.client.requestPermission).toHaveBeenCalled();
   });
 
+  it("auto-allows the speak narration tool without prompting", async () => {
+    const context = createContext("mcp__posthog-code-tools__speak", {
+      toolInput: { text: "all tests pass", kind: "done" },
+    });
+    const result = await canUseTool(context);
+
+    expect(result.behavior).toBe("allow");
+    expect(context.client.requestPermission).not.toHaveBeenCalled();
+  });
+
   it("tags MCP tools in the default permission flow with claudeCode.toolName so the renderer can show the server name and unwrap exec dispatch args", async () => {
     setMcpToolApprovalStates({ mcp__posthog__exec: "approved" });
 

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
@@ -118,6 +118,20 @@ describe("canUseTool MCP approval enforcement", () => {
     expect(context.client.requestPermission).not.toHaveBeenCalled();
   });
 
+  it("blocks speak when its approval state is do_not_use", async () => {
+    setMcpToolApprovalStates({
+      "mcp__posthog-code-tools__speak": "do_not_use",
+    });
+
+    const context = createContext("mcp__posthog-code-tools__speak", {
+      toolInput: { text: "all tests pass", kind: "done" },
+    });
+    const result = await canUseTool(context);
+
+    expect(result.behavior).toBe("deny");
+    expect(context.client.requestPermission).not.toHaveBeenCalled();
+  });
+
   it("tags MCP tools in the default permission flow with claudeCode.toolName so the renderer can show the server name and unwrap exec dispatch args", async () => {
     setMcpToolApprovalStates({ mcp__posthog__exec: "approved" });
 

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -9,6 +9,8 @@ import type {
 } from "@anthropic-ai/claude-agent-sdk";
 import { text } from "../../../utils/acp-content";
 import type { Logger } from "../../../utils/logger";
+import { qualifiedLocalToolName } from "../../local-tools";
+import { SPEAK_TOOL_NAME } from "../../local-tools/tools/speak";
 import { toolInfoFromToolUse } from "../conversion/tool-use-to-acp";
 import {
   getMcpToolApprovalState,
@@ -37,6 +39,8 @@ import {
   isPostHogDestructiveSubTool,
   isPostHogExecTool,
 } from "./posthog-exec-gate";
+
+const SPEAK_TOOL_ID = qualifiedLocalToolName(SPEAK_TOOL_NAME);
 
 export type ToolPermissionResult =
   | {
@@ -748,6 +752,15 @@ export async function canUseTool(
   }
 
   if (toolName.startsWith("mcp__")) {
+    // Narration is a fire-and-forget no-op on the agent side; a permission
+    // prompt for it interrupts the user to approve a line they may never hear.
+    if (toolName === SPEAK_TOOL_ID) {
+      return {
+        behavior: "allow",
+        updatedInput: toolInput as Record<string, unknown>,
+      };
+    }
+
     const approvalState = getMcpToolApprovalState(toolName);
 
     if (approvalState === "do_not_use") {

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -752,15 +752,6 @@ export async function canUseTool(
   }
 
   if (toolName.startsWith("mcp__")) {
-    // Narration is a fire-and-forget no-op on the agent side; a permission
-    // prompt for it interrupts the user to approve a line they may never hear.
-    if (toolName === SPEAK_TOOL_ID) {
-      return {
-        behavior: "allow",
-        updatedInput: toolInput as Record<string, unknown>,
-      };
-    }
-
     const approvalState = getMcpToolApprovalState(toolName);
 
     if (approvalState === "do_not_use") {
@@ -768,6 +759,16 @@ export async function canUseTool(
         "This tool has been blocked. To re-enable it, go to Settings > MCP Servers in PostHog Code.";
       await emitToolDenial(context, message);
       return { behavior: "deny", message, interrupt: false };
+    }
+
+    // Narration is a fire-and-forget no-op on the agent side; a permission
+    // prompt for it interrupts the user to approve a line they may never hear.
+    // An explicit do_not_use block above still wins.
+    if (toolName === SPEAK_TOOL_ID) {
+      return {
+        behavior: "allow",
+        updatedInput: toolInput as Record<string, unknown>,
+      };
     }
 
     if (approvalState === "needs_approval") {

--- a/packages/agent/src/adapters/claude/session/instructions.test.ts
+++ b/packages/agent/src/adapters/claude/session/instructions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { buildAppendedInstructions } from "./instructions";
+
+describe("buildAppendedInstructions", () => {
+  it("includes the spoken-narration block when narration is on", () => {
+    const instructions = buildAppendedInstructions({ spokenNarration: true });
+    expect(instructions).toContain("# Spoken Narration");
+  });
+
+  it("omits the spoken-narration block when narration is off", () => {
+    const instructions = buildAppendedInstructions({ spokenNarration: false });
+    expect(instructions).not.toContain("Spoken Narration");
+  });
+
+  it("keeps the base blocks in both modes", () => {
+    const withNarration = buildAppendedInstructions({ spokenNarration: true });
+    const withoutNarration = buildAppendedInstructions({
+      spokenNarration: false,
+    });
+    expect(withNarration.startsWith(withoutNarration)).toBe(true);
+    expect(withoutNarration.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/agent/src/adapters/claude/session/instructions.ts
+++ b/packages/agent/src/adapters/claude/session/instructions.ts
@@ -63,10 +63,13 @@ How to phrase the line:
 - Be theatrical: use expressive audio tags in [square brackets] — [laughs], [sighs], [groans], [excited], [whispers], [clears throat] — 1-3 per line, matched to the moment. The system-voice fallback strips tags automatically, so they never hurt.
 `;
 
-export const APPENDED_INSTRUCTIONS =
-  BRANCH_NAMING +
-  PULL_REQUEST_LINKS +
-  PLAN_MODE +
-  MCP_TOOLS +
-  SHELL_EFFICIENCY +
-  SPOKEN_NARRATION;
+const BASE_INSTRUCTIONS =
+  BRANCH_NAMING + PULL_REQUEST_LINKS + PLAN_MODE + MCP_TOOLS + SHELL_EFFICIENCY;
+
+export function buildAppendedInstructions(opts: {
+  spokenNarration: boolean;
+}): string {
+  return opts.spokenNarration
+    ? BASE_INSTRUCTIONS + SPOKEN_NARRATION
+    : BASE_INSTRUCTIONS;
+}

--- a/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/packages/agent/src/adapters/claude/session/options.test.ts
@@ -5,7 +5,7 @@ import type { HookInput, Options } from "@anthropic-ai/claude-agent-sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Logger } from "../../../utils/logger";
 import { SUBAGENT_REWRITES } from "../hooks";
-import { buildSessionOptions } from "./options";
+import { buildSessionOptions, buildSystemPrompt } from "./options";
 import { SettingsManager } from "./settings";
 
 const GIT_COMMIT_HOOK_INPUT = {
@@ -405,5 +405,68 @@ describe("buildSessionOptions", () => {
 
       expect(headers).toBe(expected);
     });
+  });
+});
+
+describe("buildSystemPrompt", () => {
+  const promptText = (prompt: Options["systemPrompt"]): string => {
+    if (typeof prompt === "string") return prompt;
+    if (Array.isArray(prompt)) return prompt.join("\n");
+    return prompt?.append ?? "";
+  };
+
+  const prompts = [
+    { name: "default preset", customPrompt: undefined },
+    { name: "string prompt", customPrompt: "You are a test agent." },
+    {
+      name: "preset with append",
+      customPrompt: {
+        type: "preset",
+        preset: "claude_code",
+        append: "Custom append.",
+      },
+    },
+  ];
+
+  it.each(prompts)(
+    "appends the narration block with narration on ($name)",
+    ({ customPrompt }) => {
+      const prompt = buildSystemPrompt(customPrompt, { spokenNarration: true });
+      expect(promptText(prompt)).toContain("# Spoken Narration");
+    },
+  );
+
+  it.each(prompts)(
+    "omits the narration block with narration off ($name)",
+    ({ customPrompt }) => {
+      const prompt = buildSystemPrompt(customPrompt, {
+        spokenNarration: false,
+      });
+      expect(promptText(prompt)).not.toContain("Spoken Narration");
+    },
+  );
+
+  it.each(prompts)(
+    "omits the narration block when opts are absent ($name)",
+    ({ customPrompt }) => {
+      const prompt = buildSystemPrompt(customPrompt);
+      expect(promptText(prompt)).not.toContain("Spoken Narration");
+    },
+  );
+
+  it("keeps the custom prompt ahead of the appended instructions", () => {
+    const prompt = buildSystemPrompt("You are a test agent.", {
+      spokenNarration: true,
+    });
+    expect(typeof prompt).toBe("string");
+    expect(prompt).toMatch(/^You are a test agent\./);
+  });
+
+  it("keeps the custom append ahead of the appended instructions", () => {
+    const prompt = buildSystemPrompt(
+      { type: "preset", preset: "claude_code", append: "Custom append." },
+      { spokenNarration: true },
+    );
+    expect(promptText(prompt)).toMatch(/^Custom append\./);
   });
 });

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -28,7 +28,7 @@ import {
 } from "../hooks";
 import { type CodeExecutionMode, toSdkPermissionMode } from "../tools";
 import type { EffortLevel } from "../types";
-import { APPENDED_INSTRUCTIONS } from "./instructions";
+import { buildAppendedInstructions } from "./instructions";
 import { loadUserClaudeJsonMcpServers } from "./mcp-config";
 import { DEFAULT_MODEL, FALLBACK_MODEL } from "./models";
 import { createRtkRewriteHook, resolveRtkPrefix } from "./rtk";
@@ -102,11 +102,15 @@ export interface BuildOptionsParams {
 
 export function buildSystemPrompt(
   customPrompt?: unknown,
+  opts?: { spokenNarration?: boolean },
 ): Options["systemPrompt"] {
+  const appendedInstructions = buildAppendedInstructions({
+    spokenNarration: opts?.spokenNarration === true,
+  });
   const defaultPrompt: Options["systemPrompt"] = {
     type: "preset",
     preset: "claude_code",
-    append: APPENDED_INSTRUCTIONS,
+    append: appendedInstructions,
   };
 
   if (!customPrompt) {
@@ -114,7 +118,7 @@ export function buildSystemPrompt(
   }
 
   if (typeof customPrompt === "string") {
-    return customPrompt + APPENDED_INSTRUCTIONS;
+    return customPrompt + appendedInstructions;
   }
 
   if (
@@ -125,7 +129,7 @@ export function buildSystemPrompt(
   ) {
     return {
       ...defaultPrompt,
-      append: customPrompt.append + APPENDED_INSTRUCTIONS,
+      append: customPrompt.append + appendedInstructions,
     };
   }
 

--- a/packages/agent/src/adapters/claude/types.ts
+++ b/packages/agent/src/adapters/claude/types.ts
@@ -194,6 +194,12 @@ export type NewSessionMeta = {
    * runtime whether it needs a repo and clones one only if so.
    */
   channelMode?: boolean;
+  /**
+   * The user's spoken-narration setting at session start. Gates the speak
+   * tool and its prompt instructions. Unset falls back by environment: cloud
+   * emits always (consumers gate playback), local stays silent.
+   */
+  spokenNarration?: boolean;
   jsonSchema?: Record<string, unknown> | null;
   mcpToolApprovals?: McpToolApprovals;
   claudeCode?: {

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -36,6 +36,7 @@ import {
   estimateTokens,
 } from "../claude/context-breakdown";
 import { isLocalSkillCommandChunk } from "../local-skill";
+import { resolveSpokenNarration } from "../session-meta";
 import {
   AppServerClient,
   type AppServerClientHandlers,
@@ -438,7 +439,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     return {
       environment: meta.environment,
       channelMode: meta.channelMode,
-      spokenNarration: meta.spokenNarration ?? meta.environment === "cloud",
+      spokenNarration: resolveSpokenNarration(meta),
       taskId: meta.taskId,
       taskRunId: meta.taskRunId,
       persistence: meta.persistence,

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -84,6 +84,7 @@ type AppServerSessionMeta = {
   persistence?: { taskId?: string };
   environment?: "local" | "cloud";
   channelMode?: boolean;
+  spokenNarration?: boolean;
   baseBranch?: string;
 };
 
@@ -437,6 +438,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     return {
       environment: meta.environment,
       channelMode: meta.channelMode,
+      spokenNarration: meta.spokenNarration ?? meta.environment === "cloud",
       taskId: meta.taskId,
       taskRunId: meta.taskRunId,
       persistence: meta.persistence,

--- a/packages/agent/src/adapters/codex-app-server/local-tools-mcp.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/local-tools-mcp.test.ts
@@ -105,12 +105,12 @@ describe("buildLocalToolsServer", () => {
     ).toBeNull();
   });
 
-  it("exposes only the always-on tools on a desktop run (no cloud-only tools)", () => {
+  it("exposes speak on a desktop run with narration on (no cloud-only tools)", () => {
     process.env.GH_TOKEN = "ghs_test";
 
     const server = buildLocalToolsServer(
       { cwd: "/repo" },
-      { environment: "local" },
+      { environment: "local", spokenNarration: true },
     );
 
     expect(server).not.toBeNull();
@@ -118,9 +118,16 @@ describe("buildLocalToolsServer", () => {
       server?.env.find((e) => e.name === "POSTHOG_LOCAL_TOOLS_ENABLED")
         ?.value ?? "";
     const names = enabled.split(",");
-    // `speak` is always on (narration works on desktop and cloud alike).
     expect(names).toContain("speak");
     // Signed-git tools are cloud-only and must not leak into a desktop run.
     expect(names).not.toContain("git_signed_commit");
+  });
+
+  it("returns null on a desktop run with narration off (no tools pass their gate)", () => {
+    process.env.GH_TOKEN = "ghs_test";
+
+    expect(
+      buildLocalToolsServer({ cwd: "/repo" }, { environment: "local" }),
+    ).toBeNull();
   });
 });

--- a/packages/agent/src/adapters/local-tools/registry.ts
+++ b/packages/agent/src/adapters/local-tools/registry.ts
@@ -28,6 +28,8 @@ export interface LocalToolGateMeta {
   environment?: "local" | "cloud";
   /** Repo-less channel session: enables the lazy-repo tools. */
   channelMode?: boolean;
+  /** Spoken narration is on for this session: enables the speak tool. */
+  spokenNarration?: boolean;
 }
 
 /**

--- a/packages/agent/src/adapters/local-tools/tools/speak.test.ts
+++ b/packages/agent/src/adapters/local-tools/tools/speak.test.ts
@@ -6,14 +6,24 @@ describe("speak tool", () => {
   it.each([
     { name: "desktop", environment: "local" as const },
     { name: "cloud", environment: "cloud" as const },
-  ])("is always exposed ($name)", ({ environment }) => {
-    const tools = enabledLocalTools({ cwd: "/repo" }, { environment });
+  ])("is exposed with narration on ($name)", ({ environment }) => {
+    const tools = enabledLocalTools(
+      { cwd: "/repo" },
+      { environment, spokenNarration: true },
+    );
     expect(tools.some((t) => t.name === SPEAK_TOOL_NAME)).toBe(true);
   });
 
-  it("is exposed even with no gate meta", () => {
-    const tools = enabledLocalTools({ cwd: "/repo" }, undefined);
-    expect(tools.some((t) => t.name === SPEAK_TOOL_NAME)).toBe(true);
+  it.each([
+    {
+      name: "narration off",
+      meta: { environment: "local" as const, spokenNarration: false },
+    },
+    { name: "narration unset", meta: { environment: "local" as const } },
+    { name: "no gate meta", meta: undefined },
+  ])("is hidden with $name", ({ meta }) => {
+    const tools = enabledLocalTools({ cwd: "/repo" }, meta);
+    expect(tools.some((t) => t.name === SPEAK_TOOL_NAME)).toBe(false);
   });
 
   it("stays visible without ToolSearch (alwaysLoad)", () => {

--- a/packages/agent/src/adapters/local-tools/tools/speak.ts
+++ b/packages/agent/src/adapters/local-tools/tools/speak.ts
@@ -48,15 +48,17 @@ export const SPEAK_TOOL_DESCRIPTION =
  * speakers, so it just acknowledges. The desktop renderer observes the
  * surfaced `tool_call` (carrying `text`/`needsUser` in its rawInput) and routes
  * it to the speech queue, exactly like completion/permission notifications are
- * pure side effects off the event stream. Always enabled — gating happens on
- * the consumer side via the user's "spoken narration" setting.
+ * pure side effects off the event stream. Gated on `spokenNarration`: local
+ * sessions pass the user's setting at session start, while cloud sessions
+ * resolve it to true at the adapter (the sandbox can't know which clients are
+ * listening, so cloud emits always and consumers gate playback).
  */
 export const speakTool = defineLocalTool({
   name: SPEAK_TOOL_NAME,
   description: SPEAK_TOOL_DESCRIPTION,
   schema: speakSchema,
   alwaysLoad: true,
-  isEnabled: () => true,
+  isEnabled: (_ctx, meta) => meta?.spokenNarration === true,
   handler: async (): Promise<LocalToolResult> => {
     return { content: [{ type: "text", text: "ok" }] };
   },

--- a/packages/agent/src/adapters/session-meta.test.ts
+++ b/packages/agent/src/adapters/session-meta.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveSpokenNarration } from "./session-meta";
+
+describe("resolveSpokenNarration", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    {
+      name: "explicit true on local",
+      meta: { environment: "local" as const, spokenNarration: true },
+      expected: true,
+    },
+    {
+      name: "explicit false on cloud",
+      meta: { environment: "cloud" as const, spokenNarration: false },
+      expected: false,
+    },
+    {
+      name: "cloud default",
+      meta: { environment: "cloud" as const },
+      expected: true,
+    },
+    {
+      name: "local default",
+      meta: { environment: "local" as const },
+      expected: false,
+    },
+    { name: "no meta", meta: undefined, expected: false },
+    { name: "empty meta", meta: {}, expected: false },
+  ])("resolves $name to $expected outside a sandbox", ({ meta, expected }) => {
+    vi.stubEnv("IS_SANDBOX", "");
+    expect(resolveSpokenNarration(meta)).toBe(expected);
+  });
+
+  it.each([
+    { name: "no meta", meta: undefined, expected: true },
+    { name: "empty meta", meta: {}, expected: true },
+    {
+      name: "explicit false",
+      meta: { spokenNarration: false },
+      expected: false,
+    },
+    {
+      name: "explicit local environment",
+      meta: { environment: "local" as const },
+      expected: false,
+    },
+  ])(
+    "resolves $name to $expected in a sandbox without an environment tag",
+    ({ meta, expected }) => {
+      vi.stubEnv("IS_SANDBOX", "1");
+      expect(resolveSpokenNarration(meta)).toBe(expected);
+    },
+  );
+});

--- a/packages/agent/src/adapters/session-meta.ts
+++ b/packages/agent/src/adapters/session-meta.ts
@@ -1,3 +1,5 @@
+import { isCloudRun } from "../utils/common";
+
 /** Minimal shape needed to resolve the effective task id from session meta. */
 interface TaskIdSource {
   taskId?: string;
@@ -13,4 +15,22 @@ export function resolveTaskId(
   meta: TaskIdSource | undefined,
 ): string | undefined {
   return meta?.taskId ?? meta?.persistence?.taskId;
+}
+
+/** Minimal shape needed to resolve spoken narration from session meta. */
+interface SpokenNarrationSource {
+  environment?: "local" | "cloud";
+  spokenNarration?: boolean;
+}
+
+/**
+ * An explicit setting wins; otherwise cloud runs (including sandbox runs
+ * detected via `IS_SANDBOX`) default to on because the sandbox can't know
+ * which clients are listening, so consumers gate playback. Local runs stay
+ * silent. Shared by the Claude and Codex adapters.
+ */
+export function resolveSpokenNarration(
+  meta: SpokenNarrationSource | undefined,
+): boolean {
+  return meta?.spokenNarration ?? isCloudRun(meta);
 }

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1069,13 +1069,14 @@ export class SessionService {
           this.d.log.warn("Failed to verify workspace", { taskId, err });
         });
 
-      const { customInstructions, rtkEnabledLocal } = this.d.settings;
+      const { customInstructions, rtkEnabledLocal, spokenNotifications } =
+        this.d.settings;
       const result = await this.d.trpc.agent.reconnect.mutate({
         taskId,
         taskRunId,
         repoPath,
         rtkEnabled: rtkEnabledLocal,
-        spokenNarration: this.d.settings.spokenNotifications === true,
+        spokenNarration: spokenNotifications === true,
         apiHost: auth.apiHost,
         projectId: auth.projectId,
         logUrl,
@@ -1395,7 +1396,11 @@ export class SessionService {
       throw new Error("Failed to create task run. Please try again.");
     }
 
-    const { customInstructions: startCustomInstructions } = this.d.settings;
+    const {
+      customInstructions: startCustomInstructions,
+      rtkEnabledLocal,
+      spokenNotifications,
+    } = this.d.settings;
     const preferredModel = model ?? this.d.DEFAULT_GATEWAY_MODEL;
     const result = await this.d.trpc.agent.start.mutate({
       taskId,
@@ -1406,8 +1411,8 @@ export class SessionService {
       permissionMode: executionMode,
       adapter,
       customInstructions: startCustomInstructions || undefined,
-      rtkEnabled: this.d.settings.rtkEnabledLocal,
-      spokenNarration: this.d.settings.spokenNotifications === true,
+      rtkEnabled: rtkEnabledLocal,
+      spokenNarration: spokenNotifications === true,
       effort: effortLevelSchema.safeParse(reasoningLevel).success
         ? (reasoningLevel as EffortLevel)
         : undefined,

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -320,6 +320,7 @@ export interface SessionServiceDeps {
     customInstructions?: string | null;
     rtkEnabledLocal?: boolean;
     rtkEnabledCloud?: boolean;
+    spokenNotifications?: boolean;
   };
   usageLimit: { show: (...args: any[]) => any };
   readonly addDirectoryDialog: { open: boolean };
@@ -1074,6 +1075,7 @@ export class SessionService {
         taskRunId,
         repoPath,
         rtkEnabled: rtkEnabledLocal,
+        spokenNarration: this.d.settings.spokenNotifications === true,
         apiHost: auth.apiHost,
         projectId: auth.projectId,
         logUrl,
@@ -1405,6 +1407,7 @@ export class SessionService {
       adapter,
       customInstructions: startCustomInstructions || undefined,
       rtkEnabled: this.d.settings.rtkEnabledLocal,
+      spokenNarration: this.d.settings.spokenNotifications === true,
       effort: effortLevelSchema.safeParse(reasoningLevel).success
         ? (reasoningLevel as EffortLevel)
         : undefined,

--- a/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/packages/workspace-server/src/services/agent/agent.test.ts
@@ -347,6 +347,36 @@ describe("AgentService", () => {
     });
   });
 
+  describe("session meta", () => {
+    it.each([{ spokenNarration: true }, { spokenNarration: false }])(
+      "threads spokenNarration $spokenNarration into newSession meta",
+      async ({ spokenNarration }) => {
+        await service.startSession({
+          ...baseSessionParams,
+          adapter: "claude",
+          spokenNarration,
+        });
+
+        expect(mockNewSession).toHaveBeenCalledTimes(1);
+        expect(mockNewSession.mock.calls[0][0]._meta).toMatchObject({
+          spokenNarration,
+        });
+      },
+    );
+
+    it("omits spokenNarration from newSession meta when unset", async () => {
+      await service.startSession({
+        ...baseSessionParams,
+        adapter: "claude",
+      });
+
+      expect(mockNewSession).toHaveBeenCalledTimes(1);
+      expect(mockNewSession.mock.calls[0][0]._meta).not.toHaveProperty(
+        "spokenNarration",
+      );
+    });
+  });
+
   describe("idle timeout", () => {
     function injectSession(
       svc: AgentService,

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -284,6 +284,8 @@ interface SessionConfig {
   importedSessionId?: string;
   /** rtk command-output compression for this session; false opts out. */
   rtkEnabled?: boolean;
+  /** The user's spoken-narration setting at session start. */
+  spokenNarration?: boolean;
 }
 
 /** Pull the adapter's `agentCapabilities._meta.posthog.steering` from initialize. */
@@ -971,6 +973,9 @@ If a repository IS genuinely required, attach one in this priority order:
               sessionId: importedSessionId,
               systemPrompt,
               ...(channelMode && { channelMode }),
+              ...(config.spokenNarration !== undefined && {
+                spokenNarration: config.spokenNarration,
+              }),
               mcpToolApprovals: toolApprovals,
               ...(permissionMode && { permissionMode }),
               ...(model != null && { model }),
@@ -1043,6 +1048,9 @@ If a repository IS genuinely required, attach one in this priority order:
             sessionId: existingSessionId,
             systemPrompt,
             ...(channelMode && { channelMode }),
+            ...(config.spokenNarration !== undefined && {
+              spokenNarration: config.spokenNarration,
+            }),
             mcpToolApprovals: toolApprovals,
             ...(permissionMode && { permissionMode }),
             ...(model != null && { model }),
@@ -1069,6 +1077,9 @@ If a repository IS genuinely required, attach one in this priority order:
             environment: "local",
             systemPrompt,
             ...(channelMode && { channelMode }),
+            ...(config.spokenNarration !== undefined && {
+              spokenNarration: config.spokenNarration,
+            }),
             mcpToolApprovals: toolApprovals,
             ...(permissionMode && { permissionMode }),
             ...(model != null && { model }),
@@ -1978,6 +1989,8 @@ For git operations while detached:
       importedSessionId:
         "importedSessionId" in params ? params.importedSessionId : undefined,
       rtkEnabled: "rtkEnabled" in params ? params.rtkEnabled : undefined,
+      spokenNarration:
+        "spokenNarration" in params ? params.spokenNarration : undefined,
     };
   }
 

--- a/packages/workspace-server/src/services/agent/schemas.ts
+++ b/packages/workspace-server/src/services/agent/schemas.ts
@@ -91,6 +91,11 @@ export const startSessionInput = z.object({
    * Defaults to enabled; false sets POSTHOG_RTK=0 on the agent environment.
    */
   rtkEnabled: z.boolean().optional(),
+  /**
+   * The user's spoken-narration setting at session start. Gates the agent's
+   * speak tool and its prompt instructions; absent means off for local runs.
+   */
+  spokenNarration: z.boolean().optional(),
 });
 
 export type StartSessionInput = z.infer<typeof startSessionInput>;
@@ -224,6 +229,8 @@ export const reconnectSessionInput = z.object({
   jsonSchema: z.record(z.string(), z.unknown()).nullish(),
   /** See startSessionInput.rtkEnabled. */
   rtkEnabled: z.boolean().optional(),
+  /** See startSessionInput.spokenNarration. */
+  spokenNarration: z.boolean().optional(),
 });
 
 export type ReconnectSessionInput = z.infer<typeof reconnectSessionInput>;

--- a/packages/workspace-server/src/services/agent/schemas.ts
+++ b/packages/workspace-server/src/services/agent/schemas.ts
@@ -93,7 +93,8 @@ export const startSessionInput = z.object({
   rtkEnabled: z.boolean().optional(),
   /**
    * The user's spoken-narration setting at session start. Gates the agent's
-   * speak tool and its prompt instructions; absent means off for local runs.
+   * speak tool and its prompt instructions; when absent the adapter defaults
+   * by environment (cloud on, local off).
    */
   spokenNarration: z.boolean().optional(),
 });


### PR DESCRIPTION
## Problem

#3060 shipped the `speak` narration tool always-on at the agent side. Every session, local or cloud, gets the "never end a turn silently, every turn MUST call speak" prompt block and the tool itself, regardless of the spoken-notifications setting (default off) or the rollout flag, which only hides the settings UI.

Nothing auto-allows the tool either, so in local attended sessions every `speak` call throws an MCP permission prompt. The result for anyone on today's master: a permission dialog on nearly every turn, an extra tool call per turn, and the narration text discarded at playback because the setting is off.

## Changes

- Plumb the spoken-notifications setting into session start: settings store into `sessionService`, through `agent.start`/`agent.reconnect` into the session `_meta` as `spokenNarration`.
- Gate both the `speak` tool registration and the Spoken Narration prompt block on it. Local sessions with narration off (the default) get neither. Cloud sessions keep emitting unconditionally since the sandbox can't know which clients are listening; playback stays consumer-gated there, and cloud runs use `bypassPermissions` so they never prompted.
- Auto-allow `mcp__posthog-code-tools__speak` in `canUseTool`. It's a fire-and-forget no-op on the agent side and never worth a permission prompt.

Known limitation: toggling narration on mid-session takes effect on the next session, since a running agent process can't be re-prompted or grow a new tool.

## How did you test this?

- New and updated unit tests: speak gate on/off/unset, local-tools server registration for the Claude and Codex adapters, `canUseTool` auto-allow, appended-instructions gating.
- Full `@posthog/agent` suite (1298 tests), `core` sessions suite and `workspace-server` agent suite all pass.
- `pnpm typecheck` and Biome across the three touched packages.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?