### PR TITLE
fix: remove duplicate bippy lockfile entry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8762,11 +8762,6 @@ packages:
   bippy@0.5.43:
     resolution: {integrity: sha512-Tvu7b1M7+d8b9/YHaCeODEsi2CgbuoBql+dWSBrNnCuqJ1gMUeY3i0r+319hvjjl5GVBP6FFWxrKnq3fhZER0w==}
     peerDependencies:
-      react: 19.2.6
-
-  bippy@0.5.43:
-    resolution: {integrity: sha512-Tvu7b1M7+d8b9/YHaCeODEsi2CgbuoBql+dWSBrNnCuqJ1gMUeY3i0r+319hvjjl5GVBP6FFWxrKnq3fhZER0w==}
-    peerDependencies:
       react: '>=17.0.1'
 
   bl@4.1.0:


### PR DESCRIPTION
## Problem

`pnpm install --frozen-lockfile` fails because `pnpm-lock.yaml` contains the `bippy@0.5.43` mapping twice. The duplicate was introduced when [#3392](https://github.com/PostHog/code/pull/3392) was merged.

**Why:** Restore dependency installation in CI by making the lockfile valid YAML again.

## Changes

Removed the duplicate `bippy@0.5.43` package mapping while retaining the canonical peer dependency metadata.

## How did you test this?

- `pnpm install --frozen-lockfile --ignore-scripts`
- Verified exactly one `bippy@0.5.43` package mapping remains.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
