### PR TITLE
test(shared): cover explicit HTTPS port

### DIFF
--- a/packages/shared/src/url.test.ts
+++ b/packages/shared/src/url.test.ts
@@ -6,6 +6,7 @@ describe("isSafeExternalUrl", () => {
     "https://github.com/PostHog/code/pull/42",
     "http://example.com",
     "https://example.com/path?q=1#frag",
+    "https://example.com:443/path",
     "HTTPS://EXAMPLE.COM",
     "mailto:hi@posthog.com",
   ])("allows %s", (url) => {

--- a/packages/shared/src/url.test.ts
+++ b/packages/shared/src/url.test.ts
@@ -6,11 +6,14 @@ describe("isSafeExternalUrl", () => {
     "https://github.com/PostHog/code/pull/42",
     "http://example.com",
     "https://example.com/path?q=1#frag",
-    "https://example.com:443/path",
     "HTTPS://EXAMPLE.COM",
     "mailto:hi@posthog.com",
   ])("allows %s", (url) => {
     expect(isSafeExternalUrl(url)).toBe(true);
+  });
+
+  it("allows HTTPS URLs with an explicit port", () => {
+    expect(isSafeExternalUrl("https://example.com:8443/path")).toBe(true);
   });
 
   it.each([


### PR DESCRIPTION
## Problem

Add a harmless test-only change to exercise the pull request workflow.

**Why:** This dummy PR verifies the end-to-end signed commit and draft PR flow without changing production behavior.

## Changes

- Cover an explicit HTTPS port in `isSafeExternalUrl` tests.

## How did you test this?

- `pnpm --filter @posthog/shared exec vitest run src/url.test.ts`
- `pnpm exec biome check packages/shared/src/url.test.ts`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*