### PR TITLE
chore(code): set billing redirect URL to scroll to phc item

### DIFF
--- a/packages/ui/src/utils/urls.test.ts
+++ b/packages/ui/src/utils/urls.test.ts
@@ -28,10 +28,16 @@ describe("getPostHogUrl", () => {
 
 describe("getBillingUrl", () => {
   it.each([
-    ["us", "https://us.posthog.com/organization/billing/overview"],
-    ["eu", "https://eu.posthog.com/organization/billing/overview"],
+    [
+      "us",
+      "https://us.posthog.com/organization/billing/overview?products=posthog_code_usage",
+    ],
+    [
+      "eu",
+      "https://eu.posthog.com/organization/billing/overview?products=posthog_code_usage",
+    ],
   ] as const)(
-    "points at /organization/billing/overview on %s",
+    "points at /organization/billing/overview?products=posthog_code_usage on %s",
     (region, expected) => {
       expect(getBillingUrl(region)).toBe(expected);
     },

--- a/packages/ui/src/utils/urls.ts
+++ b/packages/ui/src/utils/urls.ts
@@ -16,5 +16,8 @@ export function getPostHogUrl(
 export function getBillingUrl(
   regionOverride?: CloudRegion | null,
 ): string | null {
-  return getPostHogUrl("/organization/billing/overview", regionOverride);
+  return getPostHogUrl(
+    "/organization/billing/overview?products=posthog_code_usage",
+    regionOverride,
+  );
 }


### PR DESCRIPTION
## Problem

all the billing buttons just go to the top of the billing page

it's a confusing page to scroll through

<!-- Who is this for and what problem does it solve? -->

<!-- Closes #ISSUE_ID -->

## Changes

set query param so the link auto-scrolls to the phc usage based plan section

<!-- What did you change and why? -->

<!-- If there are frontend changes, include screenshots. -->

## How did you test this?

manually

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

<!-- If you're an agent, only list tests you actually ran. -->

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?