### PR TITLE
feat: group review files by type

### DIFF
--- a/packages/ui/src/features/task-detail/components/ChangesPanel.tsx
+++ b/packages/ui/src/features/task-detail/components/ChangesPanel.tsx
@@ -5,6 +5,8 @@ import {
   FilePlus,
   MinusIcon,
   PlusIcon,
+  StackIcon,
+  TreeStructure,
 } from "@phosphor-icons/react";
 import { getFileExtension } from "@posthog/shared";
 import {
@@ -19,6 +21,7 @@ import {
   DropdownMenu,
   Flex,
   IconButton,
+  SegmentedControl,
   Spinner,
   Text,
 } from "@radix-ui/themes";
@@ -47,10 +50,15 @@ import { useCloudChangedFiles } from "../hooks/useCloudChangedFiles";
 import { useDiscardFile } from "../hooks/useDiscardFile";
 import { useStageToggle } from "../hooks/useStageToggle";
 import { ChangesTreeView } from "./ChangesTreeView";
+import type { ChangesGrouping } from "./changesTree";
 
 interface ChangesPanelProps {
   taskId: string;
   task: Task;
+}
+
+interface GroupedChangesPanelProps extends ChangesPanelProps {
+  grouping: ChangesGrouping;
 }
 
 interface ChangedFileItemProps {
@@ -63,6 +71,7 @@ interface ChangedFileItemProps {
   onStageToggle?: (file: ChangedFile) => void;
   onDiscard?: (file: ChangedFile, fileName: string) => void;
   depth?: number;
+  showFullPath?: boolean;
 }
 
 function CompactIconButton({
@@ -99,6 +108,7 @@ function ChangedFileItem({
   onStageToggle,
   onDiscard,
   depth = 0,
+  showFullPath = false,
 }: ChangedFileItemProps) {
   const requestScrollToFile = useReviewNavigationStore(
     (state) => state.requestScrollToFile,
@@ -283,6 +293,7 @@ function ChangedFileItem({
     <Tooltip content={tooltipContent} side="top" delayDuration={500}>
       <TreeFileRow
         fileName={fileName}
+        displayName={showFullPath ? file.path : fileName}
         depth={depth}
         isActive={isActive}
         onClick={handleClick}
@@ -296,7 +307,11 @@ function ChangedFileItem({
   );
 }
 
-function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
+function CloudChangesPanel({
+  taskId,
+  task,
+  grouping,
+}: GroupedChangesPanelProps) {
   const {
     prUrl,
     effectiveBranch,
@@ -313,7 +328,7 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
   const effectiveFiles = changedFiles;
 
   const renderFile = useCallback(
-    (file: ChangedFile, depth: number) => (
+    (file: ChangedFile, depth: number, showFullPath: boolean) => (
       <ChangedFileItem
         key={file.path}
         file={file}
@@ -321,6 +336,7 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
         fileKey={file.path}
         isActive={activeFilePath === file.path}
         depth={depth}
+        showFullPath={showFullPath}
       />
     ),
     [taskId, activeFilePath],
@@ -379,7 +395,11 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
   return (
     <Box height="100%" overflowY="auto" py="2" id="changes-panel-cloud">
       <Flex direction="column">
-        <ChangesTreeView files={effectiveFiles} renderFile={renderFile} />
+        <ChangesTreeView
+          files={effectiveFiles}
+          grouping={grouping}
+          renderFile={renderFile}
+        />
         {isRunActive && (
           <Flex align="center" gap="2" px="3" py="2">
             <Spinner size="1" />
@@ -395,15 +415,55 @@ function CloudChangesPanel({ taskId, task }: ChangesPanelProps) {
 
 export function ChangesPanel({ taskId, task }: ChangesPanelProps) {
   const isCloud = useIsCloudTask(taskId);
+  const isExpanded = useReviewNavigationStore(
+    (state) => state.reviewModes[taskId] === "expanded",
+  );
+  const [grouping, setGrouping] = useState<ChangesGrouping>("directory");
 
-  if (isCloud) {
-    return <CloudChangesPanel taskId={taskId} task={task} />;
+  const content = isCloud ? (
+    <CloudChangesPanel taskId={taskId} task={task} grouping={grouping} />
+  ) : (
+    <LocalChangesPanel taskId={taskId} task={task} grouping={grouping} />
+  );
+
+  if (!isExpanded) {
+    return content;
   }
 
-  return <LocalChangesPanel taskId={taskId} task={task} />;
+  return (
+    <Flex direction="column" className="h-full min-h-0">
+      <Flex className="shrink-0 border-(--gray-5) border-b px-2 py-1.5">
+        <SegmentedControl.Root
+          value={grouping}
+          size="1"
+          onValueChange={(value) => setGrouping(value as ChangesGrouping)}
+          aria-label="Changed files grouping"
+          className="w-full"
+        >
+          <SegmentedControl.Item value="directory">
+            <span className="inline-flex items-center gap-1.5">
+              <TreeStructure size={12} />
+              Folders
+            </span>
+          </SegmentedControl.Item>
+          <SegmentedControl.Item value="file-type">
+            <span className="inline-flex items-center gap-1.5">
+              <StackIcon size={12} />
+              File type
+            </span>
+          </SegmentedControl.Item>
+        </SegmentedControl.Root>
+      </Flex>
+      <Box className="min-h-0 flex-1">{content}</Box>
+    </Flex>
+  );
 }
 
-function LocalChangesPanel({ taskId, task }: ChangesPanelProps) {
+function LocalChangesPanel({
+  taskId,
+  task,
+  grouping,
+}: GroupedChangesPanelProps) {
   const { effectiveSource, prUrl, linkedBranch } =
     useEffectiveDiffSource(taskId);
   const repoPath = useCwd(taskId);
@@ -414,21 +474,29 @@ function LocalChangesPanel({ taskId, task }: ChangesPanelProps) {
         taskId={taskId}
         repoPath={repoPath}
         branch={linkedBranch}
+        grouping={grouping}
       />
     );
   }
 
   if (effectiveSource === "pr") {
-    return <PrChangesPanel taskId={taskId} prUrl={prUrl} />;
+    return <PrChangesPanel taskId={taskId} prUrl={prUrl} grouping={grouping} />;
   }
 
-  return <LocalWorkingTreeChangesPanel taskId={taskId} task={task} />;
+  return (
+    <LocalWorkingTreeChangesPanel
+      taskId={taskId}
+      task={task}
+      grouping={grouping}
+    />
+  );
 }
 
 function LocalWorkingTreeChangesPanel({
   taskId,
   task: _task,
-}: ChangesPanelProps) {
+  grouping,
+}: GroupedChangesPanelProps) {
   const workspace = useWorkspace(taskId);
   const repoPath = useCwd(taskId);
   const activeFilePath = useReviewNavigationStore(
@@ -446,7 +514,7 @@ function LocalWorkingTreeChangesPanel({
   const hasStagedFiles = stagedFiles.length > 0;
 
   const renderLocalFile = useCallback(
-    (file: ChangedFile, depth: number) => {
+    (file: ChangedFile, depth: number, showFullPath: boolean) => {
       const key = makeFileKey(file.staged, file.path);
       return (
         <ChangedFileItem
@@ -460,6 +528,7 @@ function LocalWorkingTreeChangesPanel({
           onStageToggle={handleStageToggle}
           onDiscard={handleDiscard}
           depth={depth}
+          showFullPath={showFullPath}
         />
       );
     },
@@ -512,7 +581,11 @@ function LocalWorkingTreeChangesPanel({
                 </Text>
               </Flex>
             )}
-            <ChangesTreeView files={files} renderFile={renderLocalFile} />
+            <ChangesTreeView
+              files={files}
+              grouping={grouping}
+              renderFile={renderLocalFile}
+            />
           </Fragment>
         ))}
       </Flex>
@@ -526,6 +599,7 @@ interface RemoteChangesListProps {
   isLoading: boolean;
   emptyMessage: string;
   panelId: string;
+  grouping: ChangesGrouping;
 }
 
 function RemoteChangesList({
@@ -534,13 +608,14 @@ function RemoteChangesList({
   isLoading,
   emptyMessage,
   panelId,
+  grouping,
 }: RemoteChangesListProps) {
   const activeFilePath = useReviewNavigationStore(
     (s) => s.activeFilePaths[taskId] ?? null,
   );
 
   const renderFile = useCallback(
-    (file: ChangedFile, depth: number) => (
+    (file: ChangedFile, depth: number, showFullPath: boolean) => (
       <ChangedFileItem
         key={file.path}
         file={file}
@@ -548,6 +623,7 @@ function RemoteChangesList({
         fileKey={file.path}
         isActive={activeFilePath === file.path}
         depth={depth}
+        showFullPath={showFullPath}
       />
     ),
     [taskId, activeFilePath],
@@ -564,7 +640,11 @@ function RemoteChangesList({
   return (
     <Box height="100%" overflowY="auto" py="2" id={panelId}>
       <Flex direction="column">
-        <ChangesTreeView files={files} renderFile={renderFile} />
+        <ChangesTreeView
+          files={files}
+          grouping={grouping}
+          renderFile={renderFile}
+        />
       </Flex>
     </Box>
   );
@@ -574,10 +654,12 @@ function BranchChangesPanel({
   taskId,
   repoPath,
   branch,
+  grouping,
 }: {
   taskId: string;
   repoPath: string | undefined;
   branch: string | null;
+  grouping: ChangesGrouping;
 }) {
   const { data: files = [], isLoading } = useLocalBranchChangedFiles(
     repoPath ?? null,
@@ -595,6 +677,7 @@ function BranchChangesPanel({
       isLoading={isLoading}
       emptyMessage="No file changes in branch"
       panelId="changes-panel-branch"
+      grouping={grouping}
     />
   );
 }
@@ -602,9 +685,11 @@ function BranchChangesPanel({
 function PrChangesPanel({
   taskId,
   prUrl,
+  grouping,
 }: {
   taskId: string;
   prUrl: string | null;
+  grouping: ChangesGrouping;
 }) {
   const { data: files = [], isLoading } = usePrChangedFiles(prUrl);
 
@@ -619,6 +704,7 @@ function PrChangesPanel({
       isLoading={isLoading}
       emptyMessage="No file changes in pull request"
       panelId="changes-panel-pr"
+      grouping={grouping}
     />
   );
 }

--- a/packages/ui/src/features/task-detail/components/ChangesTreeView.test.ts
+++ b/packages/ui/src/features/task-detail/components/ChangesTreeView.test.ts
@@ -1,0 +1,60 @@
+import type { ChangedFile } from "@posthog/shared/domain-types";
+import { describe, expect, it } from "vitest";
+import {
+  classifyChangedFile,
+  type FileTypeCategory,
+  groupChangesByFileType,
+} from "./changesTree";
+
+const changedFile = (path: string): ChangedFile => ({
+  path,
+  status: "modified",
+});
+
+describe("classifyChangedFile", () => {
+  it.each<[string, FileTypeCategory]>([
+    ["packages/core/src/service.ts", "Implementation"],
+    ["packages/core/src/service.test.ts", "Tests"],
+    ["tests/e2e/review.spec.ts", "Tests"],
+    ["packages/core/service_test.go", "Tests"],
+    ["packages/core/test_service.py", "Tests"],
+    ["packages/api/src/__generated__/schema.ts", "Generated"],
+    ["packages/api/src/schema.generated.ts", "Generated"],
+    ["packages/api/src/messages.pb.go", "Generated"],
+    ["pnpm-lock.yaml", "Generated"],
+    ["docs/code-review.md", "Documentation"],
+    ["README.md", "Documentation"],
+    [".github/workflows/ci.yml", "Configuration"],
+    ["package.json", "Configuration"],
+    ["requirements.txt", "Configuration"],
+    ["packages/ui/src/assets/review.png", "Assets"],
+    ["Makefile", "Other"],
+  ])("classifies %s as %s", (path, expected) => {
+    expect(classifyChangedFile(path)).toBe(expected);
+  });
+});
+
+describe("groupChangesByFileType", () => {
+  it("orders categories and files consistently", () => {
+    const groups = groupChangesByFileType([
+      changedFile("docs/z-last.md"),
+      changedFile("src/z-last.ts"),
+      changedFile("src/a-first.ts"),
+      changedFile("src/service.test.ts"),
+      changedFile("src/schema.generated.ts"),
+      changedFile("package.json"),
+    ]);
+
+    expect(groups.map((group) => group.category)).toEqual([
+      "Implementation",
+      "Tests",
+      "Generated",
+      "Documentation",
+      "Configuration",
+    ]);
+    expect(groups[0]?.files.map((file) => file.path)).toEqual([
+      "src/a-first.ts",
+      "src/z-last.ts",
+    ]);
+  });
+});

--- a/packages/ui/src/features/task-detail/components/ChangesTreeView.tsx
+++ b/packages/ui/src/features/task-detail/components/ChangesTreeView.tsx
@@ -1,62 +1,24 @@
 import type { ChangedFile } from "@posthog/shared/domain-types";
 import { TreeDirectoryRow } from "@posthog/ui/primitives/TreeDirectoryRow";
 import { useCallback, useMemo, useState } from "react";
-
-export interface TreeNode {
-  name: string;
-  path: string;
-  children: Map<string, TreeNode>;
-  files: ChangedFile[];
-}
-
-export function buildChangesTree(files: ChangedFile[]): TreeNode {
-  const root: TreeNode = { name: "", path: "", children: new Map(), files: [] };
-  for (const file of files) {
-    const parts = file.path.split("/");
-    let node = root;
-    for (let i = 0; i < parts.length - 1; i++) {
-      const part = parts[i];
-      if (!node.children.has(part)) {
-        node.children.set(part, {
-          name: part,
-          path: parts.slice(0, i + 1).join("/"),
-          children: new Map(),
-          files: [],
-        });
-      }
-      const child = node.children.get(part);
-      if (!child) break;
-      node = child;
-    }
-    node.files.push(file);
-  }
-  return root;
-}
-
-/** Collapse single-child directory chains into one node (e.g. "src/utils") */
-export function compactTree(node: TreeNode): TreeNode {
-  const compacted = new Map<string, TreeNode>();
-  for (const [key, child] of node.children) {
-    let current = child;
-    let label = current.name;
-    while (current.children.size === 1 && current.files.length === 0) {
-      const [, only] = [...current.children.entries()][0];
-      label = `${label}/${only.name}`;
-      current = only;
-    }
-    const result = compactTree(current);
-    result.name = label;
-    compacted.set(key, result);
-  }
-  return { ...node, children: compacted };
-}
+import {
+  buildChangesTree,
+  type ChangesGrouping,
+  compactTree,
+  groupChangesByFileType,
+  type TreeNode,
+} from "./changesTree";
 
 interface ChangesTreeNodeProps {
   node: TreeNode;
   depth: number;
   collapsedDirs: Set<string>;
   onToggleDir: (path: string) => void;
-  renderFile: (file: ChangedFile, depth: number) => React.ReactNode;
+  renderFile: (
+    file: ChangedFile,
+    depth: number,
+    showFullPath: boolean,
+  ) => React.ReactNode;
 }
 
 function ChangesTreeNode({
@@ -105,7 +67,7 @@ function ChangesTreeNode({
             />
           ))}
           {sortedFiles.map((file) =>
-            renderFile(file, node.path ? depth + 1 : depth),
+            renderFile(file, node.path ? depth + 1 : depth, false),
           )}
         </>
       )}
@@ -115,11 +77,21 @@ function ChangesTreeNode({
 
 interface ChangesTreeViewProps {
   files: ChangedFile[];
-  renderFile: (file: ChangedFile, depth: number) => React.ReactNode;
+  grouping: ChangesGrouping;
+  renderFile: (
+    file: ChangedFile,
+    depth: number,
+    showFullPath: boolean,
+  ) => React.ReactNode;
 }
 
-export function ChangesTreeView({ files, renderFile }: ChangesTreeViewProps) {
+export function ChangesTreeView({
+  files,
+  grouping,
+  renderFile,
+}: ChangesTreeViewProps) {
   const tree = useMemo(() => compactTree(buildChangesTree(files)), [files]);
+  const fileTypeGroups = useMemo(() => groupChangesByFileType(files), [files]);
   const [collapsedDirs, setCollapsedDirs] = useState<Set<string>>(new Set());
 
   const handleToggleDir = useCallback((path: string) => {
@@ -133,6 +105,26 @@ export function ChangesTreeView({ files, renderFile }: ChangesTreeViewProps) {
       return next;
     });
   }, []);
+
+  if (grouping === "file-type") {
+    return fileTypeGroups.map(({ category, files: categoryFiles }) => {
+      const categoryPath = `file-type:${category}`;
+      const isCollapsed = collapsedDirs.has(categoryPath);
+
+      return (
+        <div key={category}>
+          <TreeDirectoryRow
+            name={`${category} (${categoryFiles.length})`}
+            depth={0}
+            isExpanded={!isCollapsed}
+            onToggle={() => handleToggleDir(categoryPath)}
+          />
+          {!isCollapsed &&
+            categoryFiles.map((file) => renderFile(file, 1, true))}
+        </div>
+      );
+    });
+  }
 
   return (
     <ChangesTreeNode

--- a/packages/ui/src/features/task-detail/components/changesTree.ts
+++ b/packages/ui/src/features/task-detail/components/changesTree.ts
@@ -1,0 +1,216 @@
+import type { ChangedFile } from "@posthog/shared/domain-types";
+
+export type ChangesGrouping = "directory" | "file-type";
+
+export type FileTypeCategory =
+  | "Implementation"
+  | "Tests"
+  | "Generated"
+  | "Documentation"
+  | "Configuration"
+  | "Assets"
+  | "Other";
+
+const FILE_TYPE_CATEGORY_ORDER: FileTypeCategory[] = [
+  "Implementation",
+  "Tests",
+  "Generated",
+  "Documentation",
+  "Configuration",
+  "Assets",
+  "Other",
+];
+
+const DOCUMENTATION_EXTENSIONS = new Set(["adoc", "md", "mdx", "rst", "txt"]);
+const ASSET_EXTENSIONS = new Set([
+  "avif",
+  "bmp",
+  "gif",
+  "ico",
+  "jpeg",
+  "jpg",
+  "mp3",
+  "mp4",
+  "ogg",
+  "pdf",
+  "svg",
+  "webm",
+  "webp",
+  "woff",
+  "woff2",
+]);
+const CONFIG_EXTENSIONS = new Set(["ini", "properties", "toml", "yaml", "yml"]);
+const CONFIG_FILE_NAMES = new Set([
+  "biome.json",
+  "cargo.toml",
+  "dockerfile",
+  "gemfile",
+  "go.mod",
+  "package.json",
+  "pnpm-workspace.yaml",
+  "pyproject.toml",
+  "requirements.txt",
+  "tsconfig.json",
+]);
+const GENERATED_FILE_NAMES = new Set([
+  "bun.lock",
+  "cargo.lock",
+  "composer.lock",
+  "gemfile.lock",
+  "go.sum",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "poetry.lock",
+  "uv.lock",
+  "yarn.lock",
+]);
+
+export function classifyChangedFile(path: string): FileTypeCategory {
+  const normalizedPath = path.toLowerCase();
+  const segments = normalizedPath.split("/");
+  const fileName = segments.at(-1) ?? normalizedPath;
+  const extension = fileName.includes(".") ? fileName.split(".").at(-1) : "";
+
+  if (
+    segments.some((segment) =>
+      ["__tests__", "e2e", "spec", "specs", "test", "tests"].includes(segment),
+    ) ||
+    /(?:^|\.)((?:e2e|integration|spec|test))\.[^.]+$/.test(fileName) ||
+    /(?:^test_.+|.+_test)\.[^.]+$/.test(fileName) ||
+    fileName.endsWith(".snap")
+  ) {
+    return "Tests";
+  }
+
+  if (
+    GENERATED_FILE_NAMES.has(fileName) ||
+    segments.some((segment) =>
+      ["__generated__", "dist", "generated"].includes(segment),
+    ) ||
+    /(?:^|[._-])generated(?:[._-]|$)/.test(fileName) ||
+    /(?:\.g|\.pb|\.designer)\.[^.]+$/.test(fileName) ||
+    /_pb2(?:_grpc)?\.py$/.test(fileName)
+  ) {
+    return "Generated";
+  }
+
+  if (CONFIG_FILE_NAMES.has(fileName)) {
+    return "Configuration";
+  }
+
+  if (
+    segments.some((segment) =>
+      ["doc", "docs", "documentation"].includes(segment),
+    ) ||
+    DOCUMENTATION_EXTENSIONS.has(extension ?? "") ||
+    /^(changelog|contributing|license|readme)(\.|$)/.test(fileName)
+  ) {
+    return "Documentation";
+  }
+
+  if (
+    segments.some((segment) =>
+      [".github", ".husky", ".vscode", "config", "configs"].includes(segment),
+    ) ||
+    CONFIG_EXTENSIONS.has(extension ?? "") ||
+    fileName.startsWith(".") ||
+    /(?:^|\.)config\.[^.]+$/.test(fileName)
+  ) {
+    return "Configuration";
+  }
+
+  if (
+    segments.some((segment) =>
+      [
+        "asset",
+        "assets",
+        "font",
+        "fonts",
+        "image",
+        "images",
+        "static",
+      ].includes(segment),
+    ) ||
+    ASSET_EXTENSIONS.has(extension ?? "")
+  ) {
+    return "Assets";
+  }
+
+  if (extension) {
+    return "Implementation";
+  }
+
+  return "Other";
+}
+
+export function groupChangesByFileType(
+  files: ChangedFile[],
+): { category: FileTypeCategory; files: ChangedFile[] }[] {
+  const groups = new Map<FileTypeCategory, ChangedFile[]>();
+
+  for (const file of files) {
+    const category = classifyChangedFile(file.path);
+    const categoryFiles = groups.get(category) ?? [];
+    categoryFiles.push(file);
+    groups.set(category, categoryFiles);
+  }
+
+  return FILE_TYPE_CATEGORY_ORDER.flatMap((category) => {
+    const categoryFiles = groups.get(category);
+    if (!categoryFiles) return [];
+    return [
+      {
+        category,
+        files: categoryFiles.sort((a, b) => a.path.localeCompare(b.path)),
+      },
+    ];
+  });
+}
+
+export interface TreeNode {
+  name: string;
+  path: string;
+  children: Map<string, TreeNode>;
+  files: ChangedFile[];
+}
+
+export function buildChangesTree(files: ChangedFile[]): TreeNode {
+  const root: TreeNode = { name: "", path: "", children: new Map(), files: [] };
+  for (const file of files) {
+    const parts = file.path.split("/");
+    let node = root;
+    for (let index = 0; index < parts.length - 1; index++) {
+      const part = parts[index];
+      if (!node.children.has(part)) {
+        node.children.set(part, {
+          name: part,
+          path: parts.slice(0, index + 1).join("/"),
+          children: new Map(),
+          files: [],
+        });
+      }
+      const child = node.children.get(part);
+      if (!child) break;
+      node = child;
+    }
+    node.files.push(file);
+  }
+  return root;
+}
+
+export function compactTree(node: TreeNode): TreeNode {
+  const compacted = new Map<string, TreeNode>();
+  for (const [key, child] of node.children) {
+    let current = child;
+    let label = current.name;
+    while (current.children.size === 1 && current.files.length === 0) {
+      const [, only] = [...current.children.entries()][0];
+      label = `${label}/${only.name}`;
+      current = only;
+    }
+    const result = compactTree(current);
+    result.name = label;
+    compacted.set(key, result);
+  }
+  return { ...node, children: compacted };
+}

--- a/packages/ui/src/primitives/TreeDirectoryRow.tsx
+++ b/packages/ui/src/primitives/TreeDirectoryRow.tsx
@@ -69,6 +69,7 @@ export function TreeDirectoryRow({
 
 interface TreeFileRowProps {
   fileName: string;
+  displayName?: string;
   depth: number;
   isActive?: boolean;
   title?: string;
@@ -83,6 +84,7 @@ interface TreeFileRowProps {
 
 export function TreeFileRow({
   fileName,
+  displayName = fileName,
   depth,
   isActive = false,
   title,
@@ -118,7 +120,7 @@ export function TreeFileRow({
       />
       <FileIcon filename={fileName} size={14} />
       <span className="ml-[4px] min-w-0 flex-1 select-none overflow-hidden text-ellipsis whitespace-nowrap text-[13px]">
-        {fileName}
+        {displayName}
       </span>
       {trailing}
     </Flex>


### PR DESCRIPTION
## Problem

Expanded code reviews only organize changed files by folder structure, which makes it harder to review implementation, tests, documentation, and generated files together.

## Changes

- Add a Folders / File type selector to the expanded review sidebar
- Group files into implementation, tests, generated, documentation, configuration, assets, and other
- Show full paths in type groups and detect common generated and test filename patterns
- Add focused classification and ordering tests

Screenshots: not included for this compact sidebar control.

## How did you test this?

- `pnpm --dir packages/ui exec vitest run src/features/task-detail/components/ChangesTreeView.test.ts`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm exec biome lint packages/ui/src/features/task-detail/components/ChangesPanel.tsx packages/ui/src/features/task-detail/components/ChangesTreeView.tsx packages/ui/src/features/task-detail/components/ChangesTreeView.test.ts packages/ui/src/features/task-detail/components/changesTree.ts packages/ui/src/primitives/TreeDirectoryRow.tsx`
- Commit hooks ran `pnpm typecheck`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*