### PR TITLE
feat(channels): ship production thread and feed UX

### DIFF
--- a/.claude/skills/quill-code/SKILL.md
+++ b/.claude/skills/quill-code/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: quill-code
+description: Edit the @posthog/quill design system locally and consume the change in this repo (posthog-code) before it is published to npm. Use when changing quill components/primitives/tokens, when a quill change must be tested inside the Code app, or when the user mentions quill, the design system, the .local-quill tarball, or the @posthog/quill pnpm override.
+---
+
+# quill-code
+
+`@posthog/quill` is **not** in this repo. It is a published catalog dependency whose
+source lives in the main PostHog monorepo at `../posthog/packages/quill`. To test an
+unpublished quill change inside this repo (posthog-code), you build quill, pack it to a
+tarball, and point a pnpm `overrides` entry at that tarball. This is a **temporary
+local-dev** state — revert before merging (see below).
+
+## Quill layout (where to edit)
+
+`../posthog/packages/quill` is the **workspace** (`@posthog/quill-workspace`). It
+contains sub-packages, each a layer of the design system:
+
+- `packages/primitives/src` — base components (Card, Badge, Button, Progress, …)
+- `packages/components/src` — composed components (DataTable, DateTimePicker, Metric)
+- `packages/blocks/src` — **product-level blocks** (e.g. `ExperimentCard`). Add the
+  file here and export it from `packages/blocks/src/index.ts`.
+- `packages/quill/src` — the **aggregate** that re-exports all layers as `@posthog/quill`.
+
+A new export in any sub-package flows to `@posthog/quill` automatically on build.
+
+## The loop (every quill change)
+
+1. Edit/add the component in the right sub-package (above) and export it from that
+   package's `src/index.ts`.
+2. Re-sync into this repo manually — build → pack → point the override → reinstall:
+
+   ```bash
+   QUILL_DIR="${QUILL_DIR:-../posthog/packages/quill/packages/quill}"
+
+   # a. Build the WHOLE quill workspace (two levels up from the aggregate), so the
+   #    sub-packages rebuild BEFORE the aggregate bundles them.
+   ( cd "$QUILL_DIR/../.." && pnpm build )
+
+   # b. Pack into .local-quill/ under a UNIQUE filename. pnpm pins a tarball by
+   #    integrity, so a stable name caches stale across re-syncs — drop old local
+   #    tarballs first, then rename the packed file to a unique local name.
+   rm -f .local-quill/posthog-quill-local-*.tgz
+   ( cd "$QUILL_DIR" && npm pack --pack-destination "$(git rev-parse --show-toplevel)/.local-quill" )
+   mv .local-quill/posthog-quill-[0-9]*.tgz ".local-quill/posthog-quill-local-$(git rev-parse --short HEAD)-$$.tgz"
+
+   # c. Point the override at the new tarball, then reinstall.
+   #    Edit pnpm-workspace.yaml so overrides['@posthog/quill'] = file:./.local-quill/<new file>
+   pnpm install
+   ```
+
+   > Building only the aggregate (`packages/quill/packages/quill`) re-bundles the
+   > sub-packages' **stale** `dist/`, so edits to primitives/components/blocks are
+   > silently dropped. Always build at the workspace root.
+3. Verify in the Code app (`pnpm dev`, or the `test-electron-app` skill). Repeat from 1.
+
+After every quill edit you **must** re-run the sync — the app consumes the tarball, not
+the quill source, so unsynced edits are invisible here.
+
+If quill lives elsewhere, set `QUILL_DIR=/abs/path/to/posthog/packages/quill/packages/quill`.
+
+## Why a tarball, not `link:`
+
+`link:` symlinks into the mono's `node_modules` and drags in its **React 18** types,
+colliding with this repo's **React 19** (dual-React → broken typecheck +
+invalid-hook-call at runtime). The tarball is copied into this repo's store and deduped
+against React 19. The filename is **content-hashed** because pnpm pins a tarball by
+integrity, so a stable filename gets cached stale across re-syncs.
+
+## The override (what the script rewrites)
+
+In `pnpm-workspace.yaml`, under `overrides:`:
+
+```yaml
+'@posthog/quill': file:./.local-quill/posthog-quill-local-<hash>.tgz
+```
+
+There is also a permanent pin you should leave alone:
+
+```yaml
+'@posthog/quill>@base-ui/react': ^1.3.0   # quill ships a broken catalog: dep; do not remove
+```
+
+## Reverting (before merge)
+
+The override is local-dev only. Once the quill change is published to npm:
+
+1. Bump the catalog version in `pnpm-workspace.yaml` (`'@posthog/quill': 0.3.0-beta.x`)
+   to the published version.
+2. Restore the override line to point back at the catalog, or remove the `file:` override.
+3. `pnpm install`.
+
+Do not commit a `file:./.local-quill/...` override or the `.local-quill/` tarballs.

--- a/apps/code/src/renderer/desktop-contributions.ts
+++ b/apps/code/src/renderer/desktop-contributions.ts
@@ -1,6 +1,7 @@
 import { agentChatCoreModule } from "@posthog/core/agent-chat/agentChat.module";
 import { autoresearchCoreModule } from "@posthog/core/autoresearch/autoresearch.module";
 import { billingCoreModule } from "@posthog/core/billing/billing.module";
+import { taskThreadCoreModule } from "@posthog/core/canvas/taskThread.module";
 import { inboxCoreModule } from "@posthog/core/inbox/inbox.module";
 import { githubConnectModule } from "@posthog/core/integrations/githubConnect.module";
 import { onboardingModule } from "@posthog/core/onboarding/onboarding.module";
@@ -36,6 +37,7 @@ export function registerDesktopContributions(): void {
     autoresearchCoreModule,
     billingUiModule,
     billingCoreModule,
+    taskThreadCoreModule,
     browserTabsUiModule,
     cloneUiModule,
     connectivityUiModule,

--- a/apps/web/src/web-container.ts
+++ b/apps/web/src/web-container.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import { TypedContainer } from "@inversifyjs/strongly-typed";
+import { taskThreadCoreModule } from "@posthog/core/canvas/taskThread.module";
 import { setRootContainer } from "@posthog/di/container";
 import { ROOT_LOGGER, type RootLogger } from "@posthog/di/logger";
 import {
@@ -95,5 +96,7 @@ container.bind(MCP_SANDBOX_PROXY_URL).toConstantValue(() => {
   }
   return sandboxProxyUrl;
 });
+
+container.load(taskThreadCoreModule);
 
 setRootContainer(container);

--- a/packages/api-client/src/posthog-client.test.ts
+++ b/packages/api-client/src/posthog-client.test.ts
@@ -1,3 +1,4 @@
+import type { TaskThreadMessage } from "@posthog/shared/domain-types";
 import { describe, expect, it, vi } from "vitest";
 import { PostHogAPIClient } from "./posthog-client";
 
@@ -1694,5 +1695,68 @@ describe("PostHogAPIClient", () => {
         });
       });
     });
+  });
+});
+
+describe("task thread messages", () => {
+  function message(
+    overrides: Partial<TaskThreadMessage> = {},
+  ): TaskThreadMessage {
+    return {
+      id: "message-id",
+      task: "task-id",
+      content: "@agent investigate this",
+      created_at: "2026-07-16T00:00:00Z",
+      ...overrides,
+    };
+  }
+
+  it("creates a message before forwarding it to the agent", async () => {
+    const client = new PostHogAPIClient(
+      "http://localhost:8000",
+      async () => "token",
+      async () => "token",
+      123,
+    );
+    const create = vi
+      .spyOn(client, "createTaskThreadMessage")
+      .mockResolvedValue(message());
+    const send = vi
+      .spyOn(client, "sendTaskThreadMessageToAgent")
+      .mockResolvedValue(
+        message({ forwarded_to_agent_at: "2026-07-16T00:00:01Z" }),
+      );
+
+    await client.createTaskThreadMessageForAgent(
+      "task-id",
+      "@agent investigate this",
+    );
+
+    expect(create).toHaveBeenCalledWith("task-id", "@agent investigate this");
+    expect(send).toHaveBeenCalledWith("task-id", "message-id");
+    expect(create.mock.invocationCallOrder[0]).toBeLessThan(
+      send.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("returns the created message when forwarding fails", async () => {
+    const client = new PostHogAPIClient(
+      "http://localhost:8000",
+      async () => "token",
+      async () => "token",
+      123,
+    );
+    const sendError = new Error("No active run");
+    vi.spyOn(client, "createTaskThreadMessage").mockResolvedValue(message());
+    vi.spyOn(client, "sendTaskThreadMessageToAgent").mockRejectedValue(
+      sendError,
+    );
+
+    await expect(
+      client.createTaskThreadMessageForAgent(
+        "task-id",
+        "@agent investigate this",
+      ),
+    ).resolves.toEqual({ message: message(), sendError });
   });
 });

--- a/packages/api-client/src/posthog-client.test.ts
+++ b/packages/api-client/src/posthog-client.test.ts
@@ -1,4 +1,3 @@
-import type { TaskThreadMessage } from "@posthog/shared/domain-types";
 import { describe, expect, it, vi } from "vitest";
 import { PostHogAPIClient } from "./posthog-client";
 
@@ -1695,68 +1694,5 @@ describe("PostHogAPIClient", () => {
         });
       });
     });
-  });
-});
-
-describe("task thread messages", () => {
-  function message(
-    overrides: Partial<TaskThreadMessage> = {},
-  ): TaskThreadMessage {
-    return {
-      id: "message-id",
-      task: "task-id",
-      content: "@agent investigate this",
-      created_at: "2026-07-16T00:00:00Z",
-      ...overrides,
-    };
-  }
-
-  it("creates a message before forwarding it to the agent", async () => {
-    const client = new PostHogAPIClient(
-      "http://localhost:8000",
-      async () => "token",
-      async () => "token",
-      123,
-    );
-    const create = vi
-      .spyOn(client, "createTaskThreadMessage")
-      .mockResolvedValue(message());
-    const send = vi
-      .spyOn(client, "sendTaskThreadMessageToAgent")
-      .mockResolvedValue(
-        message({ forwarded_to_agent_at: "2026-07-16T00:00:01Z" }),
-      );
-
-    await client.createTaskThreadMessageForAgent(
-      "task-id",
-      "@agent investigate this",
-    );
-
-    expect(create).toHaveBeenCalledWith("task-id", "@agent investigate this");
-    expect(send).toHaveBeenCalledWith("task-id", "message-id");
-    expect(create.mock.invocationCallOrder[0]).toBeLessThan(
-      send.mock.invocationCallOrder[0],
-    );
-  });
-
-  it("returns the created message when forwarding fails", async () => {
-    const client = new PostHogAPIClient(
-      "http://localhost:8000",
-      async () => "token",
-      async () => "token",
-      123,
-    );
-    const sendError = new Error("No active run");
-    vi.spyOn(client, "createTaskThreadMessage").mockResolvedValue(message());
-    vi.spyOn(client, "sendTaskThreadMessageToAgent").mockRejectedValue(
-      sendError,
-    );
-
-    await expect(
-      client.createTaskThreadMessageForAgent(
-        "task-id",
-        "@agent investigate this",
-      ),
-    ).resolves.toEqual({ message: message(), sendError });
   });
 });

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -2630,6 +2630,21 @@ export class PostHogAPIClient {
     return (await response.json()) as TaskThreadMessage;
   }
 
+  async createTaskThreadMessageForAgent(
+    taskId: string,
+    content: string,
+  ): Promise<{ message: TaskThreadMessage; sendError: unknown | null }> {
+    const message = await this.createTaskThreadMessage(taskId, content);
+    try {
+      return {
+        message: await this.sendTaskThreadMessageToAgent(taskId, message.id),
+        sendError: null,
+      };
+    } catch (sendError) {
+      return { message, sendError };
+    }
+  }
+
   async deleteTaskThreadMessage(
     taskId: string,
     messageId: string,

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -2630,21 +2630,6 @@ export class PostHogAPIClient {
     return (await response.json()) as TaskThreadMessage;
   }
 
-  async createTaskThreadMessageForAgent(
-    taskId: string,
-    content: string,
-  ): Promise<{ message: TaskThreadMessage; sendError: unknown | null }> {
-    const message = await this.createTaskThreadMessage(taskId, content);
-    try {
-      return {
-        message: await this.sendTaskThreadMessageToAgent(taskId, message.id),
-        sendError: null,
-      };
-    } catch (sendError) {
-      return { message, sendError };
-    }
-  }
-
   async deleteTaskThreadMessage(
     taskId: string,
     messageId: string,

--- a/packages/core/src/canvas/channelFeed.test.ts
+++ b/packages/core/src/canvas/channelFeed.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { taskFeedRunStatus } from "./channelFeed";
+
+describe("taskFeedRunStatus", () => {
+  it.each(["queued", "in_progress"] as const)(
+    "preserves a cloud %s status even when local session activity has settled",
+    (status) => {
+      expect(
+        taskFeedRunStatus({
+          status,
+          environment: "cloud",
+        }),
+      ).toBe(status);
+    },
+  );
+
+  it("hides an unreliable non-terminal local status", () => {
+    expect(
+      taskFeedRunStatus({ status: "queued", environment: "local" }),
+    ).toBeNull();
+  });
+
+  it("keeps a terminal local status", () => {
+    expect(
+      taskFeedRunStatus({ status: "completed", environment: "local" }),
+    ).toBe("completed");
+  });
+});

--- a/packages/core/src/canvas/channelFeed.ts
+++ b/packages/core/src/canvas/channelFeed.ts
@@ -1,0 +1,23 @@
+import type { TaskRunStatus } from "@posthog/shared/domain-types";
+import { isTerminalStatus } from "@posthog/shared/domain-types";
+
+const PERMANENT_CHANNEL_FEED_FAILURES = new Set([401, 403, 404]);
+
+export function shouldPollChannelFeed(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("status" in error)) return true;
+  const status = (error as { status?: unknown }).status;
+  return (
+    typeof status !== "number" || !PERMANENT_CHANNEL_FEED_FAILURES.has(status)
+  );
+}
+
+export function taskFeedRunStatus({
+  status,
+  environment,
+}: {
+  status: TaskRunStatus | null | undefined;
+  environment: string | null | undefined;
+}): TaskRunStatus | null {
+  if (!status) return null;
+  return environment === "cloud" || isTerminalStatus(status) ? status : null;
+}

--- a/packages/core/src/canvas/taskThread.module.ts
+++ b/packages/core/src/canvas/taskThread.module.ts
@@ -1,0 +1,7 @@
+import { ContainerModule } from "inversify";
+import { TASK_THREAD_SERVICE, TaskThreadService } from "./taskThreadService";
+
+export const taskThreadCoreModule = new ContainerModule(({ bind }) => {
+  bind(TaskThreadService).toSelf().inSingletonScope();
+  bind(TASK_THREAD_SERVICE).toService(TaskThreadService);
+});

--- a/packages/core/src/canvas/taskThreadService.test.ts
+++ b/packages/core/src/canvas/taskThreadService.test.ts
@@ -1,0 +1,66 @@
+import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
+import type { TaskThreadMessage } from "@posthog/shared/domain-types";
+import { describe, expect, it, vi } from "vitest";
+import { TaskThreadService } from "./taskThreadService";
+
+function message(
+  overrides: Partial<TaskThreadMessage> = {},
+): TaskThreadMessage {
+  return {
+    id: "message-id",
+    task: "task-id",
+    content: "@agent investigate this",
+    created_at: "2026-07-16T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function client(overrides: Partial<PostHogAPIClient> = {}): PostHogAPIClient {
+  return overrides as PostHogAPIClient;
+}
+
+describe("TaskThreadService", () => {
+  it("creates a message before forwarding it to the agent", async () => {
+    const createTaskThreadMessage = vi.fn().mockResolvedValue(message());
+    const sendTaskThreadMessageToAgent = vi
+      .fn()
+      .mockResolvedValue(
+        message({ forwarded_to_agent_at: "2026-07-16T00:00:01Z" }),
+      );
+    const service = new TaskThreadService();
+
+    await service.postMessageToAgent(
+      client({ createTaskThreadMessage, sendTaskThreadMessageToAgent }),
+      "task-id",
+      "@agent investigate this",
+    );
+
+    expect(createTaskThreadMessage).toHaveBeenCalledWith(
+      "task-id",
+      "@agent investigate this",
+    );
+    expect(sendTaskThreadMessageToAgent).toHaveBeenCalledWith(
+      "task-id",
+      "message-id",
+    );
+    expect(createTaskThreadMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      sendTaskThreadMessageToAgent.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("returns the created message when forwarding fails", async () => {
+    const sendError = new Error("No active run");
+    const service = new TaskThreadService();
+
+    await expect(
+      service.postMessageToAgent(
+        client({
+          createTaskThreadMessage: vi.fn().mockResolvedValue(message()),
+          sendTaskThreadMessageToAgent: vi.fn().mockRejectedValue(sendError),
+        }),
+        "task-id",
+        "@agent investigate this",
+      ),
+    ).resolves.toEqual({ message: message(), sendError });
+  });
+});

--- a/packages/core/src/canvas/taskThreadService.ts
+++ b/packages/core/src/canvas/taskThreadService.ts
@@ -1,0 +1,31 @@
+import type { PostHogAPIClient } from "@posthog/api-client/posthog-client";
+import type { TaskThreadMessage } from "@posthog/shared/domain-types";
+import { injectable } from "inversify";
+
+export const TASK_THREAD_SERVICE = Symbol.for(
+  "posthog.core.canvas.taskThreadService",
+);
+
+export interface PostMessageToAgentResult {
+  message: TaskThreadMessage;
+  sendError: unknown | null;
+}
+
+@injectable()
+export class TaskThreadService {
+  async postMessageToAgent(
+    client: PostHogAPIClient,
+    taskId: string,
+    content: string,
+  ): Promise<PostMessageToAgentResult> {
+    const message = await client.createTaskThreadMessage(taskId, content);
+    try {
+      return {
+        message: await client.sendTaskThreadMessageToAgent(taskId, message.id),
+        sendError: null,
+      };
+    } catch (sendError) {
+      return { message, sendError };
+    }
+  }
+}

--- a/packages/core/src/canvas/threadTimeline.test.ts
+++ b/packages/core/src/canvas/threadTimeline.test.ts
@@ -38,6 +38,45 @@ describe("normalizeAgentPromptText", () => {
 });
 
 describe("buildThreadTimeline", () => {
+  it("omits the session echo of a forwarded thread message", () => {
+    const timeline = buildThreadTimeline({
+      prompts: [
+        {
+          id: "prompt",
+          text: "[Thread comment from Peter Kirkham] @agent which model are you?",
+          timestamp: 200,
+        },
+      ],
+      humanMessages: [
+        {
+          id: "human",
+          content: "@agent which model are you?",
+          createdAt: "1970-01-01T00:00:00.100Z",
+          forwardedToAgent: true,
+        },
+      ],
+      agentMessages: [],
+    });
+
+    expect(timeline.map((row) => row.kind)).toEqual(["human"]);
+  });
+
+  it("keeps a thread-comment prompt without a matching forwarded message", () => {
+    const timeline = buildThreadTimeline({
+      prompts: [
+        {
+          id: "prompt",
+          text: "[Thread comment from Peter Kirkham] @agent which model are you?",
+          timestamp: 200,
+        },
+      ],
+      humanMessages: [],
+      agentMessages: [],
+    });
+
+    expect(timeline.map((row) => row.kind)).toEqual(["prompt"]);
+  });
+
   it("interleaves prompts, human replies, and agent turns chronologically", () => {
     const timeline = buildThreadTimeline({
       prompts: [{ id: "prompt", text: "Start", timestamp: 100 }],

--- a/packages/core/src/canvas/threadTimeline.test.ts
+++ b/packages/core/src/canvas/threadTimeline.test.ts
@@ -3,6 +3,7 @@ import {
   buildThreadTimeline,
   deriveThreadAgentStatus,
   hasAgentMention,
+  normalizeAgentPromptText,
   shouldSuspendThreadSession,
 } from "./threadTimeline";
 
@@ -15,6 +16,24 @@ describe("hasAgentMention", () => {
     ["without a mention", "human-only note", false],
   ])("detects an agent mention %s", (_name, content, expected) => {
     expect(hasAgentMention(content)).toBe(expected);
+  });
+});
+
+describe("normalizeAgentPromptText", () => {
+  it.each([
+    [
+      "forwarded thread comment",
+      "[Thread comment from Peter Kirkham] @agent which model are you?",
+      "which model are you?",
+    ],
+    ["direct prompt", "which model are you?", "which model are you?"],
+    [
+      "direct prompt with mention",
+      "@agent which model are you?",
+      "which model are you?",
+    ],
+  ])("normalizes a %s", (_name, content, expected) => {
+    expect(normalizeAgentPromptText(content)).toBe(expected);
   });
 });
 

--- a/packages/core/src/canvas/threadTimeline.test.ts
+++ b/packages/core/src/canvas/threadTimeline.test.ts
@@ -2,8 +2,21 @@ import { describe, expect, it } from "vitest";
 import {
   buildThreadTimeline,
   deriveThreadAgentStatus,
+  hasAgentMention,
   shouldSuspendThreadSession,
 } from "./threadTimeline";
+
+describe("hasAgentMention", () => {
+  it.each([
+    ["at the start", "@agent investigate this", true],
+    ["after other text", "Could you @Agent check this?", true],
+    ["inside an email-like token", "person@agent.com", false],
+    ["as part of a longer handle", "@agents", false],
+    ["without a mention", "human-only note", false],
+  ])("detects an agent mention %s", (_name, content, expected) => {
+    expect(hasAgentMention(content)).toBe(expected);
+  });
+});
 
 describe("buildThreadTimeline", () => {
   it("interleaves prompts, human replies, and agent turns chronologically", () => {

--- a/packages/core/src/canvas/threadTimeline.test.ts
+++ b/packages/core/src/canvas/threadTimeline.test.ts
@@ -72,6 +72,11 @@ describe("deriveThreadAgentStatus", () => {
       input: { hasActivity: true, hasPullRequest: true },
       expected: { phase: "complete", label: "Shipped" },
     },
+    {
+      name: "reports settled work without a pull request as done",
+      input: { hasActivity: true },
+      expected: { phase: "complete", label: "Done" },
+    },
   ])("$name", ({ input, expected }) => {
     expect(deriveThreadAgentStatus(input)).toEqual(expected);
   });

--- a/packages/core/src/canvas/threadTimeline.test.ts
+++ b/packages/core/src/canvas/threadTimeline.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildThreadTimeline,
+  deriveThreadAgentStatus,
+  shouldSuspendThreadSession,
+} from "./threadTimeline";
+
+describe("buildThreadTimeline", () => {
+  it("interleaves prompts, human replies, and agent turns chronologically", () => {
+    const timeline = buildThreadTimeline({
+      prompts: [{ id: "prompt", text: "Start", timestamp: 100 }],
+      humanMessages: [
+        {
+          id: "human",
+          content: "Reply",
+          createdAt: "1970-01-01T00:00:00.150Z",
+        },
+      ],
+      agentMessages: [{ id: "agent", text: "Done", timestamp: 200 }],
+    });
+
+    expect(timeline.map((row) => row.kind)).toEqual([
+      "prompt",
+      "human",
+      "agent",
+    ]);
+  });
+
+  it("keeps malformed timestamps at the end", () => {
+    const timeline = buildThreadTimeline({
+      prompts: [{ id: "prompt", text: "Start", timestamp: 100 }],
+      humanMessages: [{ id: "human", content: "Reply", createdAt: "invalid" }],
+      agentMessages: [{ id: "agent", text: "Done", timestamp: 200 }],
+    });
+
+    expect(timeline.map((row) => row.kind)).toEqual([
+      "prompt",
+      "agent",
+      "human",
+    ]);
+  });
+});
+
+describe("deriveThreadAgentStatus", () => {
+  it.each([
+    {
+      name: "returns no status before activity",
+      input: {},
+      expected: null,
+    },
+    {
+      name: "prioritizes failures",
+      input: { hasActivity: true, hasError: true, errorTitle: "Run failed" },
+      expected: { phase: "error", label: "Run failed" },
+    },
+    {
+      name: "prioritizes pending permissions over active work",
+      input: {
+        hasActivity: true,
+        pendingPermissionCount: 1,
+        isPromptPending: true,
+      },
+      expected: { phase: "needs_input", label: "Needs input" },
+    },
+    {
+      name: "reports active work",
+      input: { hasActivity: true, isPromptPending: true },
+      expected: { phase: "active", label: "Working…" },
+    },
+    {
+      name: "reports shipped work",
+      input: { hasActivity: true, hasPullRequest: true },
+      expected: { phase: "complete", label: "Shipped" },
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(deriveThreadAgentStatus(input)).toEqual(expected);
+  });
+});
+
+describe("shouldSuspendThreadSession", () => {
+  it("suspends a local runless task so reading cannot start work", () => {
+    expect(
+      shouldSuspendThreadSession({
+        isCloud: false,
+        hasRun: false,
+        hasSession: false,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    { isCloud: true, hasRun: false, hasSession: false },
+    { isCloud: false, hasRun: true, hasSession: false },
+    { isCloud: false, hasRun: false, hasSession: true },
+  ])("keeps an existing or cloud session attached", (input) => {
+    expect(shouldSuspendThreadSession(input)).toBe(false);
+  });
+});

--- a/packages/core/src/canvas/threadTimeline.test.ts
+++ b/packages/core/src/canvas/threadTimeline.test.ts
@@ -139,14 +139,9 @@ describe("deriveThreadAgentStatus", () => {
       expected: { phase: "active", label: "Working…" },
     },
     {
-      name: "reports shipped work",
-      input: { hasActivity: true, hasPullRequest: true },
-      expected: { phase: "complete", label: "Shipped" },
-    },
-    {
-      name: "reports settled work without a pull request as done",
+      name: "returns no status after work settles",
       input: { hasActivity: true },
-      expected: { phase: "complete", label: "Done" },
+      expected: null,
     },
   ])("$name", ({ input, expected }) => {
     expect(deriveThreadAgentStatus(input)).toEqual(expected);

--- a/packages/core/src/canvas/threadTimeline.ts
+++ b/packages/core/src/canvas/threadTimeline.ts
@@ -68,6 +68,12 @@ export interface ThreadAgentStatus {
   label: string;
 }
 
+const AGENT_MENTION_PATTERN = /(^|\s)@agent\b/i;
+
+export function hasAgentMention(content: string): boolean {
+  return AGENT_MENTION_PATTERN.test(content);
+}
+
 export function deriveThreadAgentStatus({
   hasActivity = false,
   hasError = false,

--- a/packages/core/src/canvas/threadTimeline.ts
+++ b/packages/core/src/canvas/threadTimeline.ts
@@ -1,0 +1,116 @@
+export interface ThreadAgentMessage {
+  id: string;
+  text: string;
+  timestamp?: number;
+}
+
+export interface ThreadHumanMessage<T = unknown> {
+  id: string;
+  content: string;
+  createdAt: string;
+  value?: T;
+}
+
+export type ThreadTimelineRow<T = unknown> =
+  | { kind: "prompt"; timestamp: number; message: ThreadAgentMessage }
+  | { kind: "agent"; timestamp: number; message: ThreadAgentMessage }
+  | { kind: "human"; timestamp: number; message: ThreadHumanMessage<T> };
+
+function validTimestamp(timestamp: number | undefined): number {
+  return timestamp !== undefined && Number.isFinite(timestamp)
+    ? timestamp
+    : Number.MAX_SAFE_INTEGER;
+}
+
+function parsedTimestamp(timestamp: string): number {
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? parsed : Number.MAX_SAFE_INTEGER;
+}
+
+export function buildThreadTimeline<T>({
+  prompts,
+  agentMessages,
+  humanMessages,
+}: {
+  prompts: ThreadAgentMessage[];
+  agentMessages: ThreadAgentMessage[];
+  humanMessages: ThreadHumanMessage<T>[];
+}): ThreadTimelineRow<T>[] {
+  return [
+    ...prompts.map(
+      (message): ThreadTimelineRow<T> => ({
+        kind: "prompt",
+        timestamp: validTimestamp(message.timestamp),
+        message,
+      }),
+    ),
+    ...humanMessages.map(
+      (message): ThreadTimelineRow<T> => ({
+        kind: "human",
+        timestamp: parsedTimestamp(message.createdAt),
+        message,
+      }),
+    ),
+    ...agentMessages.map(
+      (message): ThreadTimelineRow<T> => ({
+        kind: "agent",
+        timestamp: validTimestamp(message.timestamp),
+        message,
+      }),
+    ),
+  ].sort((left, right) => left.timestamp - right.timestamp);
+}
+
+export type ThreadAgentPhase = "active" | "needs_input" | "complete" | "error";
+
+export interface ThreadAgentStatus {
+  phase: ThreadAgentPhase;
+  label: string;
+}
+
+export function deriveThreadAgentStatus({
+  hasActivity = false,
+  hasError = false,
+  cloudStatus,
+  errorTitle,
+  pendingPermissionCount = 0,
+  isPromptPending = false,
+  isInitializing = false,
+  hasPullRequest = false,
+}: {
+  hasActivity?: boolean;
+  hasError?: boolean;
+  cloudStatus?: string | null;
+  errorTitle?: string | null;
+  pendingPermissionCount?: number;
+  isPromptPending?: boolean;
+  isInitializing?: boolean;
+  hasPullRequest?: boolean;
+}): ThreadAgentStatus | null {
+  if (!hasActivity) return null;
+  if (hasError || cloudStatus === "failed") {
+    return { phase: "error", label: errorTitle ?? "Failed" };
+  }
+  if (pendingPermissionCount > 0) {
+    return { phase: "needs_input", label: "Needs input" };
+  }
+  if (isPromptPending || isInitializing) {
+    return { phase: "active", label: "Working…" };
+  }
+  return {
+    phase: "complete",
+    label: hasPullRequest ? "Shipped" : "Ready to ship",
+  };
+}
+
+export function shouldSuspendThreadSession({
+  isCloud,
+  hasRun,
+  hasSession,
+}: {
+  isCloud: boolean;
+  hasRun: boolean;
+  hasSession: boolean;
+}): boolean {
+  return !isCloud && !hasRun && !hasSession;
+}

--- a/packages/core/src/canvas/threadTimeline.ts
+++ b/packages/core/src/canvas/threadTimeline.ts
@@ -8,6 +8,7 @@ export interface ThreadHumanMessage<T = unknown> {
   id: string;
   content: string;
   createdAt: string;
+  forwardedToAgent?: boolean;
   value?: T;
 }
 
@@ -36,8 +37,19 @@ export function buildThreadTimeline<T>({
   agentMessages: ThreadAgentMessage[];
   humanMessages: ThreadHumanMessage<T>[];
 }): ThreadTimelineRow<T>[] {
+  const forwardedHumanContent = new Set(
+    humanMessages
+      .filter((message) => message.forwardedToAgent)
+      .map((message) => normalizeAgentPromptText(message.content)),
+  );
+  const visiblePrompts = prompts.filter(
+    (message) =>
+      !isThreadCommentPrompt(message.text) ||
+      !forwardedHumanContent.has(normalizeAgentPromptText(message.text)),
+  );
+
   return [
-    ...prompts.map(
+    ...visiblePrompts.map(
       (message): ThreadTimelineRow<T> => ({
         kind: "prompt",
         timestamp: validTimestamp(message.timestamp),
@@ -83,6 +95,10 @@ export function normalizeAgentPromptText(content: string): string {
     .replace(THREAD_COMMENT_ATTRIBUTION_PATTERN, "")
     .replace(LEADING_AGENT_MENTION_PATTERN, "")
     .trim();
+}
+
+function isThreadCommentPrompt(content: string): boolean {
+  return THREAD_COMMENT_ATTRIBUTION_PATTERN.test(content.trim());
 }
 
 export function deriveThreadAgentStatus({

--- a/packages/core/src/canvas/threadTimeline.ts
+++ b/packages/core/src/canvas/threadTimeline.ts
@@ -73,7 +73,7 @@ export function buildThreadTimeline<T>({
   ].sort((left, right) => left.timestamp - right.timestamp);
 }
 
-export type ThreadAgentPhase = "active" | "needs_input" | "complete" | "error";
+export type ThreadAgentPhase = "active" | "needs_input" | "error";
 
 export interface ThreadAgentStatus {
   phase: ThreadAgentPhase;
@@ -109,7 +109,6 @@ export function deriveThreadAgentStatus({
   pendingPermissionCount = 0,
   isPromptPending = false,
   isInitializing = false,
-  hasPullRequest = false,
 }: {
   hasActivity?: boolean;
   hasError?: boolean;
@@ -118,7 +117,6 @@ export function deriveThreadAgentStatus({
   pendingPermissionCount?: number;
   isPromptPending?: boolean;
   isInitializing?: boolean;
-  hasPullRequest?: boolean;
 }): ThreadAgentStatus | null {
   if (!hasActivity) return null;
   if (hasError || cloudStatus === "failed") {
@@ -130,10 +128,7 @@ export function deriveThreadAgentStatus({
   if (isPromptPending || isInitializing) {
     return { phase: "active", label: "Working…" };
   }
-  return {
-    phase: "complete",
-    label: hasPullRequest ? "Shipped" : "Done",
-  };
+  return null;
 }
 
 export function shouldSuspendThreadSession({

--- a/packages/core/src/canvas/threadTimeline.ts
+++ b/packages/core/src/canvas/threadTimeline.ts
@@ -69,9 +69,20 @@ export interface ThreadAgentStatus {
 }
 
 const AGENT_MENTION_PATTERN = /(^|\s)@agent\b/i;
+const THREAD_COMMENT_ATTRIBUTION_PATTERN =
+  /^\[Thread comment from [^\]\r\n]+\]\s*/i;
+const LEADING_AGENT_MENTION_PATTERN = /^@agent\b[\s:]*/i;
 
 export function hasAgentMention(content: string): boolean {
   return AGENT_MENTION_PATTERN.test(content);
+}
+
+export function normalizeAgentPromptText(content: string): string {
+  return content
+    .trim()
+    .replace(THREAD_COMMENT_ATTRIBUTION_PATTERN, "")
+    .replace(LEADING_AGENT_MENTION_PATTERN, "")
+    .trim();
 }
 
 export function deriveThreadAgentStatus({

--- a/packages/core/src/canvas/threadTimeline.ts
+++ b/packages/core/src/canvas/threadTimeline.ts
@@ -99,7 +99,7 @@ export function deriveThreadAgentStatus({
   }
   return {
     phase: "complete",
-    label: hasPullRequest ? "Shipped" : "Ready to ship",
+    label: hasPullRequest ? "Shipped" : "Done",
   };
 }
 

--- a/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -104,7 +104,7 @@ function ActivityRow({
           <MentionText
             content={item.content}
             currentUserEmail={currentUserEmail}
-            className="mt-1 block whitespace-pre-wrap break-words"
+            className="mt-1 block whitespace-pre-wrap break-words text-xs"
           />
         </span>
       </button>

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -44,15 +44,19 @@ import { mentionChipClass } from "@posthog/ui/features/canvas/components/Mention
 import type { ChannelFeedSystemMessage } from "@posthog/ui/features/canvas/hooks/useChannelFeedMessages";
 import { useChannelTaskData } from "@posthog/ui/features/canvas/hooks/useChannelTaskData";
 import { useTaskThread } from "@posthog/ui/features/canvas/hooks/useTaskThread";
+import { shouldOpenTaskCardInline } from "@posthog/ui/features/canvas/taskCardNavigation";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { useSessionSelector } from "@posthog/ui/features/sessions/useSession";
 import {
   type SidebarPrState,
   useTaskPrStatus,
 } from "@posthog/ui/features/sidebar/useTaskPrStatus";
 import { useInView } from "@posthog/ui/primitives/hooks/useInView";
 import { Text } from "@radix-ui/themes";
+import { Link } from "@tanstack/react-router";
 import {
   Fragment,
+  type MouseEvent,
   memo,
   type ReactNode,
   useEffect,
@@ -159,6 +163,14 @@ interface TaskStatusDisplay {
 // deliberate end state we should not soften with a PR.
 function useTaskStatusDisplay(task: Task): TaskStatusDisplay {
   const data = useChannelTaskData(task);
+  const agentSettledAfterRun = useSessionSelector(
+    task.id,
+    (session) =>
+      !!session &&
+      (session.events?.length ?? 0) > 0 &&
+      !session.isPromptPending &&
+      (session.pendingPermissions?.size ?? 0) === 0,
+  );
   const { prState } = useTaskPrStatus({
     id: task.id,
     cloudPrUrl: data?.cloudPrUrl ?? null,
@@ -198,7 +210,9 @@ function useTaskStatusDisplay(task: Task): TaskStatusDisplay {
   } else if (!status) {
     base = <Badge>Draft</Badge>;
   } else if (environment === "cloud" || isTerminalStatus(status)) {
-    base = statusBadge(status);
+    const effectiveStatus =
+      agentSettledAfterRun && !isTerminalStatus(status) ? "completed" : status;
+    base = statusBadge(effectiveStatus);
   } else {
     // Local, non-terminal: the run status is unreliable (the backend row stays
     // "queued" while the agent runs on the creator's machine), so we render no
@@ -258,61 +272,84 @@ const NO_PENDING: PendingKickoff[] = [];
 
 // The task the message kicked off, as a card everyone in the channel sees:
 // bold title + status up top, then run metadata.
-function TaskCard({ task, onOpen }: { task: Task; onOpen: () => void }) {
+export function TaskCard({
+  task,
+  channelId,
+  onOpen,
+  inThread = false,
+}: {
+  task: Task;
+  channelId: string;
+  onOpen?: () => void;
+  inThread?: boolean;
+}) {
   const statusDisplay = useTaskStatusDisplay(task);
   const prUrl =
     typeof task.latest_run?.output?.pr_url === "string"
       ? task.latest_run.output.pr_url
       : undefined;
   const stage = task.latest_run?.stage;
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!onOpen || !shouldOpenTaskCardInline(event)) return;
+    event.preventDefault();
+    onOpen();
+  };
 
   return (
-    <Card
-      size="sm"
+    <Link
+      to="/website/$channelId/tasks/$taskId"
+      params={{ channelId, taskId: task.id }}
+      preload="intent"
+      onClick={handleClick}
       className={cn(
-        "mt-1.5 w-full cursor-pointer rounded-sm py-0 transition-none hover:bg-fill-hover",
-        statusDisplay.isMerged
-          ? "border-transparent bg-(--purple-a2) shadow-[0_0_0_1px_var(--purple-8)] hover:bg-(--purple-a3) dark:bg-(--purple-a1) dark:hover:bg-(--purple-a2)"
-          : "hover:border-border-primary",
+        "mt-1.5 block w-full text-inherit no-underline outline-none focus-visible:ring-(--accent-8) focus-visible:ring-2",
+        inThread ? "rounded-none" : "rounded-sm",
       )}
-      onClick={onOpen}
     >
-      <CardContent className="flex flex-col gap-1 py-2.5">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex min-w-0 items-center gap-1.5">
-            {/* Same live status icon as the code side nav, so the card and the
-                nav never disagree (generating spinner, needs-permission, cloud
-                status colors, PR state). */}
-            <TaskTabIcon task={task} size={14} />
-            <span className="line-clamp-2 font-medium text-sm">
-              {task.title || "Untitled task"}
-            </span>
-          </div>
-          <TaskStatusBadge display={statusDisplay} />
-        </div>
-        {(stage || task.repository || prUrl) && (
-          <div className="flex min-w-0 items-center gap-3">
-            {task.repository && (
-              <span className="inline-flex items-center gap-1 text-muted-foreground text-xs">
-                <GitBranchIcon size={12} />
-                {task.repository}
-              </span>
-            )}
-            {stage && (
-              <Text size="1" className="truncate text-muted-foreground">
-                {stage}
-              </Text>
-            )}
-            {prUrl && (
-              <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground text-xs">
-                <ArrowSquareOutIcon size={12} />
-                PR
-              </span>
-            )}
-          </div>
+      <Card
+        size="sm"
+        className={cn(
+          "w-full cursor-pointer py-0 transition-none hover:bg-fill-hover",
+          statusDisplay.isMerged
+            ? "border-transparent bg-(--purple-a2) shadow-[0_0_0_1px_var(--purple-8)] hover:bg-(--purple-a3) dark:bg-(--purple-a1) dark:hover:bg-(--purple-a2)"
+            : "hover:border-border-primary",
+          inThread ? "rounded-none" : "rounded-sm",
         )}
-      </CardContent>
-    </Card>
+      >
+        <CardContent className="flex flex-col gap-1 py-2.5">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <TaskTabIcon task={task} size={14} />
+              <span className="line-clamp-2 font-medium text-sm">
+                {task.title || "Untitled task"}
+              </span>
+            </div>
+            <TaskStatusBadge display={statusDisplay} />
+          </div>
+          {(stage || task.repository || prUrl) && (
+            <div className="flex min-w-0 items-center gap-3">
+              {task.repository && (
+                <span className="inline-flex items-center gap-1 text-muted-foreground text-xs">
+                  <GitBranchIcon size={12} />
+                  {task.repository}
+                </span>
+              )}
+              {stage && (
+                <Text size="1" className="truncate text-muted-foreground">
+                  {stage}
+                </Text>
+              )}
+              {prUrl && (
+                <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground text-xs">
+                  <ArrowSquareOutIcon size={12} />
+                  PR
+                </span>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
   );
 }
 
@@ -388,11 +425,13 @@ function ReplyFooter({
 
 const FeedItem = memo(function FeedItem({
   task,
+  channelId,
   inView,
   onOpenTask,
   onOpenThread,
 }: {
   task: Task;
+  channelId: string;
   inView: boolean;
   onOpenTask: (task: Task) => void;
   onOpenThread: (task: Task) => void;
@@ -435,7 +474,11 @@ const FeedItem = memo(function FeedItem({
           )}
         </ThreadItemBody>
 
-        <TaskCard task={task} onOpen={() => onOpenTask(task)} />
+        <TaskCard
+          task={task}
+          channelId={channelId}
+          onOpen={() => onOpenThread(task)}
+        />
         <ReplyFooter
           taskId={task.id}
           inView={inView}
@@ -462,10 +505,12 @@ const FeedItem = memo(function FeedItem({
 // near the viewport, letting `FeedItem` shed off-screen polling.
 function FeedRow({
   task,
+  channelId,
   onOpenTask,
   onOpenThread,
 }: {
   task: Task;
+  channelId: string;
   onOpenTask: (task: Task) => void;
   onOpenThread: (task: Task) => void;
 }) {
@@ -483,6 +528,7 @@ function FeedRow({
     >
       <FeedItem
         task={task}
+        channelId={channelId}
         inView={inView}
         onOpenTask={onOpenTask}
         onOpenThread={onOpenThread}
@@ -610,6 +656,7 @@ type FeedEntry =
 // team-visible and polls for teammates' cards and status flips. Synthetic
 // "PostHog agent" system rows (context lifecycle) are interleaved by timestamp.
 export function ChannelFeedView({
+  channelId,
   tasks,
   pending = NO_PENDING,
   systemMessages,
@@ -619,6 +666,7 @@ export function ChannelFeedView({
   onOpenTask,
   onOpenThread,
 }: {
+  channelId: string;
   tasks: Task[];
   pending?: PendingKickoff[];
   systemMessages?: ChannelFeedSystemMessage[];
@@ -701,6 +749,7 @@ export function ChannelFeedView({
                   {entry.kind === "task" ? (
                     <FeedRow
                       task={entry.task}
+                      channelId={channelId}
                       onOpenTask={onOpenTask}
                       onOpenThread={onOpenThread}
                     />

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -396,9 +396,7 @@ function ReplyFooter({
             </AvatarFallback>
           </Avatar>
         </AvatarGroup>
-        <ThreadItemRepliesLabel className="text-(--muted-foreground)">
-          Reply
-        </ThreadItemRepliesLabel>
+        <ThreadItemRepliesLabel>Reply</ThreadItemRepliesLabel>
       </ThreadItemReplies>
     );
   }

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -4,6 +4,7 @@ import {
   GitBranchIcon,
   RobotIcon,
 } from "@phosphor-icons/react";
+import { taskFeedRunStatus } from "@posthog/core/canvas/channelFeed";
 import {
   Avatar,
   AvatarFallback,
@@ -37,7 +38,6 @@ import {
 } from "@posthog/quill";
 import { formatRelativeTimeShort, getLocalDayDiff } from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
-import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { getUserInitials } from "@posthog/ui/features/auth/userInitials";
 import { TaskTabIcon } from "@posthog/ui/features/browser-tabs/TaskTabIcon";
 import { mentionChipClass } from "@posthog/ui/features/canvas/components/MentionText";
@@ -46,7 +46,6 @@ import { useChannelTaskData } from "@posthog/ui/features/canvas/hooks/useChannel
 import { useTaskThread } from "@posthog/ui/features/canvas/hooks/useTaskThread";
 import { shouldOpenTaskCardInline } from "@posthog/ui/features/canvas/taskCardNavigation";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
-import { useSessionSelector } from "@posthog/ui/features/sessions/useSession";
 import {
   type SidebarPrState,
   useTaskPrStatus,
@@ -163,14 +162,6 @@ interface TaskStatusDisplay {
 // deliberate end state we should not soften with a PR.
 function useTaskStatusDisplay(task: Task): TaskStatusDisplay {
   const data = useChannelTaskData(task);
-  const agentSettledAfterRun = useSessionSelector(
-    task.id,
-    (session) =>
-      !!session &&
-      (session.events?.length ?? 0) > 0 &&
-      !session.isPromptPending &&
-      (session.pendingPermissions?.size ?? 0) === 0,
-  );
   const { prState } = useTaskPrStatus({
     id: task.id,
     cloudPrUrl: data?.cloudPrUrl ?? null,
@@ -178,6 +169,7 @@ function useTaskStatusDisplay(task: Task): TaskStatusDisplay {
   });
   const status = data?.taskRunStatus ?? task.latest_run?.status;
   const environment = data?.taskRunEnvironment ?? task.latest_run?.environment;
+  const displayStatus = taskFeedRunStatus({ status, environment });
   // `prState` is resolved async from git/`gh` and is routinely null for cloud
   // tasks (the details fetch hasn't landed, or there's no cached row). But the
   // PR URL itself is a hard signal a PR exists — the card's "PR" link keys off
@@ -209,10 +201,8 @@ function useTaskStatusDisplay(task: Task): TaskStatusDisplay {
     base = null;
   } else if (!status) {
     base = <Badge>Draft</Badge>;
-  } else if (environment === "cloud" || isTerminalStatus(status)) {
-    const effectiveStatus =
-      agentSettledAfterRun && !isTerminalStatus(status) ? "completed" : status;
-    base = statusBadge(effectiveStatus);
+  } else if (displayStatus) {
+    base = statusBadge(displayStatus);
   } else {
     // Local, non-terminal: the run status is unreliable (the backend row stays
     // "queued" while the agent runs on the creator's machine), so we render no

--- a/packages/ui/src/features/canvas/components/MentionComposer.tsx
+++ b/packages/ui/src/features/canvas/components/MentionComposer.tsx
@@ -9,7 +9,6 @@ import {
   filterComposerMentionCandidates,
 } from "@posthog/ui/features/canvas/utils/mentionComposer";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
-import { Text } from "@radix-ui/themes";
 import Mention, { type MentionNodeAttrs } from "@tiptap/extension-mention";
 import Placeholder from "@tiptap/extension-placeholder";
 import { EditorContent, useEditor } from "@tiptap/react";
@@ -274,19 +273,16 @@ export function MentionComposer({
                     )}
                   </AvatarFallback>
                 </Avatar>
-                <Text size="1" weight="medium" className="truncate">
+                <span className="truncate font-medium text-xs">
                   {candidate.kind === "agent"
                     ? "Agent"
                     : userDisplayName(candidate.member)}
-                </Text>
-                <Text
-                  size="1"
-                  className="ml-auto shrink-0 truncate text-muted-foreground"
-                >
+                </span>
+                <span className="ml-auto shrink-0 truncate text-muted-foreground text-xs">
                   {candidate.kind === "agent"
                     ? "Send to agent"
                     : candidate.member.email}
-                </Text>
+                </span>
               </button>
             ))}
           </div>

--- a/packages/ui/src/features/canvas/components/MentionComposer.tsx
+++ b/packages/ui/src/features/canvas/components/MentionComposer.tsx
@@ -13,6 +13,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { type ReactNode, useEffect, useRef, useState } from "react";
+import "./mention-chip.css";
 import "./mention-composer.css";
 
 interface MentionComposerProps {
@@ -31,7 +32,7 @@ interface MentionComposerProps {
 }
 
 /** Styled like the chips MentionText renders on sent messages. */
-const MENTION_CHIP_CLASS = "rounded px-0.5 font-medium text-[var(--accent-11)]";
+const MENTION_CHIP_CLASS = "mention-chip";
 
 // Padding lives on the editable element (not the input-group control) so a
 // click anywhere in the box focuses the editor.

--- a/packages/ui/src/features/canvas/components/MentionComposer.tsx
+++ b/packages/ui/src/features/canvas/components/MentionComposer.tsx
@@ -1,10 +1,12 @@
+import { RobotIcon } from "@phosphor-icons/react";
 import { Avatar, AvatarFallback, InputGroup } from "@posthog/quill";
 import type { UserBasic } from "@posthog/shared/domain-types";
 import { getUserInitials } from "@posthog/ui/features/auth/userInitials";
 import {
+  type ComposerMentionCandidate,
   contentToDoc,
   docToContent,
-  filterMentionCandidates,
+  filterComposerMentionCandidates,
 } from "@posthog/ui/features/canvas/utils/mentionComposer";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import { Text } from "@radix-ui/themes";
@@ -23,6 +25,7 @@ interface MentionComposerProps {
   onSubmit: () => void;
   /** The taggable pool; typically the org's members. */
   members: UserBasic[];
+  allowAgentMention?: boolean;
   onMentionInsert?: (member: UserBasic) => void;
   placeholder?: string;
   rows?: number;
@@ -40,8 +43,8 @@ const EDITOR_CLASS =
   "w-full px-2.5 py-2 outline-none break-words [overflow-wrap:break-word] [white-space:pre-wrap] [word-break:break-word]";
 
 interface SuggestionSession {
-  items: UserBasic[];
-  command: (member: UserBasic) => void;
+  items: ComposerMentionCandidate[];
+  command: (candidate: ComposerMentionCandidate) => void;
 }
 
 /**
@@ -55,6 +58,7 @@ export function MentionComposer({
   onValueChange,
   onSubmit,
   members,
+  allowAgentMention = false,
   onMentionInsert,
   placeholder,
   rows,
@@ -78,6 +82,8 @@ export function MentionComposer({
   // latest props and popup state.
   const membersRef = useRef(members);
   membersRef.current = members;
+  const allowAgentMentionRef = useRef(allowAgentMention);
+  allowAgentMentionRef.current = allowAgentMention;
   const onValueChangeRef = useRef(onValueChange);
   onValueChangeRef.current = onValueChange;
   const onSubmitRef = useRef(onSubmit);
@@ -121,11 +127,21 @@ export function MentionComposer({
             char: "@",
             allowSpaces: true,
             items: ({ query }) =>
-              filterMentionCandidates(membersRef.current, query),
-            // The suggestion pipeline carries whole members, not node attrs,
-            // so member data survives into `command`.
+              filterComposerMentionCandidates(
+                membersRef.current,
+                query,
+                allowAgentMentionRef.current,
+              ),
             command: ({ editor: e, range, props }) => {
-              const member = props as unknown as UserBasic;
+              const candidate = props as unknown as ComposerMentionCandidate;
+              if (candidate.kind === "agent") {
+                e.chain()
+                  .focus()
+                  .insertContentAt(range, { type: "text", text: "@agent " })
+                  .run();
+                return;
+              }
+              const { member } = candidate;
               e.chain()
                 .focus()
                 .insertContentAt(range, [
@@ -143,17 +159,17 @@ export function MentionComposer({
                 setDismissed(false);
                 setSelectedIndex(0);
                 setSession({
-                  items: props.items as unknown as UserBasic[],
-                  command: (member) =>
-                    props.command(member as unknown as MentionNodeAttrs),
+                  items: props.items as unknown as ComposerMentionCandidate[],
+                  command: (candidate) =>
+                    props.command(candidate as unknown as MentionNodeAttrs),
                 });
               },
               onUpdate: (props) => {
                 setSelectedIndex(0);
                 setSession({
-                  items: props.items as unknown as UserBasic[],
-                  command: (member) =>
-                    props.command(member as unknown as MentionNodeAttrs),
+                  items: props.items as unknown as ComposerMentionCandidate[],
+                  command: (candidate) =>
+                    props.command(candidate as unknown as MentionNodeAttrs),
                 });
               },
               onKeyDown: ({ event }) => {
@@ -172,8 +188,8 @@ export function MentionComposer({
                   return true;
                 }
                 if (event.key === "Enter" || event.key === "Tab") {
-                  const member = items[highlightedRef.current];
-                  if (member) sessionRef.current?.command(member);
+                  const candidate = items[highlightedRef.current];
+                  if (candidate) sessionRef.current?.command(candidate);
                   return true;
                 }
                 return false;
@@ -227,37 +243,49 @@ export function MentionComposer({
         <div className="absolute inset-x-0 bottom-full z-50 mb-1 flex flex-col overflow-hidden rounded-md border border-[var(--gray-a6)] bg-[var(--color-panel-solid)] text-[13px] shadow-lg">
           <div
             role="listbox"
-            aria-label="Mention a teammate"
+            aria-label="Mention a teammate or agent"
             className="max-h-56 overflow-y-auto py-1"
           >
-            {session.items.map((member, index) => (
+            {session.items.map((candidate, index) => (
               <button
                 type="button"
                 role="option"
                 aria-selected={index === highlightedIndex}
-                key={member.uuid}
+                key={
+                  candidate.kind === "agent" ? "agent" : candidate.member.uuid
+                }
                 ref={(el) => {
                   itemRefs.current[index] = el;
                 }}
                 // Keep focus in the editor so insertion lands at the caret.
                 onMouseDown={(event) => event.preventDefault()}
-                onClick={() => session.command(member)}
+                onClick={() => session.command(candidate)}
                 onMouseEnter={() => setSelectedIndex(index)}
                 className={`flex w-full items-center gap-2 border-none px-2 py-1 text-left ${
                   index === highlightedIndex ? "bg-[var(--accent-a4)]" : ""
                 }`}
               >
                 <Avatar size="xs" className="shrink-0">
-                  <AvatarFallback>{getUserInitials(member)}</AvatarFallback>
+                  <AvatarFallback>
+                    {candidate.kind === "agent" ? (
+                      <RobotIcon size={12} />
+                    ) : (
+                      getUserInitials(candidate.member)
+                    )}
+                  </AvatarFallback>
                 </Avatar>
                 <Text size="1" weight="medium" className="truncate">
-                  {userDisplayName(member)}
+                  {candidate.kind === "agent"
+                    ? "Agent"
+                    : userDisplayName(candidate.member)}
                 </Text>
                 <Text
                   size="1"
                   className="ml-auto shrink-0 truncate text-muted-foreground"
                 >
-                  {member.email}
+                  {candidate.kind === "agent"
+                    ? "Send to agent"
+                    : candidate.member.email}
                 </Text>
               </button>
             ))}

--- a/packages/ui/src/features/canvas/components/MentionText.test.tsx
+++ b/packages/ui/src/features/canvas/components/MentionText.test.tsx
@@ -18,4 +18,22 @@ describe("MentionText", () => {
       "mention-chip--self",
     );
   });
+
+  it("highlights a literal agent mention", () => {
+    render(<MentionText content="@agent investigate this" />);
+
+    expect(screen.getByText("@agent")).toHaveClass("mention-chip");
+  });
+
+  it("does not highlight agent text inside another token", () => {
+    render(<MentionText content="person@agent.com" />);
+
+    expect(screen.queryByText("@agent")).not.toBeInTheDocument();
+  });
+
+  it("inherits the surrounding message text size", () => {
+    render(<MentionText content="A thread reply" />);
+
+    expect(screen.getByText("A thread reply")).not.toHaveClass("text-xs");
+  });
 });

--- a/packages/ui/src/features/canvas/components/MentionText.test.tsx
+++ b/packages/ui/src/features/canvas/components/MentionText.test.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@radix-ui/themes";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { MentionText } from "./MentionText";
@@ -6,12 +5,10 @@ import { MentionText } from "./MentionText";
 describe("MentionText", () => {
   it("uses the shared mention styles and emphasizes the current user", () => {
     render(
-      <Theme>
-        <MentionText
-          content="@[Alice](alice@example.com) and @[Bob](bob@example.com)"
-          currentUserEmail="bob@example.com"
-        />
-      </Theme>,
+      <MentionText
+        content="@[Alice](alice@example.com) and @[Bob](bob@example.com)"
+        currentUserEmail="bob@example.com"
+      />,
     );
 
     expect(screen.getByText("@Alice")).toHaveClass("mention-chip");

--- a/packages/ui/src/features/canvas/components/MentionText.test.tsx
+++ b/packages/ui/src/features/canvas/components/MentionText.test.tsx
@@ -1,0 +1,24 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MentionText } from "./MentionText";
+
+describe("MentionText", () => {
+  it("uses the shared mention styles and emphasizes the current user", () => {
+    render(
+      <Theme>
+        <MentionText
+          content="@[Alice](alice@example.com) and @[Bob](bob@example.com)"
+          currentUserEmail="bob@example.com"
+        />
+      </Theme>,
+    );
+
+    expect(screen.getByText("@Alice")).toHaveClass("mention-chip");
+    expect(screen.getByText("@Alice")).not.toHaveClass("mention-chip--self");
+    expect(screen.getByText("@Bob")).toHaveClass(
+      "mention-chip",
+      "mention-chip--self",
+    );
+  });
+});

--- a/packages/ui/src/features/canvas/components/MentionText.tsx
+++ b/packages/ui/src/features/canvas/components/MentionText.tsx
@@ -2,6 +2,7 @@ import { splitMentionSegments } from "@posthog/shared";
 import { splitLinkSegments } from "@posthog/ui/features/canvas/utils/linkify";
 import { Text } from "@radix-ui/themes";
 import { Fragment, useMemo } from "react";
+import "./mention-chip.css";
 
 type RenderSegment =
   | { type: "text"; text: string }
@@ -11,8 +12,7 @@ type RenderSegment =
 // The plain (not-the-viewer) mention chip look, also used by surfaces that
 // render a mention-styled name without real mention semantics (e.g. the
 // channel feed's "started a new task" row).
-export const mentionChipClass =
-  "rounded px-0.5 font-medium text-[var(--accent-11)]";
+export const mentionChipClass = "mention-chip";
 
 /**
  * Thread message content with inline mention tokens rendered as highlighted
@@ -60,7 +60,7 @@ export function MentionText({
               key={key}
               className={
                 selfEmail && segment.email.toLowerCase() === selfEmail
-                  ? "rounded bg-[var(--accent-a4)] px-0.5 font-medium text-[var(--accent-12)]"
+                  ? `${mentionChipClass} mention-chip--self`
                   : mentionChipClass
               }
               title={segment.email}

--- a/packages/ui/src/features/canvas/components/MentionText.tsx
+++ b/packages/ui/src/features/canvas/components/MentionText.tsx
@@ -6,6 +6,7 @@ import "./mention-chip.css";
 type RenderSegment =
   | { type: "text"; text: string }
   | { type: "link"; text: string; href: string }
+  | { type: "agent"; text: string }
   | { type: "mention"; name: string; email: string };
 
 // The plain (not-the-viewer) mention chip look, also used by surfaces that
@@ -35,6 +36,22 @@ export function MentionText({
       entries.push({ segment, key: `${offset}` });
       offset += length;
     };
+    const pushText = (text: string) => {
+      let cursor = 0;
+      for (const match of text.matchAll(/(^|\s)(@agent)\b/gi)) {
+        const mentionStart = (match.index ?? 0) + match[1].length;
+        for (const part of splitLinkSegments(
+          text.slice(cursor, mentionStart),
+        )) {
+          push(part, part.text.length);
+        }
+        push({ type: "agent", text: match[2] }, match[2].length);
+        cursor = mentionStart + match[2].length;
+      }
+      for (const part of splitLinkSegments(text.slice(cursor))) {
+        push(part, part.text.length);
+      }
+    };
     for (const segment of splitMentionSegments(content)) {
       if (segment.type === "mention") {
         push(
@@ -42,17 +59,22 @@ export function MentionText({
           segment.text.length,
         );
       } else {
-        for (const part of splitLinkSegments(segment.text)) {
-          push(part, part.text.length);
-        }
+        pushText(segment.text);
       }
     }
     return entries;
   }, [content]);
   const selfEmail = currentUserEmail?.toLowerCase();
   return (
-    <span className={`text-xs ${className ?? ""}`}>
+    <span className={className}>
       {segments.map(({ segment, key }) => {
+        if (segment.type === "agent") {
+          return (
+            <span key={key} className={mentionChipClass}>
+              {segment.text}
+            </span>
+          );
+        }
         if (segment.type === "mention") {
           return (
             <span

--- a/packages/ui/src/features/canvas/components/MentionText.tsx
+++ b/packages/ui/src/features/canvas/components/MentionText.tsx
@@ -1,6 +1,5 @@
 import { splitMentionSegments } from "@posthog/shared";
 import { splitLinkSegments } from "@posthog/ui/features/canvas/utils/linkify";
-import { Text } from "@radix-ui/themes";
 import { Fragment, useMemo } from "react";
 import "./mention-chip.css";
 
@@ -52,7 +51,7 @@ export function MentionText({
   }, [content]);
   const selfEmail = currentUserEmail?.toLowerCase();
   return (
-    <Text size="1" className={className}>
+    <span className={`text-xs ${className ?? ""}`}>
       {segments.map(({ segment, key }) => {
         if (segment.type === "mention") {
           return (
@@ -84,6 +83,6 @@ export function MentionText({
         }
         return <Fragment key={key}>{segment.text}</Fragment>;
       })}
-    </Text>
+    </span>
   );
 }

--- a/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AgentTurnRow } from "./ThreadPanel";
+
+describe("AgentTurnRow", () => {
+  it.each([
+    { phase: "active" as const, label: "Working…" },
+    { phase: "complete" as const, label: "Done" },
+  ])("renders $label in the message area", (statusValue) => {
+    render(<AgentTurnRow status={statusValue} streaming={false} />);
+
+    const author = screen.getByText("Agent");
+    const status = screen.getByText(statusValue.label);
+
+    expect(author.parentElement).not.toContainElement(status);
+    expect(author.closest("article")).toContainElement(status);
+    expect(status.closest('[data-slot="thread-item-body"]')).not.toBeNull();
+  });
+});

--- a/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { AgentTurnRow } from "./ThreadPanel";
+import { AgentTurnRow, UserPromptRow } from "./ThreadPanel";
 
 describe("AgentTurnRow", () => {
   it.each([
@@ -15,5 +15,19 @@ describe("AgentTurnRow", () => {
     expect(author.parentElement).not.toContainElement(status);
     expect(author.closest("article")).toContainElement(status);
     expect(status.closest('[data-slot="thread-item-body"]')).not.toBeNull();
+  });
+});
+
+describe("UserPromptRow", () => {
+  it("prefixes direct task prompts with @agent", () => {
+    render(
+      <UserPromptRow
+        message={{ id: "prompt", text: "Investigate this", timestamp: 1 }}
+        author={{ id: 1, uuid: "user", email: "user@example.com" }}
+      />,
+    );
+
+    expect(screen.getByText("@agent")).toBeInTheDocument();
+    expect(screen.getByText("Investigate this")).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
@@ -1,6 +1,37 @@
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { AgentStatusLine, UserPromptRow } from "./ThreadPanel";
+import { agentTurns } from "./threadAgentTurns";
+
+describe("agentTurns", () => {
+  it("accumulates every text chunk in one agent turn", () => {
+    const items = [
+      {
+        type: "session_update",
+        id: "first",
+        timestamp: 10,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Hello" },
+        },
+      },
+      {
+        type: "session_update",
+        id: "second",
+        timestamp: 20,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: " there" },
+        },
+      },
+    ] as ConversationItem[];
+
+    expect(agentTurns(items)).toEqual([
+      { id: "first", text: "Hello there", timestamp: 10 },
+    ]);
+  });
+});
 
 describe("AgentStatusLine", () => {
   it("renders working status outside the conversation timeline", () => {

--- a/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
@@ -1,20 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { AgentTurnRow, UserPromptRow } from "./ThreadPanel";
+import { AgentStatusLine, UserPromptRow } from "./ThreadPanel";
 
-describe("AgentTurnRow", () => {
-  it.each([
-    { phase: "active" as const, label: "Working…" },
-    { phase: "complete" as const, label: "Done" },
-  ])("renders $label in the message area", (statusValue) => {
-    render(<AgentTurnRow status={statusValue} streaming={false} />);
+describe("AgentStatusLine", () => {
+  it("renders working status outside the conversation timeline", () => {
+    render(<AgentStatusLine status={{ phase: "active", label: "Working…" }} />);
 
-    const author = screen.getByText("Agent");
-    const status = screen.getByText(statusValue.label);
+    const status = screen.getByText("Working…");
 
-    expect(author.parentElement).not.toContainElement(status);
-    expect(author.closest("article")).toContainElement(status);
-    expect(status.closest('[data-slot="thread-item-body"]')).not.toBeNull();
+    expect(status.closest("article")).toBeNull();
+    expect(status.closest('[data-slot="thread-item-body"]')).toBeNull();
+    expect(status.closest("output")).not.toBeNull();
   });
 });
 

--- a/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.test.tsx
@@ -30,4 +30,21 @@ describe("UserPromptRow", () => {
     expect(screen.getByText("@agent")).toBeInTheDocument();
     expect(screen.getByText("Investigate this")).toBeInTheDocument();
   });
+
+  it("hides forwarded thread attribution and duplicate agent mentions", () => {
+    render(
+      <UserPromptRow
+        message={{
+          id: "prompt",
+          text: "[Thread comment from Peter Kirkham] @agent which model are you?",
+          timestamp: 1,
+        }}
+        author={{ id: 1, uuid: "user", email: "user@example.com" }}
+      />,
+    );
+
+    expect(screen.getAllByText("@agent")).toHaveLength(1);
+    expect(screen.getByText("which model are you?")).toBeInTheDocument();
+    expect(screen.queryByText(/Thread comment from/)).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -11,6 +11,7 @@ import {
   buildThreadTimeline,
   deriveThreadAgentStatus,
   hasAgentMention,
+  normalizeAgentPromptText,
   shouldSuspendThreadSession,
   type ThreadAgentMessage,
   type ThreadAgentStatus,
@@ -271,6 +272,8 @@ export function UserPromptRow({
   message: ThreadAgentMessage;
   author: TaskThreadMessage["author"];
 }) {
+  const promptText = normalizeAgentPromptText(message.text);
+
   return (
     <ThreadItem>
       <ThreadItemGutter>
@@ -288,7 +291,7 @@ export function UserPromptRow({
           )}
         </ThreadItemHeader>
         <ThreadItemBody className="wrap-break-word whitespace-pre-wrap">
-          <span className={mentionChipClass}>@agent</span> {message.text}
+          <span className={mentionChipClass}>@agent</span> {promptText}
         </ThreadItemBody>
       </ThreadItemContent>
     </ThreadItem>

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -25,10 +25,13 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
   InputGroupAddon,
   InputGroupButton,
-  Skeleton,
-  SkeletonText,
   Spinner,
   ThreadItem,
   ThreadItemAction,
@@ -59,8 +62,11 @@ import {
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
 import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
 import {
+  useDeleteTaskThreadMessage,
+  usePostTaskThreadMessage,
+  usePostTaskThreadMessageToAgent,
+  useSendTaskThreadMessageToAgent,
   useTaskThread,
-  useTaskThreadMutations,
 } from "@posthog/ui/features/canvas/hooks/useTaskThread";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
@@ -202,10 +208,10 @@ function AgentStatusChip({ status }: { status: ThreadAgentStatus }) {
   switch (status.phase) {
     case "active":
       return (
-        <span className="flex items-center gap-1 text-muted-foreground">
+        <Badge variant="info">
           <Spinner className="size-3" />
-          <span className="text-xs">{status.label}</span>
-        </span>
+          {status.label}
+        </Badge>
       );
     case "needs_input":
       return <Badge variant="warning">{status.label}</Badge>;
@@ -298,23 +304,16 @@ export function UserPromptRow({
   );
 }
 
-function ThreadTimelineSkeleton() {
+function ThreadLoadingState() {
   return (
-    <ThreadItemGroup aria-hidden>
-      {[0, 1, 2].map((i) => (
-        <ThreadItem key={i}>
-          <ThreadItemGutter>
-            <Skeleton className="size-8 rounded-full" />
-          </ThreadItemGutter>
-          <ThreadItemContent>
-            <ThreadItemHeader>
-              <Skeleton className="h-3.5 w-24 rounded" />
-            </ThreadItemHeader>
-            <SkeletonText lines={i === 1 ? 3 : 2} />
-          </ThreadItemContent>
-        </ThreadItem>
-      ))}
-    </ThreadItemGroup>
+    <Empty className="h-full border-0">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Spinner />
+        </EmptyMedia>
+        <EmptyTitle>Loading thread</EmptyTitle>
+      </EmptyHeader>
+    </Empty>
   );
 }
 
@@ -338,14 +337,12 @@ function ThreadConversation({
   const { data: currentUser } = useCurrentUser({ client });
 
   const { messages, isLoading } = useTaskThread(taskId);
-  const {
-    postMessage,
-    postMessageToAgent,
-    deleteMessage,
-    sendToAgent,
-    isPosting,
-    isSendingToAgent,
-  } = useTaskThreadMutations(taskId);
+  const { postMessage, isPosting } = usePostTaskThreadMessage(taskId);
+  const { postMessageToAgent, isPostingToAgent } =
+    usePostTaskThreadMessageToAgent(taskId);
+  const { deleteMessage } = useDeleteTaskThreadMessage(taskId);
+  const { sendToAgent, isSending } = useSendTaskThreadMessageToAgent(taskId);
+  const isSendingToAgent = isPostingToAgent || isSending;
   const { members } = useOrgMembers();
 
   const {
@@ -549,15 +546,21 @@ function ThreadConversation({
       )}
       <div ref={scrollRef} className="flex-1 overflow-y-auto">
         {!isReady ? (
-          <ThreadTimelineSkeleton />
+          <ThreadLoadingState />
         ) : isEmpty ? (
-          <div className="px-2 py-6 text-center">
-            <p className="text-muted-foreground text-xs">
-              Discuss this task with your team. The agent's status shows up here
-              too; messages stay between humans unless the task author sends one
-              to the agent.
-            </p>
-          </div>
+          <Empty className="h-full border-0">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <RobotIcon size={18} />
+              </EmptyMedia>
+              <EmptyTitle>No messages yet</EmptyTitle>
+              <EmptyDescription>
+                Discuss this task with your team. The agent's status shows up
+                here too; messages stay between humans unless the task author
+                sends one to the agent.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
         ) : (
           <ThreadItemGroup>
             {timeline.map((row) =>
@@ -671,11 +674,7 @@ export function ThreadPanel({
   }
 
   if (!task) {
-    return (
-      <div className="flex h-full min-w-0 flex-col items-center justify-center bg-gray-1">
-        <Spinner />
-      </div>
-    );
+    return <ThreadLoadingState />;
   }
 
   return (

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -204,31 +204,27 @@ function agentPrompts(items: ConversationItem[]): ThreadAgentMessage[] {
   return prompts;
 }
 
-function AgentStatusChip({ status }: { status: ThreadAgentStatus }) {
-  switch (status.phase) {
-    case "active":
-      return (
-        <Badge variant="info">
-          <Spinner className="size-3" />
-          {status.label}
-        </Badge>
-      );
-    case "needs_input":
-      return <Badge variant="warning">{status.label}</Badge>;
-    case "error":
-      return <Badge variant="destructive">{status.label}</Badge>;
-    default:
-      return <Badge variant="success">{status.label}</Badge>;
-  }
+export function AgentStatusLine({ status }: { status: ThreadAgentStatus }) {
+  return (
+    <output
+      aria-live="polite"
+      className="flex items-center gap-1.5 px-3 py-1.5 text-muted-foreground text-xs"
+    >
+      {status.phase === "active" ? (
+        <Spinner className="size-3" />
+      ) : (
+        <RobotIcon size={12} />
+      )}
+      <span>{status.label}</span>
+    </output>
+  );
 }
 
 export function AgentTurnRow({
   message,
-  status,
   streaming,
 }: {
-  message?: ThreadAgentMessage;
-  status?: ThreadAgentStatus;
+  message: ThreadAgentMessage;
   streaming: boolean;
 }) {
   return (
@@ -243,25 +239,19 @@ export function AgentTurnRow({
       <ThreadItemContent>
         <ThreadItemHeader>
           <ThreadItemAuthor>Agent</ThreadItemAuthor>
-          {message?.timestamp !== undefined && (
+          {message.timestamp !== undefined && (
             <ThreadTimestamp
               dateTime={new Date(message.timestamp).toISOString()}
             />
           )}
         </ThreadItemHeader>
-        {(message?.text || status) && (
+        {message.text && (
           <ThreadItemBody>
             <div className="rounded-md border border-border bg-muted px-2 py-1.5">
-              {message?.text &&
-                (streaming ? (
-                  <ChatStreamingMarkdown content={message.text} />
-                ) : (
-                  <ChatMarkdown content={message.text} />
-                ))}
-              {status && (
-                <div className={message?.text ? "mt-2" : undefined}>
-                  <AgentStatusChip status={status} />
-                </div>
+              {streaming ? (
+                <ChatStreamingMarkdown content={message.text} />
+              ) : (
+                <ChatMarkdown content={message.text} />
               )}
             </div>
           </ThreadItemBody>
@@ -370,11 +360,6 @@ function ThreadConversation({
   });
   const { items } = useConversationItems(events, isPromptPending);
   const pendingPermissions = usePendingPermissionsForTask(taskId);
-  const prUrl =
-    typeof task.latest_run?.output?.pr_url === "string"
-      ? task.latest_run.output.pr_url
-      : undefined;
-
   const agentMsgs = useMemo(() => agentTurns(items), [items]);
   const promptMsgs = useMemo(() => agentPrompts(items), [items]);
 
@@ -388,7 +373,6 @@ function ThreadConversation({
         pendingPermissionCount: pendingPermissions.size,
         isPromptPending,
         isInitializing,
-        hasPullRequest: !!prUrl,
       }),
     [
       events.length,
@@ -399,7 +383,6 @@ function ThreadConversation({
       pendingPermissions.size,
       isPromptPending,
       isInitializing,
-      prUrl,
     ],
   );
 
@@ -498,7 +481,7 @@ function ThreadConversation({
     });
   };
 
-  const isEmpty = timeline.length === 0 && !agentStatus;
+  const isEmpty = timeline.length === 0;
   const isReady = !isInitializing && !isLoading;
 
   return (
@@ -595,12 +578,11 @@ function ThreadConversation({
                 />
               ),
             )}
-            {agentStatus && !(agentStatus.phase === "complete" && !!prUrl) && (
-              <AgentTurnRow status={agentStatus} streaming={false} />
-            )}
           </ThreadItemGroup>
         )}
       </div>
+
+      {agentStatus && <AgentStatusLine status={agentStatus} />}
 
       <div className="border-border border-t p-2">
         <MentionComposer

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -415,6 +415,7 @@ function ThreadConversation({
           id: message.id,
           content: message.content,
           createdAt: message.created_at,
+          forwardedToAgent: !!message.forwarded_to_agent_at,
           value: message,
         })),
       }),

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowSquareOutIcon,
   CaretRightIcon,
   DotsThreeIcon,
   PaperPlaneRightIcon,
@@ -6,6 +7,13 @@ import {
   TrashIcon,
   XIcon,
 } from "@phosphor-icons/react";
+import {
+  buildThreadTimeline,
+  deriveThreadAgentStatus,
+  shouldSuspendThreadSession,
+  type ThreadAgentMessage,
+  type ThreadAgentStatus,
+} from "@posthog/core/canvas/threadTimeline";
 import {
   Avatar,
   AvatarFallback,
@@ -17,9 +25,19 @@ import {
   DropdownMenuTrigger,
   InputGroupAddon,
   InputGroupButton,
+  Skeleton,
+  SkeletonText,
   Spinner,
+  ThreadItem,
+  ThreadItemAction,
+  ThreadItemActions,
+  ThreadItemAuthor,
+  ThreadItemBody,
+  ThreadItemContent,
+  ThreadItemGroup,
+  ThreadItemGutter,
+  ThreadItemHeader,
 } from "@posthog/quill";
-import { formatRelativeTimeShort } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type {
   Task,
@@ -30,20 +48,31 @@ import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { getUserInitials } from "@posthog/ui/features/auth/userInitials";
+import { TaskCard } from "@posthog/ui/features/canvas/components/ChannelFeedView";
 import { MentionComposer } from "@posthog/ui/features/canvas/components/MentionComposer";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
+import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
 import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
 import {
   useTaskThread,
   useTaskThreadMutations,
 } from "@posthog/ui/features/canvas/hooks/useTaskThread";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import {
+  ChatMarkdown,
+  ChatStreamingMarkdown,
+} from "@posthog/ui/features/sessions/components/chat-thread/ChatMarkdown";
+import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
+import { useConversationItems } from "@posthog/ui/features/sessions/hooks/useConversationItems";
+import { useSessionConnection } from "@posthog/ui/features/sessions/hooks/useSessionConnection";
+import { useSessionViewState } from "@posthog/ui/features/sessions/hooks/useSessionViewState";
+import { usePendingPermissionsForTask } from "@posthog/ui/features/sessions/sessionStore";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
-import { Text } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 function ThreadMessageRow({
   message,
@@ -55,7 +84,6 @@ function ThreadMessageRow({
   onDelete,
 }: {
   message: TaskThreadMessage;
-  /** Whether the current user authored the task (may forward to the agent). */
   isTaskAuthor: boolean;
   isOwnMessage: boolean;
   currentUserEmail?: string | null;
@@ -67,97 +95,237 @@ function ThreadMessageRow({
   const showMenu = (isTaskAuthor && !forwarded) || isOwnMessage;
 
   return (
-    <div className="group flex gap-2 rounded-md px-2 py-1.5 hover:bg-fill-secondary">
-      <Avatar size="xs" className="mt-0.5 shrink-0">
-        <AvatarFallback>{getUserInitials(message.author)}</AvatarFallback>
-      </Avatar>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline gap-2">
-          <Text size="1" weight="medium" className="truncate">
-            {userDisplayName(message.author)}
-          </Text>
-          <Text size="1" className="shrink-0 text-muted-foreground">
-            {formatRelativeTimeShort(message.created_at)}
-          </Text>
-        </div>
-        <MentionText
-          content={message.content}
-          currentUserEmail={currentUserEmail}
-          className="block whitespace-pre-wrap break-words"
-        />
+    <ThreadItem>
+      <ThreadItemGutter>
+        <Avatar size="lg" className="sticky top-2">
+          <AvatarFallback>{getUserInitials(message.author)}</AvatarFallback>
+        </Avatar>
+      </ThreadItemGutter>
+      <ThreadItemContent>
+        <ThreadItemHeader>
+          <ThreadItemAuthor>{userDisplayName(message.author)}</ThreadItemAuthor>
+          <ThreadTimestamp dateTime={message.created_at} />
+        </ThreadItemHeader>
+        <ThreadItemBody>
+          <MentionText
+            content={message.content}
+            currentUserEmail={currentUserEmail}
+          />
+        </ThreadItemBody>
         {forwarded && (
-          <Badge variant="info" className="mt-1">
+          <Badge variant="info" className="w-fit">
             <RobotIcon size={10} />
             Sent to agent
           </Badge>
         )}
-      </div>
+      </ThreadItemContent>
       {showMenu && (
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <Button
-                variant="default"
-                size="icon-xs"
-                aria-label="Message actions"
-                className="opacity-0 transition-opacity group-hover:opacity-100 data-popup-open:opacity-100"
-              >
-                <DotsThreeIcon size={14} />
-              </Button>
-            }
-          />
-          <DropdownMenuContent align="end">
-            {isTaskAuthor && !forwarded && (
-              <DropdownMenuItem disabled={!canForward} onClick={onSendToAgent}>
-                <PaperPlaneRightIcon size={14} />
-                Send to agent
-              </DropdownMenuItem>
-            )}
-            {isOwnMessage && (
-              <DropdownMenuItem variant="destructive" onClick={onDelete}>
-                <TrashIcon size={14} />
-                Delete message
-              </DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <ThreadItemActions>
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <ThreadItemAction label="Message actions">
+                  <DotsThreeIcon size={14} />
+                </ThreadItemAction>
+              }
+            />
+            <DropdownMenuContent align="end">
+              {isTaskAuthor && !forwarded && (
+                <DropdownMenuItem
+                  disabled={!canForward}
+                  onClick={onSendToAgent}
+                >
+                  <PaperPlaneRightIcon size={14} />
+                  Send to agent
+                </DropdownMenuItem>
+              )}
+              {isOwnMessage && (
+                <DropdownMenuItem variant="destructive" onClick={onDelete}>
+                  <TrashIcon size={14} />
+                  Delete message
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </ThreadItemActions>
       )}
-    </div>
+    </ThreadItem>
   );
 }
 
-// The right-hand thread dock: the human-only conversation around a task.
-// Nothing here reaches the agent unless the task author explicitly forwards a
-// message ("Send to agent" in the row's hover menu).
-export function ThreadPanel({
-  taskId,
-  task: taskProp,
-  onClose,
-  collapsed,
-  onToggleCollapsed,
-  showTaskTitle = true,
+function agentTurns(items: ConversationItem[]): ThreadAgentMessage[] {
+  const turns: ThreadAgentMessage[] = [];
+  let current: ThreadAgentMessage | null = null;
+  for (const item of items) {
+    if (item.type === "user_message") {
+      if (current) turns.push(current);
+      current = null;
+      continue;
+    }
+    if (
+      item.type === "session_update" &&
+      item.update.sessionUpdate === "agent_message_chunk" &&
+      "content" in item.update &&
+      item.update.content.type === "text" &&
+      item.update.content.text.trim()
+    ) {
+      current = {
+        id: item.id,
+        text: item.update.content.text,
+        timestamp: item.timestamp,
+      };
+    }
+  }
+  if (current) turns.push(current);
+  return turns;
+}
+
+function agentPrompts(items: ConversationItem[]): ThreadAgentMessage[] {
+  const prompts: ThreadAgentMessage[] = [];
+  for (const item of items) {
+    if (item.type !== "user_message") continue;
+    const text = (
+      extractChannelContext(item.content)?.stripped ?? item.content
+    ).trim();
+    if (!text) continue;
+    prompts.push({ id: item.id, text, timestamp: item.timestamp });
+  }
+  return prompts;
+}
+
+function AgentStatusChip({ status }: { status: ThreadAgentStatus }) {
+  switch (status.phase) {
+    case "active":
+      return (
+        <span className="flex items-center gap-1 text-muted-foreground">
+          <Spinner className="size-3" />
+          <span className="text-xs">{status.label}</span>
+        </span>
+      );
+    case "needs_input":
+      return <Badge variant="warning">{status.label}</Badge>;
+    case "error":
+      return <Badge variant="destructive">{status.label}</Badge>;
+    default:
+      return <Badge variant="success">{status.label}</Badge>;
+  }
+}
+
+function AgentTurnRow({
+  message,
+  status,
+  streaming,
 }: {
-  taskId: string;
-  /** The thread's task when the caller already has it; fetched otherwise. */
-  task?: Task;
-  onClose?: () => void;
-  collapsed?: boolean;
-  onToggleCollapsed?: () => void;
-  /**
-   * Show the task title under the "Thread" heading. Hidden in the task detail
-   * view, where the TaskDetail header already names the task.
-   */
-  showTaskTitle?: boolean;
+  message?: ThreadAgentMessage;
+  status?: ThreadAgentStatus;
+  streaming: boolean;
 }) {
+  return (
+    <ThreadItem>
+      <ThreadItemGutter>
+        <Avatar size="lg" className="sticky top-2">
+          <AvatarFallback>
+            <RobotIcon size={14} />
+          </AvatarFallback>
+        </Avatar>
+      </ThreadItemGutter>
+      <ThreadItemContent>
+        <ThreadItemHeader>
+          <ThreadItemAuthor>Agent</ThreadItemAuthor>
+          {status && <AgentStatusChip status={status} />}
+          {message?.timestamp !== undefined && (
+            <ThreadTimestamp
+              dateTime={new Date(message.timestamp).toISOString()}
+            />
+          )}
+        </ThreadItemHeader>
+        {message?.text && (
+          <ThreadItemBody>
+            <div className="rounded-md border border-border bg-muted px-2 py-1.5">
+              {streaming ? (
+                <ChatStreamingMarkdown content={message.text} />
+              ) : (
+                <ChatMarkdown content={message.text} />
+              )}
+            </div>
+          </ThreadItemBody>
+        )}
+      </ThreadItemContent>
+    </ThreadItem>
+  );
+}
+
+function UserPromptRow({
+  message,
+  author,
+}: {
+  message: ThreadAgentMessage;
+  author: TaskThreadMessage["author"];
+}) {
+  return (
+    <ThreadItem>
+      <ThreadItemGutter>
+        <Avatar size="lg" className="sticky top-2">
+          <AvatarFallback>{getUserInitials(author)}</AvatarFallback>
+        </Avatar>
+      </ThreadItemGutter>
+      <ThreadItemContent>
+        <ThreadItemHeader>
+          <ThreadItemAuthor>{userDisplayName(author)}</ThreadItemAuthor>
+          {message.timestamp !== undefined && (
+            <ThreadTimestamp
+              dateTime={new Date(message.timestamp).toISOString()}
+            />
+          )}
+        </ThreadItemHeader>
+        <ThreadItemBody className="wrap-break-word whitespace-pre-wrap">
+          {message.text}
+        </ThreadItemBody>
+      </ThreadItemContent>
+    </ThreadItem>
+  );
+}
+
+function ThreadTimelineSkeleton() {
+  return (
+    <ThreadItemGroup aria-hidden>
+      {[0, 1, 2].map((i) => (
+        <ThreadItem key={i}>
+          <ThreadItemGutter>
+            <Skeleton className="size-8 rounded-full" />
+          </ThreadItemGutter>
+          <ThreadItemContent>
+            <ThreadItemHeader>
+              <Skeleton className="h-3.5 w-24 rounded" />
+            </ThreadItemHeader>
+            <SkeletonText lines={i === 1 ? 3 : 2} />
+          </ThreadItemContent>
+        </ThreadItem>
+      ))}
+    </ThreadItemGroup>
+  );
+}
+
+function ThreadConversation({
+  task,
+  channelId,
+  onClose,
+  onToggleCollapsed,
+  onOpenFull,
+  showTaskSummary,
+}: {
+  task: Task;
+  channelId: string;
+  onClose?: () => void;
+  onToggleCollapsed?: () => void;
+  onOpenFull?: () => void;
+  showTaskSummary: boolean;
+}) {
+  const taskId = task.id;
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
-  const { data: fetchedTask } = useQuery({
-    ...taskDetailQuery(taskId),
-    enabled: !taskProp,
-  });
-  const task = taskProp ?? fetchedTask;
 
-  const { messages, isLoading } = useTaskThread(collapsed ? undefined : taskId);
+  const { messages, isLoading } = useTaskThread(taskId);
   const {
     postMessage,
     deleteMessage,
@@ -165,7 +333,82 @@ export function ThreadPanel({
     isPosting,
     isSendingToAgent,
   } = useTaskThreadMutations(taskId);
-  const { members } = useOrgMembers({ enabled: !collapsed });
+  const { members } = useOrgMembers();
+
+  const {
+    session,
+    repoPath,
+    isCloud,
+    events,
+    cloudStatus,
+    isPromptPending,
+    isInitializing,
+    hasError,
+    errorTitle,
+  } = useSessionViewState(taskId, task);
+  useSessionConnection({
+    taskId,
+    task,
+    session,
+    repoPath,
+    isCloud,
+    isSuspended: shouldSuspendThreadSession({
+      isCloud,
+      hasRun: Boolean(task.latest_run?.id),
+      hasSession: Boolean(session),
+    }),
+  });
+  const { items } = useConversationItems(events, isPromptPending);
+  const pendingPermissions = usePendingPermissionsForTask(taskId);
+  const prUrl =
+    typeof task.latest_run?.output?.pr_url === "string"
+      ? task.latest_run.output.pr_url
+      : undefined;
+
+  const agentMsgs = useMemo(() => agentTurns(items), [items]);
+  const promptMsgs = useMemo(() => agentPrompts(items), [items]);
+
+  const agentStatus = useMemo(
+    () =>
+      deriveThreadAgentStatus({
+        hasActivity: events.length > 0 || !!task.latest_run,
+        hasError,
+        cloudStatus,
+        errorTitle,
+        pendingPermissionCount: pendingPermissions.size,
+        isPromptPending,
+        isInitializing,
+        hasPullRequest: !!prUrl,
+      }),
+    [
+      events.length,
+      task.latest_run,
+      hasError,
+      cloudStatus,
+      errorTitle,
+      pendingPermissions.size,
+      isPromptPending,
+      isInitializing,
+      prUrl,
+    ],
+  );
+
+  const timeline = useMemo(
+    () =>
+      buildThreadTimeline({
+        prompts: promptMsgs,
+        agentMessages: agentMsgs,
+        humanMessages: messages.map((message) => ({
+          id: message.id,
+          content: message.content,
+          createdAt: message.created_at,
+          value: message,
+        })),
+      }),
+    [promptMsgs, messages, agentMsgs],
+  );
+
+  const lastAgentId = agentMsgs[agentMsgs.length - 1]?.id;
 
   const [draft, setDraft] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -182,17 +425,21 @@ export function ThreadPanel({
     [taskId],
   );
 
-  // Keep the newest message in view, Slack-style.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new messages
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new content
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
-  }, [messages.length]);
+  }, [
+    messages.length,
+    promptMsgs.length,
+    agentMsgs.length,
+    agentMsgs[agentMsgs.length - 1]?.text,
+    agentStatus?.phase,
+  ]);
 
   const isTaskAuthor =
-    !!currentUser?.uuid && currentUser.uuid === task?.created_by?.uuid;
-  // Forwarding needs a run the workflow can still signal, one send at a time.
+    !!currentUser?.uuid && currentUser.uuid === task.created_by?.uuid;
   const canForward =
-    !!task?.latest_run &&
+    !!task.latest_run &&
     !isTerminalStatus(task.latest_run.status) &&
     !isSendingToAgent;
 
@@ -224,34 +471,25 @@ export function ThreadPanel({
     });
   };
 
-  if (collapsed) {
-    return (
-      <div className="flex h-full w-9 flex-col items-center border-border border-l bg-gray-1 py-2">
-        <Button
-          variant="default"
-          size="icon-sm"
-          aria-label="Expand thread"
-          onClick={onToggleCollapsed}
-        >
-          <CaretRightIcon size={14} className="rotate-180" />
-        </Button>
-      </div>
-    );
-  }
+  const isEmpty = timeline.length === 0 && !agentStatus;
+  const isReady = !isInitializing && !isLoading;
 
   return (
     <div className="flex h-full min-w-0 flex-col bg-gray-1">
       <div className="flex items-center gap-1 border-border border-b px-3 py-2">
         <div className="min-w-0 flex-1">
-          <Text size="2" weight="medium" className="block">
-            Thread
-          </Text>
-          {showTaskTitle && task && (
-            <Text size="1" className="block truncate text-muted-foreground">
-              {task.title || "Untitled task"}
-            </Text>
-          )}
+          <span className="block font-medium text-sm">Thread</span>
         </div>
+        {onOpenFull && (
+          <Button
+            variant="default"
+            size="icon-sm"
+            aria-label="Open full task"
+            onClick={onOpenFull}
+          >
+            <ArrowSquareOutIcon size={14} />
+          </Button>
+        )}
         {onToggleCollapsed && (
           <Button
             variant="default"
@@ -274,36 +512,60 @@ export function ThreadPanel({
         )}
       </div>
 
-      <div ref={scrollRef} className="flex-1 overflow-y-auto p-2">
-        {isLoading && messages.length === 0 ? (
-          <div className="flex justify-center py-6">
-            <Spinner />
-          </div>
-        ) : messages.length === 0 ? (
+      {showTaskSummary && (
+        <div className="z-10 px-2">
+          <TaskCard task={task} channelId={channelId} inThread />
+        </div>
+      )}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto">
+        {!isReady ? (
+          <ThreadTimelineSkeleton />
+        ) : isEmpty ? (
           <div className="px-2 py-6 text-center">
-            <Text size="1" className="text-muted-foreground">
-              Discuss this task with your team. Messages stay between humans
-              unless the task author sends one to the agent.
-            </Text>
+            <p className="text-muted-foreground text-xs">
+              Discuss this task with your team. The agent's status shows up here
+              too; messages stay between humans unless the task author sends one
+              to the agent.
+            </p>
           </div>
         ) : (
-          <div className="flex flex-col gap-0.5">
-            {messages.map((message) => (
-              <ThreadMessageRow
-                key={message.id}
-                message={message}
-                isTaskAuthor={isTaskAuthor}
-                isOwnMessage={
-                  !!currentUser?.uuid &&
-                  currentUser.uuid === message.author?.uuid
-                }
-                currentUserEmail={currentUser?.email}
-                canForward={canForward}
-                onSendToAgent={() => handleSendToAgent(message.id)}
-                onDelete={() => handleDelete(message.id)}
-              />
-            ))}
-          </div>
+          <ThreadItemGroup>
+            {timeline.map((row) =>
+              row.kind === "prompt" ? (
+                <UserPromptRow
+                  key={row.message.id}
+                  message={row.message}
+                  author={task.created_by}
+                />
+              ) : row.kind === "human" ? (
+                <ThreadMessageRow
+                  key={row.message.id}
+                  message={row.message.value as TaskThreadMessage}
+                  isTaskAuthor={isTaskAuthor}
+                  isOwnMessage={
+                    !!currentUser?.uuid &&
+                    currentUser.uuid === row.message.value?.author?.uuid
+                  }
+                  currentUserEmail={currentUser?.email}
+                  canForward={canForward}
+                  onSendToAgent={() => handleSendToAgent(row.message.id)}
+                  onDelete={() => handleDelete(row.message.id)}
+                />
+              ) : (
+                <AgentTurnRow
+                  key={row.message.id}
+                  message={row.message}
+                  streaming={
+                    row.message.id === lastAgentId &&
+                    agentStatus?.phase === "active"
+                  }
+                />
+              ),
+            )}
+            {agentStatus && !(agentStatus.phase === "complete" && !!prUrl) && (
+              <AgentTurnRow status={agentStatus} streaming={false} />
+            )}
+          </ThreadItemGroup>
         )}
       </div>
 
@@ -334,5 +596,65 @@ export function ThreadPanel({
         </MentionComposer>
       </div>
     </div>
+  );
+}
+
+export function ThreadPanel({
+  taskId,
+  channelId,
+  task: taskProp,
+  onClose,
+  collapsed,
+  onToggleCollapsed,
+  onOpenFull,
+  showTaskSummary = true,
+}: {
+  taskId: string;
+  channelId: string;
+  task?: Task;
+  onClose?: () => void;
+  collapsed?: boolean;
+  onToggleCollapsed?: () => void;
+  onOpenFull?: () => void;
+  showTaskSummary?: boolean;
+}) {
+  const { data: fetchedTask } = useQuery({
+    ...taskDetailQuery(taskId),
+    enabled: !taskProp && !collapsed,
+  });
+  const task = taskProp ?? fetchedTask;
+
+  if (collapsed) {
+    return (
+      <div className="flex h-full w-9 flex-col items-center border-border border-l bg-gray-1 py-2">
+        <Button
+          variant="default"
+          size="icon-sm"
+          aria-label="Expand thread"
+          onClick={onToggleCollapsed}
+        >
+          <CaretRightIcon size={14} className="rotate-180" />
+        </Button>
+      </div>
+    );
+  }
+
+  if (!task) {
+    return (
+      <div className="flex h-full min-w-0 flex-col items-center justify-center bg-gray-1">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return (
+    <ThreadConversation
+      task={task}
+      channelId={channelId}
+      onClose={onClose}
+      onToggleCollapsed={onToggleCollapsed}
+      onOpenFull={onOpenFull}
+      showTaskSummary={showTaskSummary}
+    />
   );
 }

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -15,6 +15,7 @@ import {
   shouldSuspendThreadSession,
   type ThreadAgentMessage,
   type ThreadAgentStatus,
+  type ThreadTimelineRow,
 } from "@posthog/core/canvas/threadTimeline";
 import {
   Avatar,
@@ -60,6 +61,7 @@ import {
   mentionChipClass,
 } from "@posthog/ui/features/canvas/components/MentionText";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
+import { agentTurns } from "@posthog/ui/features/canvas/components/threadAgentTurns";
 import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
 import {
   useDeleteTaskThreadMessage,
@@ -162,33 +164,6 @@ function ThreadMessageRow({
       )}
     </ThreadItem>
   );
-}
-
-function agentTurns(items: ConversationItem[]): ThreadAgentMessage[] {
-  const turns: ThreadAgentMessage[] = [];
-  let current: ThreadAgentMessage | null = null;
-  for (const item of items) {
-    if (item.type === "user_message") {
-      if (current) turns.push(current);
-      current = null;
-      continue;
-    }
-    if (
-      item.type === "session_update" &&
-      item.update.sessionUpdate === "agent_message_chunk" &&
-      "content" in item.update &&
-      item.update.content.type === "text" &&
-      item.update.content.text.trim()
-    ) {
-      current = {
-        id: item.id,
-        text: item.update.content.text,
-        timestamp: item.timestamp,
-      };
-    }
-  }
-  if (current) turns.push(current);
-  return turns;
 }
 
 function agentPrompts(items: ConversationItem[]): ThreadAgentMessage[] {
@@ -304,6 +279,181 @@ function ThreadLoadingState() {
         <EmptyTitle>Loading thread</EmptyTitle>
       </EmptyHeader>
     </Empty>
+  );
+}
+
+function ThreadHeader({
+  onClose,
+  onToggleCollapsed,
+  onOpenFull,
+}: {
+  onClose?: () => void;
+  onToggleCollapsed?: () => void;
+  onOpenFull?: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-1 border-border border-b px-3 py-2">
+      <div className="min-w-0 flex-1">
+        <span className="block font-medium text-sm">Thread</span>
+      </div>
+      {onOpenFull && (
+        <Button
+          variant="default"
+          size="icon-sm"
+          aria-label="Open full task"
+          onClick={onOpenFull}
+        >
+          <ArrowSquareOutIcon size={14} />
+        </Button>
+      )}
+      {onToggleCollapsed && (
+        <Button
+          variant="default"
+          size="icon-sm"
+          aria-label="Collapse thread"
+          onClick={onToggleCollapsed}
+        >
+          <CaretRightIcon size={14} />
+        </Button>
+      )}
+      {onClose && (
+        <Button
+          variant="default"
+          size="icon-sm"
+          aria-label="Close thread"
+          onClick={onClose}
+        >
+          <XIcon size={14} />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function ThreadTimeline({
+  timeline,
+  isReady,
+  taskAuthor,
+  currentUserUuid,
+  currentUserEmail,
+  isTaskAuthor,
+  canForward,
+  lastAgentId,
+  agentActive,
+  onSendToAgent,
+  onDelete,
+}: {
+  timeline: ThreadTimelineRow<TaskThreadMessage>[];
+  isReady: boolean;
+  taskAuthor: UserBasic | null | undefined;
+  currentUserUuid?: string;
+  currentUserEmail?: string;
+  isTaskAuthor: boolean;
+  canForward: boolean;
+  lastAgentId?: string;
+  agentActive: boolean;
+  onSendToAgent: (messageId: string) => void;
+  onDelete: (messageId: string) => void;
+}) {
+  if (!isReady) return <ThreadLoadingState />;
+  if (timeline.length === 0) {
+    return (
+      <Empty className="h-full border-0">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <RobotIcon size={18} />
+          </EmptyMedia>
+          <EmptyTitle>No messages yet</EmptyTitle>
+          <EmptyDescription>
+            Discuss this task with your team. The agent's status shows up here
+            too; messages stay between humans unless the task author sends one
+            to the agent.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return (
+    <ThreadItemGroup>
+      {timeline.map((row) =>
+        row.kind === "prompt" ? (
+          <UserPromptRow
+            key={row.message.id}
+            message={row.message}
+            author={taskAuthor}
+          />
+        ) : row.kind === "human" ? (
+          <ThreadMessageRow
+            key={row.message.id}
+            message={row.message.value as TaskThreadMessage}
+            isTaskAuthor={isTaskAuthor}
+            isOwnMessage={
+              !!currentUserUuid &&
+              currentUserUuid === row.message.value?.author?.uuid
+            }
+            currentUserEmail={currentUserEmail}
+            canForward={canForward}
+            onSendToAgent={() => onSendToAgent(row.message.id)}
+            onDelete={() => onDelete(row.message.id)}
+          />
+        ) : (
+          <AgentTurnRow
+            key={row.message.id}
+            message={row.message}
+            streaming={row.message.id === lastAgentId && agentActive}
+          />
+        ),
+      )}
+    </ThreadItemGroup>
+  );
+}
+
+function ThreadReplyComposer({
+  draft,
+  onDraftChange,
+  onSubmit,
+  members,
+  allowAgentMention,
+  onMentionInsert,
+  disabled,
+}: {
+  draft: string;
+  onDraftChange: (value: string) => void;
+  onSubmit: () => void;
+  members: UserBasic[];
+  allowAgentMention: boolean;
+  onMentionInsert: (member: UserBasic) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="border-border border-t p-2">
+      <MentionComposer
+        value={draft}
+        onValueChange={onDraftChange}
+        onSubmit={onSubmit}
+        members={members}
+        allowAgentMention={allowAgentMention}
+        onMentionInsert={onMentionInsert}
+        placeholder="Reply in thread… @agent sends to the agent"
+        rows={2}
+        inputClassName="max-h-40 text-[13px]"
+      >
+        <InputGroupAddon align="block-end" className="p-1">
+          <span className="ml-auto flex items-center gap-1">
+            <InputGroupButton
+              variant="primary"
+              size="icon-sm"
+              aria-label="Send"
+              disabled={disabled}
+              onClick={onSubmit}
+            >
+              <PaperPlaneRightIcon size={14} />
+            </InputGroupButton>
+          </span>
+        </InputGroupAddon>
+      </MentionComposer>
+    </div>
   );
 }
 
@@ -481,46 +631,15 @@ function ThreadConversation({
     });
   };
 
-  const isEmpty = timeline.length === 0;
   const isReady = !isInitializing && !isLoading;
 
   return (
     <div className="flex h-full min-w-0 flex-col bg-gray-1">
-      <div className="flex items-center gap-1 border-border border-b px-3 py-2">
-        <div className="min-w-0 flex-1">
-          <span className="block font-medium text-sm">Thread</span>
-        </div>
-        {onOpenFull && (
-          <Button
-            variant="default"
-            size="icon-sm"
-            aria-label="Open full task"
-            onClick={onOpenFull}
-          >
-            <ArrowSquareOutIcon size={14} />
-          </Button>
-        )}
-        {onToggleCollapsed && (
-          <Button
-            variant="default"
-            size="icon-sm"
-            aria-label="Collapse thread"
-            onClick={onToggleCollapsed}
-          >
-            <CaretRightIcon size={14} />
-          </Button>
-        )}
-        {onClose && (
-          <Button
-            variant="default"
-            size="icon-sm"
-            aria-label="Close thread"
-            onClick={onClose}
-          >
-            <XIcon size={14} />
-          </Button>
-        )}
-      </div>
+      <ThreadHeader
+        onOpenFull={onOpenFull}
+        onToggleCollapsed={onToggleCollapsed}
+        onClose={onClose}
+      />
 
       {showTaskSummary && (
         <div className="z-10 px-2">
@@ -528,89 +647,32 @@ function ThreadConversation({
         </div>
       )}
       <div ref={scrollRef} className="flex-1 overflow-y-auto">
-        {!isReady ? (
-          <ThreadLoadingState />
-        ) : isEmpty ? (
-          <Empty className="h-full border-0">
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <RobotIcon size={18} />
-              </EmptyMedia>
-              <EmptyTitle>No messages yet</EmptyTitle>
-              <EmptyDescription>
-                Discuss this task with your team. The agent's status shows up
-                here too; messages stay between humans unless the task author
-                sends one to the agent.
-              </EmptyDescription>
-            </EmptyHeader>
-          </Empty>
-        ) : (
-          <ThreadItemGroup>
-            {timeline.map((row) =>
-              row.kind === "prompt" ? (
-                <UserPromptRow
-                  key={row.message.id}
-                  message={row.message}
-                  author={task.created_by}
-                />
-              ) : row.kind === "human" ? (
-                <ThreadMessageRow
-                  key={row.message.id}
-                  message={row.message.value as TaskThreadMessage}
-                  isTaskAuthor={isTaskAuthor}
-                  isOwnMessage={
-                    !!currentUser?.uuid &&
-                    currentUser.uuid === row.message.value?.author?.uuid
-                  }
-                  currentUserEmail={currentUser?.email}
-                  canForward={canForward}
-                  onSendToAgent={() => handleSendToAgent(row.message.id)}
-                  onDelete={() => handleDelete(row.message.id)}
-                />
-              ) : (
-                <AgentTurnRow
-                  key={row.message.id}
-                  message={row.message}
-                  streaming={
-                    row.message.id === lastAgentId &&
-                    agentStatus?.phase === "active"
-                  }
-                />
-              ),
-            )}
-          </ThreadItemGroup>
-        )}
+        <ThreadTimeline
+          timeline={timeline}
+          isReady={isReady}
+          taskAuthor={task.created_by}
+          currentUserUuid={currentUser?.uuid}
+          currentUserEmail={currentUser?.email}
+          isTaskAuthor={isTaskAuthor}
+          canForward={canForward}
+          lastAgentId={lastAgentId}
+          agentActive={agentStatus?.phase === "active"}
+          onSendToAgent={handleSendToAgent}
+          onDelete={handleDelete}
+        />
       </div>
 
       {agentStatus && <AgentStatusLine status={agentStatus} />}
 
-      <div className="border-border border-t p-2">
-        <MentionComposer
-          value={draft}
-          onValueChange={setDraft}
-          onSubmit={submit}
-          members={members}
-          allowAgentMention={isTaskAuthor && canForward}
-          onMentionInsert={handleMentionInsert}
-          placeholder="Reply in thread… @agent sends to the agent"
-          rows={2}
-          inputClassName="max-h-40 text-[13px]"
-        >
-          <InputGroupAddon align="block-end" className="p-1">
-            <span className="ml-auto flex items-center gap-1">
-              <InputGroupButton
-                variant="primary"
-                size="icon-sm"
-                aria-label="Send"
-                disabled={!draft.trim() || isPosting || isSendingToAgent}
-                onClick={submit}
-              >
-                <PaperPlaneRightIcon size={14} />
-              </InputGroupButton>
-            </span>
-          </InputGroupAddon>
-        </MentionComposer>
-      </div>
+      <ThreadReplyComposer
+        draft={draft}
+        onDraftChange={setDraft}
+        onSubmit={submit}
+        members={members}
+        allowAgentMention={isTaskAuthor && canForward}
+        onMentionInsert={handleMentionInsert}
+        disabled={!draft.trim() || isPosting || isSendingToAgent}
+      />
     </div>
   );
 }

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -425,16 +425,10 @@ function ThreadConversation({
     [taskId],
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new content
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll when rendered thread content changes
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
-  }, [
-    messages.length,
-    promptMsgs.length,
-    agentMsgs.length,
-    agentMsgs[agentMsgs.length - 1]?.text,
-    agentStatus?.phase,
-  ]);
+  }, [timeline, agentStatus?.phase]);
 
   const isTaskAuthor =
     !!currentUser?.uuid && currentUser.uuid === task.created_by?.uuid;

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -10,6 +10,7 @@ import {
 import {
   buildThreadTimeline,
   deriveThreadAgentStatus,
+  hasAgentMention,
   shouldSuspendThreadSession,
   type ThreadAgentMessage,
   type ThreadAgentStatus,
@@ -50,7 +51,10 @@ import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { getUserInitials } from "@posthog/ui/features/auth/userInitials";
 import { TaskCard } from "@posthog/ui/features/canvas/components/ChannelFeedView";
 import { MentionComposer } from "@posthog/ui/features/canvas/components/MentionComposer";
-import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
+import {
+  MentionText,
+  mentionChipClass,
+} from "@posthog/ui/features/canvas/components/MentionText";
 import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
 import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
 import {
@@ -260,7 +264,7 @@ export function AgentTurnRow({
   );
 }
 
-function UserPromptRow({
+export function UserPromptRow({
   message,
   author,
 }: {
@@ -284,7 +288,7 @@ function UserPromptRow({
           )}
         </ThreadItemHeader>
         <ThreadItemBody className="wrap-break-word whitespace-pre-wrap">
-          {message.text}
+          <span className={mentionChipClass}>@agent</span> {message.text}
         </ThreadItemBody>
       </ThreadItemContent>
     </ThreadItem>
@@ -333,6 +337,7 @@ function ThreadConversation({
   const { messages, isLoading } = useTaskThread(taskId);
   const {
     postMessage,
+    postMessageToAgent,
     deleteMessage,
     sendToAgent,
     isPosting,
@@ -442,16 +447,38 @@ function ThreadConversation({
     !isTerminalStatus(task.latest_run.status) &&
     !isSendingToAgent;
 
-  const submit = () => {
+  const submit = async () => {
     const content = draft.trim();
-    if (!content || isPosting) return;
+    if (!content || isPosting || isSendingToAgent) return;
+    const sendToAgentRequested = hasAgentMention(content);
+    if (sendToAgentRequested && (!isTaskAuthor || !canForward)) {
+      toast.error("Couldn't send to agent", {
+        description:
+          "Only the task author can @agent while the task has an active run.",
+      });
+      return;
+    }
     setDraft("");
-    postMessage(content).catch((error: unknown) => {
+    try {
+      if (sendToAgentRequested) {
+        const { sendError } = await postMessageToAgent(content);
+        if (sendError) {
+          toast.error("Message posted, but couldn't send it to the agent", {
+            description:
+              sendError instanceof Error
+                ? sendError.message
+                : String(sendError),
+          });
+        }
+      } else {
+        await postMessage(content);
+      }
+    } catch (error) {
       setDraft(content);
       toast.error("Couldn't post message", {
         description: error instanceof Error ? error.message : String(error),
       });
-    });
+    }
   };
 
   const handleSendToAgent = (messageId: string) => {
@@ -574,8 +601,9 @@ function ThreadConversation({
           onValueChange={setDraft}
           onSubmit={submit}
           members={members}
+          allowAgentMention={isTaskAuthor && canForward}
           onMentionInsert={handleMentionInsert}
-          placeholder="Reply in thread… @ to tag a teammate"
+          placeholder="Reply in thread… @agent sends to the agent"
           rows={2}
           inputClassName="max-h-40 text-[13px]"
         >
@@ -585,7 +613,7 @@ function ThreadConversation({
                 variant="primary"
                 size="icon-sm"
                 aria-label="Send"
-                disabled={!draft.trim() || isPosting}
+                disabled={!draft.trim() || isPosting || isSendingToAgent}
                 onClick={submit}
               >
                 <PaperPlaneRightIcon size={14} />

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -211,7 +211,7 @@ function AgentStatusChip({ status }: { status: ThreadAgentStatus }) {
   }
 }
 
-function AgentTurnRow({
+export function AgentTurnRow({
   message,
   status,
   streaming,
@@ -232,20 +232,25 @@ function AgentTurnRow({
       <ThreadItemContent>
         <ThreadItemHeader>
           <ThreadItemAuthor>Agent</ThreadItemAuthor>
-          {status && <AgentStatusChip status={status} />}
           {message?.timestamp !== undefined && (
             <ThreadTimestamp
               dateTime={new Date(message.timestamp).toISOString()}
             />
           )}
         </ThreadItemHeader>
-        {message?.text && (
+        {(message?.text || status) && (
           <ThreadItemBody>
             <div className="rounded-md border border-border bg-muted px-2 py-1.5">
-              {streaming ? (
-                <ChatStreamingMarkdown content={message.text} />
-              ) : (
-                <ChatMarkdown content={message.text} />
+              {message?.text &&
+                (streaming ? (
+                  <ChatStreamingMarkdown content={message.text} />
+                ) : (
+                  <ChatMarkdown content={message.text} />
+                ))}
+              {status && (
+                <div className={message?.text ? "mt-2" : undefined}>
+                  <AgentStatusChip status={status} />
+                </div>
               )}
             </div>
           </ThreadItemBody>

--- a/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
@@ -12,16 +12,19 @@ import { useState } from "react";
 // re-render on every resize tick.
 export function ThreadSidebar({
   taskId,
+  channelId,
   task,
   onClose,
-  showTaskTitle,
+  onOpenFull,
+  showTaskSummary,
 }: {
   taskId: string;
+  channelId: string;
   /** The thread's task when the caller already has it; fetched otherwise. */
   task?: Task;
   onClose?: () => void;
-  /** Forwarded to ThreadPanel; hidden in the task detail view. */
-  showTaskTitle?: boolean;
+  onOpenFull?: () => void;
+  showTaskSummary?: boolean;
 }) {
   const collapsed = useThreadPanelStore((s) => s.collapsed);
   const width = useThreadPanelStore((s) => s.width);
@@ -42,6 +45,7 @@ export function ThreadSidebar({
     return (
       <ThreadPanel
         taskId={taskId}
+        channelId={channelId}
         task={task}
         collapsed
         onToggleCollapsed={() => toggleCollapsed(false)}
@@ -60,10 +64,12 @@ export function ThreadSidebar({
     >
       <ThreadPanel
         taskId={taskId}
+        channelId={channelId}
         task={task}
         onClose={onClose}
         onToggleCollapsed={() => toggleCollapsed(true)}
-        showTaskTitle={showTaskTitle}
+        onOpenFull={onOpenFull}
+        showTaskSummary={showTaskSummary}
       />
     </ResizableSidebar>
   );

--- a/packages/ui/src/features/canvas/components/ThreadTimestamp.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadTimestamp.tsx
@@ -1,0 +1,45 @@
+import {
+  ThreadItemTimestamp,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@posthog/quill";
+
+function ordinal(value: number): string {
+  const remainder = value % 100;
+  const suffixes = ["th", "st", "nd", "rd"];
+  return `${value}${suffixes[(remainder - 20) % 10] ?? suffixes[remainder] ?? suffixes[0]}`;
+}
+
+function formatClock(date: Date): string {
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const meridiem = date.getHours() >= 12 ? "pm" : "am";
+  const hour = date.getHours() % 12 || 12;
+  return `${hour}:${minutes}${meridiem}`;
+}
+
+function formatTooltip(date: Date): string {
+  const month = date.toLocaleString("en-US", { month: "long" });
+  return `${month} ${ordinal(date.getDate())} at ${formatClock(date)}`;
+}
+
+export function ThreadTimestamp({ dateTime }: { dateTime: string }) {
+  const date = new Date(dateTime);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return (
+    <TooltipProvider delay={300}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <ThreadItemTimestamp dateTime={dateTime}>
+              {formatClock(date)}
+            </ThreadItemTimestamp>
+          }
+        />
+        <TooltipContent side="top">{formatTooltip(date)}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -43,7 +43,7 @@ import { track } from "@posthog/ui/shell/analytics";
 import { Heading, Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 // A channel: a Slack-style multiplayer feed. Each member message kicks off a
 // task rendered as a card everyone in the channel sees; the composer stays
@@ -107,15 +107,11 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   // onboarding checklist. Describe-mode: seeds a plan session for this context.
   const [contextMdDialogOpen, setContextMdDialogOpen] = useState(false);
 
-  const threadTaskId = useThreadPanelStore((s) => s.taskId);
+  const threadTaskId = useThreadPanelStore(
+    (s) => s.openByChannel[channelId] ?? null,
+  );
   const openThread = useThreadPanelStore((s) => s.openThread);
   const closeThread = useThreadPanelStore((s) => s.closeThread);
-
-  // A thread from another channel shouldn't linger when switching feeds.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-close per channel
-  useEffect(() => {
-    closeThread();
-  }, [closeThread, channelId]);
 
   const handleSuggestionSelect = useCallback(
     (prompt: string, mode?: string) => {
@@ -171,21 +167,23 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
     [backendChannel?.id, channelId, fileTask, invalidateFeed, queryClient],
   );
 
-  // The task route's mount effect points the panel at the task, so navigating
-  // is enough here.
-  const handleOpenTask = useCallback(
-    (task: Task) => {
+  const handleOpenFull = useCallback(
+    (taskId: string) => {
       void navigate({
         to: "/website/$channelId/tasks/$taskId",
-        params: { channelId, taskId: task.id },
+        params: { channelId, taskId },
       });
     },
     [channelId, navigate],
   );
+  const handleOpenTask = useCallback(
+    (task: Task) => handleOpenFull(task.id),
+    [handleOpenFull],
+  );
 
   const handleOpenThread = useCallback(
-    (task: Task) => openThread(task.id),
-    [openThread],
+    (task: Task) => openThread(channelId, task.id),
+    [channelId, openThread],
   );
 
   const threadTask = threadTaskId
@@ -262,6 +260,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
     <div className="flex h-full min-w-0 bg-gray-1">
       <div className="flex min-w-0 flex-1 flex-col">
         <ChannelFeedView
+          channelId={channelId}
           tasks={tasks}
           pending={visiblePending}
           systemMessages={systemMessages}
@@ -288,8 +287,10 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
       {threadTaskId && (
         <ThreadSidebar
           taskId={threadTaskId}
+          channelId={channelId}
           task={threadTask}
-          onClose={closeThread}
+          onClose={() => closeThread(channelId)}
+          onOpenFull={() => handleOpenFull(threadTaskId)}
         />
       )}
 

--- a/packages/ui/src/features/canvas/components/mention-chip.css
+++ b/packages/ui/src/features/canvas/components/mention-chip.css
@@ -1,0 +1,12 @@
+.mention-chip {
+  border-radius: var(--radius-1);
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  color: color-mix(in oklab, var(--primary) 80%, transparent);
+  font-weight: 500;
+  padding-inline: 0.125rem;
+}
+
+.mention-chip--self {
+  background: color-mix(in oklab, var(--primary) 50%, transparent);
+  color: var(--primary);
+}

--- a/packages/ui/src/features/canvas/components/threadAgentTurns.ts
+++ b/packages/ui/src/features/canvas/components/threadAgentTurns.ts
@@ -1,0 +1,33 @@
+import type { ThreadAgentMessage } from "@posthog/core/canvas/threadTimeline";
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+
+export function agentTurns(items: ConversationItem[]): ThreadAgentMessage[] {
+  const turns: ThreadAgentMessage[] = [];
+  let current: ThreadAgentMessage | null = null;
+  for (const item of items) {
+    if (item.type === "user_message") {
+      if (current) turns.push(current);
+      current = null;
+      continue;
+    }
+    if (
+      item.type === "session_update" &&
+      item.update.sessionUpdate === "agent_message_chunk" &&
+      "content" in item.update &&
+      item.update.content.type === "text" &&
+      item.update.content.text.trim()
+    ) {
+      if (current) {
+        current.text += item.update.content.text;
+      } else {
+        current = {
+          id: item.id,
+          text: item.update.content.text,
+          timestamp: item.timestamp,
+        };
+      }
+    }
+  }
+  if (current) turns.push(current);
+  return turns;
+}

--- a/packages/ui/src/features/canvas/hooks/useChannelFeedMessages.test.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelFeedMessages.test.ts
@@ -12,12 +12,43 @@ describe("useChannelFeedMessages", () => {
     vi.mocked(useAuthenticatedQuery).mockClear();
   });
 
-  it("keeps polling after a transient query error", () => {
+  function refetchInterval() {
     renderHook(() => useChannelFeedMessages("channel-id"));
 
-    expect(vi.mocked(useAuthenticatedQuery).mock.calls[0]?.[2]).toMatchObject({
-      retry: false,
-      refetchInterval: 5_000,
-    });
+    return vi.mocked(useAuthenticatedQuery).mock.calls[0]?.[2]?.refetchInterval;
+  }
+
+  it("keeps polling after a transient query error", () => {
+    const interval = refetchInterval();
+
+    expect(interval).toBeTypeOf("function");
+    expect(
+      typeof interval === "function"
+        ? interval({ state: { error: new Error("Network failure") } } as never)
+        : interval,
+    ).toBe(5_000);
+  });
+
+  it.each([401, 403, 404])(
+    "stops polling after a permanent %s response",
+    (status) => {
+      const interval = refetchInterval();
+      const error = Object.assign(new Error("Request failed"), { status });
+
+      expect(interval).toBeTypeOf("function");
+      expect(
+        typeof interval === "function"
+          ? interval({ state: { error } } as never)
+          : interval,
+      ).toBe(false);
+    },
+  );
+
+  it("disables query retries", () => {
+    renderHook(() => useChannelFeedMessages("channel-id"));
+
+    expect(vi.mocked(useAuthenticatedQuery).mock.calls[0]?.[2]?.retry).toBe(
+      false,
+    );
   });
 });

--- a/packages/ui/src/features/canvas/hooks/useChannelFeedMessages.test.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelFeedMessages.test.ts
@@ -1,0 +1,23 @@
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useChannelFeedMessages } from "./useChannelFeedMessages";
+
+vi.mock("@posthog/ui/hooks/useAuthenticatedQuery", () => ({
+  useAuthenticatedQuery: vi.fn(() => ({ data: [], isLoading: false })),
+}));
+
+describe("useChannelFeedMessages", () => {
+  beforeEach(() => {
+    vi.mocked(useAuthenticatedQuery).mockClear();
+  });
+
+  it("keeps polling after a transient query error", () => {
+    renderHook(() => useChannelFeedMessages("channel-id"));
+
+    expect(vi.mocked(useAuthenticatedQuery).mock.calls[0]?.[2]).toMatchObject({
+      retry: false,
+      refetchInterval: 5_000,
+    });
+  });
+});

--- a/packages/ui/src/features/canvas/hooks/useChannelFeedMessages.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelFeedMessages.ts
@@ -80,14 +80,8 @@ export function useChannelFeedMessages(channelId: string | undefined): {
     (client) => client.getChannelFeed(channelId as string),
     {
       enabled: !!channelId,
-      // The endpoint may not be deployed yet (posthog#70320): don't retry, and
-      // stop polling once the query errors — otherwise every open channel view
-      // streams 404s (poll tick × default retries) forever.
       retry: false,
-      refetchInterval: (query) =>
-        query.state.status === "error"
-          ? false
-          : CHANNEL_FEED_MESSAGES_POLL_INTERVAL_MS,
+      refetchInterval: CHANNEL_FEED_MESSAGES_POLL_INTERVAL_MS,
     },
   );
   const messages = useMemo(

--- a/packages/ui/src/features/canvas/hooks/useChannelFeedMessages.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelFeedMessages.ts
@@ -1,3 +1,4 @@
+import { shouldPollChannelFeed } from "@posthog/core/canvas/channelFeed";
 import type {
   ChannelFeedMessage,
   TaskChannel,
@@ -81,7 +82,10 @@ export function useChannelFeedMessages(channelId: string | undefined): {
     {
       enabled: !!channelId,
       retry: false,
-      refetchInterval: CHANNEL_FEED_MESSAGES_POLL_INTERVAL_MS,
+      refetchInterval: (query) =>
+        shouldPollChannelFeed(query.state.error)
+          ? CHANNEL_FEED_MESSAGES_POLL_INTERVAL_MS
+          : false,
     },
   );
   const messages = useMemo(

--- a/packages/ui/src/features/canvas/hooks/useTaskThread.test.tsx
+++ b/packages/ui/src/features/canvas/hooks/useTaskThread.test.tsx
@@ -6,15 +6,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockClient = vi.hoisted(() => ({
   createTaskThreadMessage: vi.fn(),
-  createTaskThreadMessageForAgent: vi.fn(),
   sendTaskThreadMessageToAgent: vi.fn(),
+}));
+const mockTaskThreadService = vi.hoisted(() => ({
+  postMessageToAgent: vi.fn(),
 }));
 
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
   useOptionalAuthenticatedClient: () => mockClient,
 }));
+vi.mock("@posthog/di/react", () => ({
+  useService: () => mockTaskThreadService,
+}));
 
-import { useTaskThreadMutations } from "./useTaskThread";
+import { usePostTaskThreadMessageToAgent } from "./useTaskThread";
 
 let queryClient: QueryClient;
 
@@ -34,7 +39,7 @@ function message(overrides?: Partial<TaskThreadMessage>): TaskThreadMessage {
   };
 }
 
-describe("useTaskThreadMutations", () => {
+describe("usePostTaskThreadMessageToAgent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     queryClient = new QueryClient({
@@ -43,19 +48,21 @@ describe("useTaskThreadMutations", () => {
   });
 
   it("posts an @agent message through the combined client operation", async () => {
-    mockClient.createTaskThreadMessageForAgent.mockResolvedValue({
+    mockTaskThreadService.postMessageToAgent.mockResolvedValue({
       message: message({ forwarded_to_agent_at: "2026-07-16T00:00:01Z" }),
       sendError: null,
     });
-    const { result } = renderHook(() => useTaskThreadMutations("task-id"), {
-      wrapper,
-    });
+    const { result } = renderHook(
+      () => usePostTaskThreadMessageToAgent("task-id"),
+      { wrapper },
+    );
 
     await act(async () => {
       await result.current.postMessageToAgent("@agent investigate this");
     });
 
-    expect(mockClient.createTaskThreadMessageForAgent).toHaveBeenCalledWith(
+    expect(mockTaskThreadService.postMessageToAgent).toHaveBeenCalledWith(
+      mockClient,
       "task-id",
       "@agent investigate this",
     );
@@ -63,13 +70,14 @@ describe("useTaskThreadMutations", () => {
 
   it("returns a forwarding error after the message has been posted", async () => {
     const sendError = new Error("No active run");
-    mockClient.createTaskThreadMessageForAgent.mockResolvedValue({
+    mockTaskThreadService.postMessageToAgent.mockResolvedValue({
       message: message(),
       sendError,
     });
-    const { result } = renderHook(() => useTaskThreadMutations("task-id"), {
-      wrapper,
-    });
+    const { result } = renderHook(
+      () => usePostTaskThreadMessageToAgent("task-id"),
+      { wrapper },
+    );
 
     let outcome: Awaited<
       ReturnType<typeof result.current.postMessageToAgent>
@@ -81,6 +89,6 @@ describe("useTaskThreadMutations", () => {
     });
 
     expect(outcome).toEqual({ message: message(), sendError });
-    expect(mockClient.createTaskThreadMessageForAgent).toHaveBeenCalledTimes(1);
+    expect(mockTaskThreadService.postMessageToAgent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/features/canvas/hooks/useTaskThread.test.tsx
+++ b/packages/ui/src/features/canvas/hooks/useTaskThread.test.tsx
@@ -1,0 +1,86 @@
+import type { TaskThreadMessage } from "@posthog/shared/domain-types";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockClient = vi.hoisted(() => ({
+  createTaskThreadMessage: vi.fn(),
+  createTaskThreadMessageForAgent: vi.fn(),
+  sendTaskThreadMessageToAgent: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => mockClient,
+}));
+
+import { useTaskThreadMutations } from "./useTaskThread";
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function message(overrides?: Partial<TaskThreadMessage>): TaskThreadMessage {
+  return {
+    id: "message-id",
+    task: "task-id",
+    content: "@agent investigate this",
+    created_at: "2026-07-16T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("useTaskThreadMutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+  });
+
+  it("posts an @agent message through the combined client operation", async () => {
+    mockClient.createTaskThreadMessageForAgent.mockResolvedValue({
+      message: message({ forwarded_to_agent_at: "2026-07-16T00:00:01Z" }),
+      sendError: null,
+    });
+    const { result } = renderHook(() => useTaskThreadMutations("task-id"), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.postMessageToAgent("@agent investigate this");
+    });
+
+    expect(mockClient.createTaskThreadMessageForAgent).toHaveBeenCalledWith(
+      "task-id",
+      "@agent investigate this",
+    );
+  });
+
+  it("returns a forwarding error after the message has been posted", async () => {
+    const sendError = new Error("No active run");
+    mockClient.createTaskThreadMessageForAgent.mockResolvedValue({
+      message: message(),
+      sendError,
+    });
+    const { result } = renderHook(() => useTaskThreadMutations("task-id"), {
+      wrapper,
+    });
+
+    let outcome: Awaited<
+      ReturnType<typeof result.current.postMessageToAgent>
+    > | null = null;
+    await act(async () => {
+      outcome = await result.current.postMessageToAgent(
+        "@agent investigate this",
+      );
+    });
+
+    expect(outcome).toEqual({ message: message(), sendError });
+    expect(mockClient.createTaskThreadMessageForAgent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/features/canvas/hooks/useTaskThread.ts
+++ b/packages/ui/src/features/canvas/hooks/useTaskThread.ts
@@ -60,6 +60,14 @@ export function useTaskThreadMutations(taskId: string | undefined) {
     onSuccess: invalidate,
   });
 
+  const postToAgentMutation = useMutation({
+    mutationFn: async (content: string) => {
+      if (!client || !taskId) throw new Error("Not authenticated");
+      return client.createTaskThreadMessageForAgent(taskId, content);
+    },
+    onSuccess: invalidate,
+  });
+
   const deleteMutation = useMutation({
     mutationFn: async (messageId: string) => {
       if (!client || !taskId) throw new Error("Not authenticated");
@@ -78,10 +86,13 @@ export function useTaskThreadMutations(taskId: string | undefined) {
 
   return {
     postMessage: (content: string) => postMutation.mutateAsync(content),
+    postMessageToAgent: (content: string) =>
+      postToAgentMutation.mutateAsync(content),
     deleteMessage: (messageId: string) => deleteMutation.mutateAsync(messageId),
     sendToAgent: (messageId: string) =>
       sendToAgentMutation.mutateAsync(messageId),
     isPosting: postMutation.isPending,
-    isSendingToAgent: sendToAgentMutation.isPending,
+    isSendingToAgent:
+      postToAgentMutation.isPending || sendToAgentMutation.isPending,
   };
 }

--- a/packages/ui/src/features/canvas/hooks/useTaskThread.ts
+++ b/packages/ui/src/features/canvas/hooks/useTaskThread.ts
@@ -1,8 +1,12 @@
+import {
+  TASK_THREAD_SERVICE,
+  type TaskThreadService,
+} from "@posthog/core/canvas/taskThreadService";
+import { useService } from "@posthog/di/react";
 import type { TaskThreadMessage } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback } from "react";
 
 const THREAD_POLL_INTERVAL_MS = 5_000;
 
@@ -10,18 +14,9 @@ export function taskThreadQueryKey(taskId: string | undefined) {
   return ["task-thread", taskId ?? "none"] as const;
 }
 
-/** A task's thread — the human side conversation — in chronological order. */
 export function useTaskThread(
   taskId: string | undefined,
-  options?: {
-    /** Poll cadence override; feed rows poll slower than the open panel. */
-    pollIntervalMs?: number;
-    /**
-     * Gate the fetch/poll. Feed rows pass `inView` so only near-viewport rows
-     * hit the network; off-screen rows keep any cached messages but idle.
-     */
-    enabled?: boolean;
-  },
+  options?: { pollIntervalMs?: number; enabled?: boolean },
 ): {
   messages: TaskThreadMessage[];
   isLoading: boolean;
@@ -34,65 +29,68 @@ export function useTaskThread(
     {
       enabled: !!taskId && enabled,
       refetchInterval: pollIntervalMs,
-      // Fresh-within-the-poll-window so focus/remount doesn't refire every
-      // feed row's thread query on top of the interval.
       staleTime: pollIntervalMs,
     },
   );
   return { messages: query.data ?? [], isLoading: query.isLoading };
 }
 
-export function useTaskThreadMutations(taskId: string | undefined) {
+export function usePostTaskThreadMessage(taskId: string | undefined) {
   const client = useOptionalAuthenticatedClient();
   const queryClient = useQueryClient();
-
-  const invalidate = useCallback(() => {
-    void queryClient.invalidateQueries({
-      queryKey: taskThreadQueryKey(taskId),
-    });
-  }, [queryClient, taskId]);
-
-  const postMutation = useMutation({
+  const mutation = useMutation({
     mutationFn: async (content: string) => {
       if (!client || !taskId) throw new Error("Not authenticated");
       return client.createTaskThreadMessage(taskId, content);
     },
-    onSuccess: invalidate,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: taskThreadQueryKey(taskId) }),
   });
+  return { postMessage: mutation.mutateAsync, isPosting: mutation.isPending };
+}
 
-  const postToAgentMutation = useMutation({
+export function usePostTaskThreadMessageToAgent(taskId: string | undefined) {
+  const client = useOptionalAuthenticatedClient();
+  const queryClient = useQueryClient();
+  const service = useService<TaskThreadService>(TASK_THREAD_SERVICE);
+  const mutation = useMutation({
     mutationFn: async (content: string) => {
       if (!client || !taskId) throw new Error("Not authenticated");
-      return client.createTaskThreadMessageForAgent(taskId, content);
+      return service.postMessageToAgent(client, taskId, content);
     },
-    onSuccess: invalidate,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: taskThreadQueryKey(taskId) }),
   });
+  return {
+    postMessageToAgent: mutation.mutateAsync,
+    isPostingToAgent: mutation.isPending,
+  };
+}
 
-  const deleteMutation = useMutation({
+export function useDeleteTaskThreadMessage(taskId: string | undefined) {
+  const client = useOptionalAuthenticatedClient();
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
     mutationFn: async (messageId: string) => {
       if (!client || !taskId) throw new Error("Not authenticated");
       return client.deleteTaskThreadMessage(taskId, messageId);
     },
-    onSuccess: invalidate,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: taskThreadQueryKey(taskId) }),
   });
+  return { deleteMessage: mutation.mutateAsync };
+}
 
-  const sendToAgentMutation = useMutation({
+export function useSendTaskThreadMessageToAgent(taskId: string | undefined) {
+  const client = useOptionalAuthenticatedClient();
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
     mutationFn: async (messageId: string) => {
       if (!client || !taskId) throw new Error("Not authenticated");
       return client.sendTaskThreadMessageToAgent(taskId, messageId);
     },
-    onSuccess: invalidate,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: taskThreadQueryKey(taskId) }),
   });
-
-  return {
-    postMessage: (content: string) => postMutation.mutateAsync(content),
-    postMessageToAgent: (content: string) =>
-      postToAgentMutation.mutateAsync(content),
-    deleteMessage: (messageId: string) => deleteMutation.mutateAsync(messageId),
-    sendToAgent: (messageId: string) =>
-      sendToAgentMutation.mutateAsync(messageId),
-    isPosting: postMutation.isPending,
-    isSendingToAgent:
-      postToAgentMutation.isPending || sendToAgentMutation.isPending,
-  };
+  return { sendToAgent: mutation.mutateAsync, isSending: mutation.isPending };
 }

--- a/packages/ui/src/features/canvas/stores/threadPanelStore.test.ts
+++ b/packages/ui/src/features/canvas/stores/threadPanelStore.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useThreadPanelStore } from "./threadPanelStore";
+
+describe("threadPanelStore", () => {
+  beforeEach(() => {
+    useThreadPanelStore.setState({
+      openByChannel: {},
+      collapsed: false,
+      width: 360,
+    });
+  });
+
+  it("keeps each channel tab's open thread independent", () => {
+    const { openThread } = useThreadPanelStore.getState();
+
+    openThread("channel-a", "task-a");
+    openThread("channel-b", "task-b");
+
+    expect(useThreadPanelStore.getState().openByChannel).toEqual({
+      "channel-a": "task-a",
+      "channel-b": "task-b",
+    });
+  });
+
+  it("closes only the active channel's thread", () => {
+    useThreadPanelStore.setState({
+      openByChannel: { "channel-a": "task-a", "channel-b": "task-b" },
+    });
+
+    useThreadPanelStore.getState().closeThread("channel-a");
+
+    expect(useThreadPanelStore.getState().openByChannel).toEqual({
+      "channel-a": null,
+      "channel-b": "task-b",
+    });
+  });
+});

--- a/packages/ui/src/features/canvas/stores/threadPanelStore.ts
+++ b/packages/ui/src/features/canvas/stores/threadPanelStore.ts
@@ -2,20 +2,18 @@ import { electronStorage } from "@posthog/ui/shell/rendererStorage";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-// View state for the thread side panel — the right-hand human conversation
-// dock next to a channel feed or task detail. Which thread is open is
-// per-navigation state; collapse and width are persisted user preferences so
-// the panel keeps its shape across tasks and channels.
 const DEFAULT_PANEL_WIDTH = 360;
 
 interface ThreadPanelState {
-  /** Task whose thread is open, or null when the panel is closed. */
-  taskId: string | null;
+  openByChannel: Record<string, string | null>;
   collapsed: boolean;
   width: number;
-  /** Points the panel at a task; expands it unless `expand: false`. */
-  openThread: (taskId: string, opts?: { expand?: boolean }) => void;
-  closeThread: () => void;
+  openThread: (
+    channelId: string,
+    taskId: string,
+    opts?: { expand?: boolean },
+  ) => void;
+  closeThread: (channelId: string) => void;
   setCollapsed: (collapsed: boolean) => void;
   setWidth: (width: number) => void;
 }
@@ -23,12 +21,18 @@ interface ThreadPanelState {
 export const useThreadPanelStore = create<ThreadPanelState>()(
   persist(
     (set) => ({
-      taskId: null,
+      openByChannel: {},
       collapsed: false,
       width: DEFAULT_PANEL_WIDTH,
-      openThread: (taskId, opts) =>
-        set(opts?.expand === false ? { taskId } : { taskId, collapsed: false }),
-      closeThread: () => set({ taskId: null }),
+      openThread: (channelId, taskId, opts) =>
+        set((state) => ({
+          openByChannel: { ...state.openByChannel, [channelId]: taskId },
+          ...(opts?.expand === false ? {} : { collapsed: false }),
+        })),
+      closeThread: (channelId) =>
+        set((state) => ({
+          openByChannel: { ...state.openByChannel, [channelId]: null },
+        })),
       setCollapsed: (collapsed) => set({ collapsed }),
       setWidth: (width) => set({ width }),
     }),

--- a/packages/ui/src/features/canvas/taskCardNavigation.test.ts
+++ b/packages/ui/src/features/canvas/taskCardNavigation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { shouldOpenTaskCardInline } from "./taskCardNavigation";
+
+const PRIMARY_CLICK = {
+  defaultPrevented: false,
+  button: 0,
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+};
+
+describe("shouldOpenTaskCardInline", () => {
+  it("opens an unmodified primary click in the thread dock", () => {
+    expect(shouldOpenTaskCardInline(PRIMARY_CLICK)).toBe(true);
+  });
+
+  it.each([
+    { defaultPrevented: true },
+    { button: 1 },
+    { metaKey: true },
+    { ctrlKey: true },
+    { shiftKey: true },
+    { altKey: true },
+  ])("leaves browser navigation intact for %o", (override) => {
+    expect(shouldOpenTaskCardInline({ ...PRIMARY_CLICK, ...override })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/ui/src/features/canvas/taskCardNavigation.ts
+++ b/packages/ui/src/features/canvas/taskCardNavigation.ts
@@ -1,0 +1,21 @@
+export interface TaskCardPointerIntent {
+  defaultPrevented: boolean;
+  button: number;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+export function shouldOpenTaskCardInline(
+  event: TaskCardPointerIntent,
+): boolean {
+  return (
+    !event.defaultPrevented &&
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
+  );
+}

--- a/packages/ui/src/features/canvas/utils/mentionComposer.test.ts
+++ b/packages/ui/src/features/canvas/utils/mentionComposer.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   contentToDoc,
   docToContent,
+  filterComposerMentionCandidates,
   filterMentionCandidates,
 } from "./mentionComposer";
 
@@ -65,6 +66,22 @@ describe("filterMentionCandidates", () => {
 
   it("returns empty when nothing matches", () => {
     expect(filterMentionCandidates(members, "zzz")).toEqual([]);
+  });
+});
+
+describe("filterComposerMentionCandidates", () => {
+  it("offers the agent before matching teammates when enabled", () => {
+    expect(filterComposerMentionCandidates(members, "a", true)).toEqual([
+      { kind: "agent" },
+      { kind: "member", member: ann },
+      { kind: "member", member: raquel },
+    ]);
+  });
+
+  it("does not offer the agent when forwarding is unavailable", () => {
+    expect(filterComposerMentionCandidates(members, "agent", false)).toEqual(
+      [],
+    );
   });
 });
 

--- a/packages/ui/src/features/canvas/utils/mentionComposer.ts
+++ b/packages/ui/src/features/canvas/utils/mentionComposer.ts
@@ -4,6 +4,10 @@ import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import type { Node as PmNode } from "@tiptap/pm/model";
 import type { JSONContent } from "@tiptap/react";
 
+export type ComposerMentionCandidate =
+  | { kind: "agent" }
+  | { kind: "member"; member: UserBasic };
+
 /** Members matching the query, best-first: name prefix, word prefix, email, substring. */
 export function filterMentionCandidates(
   members: UserBasic[],
@@ -30,6 +34,24 @@ export function filterMentionCandidates(
     )
     .slice(0, limit)
     .map((entry) => entry.member);
+}
+
+export function filterComposerMentionCandidates(
+  members: UserBasic[],
+  query: string,
+  includeAgent: boolean,
+  limit = 8,
+): ComposerMentionCandidate[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const includeAgentCandidate =
+    includeAgent && (!normalizedQuery || "agent".startsWith(normalizedQuery));
+  const memberLimit = Math.max(0, limit - (includeAgentCandidate ? 1 : 0));
+  return [
+    ...(includeAgentCandidate ? [{ kind: "agent" as const }] : []),
+    ...filterMentionCandidates(members, query, memberLimit).map(
+      (member): ComposerMentionCandidate => ({ kind: "member", member }),
+    ),
+  ];
 }
 
 /** Serialize the composer's editor doc back to content with inline mention tokens. */

--- a/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
+++ b/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
@@ -1,7 +1,6 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { ThreadSidebar } from "@posthog/ui/features/canvas/components/ThreadSidebar";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
-import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { TaskDetail } from "@posthog/ui/features/task-detail/components/TaskDetail";
 import {
@@ -49,13 +48,6 @@ function ChannelTaskDetailRoute() {
     markAsViewed(taskId);
   }, [taskId, markAsViewed]);
 
-  // Opening a task shows its thread docked on the right, keeping the user's
-  // collapse preference. The panel follows the task being viewed.
-  const openThread = useThreadPanelStore((s) => s.openThread);
-  useEffect(() => {
-    openThread(taskId, { expand: false });
-  }, [openThread, taskId]);
-
   const { data: fetched } = useQuery({
     ...taskDetailQuery(taskId),
     enabled: !fromList && !loaderTask,
@@ -77,7 +69,12 @@ function ChannelTaskDetailRoute() {
           channelId={channelId}
         />
       </div>
-      <ThreadSidebar taskId={taskId} task={task} showTaskTitle={false} />
+      <ThreadSidebar
+        taskId={taskId}
+        channelId={channelId}
+        task={task}
+        showTaskSummary={false}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

**Why:** The two open channel-thread experiments overlap, but include conflicting and demo-only behavior. This consolidates the production-ready interaction model while keeping the channel UI aligned with current backend contracts.

Supersedes [#3387](https://github.com/PostHog/code/pull/3387) and [#3287](https://github.com/PostHog/code/pull/3287).

## Changes

- Preserve docked threads independently per channel and make task cards accessible links with standard new-tab behavior.
- Render prompts, human replies, and agent output chronologically, with live status anchored at the bottom and safe handling for runless local tasks.
- Reconcile stale feed state with settled sessions and recover feed polling after transient failures.
- Retain the shared mention-chip presentation and the local Quill development skill from the source work.
- Keep the context-generation workflow already shipped on `main` through [#3370](https://github.com/PostHog/code/pull/3370); exclude only the fake feed composer, placeholder Inbox tab, and other demo-only UI.

## How did you test this?

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `node scripts/check-host-boundaries.mjs`
- `pnpm --filter @posthog/core test`
- `pnpm --filter @posthog/ui test`
- Focused timeline, thread-store, task-navigation, feed-polling, and mention-rendering tests

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
