### PR TITLE
feat(sessions): surface per-task cost estimate

### DIFF
--- a/packages/core/src/sessions/contextUsage.test.ts
+++ b/packages/core/src/sessions/contextUsage.test.ts
@@ -17,6 +17,31 @@ function usageUpdateEvent(used: number, size: number): AcpMessage {
   };
 }
 
+function costUsageUpdateEvent(
+  used: number,
+  size: number,
+  amount: number,
+  currency = "USD",
+): AcpMessage {
+  return {
+    type: "acp_message",
+    ts: 1,
+    message: {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "usage_update",
+          used,
+          size,
+          cost: { amount, currency },
+        },
+      },
+    },
+  };
+}
+
 function sizelessUsageUpdateEvent(used: number): AcpMessage {
   return {
     type: "acp_message",
@@ -119,6 +144,30 @@ describe("extractContextUsage", () => {
     expect(result?.breakdown?.conversation).toBe(45_500);
   });
 
+  it("reports null cost when no update carries a cost", () => {
+    const result = extractContextUsage([usageUpdateEvent(50_000, 200_000)]);
+    expect(result?.cost).toBeNull();
+  });
+
+  it("surfaces the cost from a single turn", () => {
+    const result = extractContextUsage([
+      costUsageUpdateEvent(50_000, 200_000, 0.42),
+    ]);
+    expect(result?.cost).toEqual({ amount: 0.42, currency: "USD" });
+  });
+
+  it("sums cost across turns since each result reports only its own spend", () => {
+    const result = extractContextUsage([
+      costUsageUpdateEvent(40_000, 200_000, 0.4),
+      costUsageUpdateEvent(90_000, 200_000, 0.35),
+      costUsageUpdateEvent(120_000, 200_000, 0.25),
+    ]);
+    // Context occupancy tracks the newest turn; cost accrues across all of them.
+    expect(result?.used).toBe(120_000);
+    expect(result?.cost?.amount).toBeCloseTo(1.0, 10);
+    expect(result?.cost?.currency).toBe("USD");
+  });
+
   it("tolerates the double-underscore method prefix from extNotification", () => {
     const result = extractContextUsage([
       usageUpdateEvent(50_000, 200_000),
@@ -178,6 +227,28 @@ describe("createContextUsageTracker", () => {
     // Dropping the latest usage event must lower the reported value, not keep
     // the stale append-path total.
     expect(tracker.update([earlier])?.used).toBe(50_000);
+  });
+
+  it("accumulates cost only over newly appended turns", () => {
+    const tracker = createContextUsageTracker();
+    const first = costUsageUpdateEvent(40_000, 200_000, 0.4);
+
+    expect(tracker.update([first])?.cost?.amount).toBeCloseTo(0.4, 10);
+
+    const result = tracker.update([
+      first,
+      costUsageUpdateEvent(90_000, 200_000, 0.35),
+    ]);
+    expect(result?.cost?.amount).toBeCloseTo(0.75, 10);
+  });
+
+  it("matches the batch extractor for a cost-bearing log", () => {
+    const tracker = createContextUsageTracker();
+    const events = [
+      costUsageUpdateEvent(40_000, 200_000, 0.4),
+      costUsageUpdateEvent(90_000, 200_000, 0.35),
+    ];
+    expect(tracker.update(events)).toEqual(extractContextUsage(events));
   });
 
   it("rebuilds when the tail changes at the same length", () => {

--- a/packages/core/src/sessions/contextUsage.ts
+++ b/packages/core/src/sessions/contextUsage.ts
@@ -15,18 +15,33 @@ export interface ContextUsage {
   used: number;
   size: number;
   percentage: number;
+  /**
+   * Cumulative estimated cost of the whole session, summed across turns. `used`
+   * is a point-in-time snapshot of resident context, but each turn's cost is a
+   * spend that accrues, so cost is totalled rather than replaced. `null` when
+   * no turn reported a cost (e.g. codex, which emits tokens without a cost).
+   */
   cost: { amount: number; currency: string } | null;
   breakdown: ContextBreakdown | null;
 }
 
-type ContextUsageAggregate = Omit<ContextUsage, "breakdown">;
+type ContextUsageAggregate = Omit<ContextUsage, "breakdown" | "cost">;
 
 export function extractContextUsage(events: AcpMessage[]): ContextUsage | null {
   let aggregate: ContextUsageAggregate | null = null;
   let breakdown: ContextBreakdown | null = null;
+  let costAmount: number | null = null;
+  let costCurrency = "USD";
 
+  // Cost sums over every turn, so this can't early-break once the newest
+  // aggregate/breakdown is found — it walks the full log.
   for (let i = events.length - 1; i >= 0; i--) {
     const msg = events[i].message;
+    const cost = extractCost(msg);
+    if (cost) {
+      costAmount = (costAmount ?? 0) + cost.amount;
+      costCurrency = cost.currency;
+    }
     if (!aggregate) {
       aggregate = extractAggregate(msg);
     } else if (aggregate.size <= 0) {
@@ -37,34 +52,53 @@ export function extractContextUsage(events: AcpMessage[]): ContextUsage | null {
     if (!breakdown) {
       breakdown = extractBreakdown(msg);
     }
-    if (aggregate && aggregate.size > 0 && breakdown) break;
   }
 
   if (!aggregate) return null;
-  return { ...aggregate, breakdown };
+  return { ...aggregate, cost: toCost(costAmount, costCurrency), breakdown };
 }
 
 interface ContextUsageState {
   aggregate: ContextUsageAggregate | null;
+  costAmount: number | null;
+  costCurrency: string;
   breakdown: ContextBreakdown | null;
 }
 
 export function createContextUsageTracker() {
   return createAppendOnlyTracker<ContextUsageState, ContextUsage | null>({
-    init: () => ({ aggregate: null, breakdown: null }),
+    init: () => ({
+      aggregate: null,
+      costAmount: null,
+      costCurrency: "USD",
+      breakdown: null,
+    }),
     processEvent: (state, event) => {
       const msg = event.message;
       const next = extractAggregate(msg);
       if (next) {
         state.aggregate = withCarriedSize(next, state.aggregate);
       }
+      const cost = extractCost(msg);
+      if (cost) {
+        state.costAmount = (state.costAmount ?? 0) + cost.amount;
+        state.costCurrency = cost.currency;
+      }
       state.breakdown = extractBreakdown(msg) ?? state.breakdown;
     },
     getResult: (state) =>
       state.aggregate
-        ? { ...state.aggregate, breakdown: state.breakdown }
+        ? {
+            ...state.aggregate,
+            cost: toCost(state.costAmount, state.costCurrency),
+            breakdown: state.breakdown,
+          }
         : null,
   });
+}
+
+function toCost(amount: number | null, currency: string): ContextUsage["cost"] {
+  return amount != null ? { amount, currency } : null;
 }
 
 /**
@@ -116,11 +150,38 @@ function extractAggregate(
       const size = typeof update.size === "number" ? update.size : 0;
       const percentage =
         size > 0 ? Math.min(100, Math.round((update.used / size) * 100)) : 0;
+      return { used: update.used, size, percentage };
+    }
+  }
+  return null;
+}
+
+function extractCost(
+  msg: AcpMessage["message"],
+): { amount: number; currency: string } | null {
+  if (
+    "method" in msg &&
+    msg.method === "session/update" &&
+    !("id" in msg) &&
+    "params" in msg
+  ) {
+    const params = msg.params as
+      | {
+          update?: {
+            sessionUpdate?: string;
+            cost?: { amount: number; currency: string } | null;
+          };
+        }
+      | undefined;
+    const update = params?.update;
+    if (
+      update?.sessionUpdate === "usage_update" &&
+      update.cost &&
+      typeof update.cost.amount === "number"
+    ) {
       return {
-        used: update.used,
-        size,
-        percentage,
-        cost: update.cost ?? null,
+        amount: update.cost.amount,
+        currency: update.cost.currency ?? "USD",
       };
     }
   }

--- a/packages/core/src/sessions/contextUsage.ts
+++ b/packages/core/src/sessions/contextUsage.ts
@@ -15,12 +15,7 @@ export interface ContextUsage {
   used: number;
   size: number;
   percentage: number;
-  /**
-   * Cumulative estimated cost of the whole session, summed across turns. `used`
-   * is a point-in-time snapshot of resident context, but each turn's cost is a
-   * spend that accrues, so cost is totalled rather than replaced. `null` when
-   * no turn reported a cost (e.g. codex, which emits tokens without a cost).
-   */
+  /** Cumulative estimated session cost, summed across turns; `null` if none reported (e.g. codex). */
   cost: { amount: number; currency: string } | null;
   breakdown: ContextBreakdown | null;
 }

--- a/packages/shared/src/flags.ts
+++ b/packages/shared/src/flags.ts
@@ -21,3 +21,5 @@ export const GLM_MODEL_FLAG = "posthog-code-glm-model";
 export const SPOKEN_NARRATION_FLAG = "posthog-code-spoken-narration";
 // Gates importing and relaying local MCP servers into cloud task runs.
 export const LOCAL_MCP_IMPORT_FLAG = "posthog-code-local-mcp-import";
+/** Per-task estimated cost readout in the context usage indicator. */
+export const TASK_COST_FLAG = "posthog-code-task-cost";

--- a/packages/ui/src/features/sessions/components/ContextBreakdownPopover.tsx
+++ b/packages/ui/src/features/sessions/components/ContextBreakdownPopover.tsx
@@ -9,10 +9,12 @@ import { Flex, Text } from "@radix-ui/themes";
 
 interface ContextBreakdownPopoverProps {
   usage: ContextUsage;
+  showCost?: boolean;
 }
 
 export function ContextBreakdownPopover({
   usage,
+  showCost = false,
 }: ContextBreakdownPopoverProps) {
   const { used, size, percentage, cost, breakdown } = usage;
   const fillColor = getOverallUsageColor(percentage);
@@ -73,7 +75,7 @@ export function ContextBreakdownPopover({
         </Text>
       )}
 
-      {cost && (
+      {showCost && cost && (
         <Flex
           align="center"
           justify="between"

--- a/packages/ui/src/features/sessions/components/ContextBreakdownPopover.tsx
+++ b/packages/ui/src/features/sessions/components/ContextBreakdownPopover.tsx
@@ -1,5 +1,6 @@
 import {
   CONTEXT_CATEGORIES,
+  formatCostUsd,
   formatTokensCompact,
   getOverallUsageColor,
 } from "@posthog/ui/features/sessions/contextColors";
@@ -13,7 +14,7 @@ interface ContextBreakdownPopoverProps {
 export function ContextBreakdownPopover({
   usage,
 }: ContextBreakdownPopoverProps) {
-  const { used, size, percentage, breakdown } = usage;
+  const { used, size, percentage, cost, breakdown } = usage;
   const fillColor = getOverallUsageColor(percentage);
   // The context window can be unknown (size 0) — show just the token count
   // rather than a misleading "~X / 0 tokens · 0% full".
@@ -70,6 +71,19 @@ export function ContextBreakdownPopover({
         <Text className="text-(--gray-10) text-[12px]">
           Detailed breakdown available after the first response.
         </Text>
+      )}
+
+      {cost && (
+        <Flex
+          align="center"
+          justify="between"
+          className="border-(--gray-4) border-t pt-2 text-[13px]"
+        >
+          <Text className="text-(--gray-11)">Estimated cost</Text>
+          <Text className="font-medium text-(--gray-12) tabular-nums">
+            {formatCostUsd(cost.amount)}
+          </Text>
+        </Flex>
       )}
     </Flex>
   );

--- a/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
+++ b/packages/ui/src/features/sessions/components/ContextUsageIndicator.test.tsx
@@ -1,8 +1,17 @@
 import type { ContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
 import { Theme } from "@radix-ui/themes";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ContextUsageIndicator } from "./ContextUsageIndicator";
+
+const flagState = vi.hoisted(() => ({ enabled: false }));
+vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
+  useFeatureFlag: () => flagState.enabled,
+}));
+
+beforeEach(() => {
+  flagState.enabled = false;
+});
 
 function usage(overrides?: Partial<ContextUsage>): ContextUsage {
   return {
@@ -51,6 +60,18 @@ describe("ContextUsageIndicator", () => {
     expect(
       screen.getByRole("button", { name: "Context usage: 50K tokens" }),
     ).toBeInTheDocument();
+  });
+
+  it("appends the estimated cost to the label when the flag is enabled", () => {
+    flagState.enabled = true;
+    render(
+      <Theme>
+        <ContextUsageIndicator
+          usage={usage({ cost: { amount: 0.42, currency: "USD" } })}
+        />
+      </Theme>,
+    );
+    expect(screen.getByText(/50K\/200K · 25% · \$0\.42/)).toBeInTheDocument();
   });
 
   it("renders a finite stroke offset at 0% (no NaN/Infinity)", () => {

--- a/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
+++ b/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
@@ -1,4 +1,5 @@
 import {
+  formatCostUsd,
   formatTokensCompact,
   getOverallUsageColor,
 } from "@posthog/ui/features/sessions/contextColors";
@@ -18,12 +19,18 @@ interface ContextUsageIndicatorProps {
 export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
   if (!usage) return null;
 
-  const { used, size, percentage } = usage;
+  const { used, size, percentage, cost } = usage;
   // The context window can be unknown (size 0) — show just the token count
   // rather than a misleading "X/0 · 0%".
   const hasSize = size > 0;
   const strokeDashoffset = CIRCUMFERENCE - (percentage / 100) * CIRCUMFERENCE;
   const color = getOverallUsageColor(percentage);
+  const tokenLabel = hasSize
+    ? `${formatTokensCompact(used)}/${formatTokensCompact(size)} · ${percentage}%`
+    : formatTokensCompact(used);
+  const label = cost
+    ? `${tokenLabel} · ${formatCostUsd(cost.amount)}`
+    : tokenLabel;
 
   return (
     <Popover.Root>
@@ -66,9 +73,7 @@ export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
               />
             </svg>
             <Text className="text-[13px] text-muted-foreground tabular-nums">
-              {hasSize
-                ? `${formatTokensCompact(used)}/${formatTokensCompact(size)} · ${percentage}%`
-                : formatTokensCompact(used)}
+              {label}
             </Text>
           </Flex>
         </button>

--- a/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
+++ b/packages/ui/src/features/sessions/components/ContextUsageIndicator.tsx
@@ -1,3 +1,5 @@
+import { TASK_COST_FLAG } from "@posthog/shared";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import {
   formatCostUsd,
   formatTokensCompact,
@@ -17,6 +19,8 @@ interface ContextUsageIndicatorProps {
 }
 
 export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
+  const costEnabled = useFeatureFlag(TASK_COST_FLAG) || import.meta.env.DEV;
+
   if (!usage) return null;
 
   const { used, size, percentage, cost } = usage;
@@ -25,10 +29,11 @@ export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
   const hasSize = size > 0;
   const strokeDashoffset = CIRCUMFERENCE - (percentage / 100) * CIRCUMFERENCE;
   const color = getOverallUsageColor(percentage);
+  const showCost = costEnabled && cost !== null;
   const tokenLabel = hasSize
     ? `${formatTokensCompact(used)}/${formatTokensCompact(size)} · ${percentage}%`
     : formatTokensCompact(used);
-  const label = cost
+  const label = showCost
     ? `${tokenLabel} · ${formatCostUsd(cost.amount)}`
     : tokenLabel;
 
@@ -79,7 +84,7 @@ export function ContextUsageIndicator({ usage }: ContextUsageIndicatorProps) {
         </button>
       </Popover.Trigger>
       <Popover.Content size="2" side="top" align="end" sideOffset={6}>
-        <ContextBreakdownPopover usage={usage} />
+        <ContextBreakdownPopover usage={usage} showCost={showCost} />
       </Popover.Content>
     </Popover.Root>
   );

--- a/packages/ui/src/features/sessions/contextColors.ts
+++ b/packages/ui/src/features/sessions/contextColors.ts
@@ -28,3 +28,14 @@ export function formatTokensCompact(tokens: number): string {
   if (tokens >= 1000) return `${Math.round(tokens / 1000)}K`;
   return tokens.toString();
 }
+
+/**
+ * Formats a USD cost estimate for display. Sub-cent amounts collapse to
+ * `<$0.01` so a non-zero spend never reads as free; everything else shows two
+ * decimals ($0.42, $12.34).
+ */
+export function formatCostUsd(amount: number): string {
+  if (amount <= 0) return "$0.00";
+  if (amount < 0.01) return "<$0.01";
+  return `$${amount.toFixed(2)}`;
+}


### PR DESCRIPTION
## Summary

<img width="327" height="51" alt="Screenshot 2026-07-17 at 10 45 14 AM" src="https://github.com/user-attachments/assets/19aad9c5-8702-4bd1-ae66-ac91825904ba" />


Surfaces a **per-task cost estimate** in the session UI, gated behind a feature flag. The Claude Agent SDK already reports a per-turn `total_cost_usd`, which flowed into `ContextUsage.cost` but was never rendered anywhere. This wires it through to the UI.

- **Sum cost across turns.** Each `result` message reports only that turn's spend, so the running session total is the sum — mirroring how the codebase already resets and re-accumulates per-turn token usage. Split cost out of the point-in-time context aggregate (`used`/`size` stay a snapshot of the newest turn; `cost` accrues), in both the batch extractor and the streaming append-only tracker (kept equivalent).
- **Render it.** `ContextUsageIndicator` chip shows `· $X.XX`, and `ContextBreakdownPopover` gets an "Estimated cost" row.
- **Feature-flagged.** Both readouts are gated behind `posthog-code-task-cost` (`TASK_COST_FLAG`). On in local dev via the `import.meta.env.DEV` fallback, matching the other UI flags. Until the flag is created/enabled in PostHog, `isFeatureEnabled` returns `false`, so the cost stays hidden in production.
- **Codex** emits tokens without a cost, so `cost` stays `null` and the UI hides it regardless of the flag.

Labeled "Estimated cost" since it's the SDK's own estimate. Background task-notification turns are excluded (they don't feed the ACP `usage_update` that carries cost).

## Rollout

Create the `posthog-code-task-cost` flag in the PostHog project the desktop app reads flags from, then enable for the target cohort.

## Test plan

- `contextUsage.test.ts`: added cases for single-turn cost, cross-turn summation, null-when-absent, append-only accumulation, and batch/tracker equivalence — 15 tests pass.
- `@posthog/core` + `@posthog/ui` typecheck clean; Biome lint clean on all changed files (zero `noRestrictedImports`).

## Follow-up (not in this PR)

Phase 2 — a local per-model pricing table for a per-model cost breakdown and Codex coverage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*