### PR TITLE
Keep new browser tabs in the current channel

### DIFF
--- a/packages/ui/src/features/browser-tabs/BrowserTabStrip.tsx
+++ b/packages/ui/src/features/browser-tabs/BrowserTabStrip.tsx
@@ -717,18 +717,31 @@ export function BrowserTabStrip() {
   };
 
   // The default landing, keyed off the channels toggle (not the current route,
-  // which lags a toggle flip): #me when channels are on, the Code new-task
-  // screen otherwise. Deliberately never routes through the /website index,
-  // which would redirect to channels[0]. `tabId` (a fresh blank tab) fills that
-  // tab in place; without one (last tab closed) the navigation opens a new tab.
+  // which lags a toggle flip): the channel currently in view when there is one,
+  // otherwise #me, and the Code new-task screen when channels are off.
+  // Deliberately never routes through the /website index, which would redirect
+  // to channels[0]. `tabId` (a fresh blank tab) fills that tab in place;
+  // without one (last tab closed) the navigation opens a new tab.
   const landOnDefault = (tabId?: string) => {
     const state = tabId ? (prev: object) => ({ ...prev, tabId }) : undefined;
     if (!channelsEnabled) {
       navigate({ to: "/code", state });
       return;
     }
-    // #me is provisioned lazily the first time (same bridge the sidebar's #me
-    // row uses); fall back to the new-task screen if it can't be created.
+    // Keep a new tab relative to the channel the user is working in, so opening
+    // a tab from a channel canvas stays in that channel instead of jumping to
+    // the personal folder.
+    if (params.channelId) {
+      navigate({
+        to: "/website/$channelId",
+        params: { channelId: params.channelId },
+        state,
+      });
+      return;
+    }
+    // Not currently in a channel: fall back to #me, provisioned lazily the
+    // first time (same bridge the sidebar's #me row uses); fall back to the
+    // new-task screen if it can't be created.
     void (async () => {
       try {
         const folder = await ensurePersonalChannel(channels, createChannel);


### PR DESCRIPTION
## Problem

When working on a canvas inside a channel and opening a new tab (the "+" button or Cmd/Ctrl+T), the new tab jumped to the personal `#me` folder instead of staying in the channel currently in view. A new tab should be relative to the channel you're already working in.

## Changes

`landOnDefault` in `BrowserTabStrip.tsx` now navigates to the current route's `channelId` when there is one, so a new tab opened from a channel canvas stays in that channel. It falls back to `#me` only when the user isn't in a channel, and to the Code new-task screen when channels are off.

## How did you test this?

`pnpm --filter @posthog/ui typecheck` passes cleanly for the changed file. Not manually verified in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1784298584385859?thread_ts=1784298584.385859&cid=C0ACRAMJUAG)*
