### PR TITLE
fix(billing): clarify org usage vs personal spend on Plan & usage

### DIFF
--- a/packages/core/src/billing/usageDisplay.test.ts
+++ b/packages/core/src/billing/usageDisplay.test.ts
@@ -264,11 +264,27 @@ describe("formatResetTime", () => {
       expected: "Resets shortly",
     },
   ])("$name", ({ resetAt, expected }) => {
-    const result = formatResetTime(resetAt, NOW);
+    const result = formatResetTime(resetAt, { now: NOW });
     if (expected instanceof RegExp) {
       expect(result).toMatch(expected);
     } else {
       expect(result).toBe(expected);
     }
+  });
+
+  it("swaps the leading phrase when a custom label is given", () => {
+    const opts = { now: NOW, label: "Billing period ends" };
+    expect(formatResetTime(isoAt(30 * 60 * 1000), opts)).toBe(
+      "Billing period ends in 30m",
+    );
+    expect(formatResetTime(isoAt(4 * 3600 * 1000), opts)).toBe(
+      "Billing period ends in 4h",
+    );
+    expect(formatResetTime(isoAt(-60_000), opts)).toBe(
+      "Billing period ends shortly",
+    );
+    expect(formatResetTime(isoAt(30 * 86400 * 1000), opts)).toMatch(
+      /^Billing period ends [A-Za-z]+ \d+ at /,
+    );
   });
 });

--- a/packages/core/src/billing/usageDisplay.ts
+++ b/packages/core/src/billing/usageDisplay.ts
@@ -88,14 +88,14 @@ export function isUsageExceeded(usage: UsageOutput): boolean {
 
 export function formatResetTime(
   resetAtIso: string,
-  now: number = Date.now(),
+  { now = Date.now(), label = "Resets" }: { now?: number; label?: string } = {},
 ): string {
   const parsed = Date.parse(resetAtIso);
   const ms = Number.isNaN(parsed) ? 0 : Math.max(0, parsed - now);
 
   const totalMinutes = Math.ceil(ms / 60_000);
-  if (totalMinutes <= 0) return "Resets shortly";
-  if (totalMinutes < 60) return `Resets in ${totalMinutes}m`;
+  if (totalMinutes <= 0) return `${label} shortly`;
+  if (totalMinutes < 60) return `${label} in ${totalMinutes}m`;
 
   const totalHours = ms / 3_600_000;
   if (totalHours < 24) {
@@ -106,8 +106,8 @@ export function formatResetTime(
       minutes = 0;
     }
     return minutes === 0
-      ? `Resets in ${hours}h`
-      : `Resets in ${hours}h ${minutes}m`;
+      ? `${label} in ${hours}h`
+      : `${label} in ${hours}h ${minutes}m`;
   }
 
   const target = new Date(now + ms);
@@ -120,5 +120,5 @@ export function formatResetTime(
     minute: "2-digit",
     timeZoneName: "short",
   });
-  return `Resets ${date} at ${time}`;
+  return `${label} ${date} at ${time}`;
 }

--- a/packages/ui/src/features/billing/UsageButton.tsx
+++ b/packages/ui/src/features/billing/UsageButton.tsx
@@ -68,9 +68,10 @@ export function UsageButton() {
     meter.kind === "dollars"
       ? `${formatUsdAmount(meter.usedUsd)} of ${formatUsdAmount(meter.limitUsd)} used`
       : `${percent}% used`;
-  const resetLabel = formatResetTime(
-    meter.kind === "dollars" ? meter.resetAt : meter.bucket.reset_at,
-  );
+  const resetLabel =
+    meter.kind === "dollars"
+      ? formatResetTime(meter.resetAt, { label: "Billing period ends" })
+      : formatResetTime(meter.bucket.reset_at);
   const breakdownLabel =
     meter.kind === "dollars" && meter.breakdown
       ? formatUsageBreakdown(meter.breakdown)

--- a/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -29,7 +29,7 @@ import { Badge, Button, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
 import { useEffect } from "react";
 
 export function PlanUsageSettings() {
-  const billingEnabled = true;
+  const billingEnabled = useFeatureFlag(BILLING_FLAG);
   const spendAnalysisEnabled = useSpendAnalysisEnabled();
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
   const billingUrl = getBillingUrl(cloudRegion);

--- a/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -16,10 +16,12 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@posthog/quill";
+import { BILLING_FLAG } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { UsageMeter } from "@posthog/ui/features/billing/UsageMeter";
 import { useUsage } from "@posthog/ui/features/billing/useUsage";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { SpendAnalysisSection } from "@posthog/ui/features/usage/components/SpendAnalysisSection";
 import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnalysisEnabled";
 import { useTrackUsageViewed } from "@posthog/ui/features/usage/useTrackUsageViewed";
@@ -44,7 +46,7 @@ export function PlanUsageSettings() {
     // refetchUsage is a refresh mutation, so it bypasses useUsage's `enabled`
     // gate — skip it for spend-only users.
     if (billingEnabled) void refetchUsage();
-  }, [refetchUsage]);
+  }, [refetchUsage, billingEnabled]);
 
   useTrackUsageViewed({
     isLoading: billingEnabled && usageLoading,

--- a/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -16,12 +16,10 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@posthog/quill";
-import { BILLING_FLAG } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { UsageMeter } from "@posthog/ui/features/billing/UsageMeter";
 import { useUsage } from "@posthog/ui/features/billing/useUsage";
-import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { SpendAnalysisSection } from "@posthog/ui/features/usage/components/SpendAnalysisSection";
 import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnalysisEnabled";
 import { useTrackUsageViewed } from "@posthog/ui/features/usage/useTrackUsageViewed";
@@ -30,14 +28,8 @@ import { getBillingUrl } from "@posthog/ui/utils/urls";
 import { Badge, Button, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
 import { useEffect } from "react";
 
-/**
- * Plan & usage under usage-based billing: no seats or plans to manage in-app —
- * payment methods, spend limits, and org-level usage live on the PostHog
- * billing page. The free-tier meters show the per-user allowance for
- * confirmed free-tier orgs; subscribed orgs have no per-user caps to meter.
- */
 export function PlanUsageSettings() {
-  const billingEnabled = useFeatureFlag(BILLING_FLAG);
+  const billingEnabled = true;
   const spendAnalysisEnabled = useSpendAnalysisEnabled();
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
   const billingUrl = getBillingUrl(cloudRegion);
@@ -52,7 +44,7 @@ export function PlanUsageSettings() {
     // refetchUsage is a refresh mutation, so it bypasses useUsage's `enabled`
     // gate — skip it for spend-only users.
     if (billingEnabled) void refetchUsage();
-  }, [refetchUsage, billingEnabled]);
+  }, [refetchUsage]);
 
   useTrackUsageViewed({
     isLoading: billingEnabled && usageLoading,
@@ -66,7 +58,6 @@ export function PlanUsageSettings() {
   const subscribed = usage?.code_usage_subscribed === true;
   const orgLimitReached = usage?.ai_credits?.exhausted === true;
   const meter = codeUsageMeter(usage);
-  const usageIsPerUser = meter.kind === "bucket";
 
   const openBilling = () => {
     if (billingUrl) window.open(billingUrl, "_blank");
@@ -164,16 +155,9 @@ export function PlanUsageSettings() {
           </Flex>
 
           <Flex direction="column" gap="3">
-            <Flex direction="column" gap="1">
-              <Text className="font-medium text-(--gray-9) text-sm">
-                {usageIsPerUser ? "Your usage" : "Organization usage"}
-              </Text>
-              <Text className="text-(--gray-11) text-[13px]">
-                {usageIsPerUser
-                  ? "Your personal free-tier allowance for this period."
-                  : "Usage-based billing shared across your whole organization."}
-              </Text>
-            </Flex>
+            <Text className="font-medium text-(--gray-9) text-sm">
+              Organization usage
+            </Text>
             {usageLoading ? (
               <Flex
                 align="center"

--- a/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -66,6 +66,7 @@ export function PlanUsageSettings() {
   const subscribed = usage?.code_usage_subscribed === true;
   const orgLimitReached = usage?.ai_credits?.exhausted === true;
   const meter = codeUsageMeter(usage);
+  const usageIsPerUser = meter.kind === "bucket";
 
   const openBilling = () => {
     if (billingUrl) window.open(billingUrl, "_blank");
@@ -163,7 +164,16 @@ export function PlanUsageSettings() {
           </Flex>
 
           <Flex direction="column" gap="3">
-            <Text className="font-medium text-(--gray-9) text-sm">Usage</Text>
+            <Flex direction="column" gap="1">
+              <Text className="font-medium text-(--gray-9) text-sm">
+                {usageIsPerUser ? "Your usage" : "Organization usage"}
+              </Text>
+              <Text className="text-(--gray-11) text-[13px]">
+                {usageIsPerUser
+                  ? "Your personal free-tier allowance for this period."
+                  : "Usage-based billing shared across your whole organization."}
+              </Text>
+            </Flex>
             {usageLoading ? (
               <Flex
                 align="center"
@@ -178,7 +188,7 @@ export function PlanUsageSettings() {
                 label={freeTier ? "Monthly free usage" : "Usage this period"}
                 percent={meter.percent}
                 valueLabel={`${formatUsdAmount(meter.usedUsd)} of ${formatUsdAmount(meter.limitUsd)}${freeTier ? " included" : ""}`}
-                detail={`${meter.exceeded ? "Limit exceeded. " : ""}${formatResetTime(meter.resetAt)}`}
+                detail={`${meter.exceeded ? "Limit exceeded. " : ""}${formatResetTime(meter.resetAt, { label: "Billing period ends" })}`}
                 breakdown={
                   meter.breakdown
                     ? { ...meter.breakdown, usedUsd: meter.usedUsd }

--- a/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
+++ b/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
@@ -36,10 +36,15 @@ export function SpendAnalysisSection() {
 
   return (
     <Flex direction="column" gap="3">
-      <Flex align="center" justify="between">
-        <Text className="font-medium text-(--gray-9) text-sm">
-          Spend analysis
-        </Text>
+      <Flex align="start" justify="between" gap="4">
+        <Flex direction="column" gap="1">
+          <Text className="font-medium text-(--gray-9) text-sm">
+            Your spend analysis
+          </Text>
+          <Text className="text-(--gray-11) text-[13px]">
+            Just your own usage, not your whole organization's.
+          </Text>
+        </Flex>
         <Flex align="center" gap="4">
           <WindowSelector value={spendWindow} onChange={setSpendWindow} />
           <Button

--- a/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
+++ b/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
@@ -36,15 +36,10 @@ export function SpendAnalysisSection() {
 
   return (
     <Flex direction="column" gap="3">
-      <Flex align="start" justify="between" gap="4">
-        <Flex direction="column" gap="1">
-          <Text className="font-medium text-(--gray-9) text-sm">
-            Your spend analysis
-          </Text>
-          <Text className="text-(--gray-11) text-[13px]">
-            Just your own usage, not your whole organization's.
-          </Text>
-        </Flex>
+      <Flex align="center" justify="between">
+        <Text className="font-medium text-(--gray-9) text-sm">
+          Personal spend analysis
+        </Text>
         <Flex align="center" gap="4">
           <WindowSelector value={spendWindow} onChange={setSpendWindow} />
           <Button


### PR DESCRIPTION
## Problem

it's not clear that usage is org-level, and spend analysis is user-level

## Changes

updates the UI / copy a bit

![Screenshot 2026-07-16 at 10.26.38 AM.png](https://app.graphite.com/user-attachments/assets/0a5b7444-3b89-4a34-9dca-72d6beea866b.png)



## How did you test this?

manually

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)