### PR TITLE
Don't serialize the GitHub chip's "Loading..." placeholder title

### DIFF
--- a/packages/core/src/message-editor/content.test.ts
+++ b/packages/core/src/message-editor/content.test.ts
@@ -6,6 +6,7 @@ import {
   xmlToContent,
   xmlToPlainText,
 } from "./content";
+import { buildGithubRefPlaceholderChip } from "./githubIssueChip";
 
 describe("xmlToContent", () => {
   it("parses a file tag into a file chip", () => {
@@ -94,6 +95,26 @@ describe("xmlToContent", () => {
     };
     expect(contentToXml(content)).toBe(
       '<github_issue number="1454" title="" url="https://github.com/org/repo/issues/1454" />',
+    );
+  });
+
+  it("serializes an unresolved github_pr placeholder chip with an empty title", () => {
+    const content: EditorContent = {
+      segments: [
+        {
+          type: "chip",
+          chip: buildGithubRefPlaceholderChip({
+            kind: "pr",
+            owner: "org",
+            repo: "repo",
+            number: 71827,
+            normalizedUrl: "https://github.com/org/repo/pull/71827",
+          }),
+        },
+      ],
+    };
+    expect(contentToXml(content)).toBe(
+      '<github_pr number="71827" title="" url="https://github.com/org/repo/pull/71827" />',
     );
   });
 

--- a/packages/core/src/message-editor/content.ts
+++ b/packages/core/src/message-editor/content.ts
@@ -21,6 +21,9 @@ export interface MentionChip {
   skillName?: string;
 }
 
+/** Chip title shown while a pasted GitHub ref's real title is being fetched. */
+export const GITHUB_REF_PLACEHOLDER_TITLE = "Loading...";
+
 export interface FileAttachment {
   id: string;
   label: string;
@@ -83,7 +86,9 @@ export function contentToXml(content: EditorContent): string {
       case "github_pr": {
         const labelMatch = chip.label.match(/^#(\d+)(?:\s*-\s*(.*))?$/);
         const number = labelMatch?.[1] ?? "";
-        const title = labelMatch?.[2] ?? "";
+        const rawTitle = labelMatch?.[2] ?? "";
+        // A chip sent before its title fetch resolves must not leak the placeholder
+        const title = rawTitle === GITHUB_REF_PLACEHOLDER_TITLE ? "" : rawTitle;
         return `<${chip.type} number="${escapeXmlAttr(number)}" title="${escapeXmlAttr(title)}" url="${escapedId}" />`;
       }
       default:

--- a/packages/core/src/message-editor/githubIssueChip.ts
+++ b/packages/core/src/message-editor/githubIssueChip.ts
@@ -1,5 +1,5 @@
 import type { GithubRefState } from "@posthog/shared";
-import type { MentionChip } from "./content";
+import { GITHUB_REF_PLACEHOLDER_TITLE, type MentionChip } from "./content";
 import type { ParsedGithubIssueUrl } from "./githubIssueUrl";
 
 export interface GithubIssueChipSource {
@@ -43,7 +43,7 @@ export function buildGithubRefPlaceholderChip(
 ): MentionChip {
   const source = {
     number: parsed.number,
-    title: "Loading...",
+    title: GITHUB_REF_PLACEHOLDER_TITLE,
     url: parsed.normalizedUrl,
   };
   return parsed.kind === "pr"


### PR DESCRIPTION
## Problem

Pasting a GitHub PR/issue URL into the message editor inserts a chip labeled `#<n> - Loading...` while the real title is fetched. If the message is sent before the fetch resolves (or the fetch silently fails at the wrong moment), the placeholder is serialized into the message as `title="Loading..."` and rendered that way forever - e.g. `<github_pr number="71827" title="Loading..." url="..." />` showing up in an agent conversation.

## Changes

- Hoisted the placeholder into `GITHUB_REF_PLACEHOLDER_TITLE` in `content.ts` (single source of truth, used by `buildGithubRefPlaceholderChip`).
- `contentToXml` now serializes a still-unresolved chip with `title=""`, the same shape as the existing failed-fetch fallback (`#<n>` labels), which the parser already round-trips as a title-less chip.
- The chip still shows "Loading..." in the editor while fetching - only the serialized message changes.

## How did you test this?

- Added a regression test in `content.test.ts` that serializes a chip built by `buildGithubRefPlaceholderChip` and asserts the placeholder does not leak (this also pins the builder and serializer to the same constant).
- `pnpm --filter @posthog/core test` - 213 files / 2415 tests pass.
- `pnpm --filter @posthog/core typecheck` and `biome lint packages/core` - clean.
- I (the agent) did not run the desktop app; the change is confined to pure serialization logic.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
