### PR TITLE
fix(agent): support /goal in Codex cloud runs

### DIFF
--- a/packages/agent/src/acp-extensions.ts
+++ b/packages/agent/src/acp-extensions.ts
@@ -86,7 +86,21 @@ export const POSTHOG_NOTIFICATIONS = {
 
   /** RTK output-compression token savings tallied at the end of a run */
   RTK_SAVINGS: "_posthog/rtk_savings",
+
+  /** Latest native Codex goal state, persisted so cold cloud resumes can restore it. */
+  CODEX_GOAL: "_posthog/codex_goal",
 } as const;
+
+export type CodexGoalState = {
+  objective: string;
+  status:
+    | "active"
+    | "paused"
+    | "blocked"
+    | "usageLimited"
+    | "budgetLimited"
+    | "complete";
+};
 
 /**
  * Custom request methods for PostHog-specific operations that need a response

--- a/packages/agent/src/acp-extensions.ts
+++ b/packages/agent/src/acp-extensions.ts
@@ -91,7 +91,7 @@ export const POSTHOG_NOTIFICATIONS = {
   CODEX_GOAL: "_posthog/codex_goal",
 } as const;
 
-export type CodexGoalState = {
+export type NativeGoalState = {
   objective: string;
   status:
     | "active"

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -14,6 +14,9 @@ import { sandboxPolicyFor } from "./session-config";
 
 // Required-field invariants the native codex app-server enforces on each request.
 const REQUIRED_FIELDS: Record<string, string[]> = {
+  "thread/goal/clear": ["threadId"],
+  "thread/goal/get": ["threadId"],
+  "thread/goal/set": ["threadId"],
   "turn/interrupt": ["threadId", "turnId"],
   "turn/steer": ["threadId", "input", "expectedTurnId"],
 };
@@ -293,6 +296,89 @@ describe("CodexAppServerAgent", () => {
         (notification) => notification.method === "_posthog/turn_complete",
       ),
     ).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      label: "reads an empty goal",
+      prompt: "/goal",
+      method: "thread/goal/get",
+      response: { goal: null },
+      expectedParams: { threadId: "thr_1" },
+      expectedText: "No goal set. Usage: `/goal <objective>`",
+    },
+    {
+      label: "reads an active goal",
+      prompt: "/goal",
+      method: "thread/goal/get",
+      response: { goal: { objective: "Ship the fix", status: "active" } },
+      expectedParams: { threadId: "thr_1" },
+      expectedText: "Goal active: Ship the fix",
+    },
+    {
+      label: "sets a goal",
+      prompt: "/goal Ship the fix",
+      method: "thread/goal/set",
+      response: { goal: { objective: "Ship the fix", status: "active" } },
+      expectedParams: { threadId: "thr_1", objective: "Ship the fix" },
+      expectedText: "Goal set: Ship the fix",
+    },
+    {
+      label: "clears a goal",
+      prompt: "/goal clear",
+      method: "thread/goal/clear",
+      response: { cleared: true },
+      expectedParams: { threadId: "thr_1" },
+      expectedText: "Goal cleared.",
+    },
+    {
+      label: "pauses a goal",
+      prompt: "/goal pause",
+      method: "thread/goal/set",
+      response: { goal: { objective: "Ship the fix", status: "paused" } },
+      expectedParams: { threadId: "thr_1", status: "paused" },
+      expectedText: "Goal paused: Ship the fix",
+    },
+    {
+      label: "resumes a goal",
+      prompt: "/goal resume",
+      method: "thread/goal/set",
+      response: { goal: { objective: "Ship the fix", status: "active" } },
+      expectedParams: { threadId: "thr_1", status: "active" },
+      expectedText: "Goal resumed: Ship the fix",
+    },
+  ])("$label without starting a model turn", async (testCase) => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "thr_1" } },
+      [testCase.method]: testCase.response,
+    });
+    const { client, sessionUpdates } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/bundle/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+    const result = await agent.prompt({
+      sessionId: "thr_1",
+      prompt: [{ type: "text", text: testCase.prompt }],
+    } as unknown as PromptRequest);
+
+    expect(result.stopReason).toBe("end_turn");
+    expect(stub.requests).toContainEqual({
+      method: testCase.method,
+      params: testCase.expectedParams,
+    });
+    expect(
+      stub.requests.some((request) => request.method === "turn/start"),
+    ).toBe(false);
+    expect(sessionUpdates).toContainEqual({
+      sessionId: "thr_1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: testCase.expectedText },
+      },
+    });
   });
 
   it("includes buffered command output when completion omits aggregatedOutput", async () => {
@@ -1711,6 +1797,7 @@ describe("CodexAppServerAgent", () => {
           {
             skills: [
               { name: "deploy", description: "Deploy", enabled: true },
+              { name: "goal", description: "Duplicate", enabled: true },
               { name: "danger", description: "Disabled", enabled: false },
             ],
           },
@@ -1729,7 +1816,14 @@ describe("CodexAppServerAgent", () => {
         (u: any) => u.update?.sessionUpdate === "available_commands_update",
       ) as any
     )?.update?.availableCommands;
-    expect(cmds.map((c: { name: string }) => c.name)).toEqual(["deploy"]);
+    expect(cmds).toEqual([
+      {
+        name: "goal",
+        description: "Set or view the goal for a long-running task",
+        input: { hint: "[<objective>|clear|pause|resume]" },
+      },
+      { name: "deploy", description: "Deploy" },
+    ]);
   });
 
   it("emits _posthog/sdk_session when a taskRunId is present", async () => {

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -46,7 +46,12 @@ function makeStubRpc(responses: Record<string, unknown>) {
           message: `Invalid request: missing field \`${missing}\``,
         };
       }
-      return (responses[method] ?? {}) as T;
+      const response = responses[method];
+      return (
+        typeof response === "function"
+          ? await response(params)
+          : (response ?? {})
+      ) as T;
     },
     notify() {},
     async close() {},
@@ -492,6 +497,52 @@ describe("CodexAppServerAgent", () => {
       method: "turn/interrupt",
       params: { threadId: "thr_1", turnId: "goal_tick_1" },
     });
+  });
+
+  it("retries queued goal cancellation after an interrupt failure", async () => {
+    let interruptAttempts = 0;
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "thr_1" } },
+      "thread/goal/set": {
+        goal: { objective: "Ship the fix", status: "paused" },
+      },
+      "turn/interrupt": () => {
+        interruptAttempts++;
+        if (interruptAttempts === 1) {
+          throw new Error("interrupt failed");
+        }
+        return {};
+      },
+    });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/bundle/codex" },
+      rpcFactory: stub.factory,
+    });
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+
+    await agent.prompt({
+      sessionId: "thr_1",
+      prompt: [{ type: "text", text: "/goal pause" }],
+    } as unknown as PromptRequest);
+    stub.emit("turn/started", { turn: { id: "goal_tick_1" } });
+    await Promise.resolve();
+    await Promise.resolve();
+    stub.emit("turn/started", { turn: { id: "goal_tick_2" } });
+    await Promise.resolve();
+
+    expect(
+      stub.requests.filter((request) => request.method === "turn/interrupt"),
+    ).toEqual([
+      {
+        method: "turn/interrupt",
+        params: { threadId: "thr_1", turnId: "goal_tick_1" },
+      },
+      {
+        method: "turn/interrupt",
+        params: { threadId: "thr_1", turnId: "goal_tick_2" },
+      },
+    ]);
   });
 
   it("includes buffered command output when completion omits aggregatedOutput", async () => {

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -499,6 +499,32 @@ describe("CodexAppServerAgent", () => {
     });
   });
 
+  it("interrupts a native goal turn that started before it was paused", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "thr_1" } },
+      "thread/goal/set": {
+        goal: { objective: "Ship the fix", status: "paused" },
+      },
+    });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/bundle/codex" },
+      rpcFactory: stub.factory,
+    });
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+    stub.emit("turn/started", { turn: { id: "goal_tick_1" } });
+
+    await agent.prompt({
+      sessionId: "thr_1",
+      prompt: [{ type: "text", text: "/goal pause" }],
+    } as unknown as PromptRequest);
+
+    expect(stub.requests).toContainEqual({
+      method: "turn/interrupt",
+      params: { threadId: "thr_1", turnId: "goal_tick_1" },
+    });
+  });
+
   it("retries queued goal cancellation after an interrupt failure", async () => {
     let interruptAttempts = 0;
     const stub = makeStubRpc({

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -306,6 +306,7 @@ describe("CodexAppServerAgent", () => {
       response: { goal: null },
       expectedParams: { threadId: "thr_1" },
       expectedText: "No goal set. Usage: `/goal <objective>`",
+      expectedGoal: undefined,
     },
     {
       label: "reads an active goal",
@@ -314,6 +315,7 @@ describe("CodexAppServerAgent", () => {
       response: { goal: { objective: "Ship the fix", status: "active" } },
       expectedParams: { threadId: "thr_1" },
       expectedText: "Goal active: Ship the fix",
+      expectedGoal: undefined,
     },
     {
       label: "sets a goal",
@@ -322,6 +324,7 @@ describe("CodexAppServerAgent", () => {
       response: { goal: { objective: "Ship the fix", status: "active" } },
       expectedParams: { threadId: "thr_1", objective: "Ship the fix" },
       expectedText: "Goal set: Ship the fix",
+      expectedGoal: { objective: "Ship the fix", status: "active" },
     },
     {
       label: "clears a goal",
@@ -330,6 +333,7 @@ describe("CodexAppServerAgent", () => {
       response: { cleared: true },
       expectedParams: { threadId: "thr_1" },
       expectedText: "Goal cleared.",
+      expectedGoal: null,
     },
     {
       label: "pauses a goal",
@@ -338,6 +342,7 @@ describe("CodexAppServerAgent", () => {
       response: { goal: { objective: "Ship the fix", status: "paused" } },
       expectedParams: { threadId: "thr_1", status: "paused" },
       expectedText: "Goal paused: Ship the fix",
+      expectedGoal: { objective: "Ship the fix", status: "paused" },
     },
     {
       label: "resumes a goal",
@@ -346,13 +351,14 @@ describe("CodexAppServerAgent", () => {
       response: { goal: { objective: "Ship the fix", status: "active" } },
       expectedParams: { threadId: "thr_1", status: "active" },
       expectedText: "Goal resumed: Ship the fix",
+      expectedGoal: { objective: "Ship the fix", status: "active" },
     },
   ])("$label without starting a model turn", async (testCase) => {
     const stub = makeStubRpc({
       "thread/start": { thread: { id: "thr_1" } },
       [testCase.method]: testCase.response,
     });
-    const { client, sessionUpdates } = makeFakeClient();
+    const { client, sessionUpdates, extNotifications } = makeFakeClient();
     const agent = new CodexAppServerAgent(client, {
       processOptions: { binaryPath: "/bundle/codex" },
       rpcFactory: stub.factory,
@@ -378,6 +384,113 @@ describe("CodexAppServerAgent", () => {
         sessionUpdate: "agent_message_chunk",
         content: { type: "text", text: testCase.expectedText },
       },
+    });
+    if (testCase.expectedGoal !== undefined) {
+      expect(extNotifications).toContainEqual({
+        method: "_posthog/codex_goal",
+        params: { goal: testCase.expectedGoal },
+      });
+    }
+  });
+
+  it("handles a goal command wrapped in hidden cold-resume context", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "thr_1" } },
+      "thread/goal/get": {
+        goal: { objective: "Ship the fix", status: "paused" },
+      },
+    });
+    const { client, sessionUpdates } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/bundle/codex" },
+      rpcFactory: stub.factory,
+    });
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+
+    await agent.prompt({
+      sessionId: "thr_1",
+      prompt: [
+        {
+          type: "text",
+          text: "Previous conversation context",
+          _meta: { ui: { hidden: true } },
+        },
+        { type: "text", text: "/goal" },
+        {
+          type: "text",
+          text: "Respond to the user above",
+          _meta: { ui: { hidden: true } },
+        },
+      ],
+    } as unknown as PromptRequest);
+
+    expect(stub.requests).toContainEqual({
+      method: "thread/goal/get",
+      params: { threadId: "thr_1" },
+    });
+    expect(
+      stub.requests.some((request) => request.method === "turn/start"),
+    ).toBe(false);
+    expect(sessionUpdates).toContainEqual({
+      sessionId: "thr_1",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        content: { type: "text", text: "/goal" },
+      },
+    });
+  });
+
+  it("restores a persisted goal when starting a replacement thread", async () => {
+    const restoredGoal = { objective: "Ship the fix", status: "paused" };
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "thr_1" } },
+      "thread/goal/set": { goal: restoredGoal },
+    });
+    const { client, extNotifications } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/bundle/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({
+      cwd: "/repo",
+      _meta: { codexGoal: restoredGoal },
+    } as unknown as NewSessionRequest);
+
+    expect(stub.requests).toContainEqual({
+      method: "thread/goal/set",
+      params: { threadId: "thr_1", ...restoredGoal },
+    });
+    expect(extNotifications).toContainEqual({
+      method: "_posthog/codex_goal",
+      params: { goal: restoredGoal },
+    });
+  });
+
+  it("interrupts a native goal turn that was already queued when paused", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "thr_1" } },
+      "thread/goal/set": {
+        goal: { objective: "Ship the fix", status: "paused" },
+      },
+    });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/bundle/codex" },
+      rpcFactory: stub.factory,
+    });
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+
+    await agent.prompt({
+      sessionId: "thr_1",
+      prompt: [{ type: "text", text: "/goal pause" }],
+    } as unknown as PromptRequest);
+    stub.emit("turn/started", { turn: { id: "goal_tick_1" } });
+    await Promise.resolve();
+
+    expect(stub.requests).toContainEqual({
+      method: "turn/interrupt",
+      params: { threadId: "thr_1", turnId: "goal_tick_1" },
     });
   });
 

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -454,7 +454,7 @@ describe("CodexAppServerAgent", () => {
 
     await agent.newSession({
       cwd: "/repo",
-      _meta: { codexGoal: restoredGoal },
+      _meta: { nativeGoal: restoredGoal },
     } as unknown as NewSessionRequest);
 
     expect(stub.requests).toContainEqual({

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -21,7 +21,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 import { mcpToolKey, posthogToolMeta } from "@posthog/shared";
 import {
-  type CodexGoalState,
+  type NativeGoalState,
   POSTHOG_NOTIFICATIONS,
 } from "../../acp-extensions";
 import { DEFAULT_CODEX_MODEL } from "../../gateway-models";
@@ -90,7 +90,7 @@ type AppServerSessionMeta = {
   channelMode?: boolean;
   spokenNarration?: boolean;
   baseBranch?: string;
-  codexGoal?: CodexGoalState;
+  nativeGoal?: NativeGoalState;
 };
 
 /** The subset of codex's `Thread` the adapter reads: id + persisted `turns` for history replay. */
@@ -101,7 +101,7 @@ type AppServerThread = {
 
 type ThreadGoal = {
   objective: string;
-  status: CodexGoalState["status"];
+  status: NativeGoalState["status"];
 };
 
 type GoalCommand =
@@ -482,8 +482,8 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     }
     this.threadId = threadId;
     this.sessionId = threadId;
-    if (method === APP_SERVER_METHODS.THREAD_START && params.meta?.codexGoal) {
-      await this.restoreGoal(params.meta.codexGoal);
+    if (method === APP_SERVER_METHODS.THREAD_START && params.meta?.nativeGoal) {
+      await this.restoreGoal(params.meta.nativeGoal);
     }
     await this.loadModelConfig();
     this.emitConfigOptions();
@@ -785,7 +785,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     this.broadcastAgentText(`${prefix}: ${result.goal.objective}`);
   }
 
-  private async restoreGoal(goal: CodexGoalState): Promise<void> {
+  private async restoreGoal(goal: NativeGoalState): Promise<void> {
     if (!this.threadId) return;
     const result = await this.rpc.request<{ goal: ThreadGoal }>(
       APP_SERVER_METHODS.THREAD_GOAL_SET,
@@ -798,7 +798,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     await this.emitGoalState(result.goal);
   }
 
-  private async emitGoalState(goal: CodexGoalState | null): Promise<void> {
+  private async emitGoalState(goal: NativeGoalState | null): Promise<void> {
     await this.client
       .extNotification(POSTHOG_NOTIFICATIONS.CODEX_GOAL, { goal })
       .catch((error) =>

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -95,6 +95,52 @@ type AppServerThread = {
   turns?: Array<{ items?: Parameters<typeof mapHistoryItem>[1][] }>;
 };
 
+type ThreadGoal = {
+  objective: string;
+  status: string;
+};
+
+type GoalCommand =
+  | { kind: "get" }
+  | { kind: "clear" }
+  | { kind: "pause" }
+  | { kind: "resume" }
+  | { kind: "set"; objective: string };
+
+type CodexSkill = {
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+};
+
+const GOAL_COMMAND = {
+  name: "goal",
+  description: "Set or view the goal for a long-running task",
+  input: { hint: "[<objective>|clear|pause|resume]" },
+};
+
+function parseGoalCommand(prompt: PromptRequest["prompt"]): GoalCommand | null {
+  if (prompt.some((block) => block.type !== "text")) return null;
+  const text = prompt
+    .map((block) => (block.type === "text" ? block.text : ""))
+    .join("\n")
+    .trim();
+  const match = text.match(/^\/goal(?:\s+([\s\S]*))?$/);
+  if (!match) return null;
+  const argument = match[1]?.trim();
+  if (!argument) return { kind: "get" };
+  switch (argument.toLowerCase()) {
+    case "clear":
+      return { kind: "clear" };
+    case "pause":
+      return { kind: "pause" };
+    case "resume":
+      return { kind: "resume" };
+    default:
+      return { kind: "set", objective: argument };
+  }
+}
+
 // The native app-server owns its config; BaseAcpAgent only calls dispose() on this.
 class NoopSettingsManager implements BaseSettingsManager {
   constructor(private cwd: string) {}
@@ -519,17 +565,29 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   /** skills/list → available_commands_update so the slash-command menu fills. */
   private async emitAvailableCommands(): Promise<void> {
     if (!this.sessionId) return;
-    let commands: Array<{ name: string; description: string }> = [];
+    let commands: Array<{
+      name: string;
+      description: string;
+      input?: { hint: string };
+    }> = [GOAL_COMMAND];
     try {
-      const res = await this.rpc.request<{ data?: Array<{ skills?: any[] }> }>(
-        APP_SERVER_METHODS.SKILLS_LIST,
-        {},
-      );
-      commands = (res?.data ?? [])
+      const res = await this.rpc.request<{
+        data?: Array<{ skills?: CodexSkill[] }>;
+      }>(APP_SERVER_METHODS.SKILLS_LIST, {});
+      const skills = (res?.data ?? [])
         .flatMap((entry) => entry?.skills ?? [])
         // Drop explicitly-disabled skills; lenient `!== false` so a malformed payload still shows.
-        .filter((s) => s?.name && s?.enabled !== false)
-        .map((s: any) => ({ name: s.name, description: s.description ?? "" }));
+        .filter(
+          (skill): skill is CodexSkill & { name: string } =>
+            !!skill.name &&
+            skill.name !== GOAL_COMMAND.name &&
+            skill.enabled !== false,
+        )
+        .map((skill) => ({
+          name: skill.name,
+          description: skill.description ?? "",
+        }));
+      commands = [GOAL_COMMAND, ...skills];
     } catch (err) {
       this.logger.warn("skills/list failed", { error: String(err) });
     }
@@ -547,6 +605,12 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   async prompt(params: PromptRequest): Promise<PromptResponse> {
     if (!this.threadId) {
       throw new Error("prompt() called before newSession()");
+    }
+    const goalCommand = parseGoalCommand(params.prompt);
+    if (goalCommand) {
+      this.broadcastUserInput(params.prompt);
+      await this.handleGoalCommand(goalCommand);
+      return { stopReason: "end_turn" };
     }
     // Reopen the notification gate (a prior interrupt may have left session.cancelled set).
     this.session.cancelled = false;
@@ -641,6 +705,52 @@ export class CodexAppServerAgent extends BaseAcpAgent {
 
     const stopReason = await this.runTurn(input);
     return { stopReason: await this.maybeOfferPlanImplementation(stopReason) };
+  }
+
+  private async handleGoalCommand(command: GoalCommand): Promise<void> {
+    if (!this.threadId) return;
+    if (command.kind === "clear") {
+      const result = await this.rpc.request<{ cleared?: boolean }>(
+        APP_SERVER_METHODS.THREAD_GOAL_CLEAR,
+        { threadId: this.threadId },
+      );
+      this.broadcastAgentText(
+        result.cleared ? "Goal cleared." : "No goal was set.",
+      );
+      return;
+    }
+
+    if (command.kind === "get") {
+      const result = await this.rpc.request<{ goal?: ThreadGoal | null }>(
+        APP_SERVER_METHODS.THREAD_GOAL_GET,
+        { threadId: this.threadId },
+      );
+      this.broadcastAgentText(
+        result.goal
+          ? `Goal ${result.goal.status}: ${result.goal.objective}`
+          : "No goal set. Usage: `/goal <objective>`",
+      );
+      return;
+    }
+
+    const params =
+      command.kind === "set"
+        ? { threadId: this.threadId, objective: command.objective }
+        : {
+            threadId: this.threadId,
+            status: command.kind === "pause" ? "paused" : "active",
+          };
+    const result = await this.rpc.request<{ goal: ThreadGoal }>(
+      APP_SERVER_METHODS.THREAD_GOAL_SET,
+      params,
+    );
+    const prefix =
+      command.kind === "set"
+        ? "Goal set"
+        : command.kind === "pause"
+          ? "Goal paused"
+          : "Goal resumed";
+    this.broadcastAgentText(`${prefix}: ${result.goal.objective}`);
   }
 
   /** Start one codex turn and await its completion. */

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -814,11 +814,13 @@ export class CodexAppServerAgent extends BaseAcpAgent {
 
   private interruptQueuedGoalTurn(turnId: string | undefined): void {
     if (!this.cancelNextGoalTurn || !this.threadId || !turnId) return;
-    this.cancelNextGoalTurn = false;
     void this.rpc
       .request(APP_SERVER_METHODS.TURN_INTERRUPT, {
         threadId: this.threadId,
         turnId,
+      })
+      .then(() => {
+        this.cancelNextGoalTurn = false;
       })
       .catch((error) =>
         this.logger.warn("Queued goal turn interrupt failed", error),

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -222,6 +222,8 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   private readonly usage = new UsageTracker();
   /** Pause/clear can race a goal continuation already queued by app-server. */
   private cancelNextGoalTurn = false;
+  /** Native goal ticks start outside prompt(), so TurnController does not own them. */
+  private nativeGoalTurnId?: string;
 
   constructor(
     client: AgentSideConnection,
@@ -427,6 +429,8 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       additionalDirectories?: string[];
     },
   ): Promise<{ threadId: string; thread: AppServerThread | undefined }> {
+    this.cancelNextGoalTurn = false;
+    this.nativeGoalTurnId = undefined;
     this.jsonSchema = params.meta?.jsonSchema ?? undefined;
     this.taskRunId = params.meta?.taskRunId;
     this.environment = params.meta?.environment;
@@ -807,23 +811,36 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   }
 
   private async cancelRunningGoalTurn(): Promise<void> {
-    if (!this.turns.isRunning) return;
-    this.cancelNextGoalTurn = false;
-    await this.interrupt();
+    if (this.turns.isRunning) {
+      this.cancelNextGoalTurn = false;
+      await this.interrupt();
+      return;
+    }
+    if (this.nativeGoalTurnId) {
+      await this.interruptNativeGoalTurn(this.nativeGoalTurnId);
+    }
   }
 
   private interruptQueuedGoalTurn(turnId: string | undefined): void {
     if (!this.cancelNextGoalTurn || !this.threadId || !turnId) return;
-    void this.rpc
+    void this.interruptNativeGoalTurn(turnId);
+  }
+
+  private async interruptNativeGoalTurn(turnId: string): Promise<void> {
+    if (!this.threadId) return;
+    await this.rpc
       .request(APP_SERVER_METHODS.TURN_INTERRUPT, {
         threadId: this.threadId,
         turnId,
       })
       .then(() => {
         this.cancelNextGoalTurn = false;
+        if (this.nativeGoalTurnId === turnId) {
+          this.nativeGoalTurnId = undefined;
+        }
       })
       .catch((error) =>
-        this.logger.warn("Queued goal turn interrupt failed", error),
+        this.logger.warn("Native goal turn interrupt failed", error),
       );
   }
 
@@ -1106,6 +1123,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
 
   async closeSession(): Promise<void> {
     this.commandOutputs.clear();
+    this.nativeGoalTurnId = undefined;
     this.session.abortController.abort();
     this.session.cancelled = true;
     this.planHandoffCancel?.();
@@ -1156,6 +1174,9 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     if (method === APP_SERVER_NOTIFICATIONS.TURN_STARTED) {
       // Capture the active turn id (steer precondition / interrupt target).
       const turnId = (params as { turn?: { id?: string } })?.turn?.id;
+      if (!this.turns.isPending && turnId) {
+        this.nativeGoalTurnId = turnId;
+      }
       this.turns.onStarted(turnId);
       this.interruptQueuedGoalTurn(turnId);
     }
@@ -1200,6 +1221,9 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       this.commandOutputs.clear();
       const turn = (params as { turn?: { id?: string; status?: string } })
         ?.turn;
+      if (turn?.id === this.nativeGoalTurnId) {
+        this.nativeGoalTurnId = undefined;
+      }
       // Drop the late completion of an already-interrupted turn (else it cancels the follow-up).
       if (this.turns.shouldDropCompletion(turn?.id)) return;
       void this.finalizeTurn(mapTurnStopReason(turn?.status));

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -20,7 +20,10 @@ import type {
   StopReason,
 } from "@agentclientprotocol/sdk";
 import { mcpToolKey, posthogToolMeta } from "@posthog/shared";
-import { POSTHOG_NOTIFICATIONS } from "../../acp-extensions";
+import {
+  type CodexGoalState,
+  POSTHOG_NOTIFICATIONS,
+} from "../../acp-extensions";
 import { DEFAULT_CODEX_MODEL } from "../../gateway-models";
 import type { ProcessSpawnedCallback } from "../../types";
 import { ALLOW_BYPASS } from "../../utils/common";
@@ -87,6 +90,7 @@ type AppServerSessionMeta = {
   channelMode?: boolean;
   spokenNarration?: boolean;
   baseBranch?: string;
+  codexGoal?: CodexGoalState;
 };
 
 /** The subset of codex's `Thread` the adapter reads: id + persisted `turns` for history replay. */
@@ -97,7 +101,7 @@ type AppServerThread = {
 
 type ThreadGoal = {
   objective: string;
-  status: string;
+  status: CodexGoalState["status"];
 };
 
 type GoalCommand =
@@ -119,9 +123,21 @@ const GOAL_COMMAND = {
   input: { hint: "[<objective>|clear|pause|resume]" },
 };
 
+function isHiddenPromptBlock(block: PromptRequest["prompt"][number]): boolean {
+  const meta = block._meta as { ui?: { hidden?: boolean } } | undefined;
+  return meta?.ui?.hidden === true;
+}
+
+function visiblePromptBlocks(
+  prompt: PromptRequest["prompt"],
+): PromptRequest["prompt"] {
+  return prompt.filter((block) => !isHiddenPromptBlock(block));
+}
+
 function parseGoalCommand(prompt: PromptRequest["prompt"]): GoalCommand | null {
-  if (prompt.some((block) => block.type !== "text")) return null;
-  const text = prompt
+  const visible = visiblePromptBlocks(prompt);
+  if (visible.some((block) => block.type !== "text")) return null;
+  const text = visible
     .map((block) => (block.type === "text" ? block.text : ""))
     .join("\n")
     .trim();
@@ -204,6 +220,8 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   private readonly mcp = new McpManager();
   private readonly turns = new TurnController();
   private readonly usage = new UsageTracker();
+  /** Pause/clear can race a goal continuation already queued by app-server. */
+  private cancelNextGoalTurn = false;
 
   constructor(
     client: AgentSideConnection,
@@ -464,6 +482,9 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     }
     this.threadId = threadId;
     this.sessionId = threadId;
+    if (method === APP_SERVER_METHODS.THREAD_START && params.meta?.codexGoal) {
+      await this.restoreGoal(params.meta.codexGoal);
+    }
     await this.loadModelConfig();
     this.emitConfigOptions();
     await this.emitAvailableCommands();
@@ -608,10 +629,11 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     }
     const goalCommand = parseGoalCommand(params.prompt);
     if (goalCommand) {
-      this.broadcastUserInput(params.prompt);
+      this.broadcastUserInput(visiblePromptBlocks(params.prompt));
       await this.handleGoalCommand(goalCommand);
       return { stopReason: "end_turn" };
     }
+    this.cancelNextGoalTurn = false;
     // Reopen the notification gate (a prior interrupt may have left session.cancelled set).
     this.session.cancelled = false;
     // A new prompt while the plan handoff awaits approval implicitly declines it:
@@ -710,10 +732,13 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   private async handleGoalCommand(command: GoalCommand): Promise<void> {
     if (!this.threadId) return;
     if (command.kind === "clear") {
+      this.cancelNextGoalTurn = true;
       const result = await this.rpc.request<{ cleared?: boolean }>(
         APP_SERVER_METHODS.THREAD_GOAL_CLEAR,
         { threadId: this.threadId },
       );
+      await this.emitGoalState(null);
+      await this.cancelRunningGoalTurn();
       this.broadcastAgentText(
         result.cleared ? "Goal cleared." : "No goal was set.",
       );
@@ -733,6 +758,9 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       return;
     }
 
+    if (command.kind === "pause") {
+      this.cancelNextGoalTurn = true;
+    }
     const params =
       command.kind === "set"
         ? { threadId: this.threadId, objective: command.objective }
@@ -744,6 +772,10 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       APP_SERVER_METHODS.THREAD_GOAL_SET,
       params,
     );
+    await this.emitGoalState(result.goal);
+    if (command.kind === "pause") {
+      await this.cancelRunningGoalTurn();
+    }
     const prefix =
       command.kind === "set"
         ? "Goal set"
@@ -751,6 +783,46 @@ export class CodexAppServerAgent extends BaseAcpAgent {
           ? "Goal paused"
           : "Goal resumed";
     this.broadcastAgentText(`${prefix}: ${result.goal.objective}`);
+  }
+
+  private async restoreGoal(goal: CodexGoalState): Promise<void> {
+    if (!this.threadId) return;
+    const result = await this.rpc.request<{ goal: ThreadGoal }>(
+      APP_SERVER_METHODS.THREAD_GOAL_SET,
+      {
+        threadId: this.threadId,
+        objective: goal.objective,
+        status: goal.status,
+      },
+    );
+    await this.emitGoalState(result.goal);
+  }
+
+  private async emitGoalState(goal: CodexGoalState | null): Promise<void> {
+    await this.client
+      .extNotification(POSTHOG_NOTIFICATIONS.CODEX_GOAL, { goal })
+      .catch((error) =>
+        this.logger.warn("Failed to persist Codex goal state", error),
+      );
+  }
+
+  private async cancelRunningGoalTurn(): Promise<void> {
+    if (!this.turns.isRunning) return;
+    this.cancelNextGoalTurn = false;
+    await this.interrupt();
+  }
+
+  private interruptQueuedGoalTurn(turnId: string | undefined): void {
+    if (!this.cancelNextGoalTurn || !this.threadId || !turnId) return;
+    this.cancelNextGoalTurn = false;
+    void this.rpc
+      .request(APP_SERVER_METHODS.TURN_INTERRUPT, {
+        threadId: this.threadId,
+        turnId,
+      })
+      .catch((error) =>
+        this.logger.warn("Queued goal turn interrupt failed", error),
+      );
   }
 
   /** Start one codex turn and await its completion. */
@@ -1081,7 +1153,9 @@ export class CodexAppServerAgent extends BaseAcpAgent {
 
     if (method === APP_SERVER_NOTIFICATIONS.TURN_STARTED) {
       // Capture the active turn id (steer precondition / interrupt target).
-      this.turns.onStarted((params as { turn?: { id?: string } })?.turn?.id);
+      const turnId = (params as { turn?: { id?: string } })?.turn?.id;
+      this.turns.onStarted(turnId);
+      this.interruptQueuedGoalTurn(turnId);
     }
 
     // codex auto-compaction surfaces as a contextCompaction item: item/started → in progress,

--- a/packages/agent/src/adapters/codex-app-server/protocol.ts
+++ b/packages/agent/src/adapters/codex-app-server/protocol.ts
@@ -15,6 +15,9 @@ export const APP_SERVER_METHODS = {
   TURN_INTERRUPT: "turn/interrupt",
   MODEL_LIST: "model/list",
   SKILLS_LIST: "skills/list",
+  THREAD_GOAL_SET: "thread/goal/set",
+  THREAD_GOAL_GET: "thread/goal/get",
+  THREAD_GOAL_CLEAR: "thread/goal/clear",
   THREAD_LIST: "thread/list",
 } as const;
 

--- a/packages/agent/src/resume.ts
+++ b/packages/agent/src/resume.ts
@@ -16,6 +16,7 @@
  */
 
 import type { ContentBlock } from "@agentclientprotocol/sdk";
+import type { CodexGoalState } from "./acp-extensions";
 import { selectRecentTurns } from "./adapters/claude/session/jsonl-hydration";
 import type { PostHogAPIClient } from "./posthog-api";
 import { ResumeSaga } from "./sagas/resume-saga";
@@ -29,6 +30,7 @@ export interface ResumeState {
   lastDevice?: DeviceInfo;
   logEntryCount: number;
   sessionId: string | null;
+  codexGoal?: CodexGoalState | null;
 }
 
 export interface ConversationTurn {
@@ -95,6 +97,7 @@ export async function resumeFromLog(
     lastDevice: result.data.lastDevice,
     logEntryCount: result.data.logEntryCount,
     sessionId: result.data.sessionId,
+    codexGoal: result.data.codexGoal,
   };
 }
 

--- a/packages/agent/src/resume.ts
+++ b/packages/agent/src/resume.ts
@@ -16,7 +16,7 @@
  */
 
 import type { ContentBlock } from "@agentclientprotocol/sdk";
-import type { CodexGoalState } from "./acp-extensions";
+import type { NativeGoalState } from "./acp-extensions";
 import { selectRecentTurns } from "./adapters/claude/session/jsonl-hydration";
 import type { PostHogAPIClient } from "./posthog-api";
 import { ResumeSaga } from "./sagas/resume-saga";
@@ -30,7 +30,7 @@ export interface ResumeState {
   lastDevice?: DeviceInfo;
   logEntryCount: number;
   sessionId: string | null;
-  codexGoal?: CodexGoalState | null;
+  nativeGoal?: NativeGoalState | null;
 }
 
 export interface ConversationTurn {
@@ -97,7 +97,7 @@ export async function resumeFromLog(
     lastDevice: result.data.lastDevice,
     logEntryCount: result.data.logEntryCount,
     sessionId: result.data.sessionId,
-    codexGoal: result.data.codexGoal,
+    nativeGoal: result.data.nativeGoal,
   };
 }
 

--- a/packages/agent/src/sagas/resume-saga.test.ts
+++ b/packages/agent/src/sagas/resume-saga.test.ts
@@ -617,6 +617,56 @@ describe("ResumeSaga", () => {
     });
   });
 
+  describe("Codex goal state", () => {
+    it.each([
+      {
+        name: "restores the latest persisted goal",
+        entries: [
+          createNotification(POSTHOG_NOTIFICATIONS.CODEX_GOAL, {
+            goal: { objective: "Old goal", status: "active" },
+          }),
+          createNotification(`_${POSTHOG_NOTIFICATIONS.CODEX_GOAL}`, {
+            goal: { objective: "Ship the fix", status: "paused" },
+          }),
+        ],
+        expected: { objective: "Ship the fix", status: "paused" },
+      },
+      {
+        name: "preserves an explicit goal clear",
+        entries: [
+          createNotification(POSTHOG_NOTIFICATIONS.CODEX_GOAL, {
+            goal: { objective: "Ship the fix", status: "active" },
+          }),
+          createNotification(POSTHOG_NOTIFICATIONS.CODEX_GOAL, { goal: null }),
+        ],
+        expected: null,
+      },
+      {
+        name: "leaves goal state undefined when no notification exists",
+        entries: [createUserMessage("Hello")],
+        expected: undefined,
+      },
+    ])("$name", async ({ entries, expected }) => {
+      (mockApiClient.getTaskRun as ReturnType<typeof vi.fn>).mockResolvedValue(
+        createTaskRun(),
+      );
+      (
+        mockApiClient.fetchTaskRunLogs as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(entries);
+
+      const result = await new ResumeSaga(mockLogger).run({
+        taskId: "task-1",
+        runId: "run-1",
+        repositoryPath: repo.path,
+        apiClient: mockApiClient,
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.codexGoal).toEqual(expected);
+    });
+  });
+
   describe("log entry count", () => {
     it("reports correct log entry count", async () => {
       (mockApiClient.getTaskRun as ReturnType<typeof vi.fn>).mockResolvedValue(

--- a/packages/agent/src/sagas/resume-saga.test.ts
+++ b/packages/agent/src/sagas/resume-saga.test.ts
@@ -663,7 +663,7 @@ describe("ResumeSaga", () => {
 
       expect(result.success).toBe(true);
       if (!result.success) return;
-      expect(result.data.codexGoal).toEqual(expected);
+      expect(result.data.nativeGoal).toEqual(expected);
     });
   });
 

--- a/packages/agent/src/sagas/resume-saga.test.ts
+++ b/packages/agent/src/sagas/resume-saga.test.ts
@@ -642,6 +642,19 @@ describe("ResumeSaga", () => {
         expected: null,
       },
       {
+        name: "skips malformed newer goal notifications",
+        entries: [
+          createNotification(POSTHOG_NOTIFICATIONS.CODEX_GOAL, {
+            goal: { objective: "Ship the fix", status: "paused" },
+          }),
+          createNotification(POSTHOG_NOTIFICATIONS.CODEX_GOAL, {
+            goal: { objective: "Invalid goal", status: "unknown" },
+          }),
+          createNotification(POSTHOG_NOTIFICATIONS.CODEX_GOAL, {}),
+        ],
+        expected: { objective: "Ship the fix", status: "paused" },
+      },
+      {
         name: "leaves goal state undefined when no notification exists",
         entries: [createUserMessage("Hello")],
         expected: undefined,

--- a/packages/agent/src/sagas/resume-saga.ts
+++ b/packages/agent/src/sagas/resume-saga.ts
@@ -1,6 +1,6 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import { Saga } from "@posthog/shared";
-import { POSTHOG_NOTIFICATIONS } from "../acp-extensions";
+import { type CodexGoalState, POSTHOG_NOTIFICATIONS } from "../acp-extensions";
 import type { PostHogAPIClient } from "../posthog-api";
 import type {
   DeviceInfo,
@@ -37,6 +37,7 @@ export interface ResumeOutput {
   lastDevice?: DeviceInfo;
   logEntryCount: number;
   sessionId: string | null;
+  codexGoal?: CodexGoalState | null;
 }
 
 export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
@@ -91,6 +92,9 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
     const sessionId = await this.readOnlyStep("find_session_id", () =>
       Promise.resolve(this.findSessionId(entries)),
     );
+    const codexGoal = await this.readOnlyStep("find_codex_goal", () =>
+      Promise.resolve(this.findCodexGoal(entries)),
+    );
 
     this.log.info("Resume state rebuilt", {
       turns: conversation.length,
@@ -106,6 +110,7 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
       lastDevice,
       logEntryCount: entries.length,
       sessionId,
+      codexGoal,
     };
   }
 
@@ -116,7 +121,46 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
       interrupted: false,
       logEntryCount: 0,
       sessionId: null,
+      codexGoal: undefined,
     };
+  }
+
+  private findCodexGoal(
+    entries: StoredNotification[],
+  ): CodexGoalState | null | undefined {
+    const statuses = new Set<CodexGoalState["status"]>([
+      "active",
+      "paused",
+      "blocked",
+      "usageLimited",
+      "budgetLimited",
+      "complete",
+    ]);
+    const methods = new Set([
+      POSTHOG_NOTIFICATIONS.CODEX_GOAL,
+      `_${POSTHOG_NOTIFICATIONS.CODEX_GOAL}`,
+    ]);
+    for (let index = entries.length - 1; index >= 0; index--) {
+      const notification = entries[index].notification;
+      if (!methods.has(notification?.method ?? "")) continue;
+      const goal = (notification?.params as { goal?: unknown } | undefined)
+        ?.goal;
+      if (goal === null) return null;
+      if (!goal || typeof goal !== "object") return undefined;
+      const value = goal as Record<string, unknown>;
+      if (
+        typeof value.objective === "string" &&
+        typeof value.status === "string" &&
+        statuses.has(value.status as CodexGoalState["status"])
+      ) {
+        return {
+          objective: value.objective,
+          status: value.status as CodexGoalState["status"],
+        };
+      }
+      return undefined;
+    }
+    return undefined;
   }
 
   private findSessionId(entries: StoredNotification[]): string | null {

--- a/packages/agent/src/sagas/resume-saga.ts
+++ b/packages/agent/src/sagas/resume-saga.ts
@@ -146,7 +146,7 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
       const goal = (notification?.params as { goal?: unknown } | undefined)
         ?.goal;
       if (goal === null) return null;
-      if (!goal || typeof goal !== "object") return undefined;
+      if (!goal || typeof goal !== "object") continue;
       const value = goal as Record<string, unknown>;
       if (
         typeof value.objective === "string" &&
@@ -158,7 +158,6 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
           status: value.status as NativeGoalState["status"],
         };
       }
-      return undefined;
     }
     return undefined;
   }

--- a/packages/agent/src/sagas/resume-saga.ts
+++ b/packages/agent/src/sagas/resume-saga.ts
@@ -1,6 +1,6 @@
 import type { ContentBlock } from "@agentclientprotocol/sdk";
 import { Saga } from "@posthog/shared";
-import { type CodexGoalState, POSTHOG_NOTIFICATIONS } from "../acp-extensions";
+import { type NativeGoalState, POSTHOG_NOTIFICATIONS } from "../acp-extensions";
 import type { PostHogAPIClient } from "../posthog-api";
 import type {
   DeviceInfo,
@@ -37,7 +37,7 @@ export interface ResumeOutput {
   lastDevice?: DeviceInfo;
   logEntryCount: number;
   sessionId: string | null;
-  codexGoal?: CodexGoalState | null;
+  nativeGoal?: NativeGoalState | null;
 }
 
 export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
@@ -92,8 +92,8 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
     const sessionId = await this.readOnlyStep("find_session_id", () =>
       Promise.resolve(this.findSessionId(entries)),
     );
-    const codexGoal = await this.readOnlyStep("find_codex_goal", () =>
-      Promise.resolve(this.findCodexGoal(entries)),
+    const nativeGoal = await this.readOnlyStep("find_native_goal", () =>
+      Promise.resolve(this.findNativeGoal(entries)),
     );
 
     this.log.info("Resume state rebuilt", {
@@ -110,7 +110,7 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
       lastDevice,
       logEntryCount: entries.length,
       sessionId,
-      codexGoal,
+      nativeGoal,
     };
   }
 
@@ -121,14 +121,14 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
       interrupted: false,
       logEntryCount: 0,
       sessionId: null,
-      codexGoal: undefined,
+      nativeGoal: undefined,
     };
   }
 
-  private findCodexGoal(
+  private findNativeGoal(
     entries: StoredNotification[],
-  ): CodexGoalState | null | undefined {
-    const statuses = new Set<CodexGoalState["status"]>([
+  ): NativeGoalState | null | undefined {
+    const statuses = new Set<NativeGoalState["status"]>([
       "active",
       "paused",
       "blocked",
@@ -151,11 +151,11 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
       if (
         typeof value.objective === "string" &&
         typeof value.status === "string" &&
-        statuses.has(value.status as CodexGoalState["status"])
+        statuses.has(value.status as NativeGoalState["status"])
       ) {
         return {
           objective: value.objective,
-          status: value.status as CodexGoalState["status"],
+          status: value.status as NativeGoalState["status"],
         };
       }
       return undefined;

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -242,6 +242,10 @@ interface TestableServer {
   buildClaudeCodeSessionMeta(
     runtimeAdapter: Adapter,
   ): { claudeCode: { options: Record<string, unknown> } } | undefined;
+  resumeState: ResumeState | null;
+  getCodexGoalForFreshSession(
+    runtimeAdapter: Adapter,
+  ): ResumeState["codexGoal"];
 }
 
 interface NativeResumeTestServer {
@@ -435,6 +439,37 @@ describe("AgentServer HTTP Mode", () => {
       TEST_PRIVATE_KEY,
     );
   };
+
+  it("replays ACP notifications emitted before cloud session assignment", () => {
+    const testServer = createServer() as unknown as {
+      session: { sseController: null } | null;
+      pendingEvents: Record<string, unknown>[];
+      preSessionEvents: Record<string, unknown>[];
+      handleAcpTransportMessage(message: unknown): void;
+      flushPreSessionEvents(): void;
+    };
+    const message = {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "available_commands_update",
+          availableCommands: [{ name: "goal" }],
+        },
+      },
+    };
+
+    testServer.handleAcpTransportMessage(message);
+    expect(testServer.preSessionEvents).toHaveLength(1);
+
+    testServer.session = { sseController: null };
+    testServer.flushPreSessionEvents();
+
+    expect(testServer.preSessionEvents).toHaveLength(0);
+    expect(testServer.pendingEvents).toContainEqual(
+      expect.objectContaining({ notification: message }),
+    );
+    testServer.session = null;
+  });
 
   describe("GET /health", () => {
     it("returns ok status with active session", async () => {
@@ -2345,6 +2380,22 @@ describe("AgentServer HTTP Mode", () => {
   });
 
   describe("native resume", () => {
+    it("restores persisted Codex goals only for fresh Codex sessions", () => {
+      const s = createServer() as unknown as TestableServer;
+      const goal = { objective: "Ship the fix", status: "paused" as const };
+      s.resumeState = {
+        conversation: [],
+        latestGitCheckpoint: null,
+        interrupted: false,
+        logEntryCount: 1,
+        sessionId: "prior-session",
+        codexGoal: goal,
+      };
+
+      expect(s.getCodexGoalForFreshSession("codex")).toEqual(goal);
+      expect(s.getCodexGoalForFreshSession("claude")).toBeUndefined();
+    });
+
     it.each([
       { retryOutcome: "succeeds", retryFails: false },
       { retryOutcome: "fails", retryFails: true },

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -243,9 +243,9 @@ interface TestableServer {
     runtimeAdapter: Adapter,
   ): { claudeCode: { options: Record<string, unknown> } } | undefined;
   resumeState: ResumeState | null;
-  getCodexGoalForFreshSession(
+  getNativeGoalForFreshSession(
     runtimeAdapter: Adapter,
-  ): ResumeState["codexGoal"];
+  ): ResumeState["nativeGoal"];
 }
 
 interface NativeResumeTestServer {
@@ -2389,11 +2389,11 @@ describe("AgentServer HTTP Mode", () => {
         interrupted: false,
         logEntryCount: 1,
         sessionId: "prior-session",
-        codexGoal: goal,
+        nativeGoal: goal,
       };
 
-      expect(s.getCodexGoalForFreshSession("codex")).toEqual(goal);
-      expect(s.getCodexGoalForFreshSession("claude")).toBeUndefined();
+      expect(s.getNativeGoalForFreshSession("codex")).toEqual(goal);
+      expect(s.getNativeGoalForFreshSession("claude")).toBeUndefined();
     });
 
     it.each([

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -802,11 +802,11 @@ export class AgentServer {
     return { sessionId: priorSessionId, warm };
   }
 
-  private getCodexGoalForFreshSession(
+  private getNativeGoalForFreshSession(
     runtimeAdapter: Adapter,
-  ): ResumeState["codexGoal"] {
+  ): ResumeState["nativeGoal"] {
     if (runtimeAdapter !== "codex") return undefined;
-    return this.resumeState?.codexGoal;
+    return this.resumeState?.nativeGoal;
   }
 
   async stop(): Promise<void> {
@@ -1438,7 +1438,7 @@ export class AgentServer {
       initialPermissionMode,
     );
     let effectiveSessionMeta: typeof sessionMeta & {
-      codexGoal?: NonNullable<ResumeState["codexGoal"]>;
+      nativeGoal?: NonNullable<ResumeState["nativeGoal"]>;
     } = sessionMeta;
 
     let acpSessionId: string | null = null;
@@ -1467,10 +1467,10 @@ export class AgentServer {
       }
     }
     if (!acpSessionId) {
-      const restoredCodexGoal =
-        this.getCodexGoalForFreshSession(runtimeAdapter);
-      effectiveSessionMeta = restoredCodexGoal
-        ? { ...sessionMeta, codexGoal: restoredCodexGoal }
+      const restoredNativeGoal =
+        this.getNativeGoalForFreshSession(runtimeAdapter);
+      effectiveSessionMeta = restoredNativeGoal
+        ? { ...sessionMeta, nativeGoal: restoredNativeGoal }
         : sessionMeta;
       const sessionResponse = await clientConnection.newSession({
         cwd: sessionCwd,

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -368,6 +368,8 @@ export class AgentServer {
   // causing a second session to be created and duplicate Slack messages to be sent.
   private initializationPromise: Promise<void> | null = null;
   private pendingEvents: Record<string, unknown>[] = [];
+  /** ACP notifications emitted by newSession/resumeSession before this.session is assigned. */
+  private preSessionEvents: Record<string, unknown>[] = [];
   private deliveredMessageIds = new Set<string>();
   private pendingCompactContinuationMessageIds = new Set<string>();
   private pendingPermissions = new Map<
@@ -800,6 +802,13 @@ export class AgentServer {
     return { sessionId: priorSessionId, warm };
   }
 
+  private getCodexGoalForFreshSession(
+    runtimeAdapter: Adapter,
+  ): ResumeState["codexGoal"] {
+    if (runtimeAdapter !== "codex") return undefined;
+    return this.resumeState?.codexGoal;
+  }
+
   async stop(): Promise<void> {
     this.logger.debug("Stopping agent server...");
 
@@ -1220,6 +1229,7 @@ export class AgentServer {
 
     this.resumeState = null;
     this.nativeResume = null;
+    this.preSessionEvents = [];
     this.prewarmedRun = false;
     this.warmAutoPublishResolved = false;
 
@@ -1427,6 +1437,9 @@ export class AgentServer {
       sessionCwd,
       initialPermissionMode,
     );
+    let effectiveSessionMeta: typeof sessionMeta & {
+      codexGoal?: NonNullable<ResumeState["codexGoal"]>;
+    } = sessionMeta;
 
     let acpSessionId: string | null = null;
     if (nativeResume) {
@@ -1435,7 +1448,7 @@ export class AgentServer {
           sessionId: nativeResume.sessionId,
           cwd: sessionCwd,
           mcpServers: this.config.mcpServers ?? [],
-          _meta: { ...sessionMeta, sessionId: nativeResume.sessionId },
+          _meta: { ...effectiveSessionMeta, sessionId: nativeResume.sessionId },
         });
         acpSessionId = nativeResume.sessionId;
         this.nativeResume = nativeResume;
@@ -1454,10 +1467,15 @@ export class AgentServer {
       }
     }
     if (!acpSessionId) {
+      const restoredCodexGoal =
+        this.getCodexGoalForFreshSession(runtimeAdapter);
+      effectiveSessionMeta = restoredCodexGoal
+        ? { ...sessionMeta, codexGoal: restoredCodexGoal }
+        : sessionMeta;
       const sessionResponse = await clientConnection.newSession({
         cwd: sessionCwd,
         mcpServers: this.config.mcpServers ?? [],
-        _meta: sessionMeta,
+        _meta: effectiveSessionMeta,
       });
       acpSessionId = sessionResponse.sessionId;
       this.logger.debug("ACP session created", {
@@ -1480,8 +1498,9 @@ export class AgentServer {
       permissionMode: initialPermissionMode,
       hasDesktopConnected: sseController !== null,
       pendingHandoffGitState: undefined,
-      sessionMeta,
+      sessionMeta: effectiveSessionMeta,
     };
+    this.flushPreSessionEvents();
 
     this.logger = new Logger({
       debug: true,
@@ -3977,6 +3996,7 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
     }
 
     this.pendingEvents = [];
+    this.preSessionEvents = [];
     this.lastReportedBranch = null;
     // Run usage is per run: a later session on this instance (e.g. a resume
     // with a different run_id) must not inherit the previous run's totals.
@@ -4098,11 +4118,16 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
       }
       this.adapterEmittedTurnComplete = true;
     }
-    this.broadcastEvent({
+    const event = {
       type: "notification",
       timestamp: new Date().toISOString(),
       notification: message,
-    });
+    };
+    if (!this.session) {
+      this.preSessionEvents.push(event);
+      return;
+    }
+    this.broadcastEvent(event);
   }
 
   private broadcastTurnComplete(stopReason: string): void {
@@ -4142,6 +4167,15 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
     } else {
       // Buffer events during initialization (sseController not yet attached)
       this.pendingEvents.push(event);
+    }
+  }
+
+  private flushPreSessionEvents(): void {
+    if (!this.session || this.preSessionEvents.length === 0) return;
+    const events = this.preSessionEvents;
+    this.preSessionEvents = [];
+    for (const event of events) {
+      this.broadcastEvent(event);
     }
   }
 


### PR DESCRIPTION
## Problem

Codex cloud runs pass `/goal` through as ordinary model input because they bypass Codex's interactive TUI command dispatcher.

**Why:** Cloud tasks should support the same long-running goal controls regardless of whether they use the Claude or Codex runtime adapter.

## Changes

- translate Codex `/goal` commands to the native app-server goal RPCs
- advertise `/goal` alongside available Codex skills
- cover reading, setting, clearing, pausing, and resuming goals without starting a model turn
