### PR TITLE
fix(agent): prompt for destructive PostHog exec sub-tools in auto mode

### DIFF
--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
@@ -200,7 +200,7 @@ describe("canUseTool MCP approval enforcement", () => {
     expect(result.behavior).toBe("allow");
   });
 
-  it("bypasses the PostHog exec gate in auto mode", async () => {
+  it("prompts through the PostHog exec gate in auto mode", async () => {
     setMcpToolApprovalStates({ mcp__posthog__exec: "approved" });
     const hasApproval = vi.fn().mockReturnValue(false);
     const addApproval = vi.fn().mockResolvedValue(undefined);
@@ -215,12 +215,23 @@ describe("canUseTool MCP approval enforcement", () => {
           addPostHogExecApproval: addApproval,
         },
       },
+      client: createClient({
+        outcome: { outcome: "selected", optionId: "allow" },
+      }),
     });
     const result = await canUseTool(context);
 
+    // Auto mode only auto-approves file edits and shell commands; destructive
+    // PostHog sub-tools must still reach the client as a permission prompt.
     expect(result.behavior).toBe("allow");
-    expect(context.client.requestPermission).not.toHaveBeenCalled();
-    expect(hasApproval).not.toHaveBeenCalled();
+    expect(hasApproval).toHaveBeenCalledWith("experiment-update");
+    expect(context.client.requestPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCall: expect.objectContaining({
+          title: "The agent wants to run `experiment-update` on PostHog",
+        }),
+      }),
+    );
     expect(addApproval).not.toHaveBeenCalled();
   });
 

--- a/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -778,10 +778,10 @@ export async function canUseTool(
     if (isPostHogExecTool(toolName)) {
       const subTool = extractPostHogSubTool(toolInput);
       if (subTool && isPostHogDestructiveSubTool(subTool)) {
-        if (
-          session.permissionMode === "auto" ||
-          session.permissionMode === "bypassPermissions"
-        ) {
+        // "auto" deliberately does NOT skip this gate: the mode only promises
+        // hands-off file edits and shell commands, and destructive PostHog
+        // sub-tools must still surface a permission prompt to the client.
+        if (session.permissionMode === "bypassPermissions") {
           return {
             behavior: "allow",
             updatedInput: toolInput as Record<string, unknown>,


### PR DESCRIPTION
## Problem

The PostHog MCP exec destructive gate (#1991) re-gates `update` / `partial-update` / `delete` / `destroy` sub-tools at sub-tool granularity — but it short-circuits to a silent allow when the session permission mode is `auto`, not just `bypassPermissions`.

The posthog_ai web surface creates runs in `auto` mode and relies on its client-side policy (`products/posthog_ai/frontend/policy/toolPolicy.ts` in PostHog/posthog) to auto-approve safe `permission_request`s and show an approval card for destructive ones. Because the gate never emits a request in `auto` mode, that card never triggers.

The result is exactly backwards in `auto` mode: non-destructive exec calls (e.g. `call insight-create`) are not in the auto-allowed tool set and `exec` is annotated `readOnlyHint: false`, so they fall through to the default permission flow and do prompt — while destructive calls are the only exec calls that run with no permission request at all.

## Changes

- `canUseTool`: the destructive PostHog exec gate now only skips prompting in `bypassPermissions` mode. In `auto` mode it consults persisted `allow_always` sub-tool approvals and otherwise goes through `handlePostHogExecApprovalFlow`, emitting a `permission_request` the client can decide on.
- This matches the advertised scope of auto mode ("Auto-approve file edits and shell commands") and the existing intent that "auto stays narrower than bypassPermissions" for MCP tools.

Behavior on other surfaces:

- Desktop PostHog Code in Auto Mode now prompts once per destructive sub-tool (silenceable via "always allow").
- Slack-origin runs: the request is answered by the backend permission broker, which fails closed on non-read-only tools unless the run is `full_auto`.
- Background-mode cloud runs: the cloud client still auto-selects the first allow option, so no behavior change and no hang.

## How did you test this?

- Flipped the `"bypasses the PostHog exec gate in auto mode"` unit test to assert the new prompting behavior (gate consulted, `requestPermission` called with the PostHog-specific title, no approval persisted on `allow_once`).
- `pnpm vitest run src/adapters/claude/permissions/ src/adapters/claude/hooks.test.ts` — 86 tests pass.
- `biome check` clean on changed files; repo-wide `pnpm typecheck` passes via the pre-commit hook.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

🤖 Generated with [Claude Code](https://claude.com/claude-code)