### PR TITLE
Lower handoff artifact warnings to debug

### DIFF
--- a/packages/agent/src/handoff-checkpoint.ts
+++ b/packages/agent/src/handoff-checkpoint.ts
@@ -128,7 +128,7 @@ export class HandoffCheckpointTracker {
         !!capture.headPack && !uploads.pack?.storagePath;
       const indexUploadMissing = !uploads.index?.storagePath;
       if (packUploadMissing || indexUploadMissing) {
-        this.logger.warn(
+        this.logger.debug(
           "Discarding handoff checkpoint: required artifact uploads did not complete",
           {
             checkpointId: capture.checkpoint.checkpointId,
@@ -245,7 +245,7 @@ export class HandoffCheckpointTracker {
 
     const content = await readFile(filePath);
     if (content.byteLength > MAX_ARTIFACT_UPLOAD_BYTES) {
-      this.logger.warn(
+      this.logger.debug(
         "Skipping handoff artifact upload: file exceeds the artifact size limit",
         {
           name,


### PR DESCRIPTION
## Problem

Routine handoff artifact size limits are expected behavior but currently appear as warnings to users, adding noise to the visible log stream.

## Changes

Lower the artifact-size skip and resulting checkpoint-discard messages from warning to debug level.
