### PR TITLE
feat(inbox): add "Any" option to Source and Priority filters

### DIFF
--- a/packages/ui/src/features/inbox/components/InboxSearchFilterBar.tsx
+++ b/packages/ui/src/features/inbox/components/InboxSearchFilterBar.tsx
@@ -40,8 +40,14 @@ export function InboxSearchFilterBar({
   const toggleSourceProduct = useInboxSignalsFilterStore(
     (s) => s.toggleSourceProduct,
   );
+  const clearSourceProductFilter = useInboxSignalsFilterStore(
+    (s) => s.clearSourceProductFilter,
+  );
   const priorityFilter = useInboxSignalsFilterStore((s) => s.priorityFilter);
   const togglePriority = useInboxSignalsFilterStore((s) => s.togglePriority);
+  const clearPriorityFilter = useInboxSignalsFilterStore(
+    (s) => s.clearPriorityFilter,
+  );
 
   const activeSort = INBOX_SORT_OPTIONS.find(
     (option) =>
@@ -73,6 +79,11 @@ export function InboxSearchFilterBar({
         active={sourceProductFilter.length > 0}
       >
         <Flex direction="column" gap="0">
+          <InboxFilterAnyItem
+            label="Any"
+            active={sourceProductFilter.length === 0}
+            onClick={clearSourceProductFilter}
+          />
           {INBOX_SOURCE_OPTIONS.map((option) => {
             const isActive = sourceProductFilter.includes(option.value);
             return (
@@ -132,6 +143,11 @@ export function InboxSearchFilterBar({
         active={priorityFilter.length > 0}
       >
         <Flex direction="column" gap="0">
+          <InboxFilterAnyItem
+            label="Any"
+            active={priorityFilter.length === 0}
+            onClick={clearPriorityFilter}
+          />
           {INBOX_PRIORITY_OPTIONS.map((option) => {
             const isActive = priorityFilter.includes(option.value);
             return (
@@ -157,6 +173,25 @@ export function InboxSearchFilterBar({
         </Flex>
       </InboxFilterPopover>
     </Flex>
+  );
+}
+
+function InboxFilterAnyItem({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button type="button" className={FILTER_ITEM_CLASS} onClick={onClick}>
+      <span className="truncate">{label}</span>
+      {active ? (
+        <CheckIcon size={12} className="shrink-0 text-gray-12" />
+      ) : null}
+    </button>
   );
 }
 

--- a/packages/ui/src/features/inbox/components/InboxSearchFilterBar.tsx
+++ b/packages/ui/src/features/inbox/components/InboxSearchFilterBar.tsx
@@ -80,7 +80,6 @@ export function InboxSearchFilterBar({
       >
         <Flex direction="column" gap="0">
           <InboxFilterAnyItem
-            label="Any"
             active={sourceProductFilter.length === 0}
             onClick={clearSourceProductFilter}
           />
@@ -144,7 +143,6 @@ export function InboxSearchFilterBar({
       >
         <Flex direction="column" gap="0">
           <InboxFilterAnyItem
-            label="Any"
             active={priorityFilter.length === 0}
             onClick={clearPriorityFilter}
           />
@@ -177,17 +175,15 @@ export function InboxSearchFilterBar({
 }
 
 function InboxFilterAnyItem({
-  label,
   active,
   onClick,
 }: {
-  label: string;
   active: boolean;
   onClick: () => void;
 }) {
   return (
     <button type="button" className={FILTER_ITEM_CLASS} onClick={onClick}>
-      <span className="truncate">{label}</span>
+      <span className="truncate">Any</span>
       {active ? (
         <CheckIcon size={12} className="shrink-0 text-gray-12" />
       ) : null}

--- a/packages/ui/src/features/inbox/components/InboxSearchFilterBar.tsx
+++ b/packages/ui/src/features/inbox/components/InboxSearchFilterBar.tsx
@@ -45,8 +45,8 @@ export function InboxSearchFilterBar({
   );
   const priorityFilter = useInboxSignalsFilterStore((s) => s.priorityFilter);
   const togglePriority = useInboxSignalsFilterStore((s) => s.togglePriority);
-  const clearPriorityFilter = useInboxSignalsFilterStore(
-    (s) => s.clearPriorityFilter,
+  const setPriorityFilter = useInboxSignalsFilterStore(
+    (s) => s.setPriorityFilter,
   );
 
   const activeSort = INBOX_SORT_OPTIONS.find(
@@ -144,7 +144,7 @@ export function InboxSearchFilterBar({
         <Flex direction="column" gap="0">
           <InboxFilterAnyItem
             active={priorityFilter.length === 0}
-            onClick={clearPriorityFilter}
+            onClick={() => setPriorityFilter([])}
           />
           {INBOX_PRIORITY_OPTIONS.map((option) => {
             const isActive = priorityFilter.includes(option.value);

--- a/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.test.ts
+++ b/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.test.ts
@@ -71,6 +71,34 @@ describe("inboxSignalsFilterStore", () => {
     ]);
   });
 
+  it("clearPriorityFilter resets priorities back to Any (empty)", () => {
+    useInboxSignalsFilterStore.getState().setPriorityFilter(["P0", "P1"]);
+
+    useInboxSignalsFilterStore.getState().clearPriorityFilter();
+
+    expect(useInboxSignalsFilterStore.getState().priorityFilter).toEqual([]);
+  });
+
+  it("clearSourceProductFilter resets sources back to Any (empty)", () => {
+    useInboxSignalsFilterStore.getState().toggleSourceProduct("github");
+    useInboxSignalsFilterStore.getState().toggleSourceProduct("linear");
+
+    useInboxSignalsFilterStore.getState().clearSourceProductFilter();
+
+    expect(useInboxSignalsFilterStore.getState().sourceProductFilter).toEqual(
+      [],
+    );
+  });
+
+  it("toggling off the last source is equivalent to Any (empty)", () => {
+    useInboxSignalsFilterStore.getState().toggleSourceProduct("github");
+    useInboxSignalsFilterStore.getState().toggleSourceProduct("github");
+
+    expect(useInboxSignalsFilterStore.getState().sourceProductFilter).toEqual(
+      [],
+    );
+  });
+
   it("setPriorityFilter de-duplicates priorities", () => {
     useInboxSignalsFilterStore.getState().setPriorityFilter(["P0", "P1", "P0"]);
 

--- a/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.test.ts
+++ b/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.test.ts
@@ -71,10 +71,10 @@ describe("inboxSignalsFilterStore", () => {
     ]);
   });
 
-  it("clearPriorityFilter resets priorities back to Any (empty)", () => {
+  it("setPriorityFilter resets priorities back to Any (empty)", () => {
     useInboxSignalsFilterStore.getState().setPriorityFilter(["P0", "P1"]);
 
-    useInboxSignalsFilterStore.getState().clearPriorityFilter();
+    useInboxSignalsFilterStore.getState().setPriorityFilter([]);
 
     expect(useInboxSignalsFilterStore.getState().priorityFilter).toEqual([]);
   });

--- a/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.ts
+++ b/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.ts
@@ -31,6 +31,10 @@ interface InboxSignalsFilterActions {
   toggleSourceProduct: (source: SourceProduct) => void;
   togglePriority: (priority: SignalReportPriority) => void;
   setPriorityFilter: (priorities: SignalReportPriority[]) => void;
+  /** Clear the source filter back to "Any" (empty = all sources). */
+  clearSourceProductFilter: () => void;
+  /** Clear the priority filter back to "Any" (empty = all priorities). */
+  clearPriorityFilter: () => void;
   /** Reset all filters when a deep link arrives so the linked report isn't hidden. */
   resetFilters: () => void;
 }
@@ -74,6 +78,8 @@ export const useInboxSignalsFilterStore = create<InboxSignalsFilterStore>()(
         set({
           priorityFilter: Array.from(new Set(priorities)),
         }),
+      clearSourceProductFilter: () => set({ sourceProductFilter: [] }),
+      clearPriorityFilter: () => set({ priorityFilter: [] }),
       resetFilters: () =>
         set({
           searchQuery: "",

--- a/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.ts
+++ b/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.ts
@@ -33,8 +33,6 @@ interface InboxSignalsFilterActions {
   setPriorityFilter: (priorities: SignalReportPriority[]) => void;
   /** Clear the source filter back to "Any" (empty = all sources). */
   clearSourceProductFilter: () => void;
-  /** Clear the priority filter back to "Any" (empty = all priorities). */
-  clearPriorityFilter: () => void;
   /** Reset all filters when a deep link arrives so the linked report isn't hidden. */
   resetFilters: () => void;
 }
@@ -79,7 +77,6 @@ export const useInboxSignalsFilterStore = create<InboxSignalsFilterStore>()(
           priorityFilter: Array.from(new Set(priorities)),
         }),
       clearSourceProductFilter: () => set({ sourceProductFilter: [] }),
-      clearPriorityFilter: () => set({ priorityFilter: [] }),
       resetFilters: () =>
         set({
           searchQuery: "",


### PR DESCRIPTION
## Problem

In the inbox toolbar, the **Source** and **Priority** filter dropdowns had no explicit way to get back to "no filter". Once you picked one or more values, the only way to clear was to manually unselect each one — there was no "Any" affordance, which is unintuitive (raised in the Slack thread linked below).

## Changes

- Add an **Any** row as the first item in both the Source and Priority filter popovers.
- "Any" is shown as selected (check mark) whenever no specific value is selected, and clicking it clears that filter back to empty.
- Unselecting the last remaining option collapses to the same empty state — i.e. it is equivalent to clicking "Any".
- Backed by two small per-filter store actions (`clearSourceProductFilter`, `clearPriorityFilter`); empty array still means "all", so no query/serialization changes.

Note: the mobile `FilterSheet` uses a different paradigm (a sheet with a global "Reset" button), so it's left as-is; we can mirror the per-select "Any" there as a follow-up if desired.

## How did you test this?

- `pnpm --filter @posthog/ui test inboxSignalsFilterStore` — 14 tests pass, including new cases for `clearPriorityFilter`, `clearSourceProductFilter`, and "toggling off the last source is equivalent to Any".
- `pnpm --filter @posthog/ui typecheck` — clean.
- `biome lint` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1784192170661609?thread_ts=1784192170.661609&cid=C0ACRAMJUAG)*
