### PR TITLE
Fix unstaging renamed files

### DIFF
--- a/packages/ui/src/features/task-detail/hooks/stageTogglePaths.test.ts
+++ b/packages/ui/src/features/task-detail/hooks/stageTogglePaths.test.ts
@@ -1,0 +1,24 @@
+import type { ChangedFile } from "@posthog/shared/domain-types";
+import { describe, expect, it } from "vitest";
+import { getStageTogglePaths } from "./stageTogglePaths";
+
+describe("getStageTogglePaths", () => {
+  it.each([
+    {
+      name: "uses the current path for a regular file",
+      file: { path: "current.ts", status: "modified" } satisfies ChangedFile,
+      expected: ["current.ts"],
+    },
+    {
+      name: "uses both paths for a renamed file",
+      file: {
+        path: "new.ts",
+        originalPath: "old.ts",
+        status: "renamed",
+      } satisfies ChangedFile,
+      expected: ["old.ts", "new.ts"],
+    },
+  ])("$name", ({ file, expected }) => {
+    expect(getStageTogglePaths(file)).toEqual(expected);
+  });
+});

--- a/packages/ui/src/features/task-detail/hooks/stageTogglePaths.ts
+++ b/packages/ui/src/features/task-detail/hooks/stageTogglePaths.ts
@@ -1,0 +1,9 @@
+import type { ChangedFile } from "@posthog/shared/domain-types";
+
+export function getStageTogglePaths(file: ChangedFile): string[] {
+  if (file.originalPath && file.originalPath !== file.path) {
+    return [file.originalPath, file.path];
+  }
+
+  return [file.path];
+}

--- a/packages/ui/src/features/task-detail/hooks/useStageToggle.ts
+++ b/packages/ui/src/features/task-detail/hooks/useStageToggle.ts
@@ -5,6 +5,7 @@ import { useCallback } from "react";
 import { logger } from "../../../shell/logger";
 import { invalidateGitWorkingTreeQueries } from "../../git-interaction/gitCacheKeys";
 import { updateGitCacheFromSnapshot } from "../../git-interaction/utils/updateGitCache";
+import { getStageTogglePaths } from "./stageTogglePaths";
 
 const log = logger.scope("use-stage-toggle");
 
@@ -21,7 +22,7 @@ export function useStageToggle(repoPath: string | undefined) {
       try {
         const result = await endpoint.mutateAsync({
           directoryPath: repoPath,
-          paths: [file.originalPath ?? file.path],
+          paths: getStageTogglePaths(file),
         });
         updateGitCacheFromSnapshot(queryClient, repoPath, result);
         invalidateGitWorkingTreeQueries(repoPath);


### PR DESCRIPTION
## Problem

Renamed files in code review could not be fully unstaged because the action only sent the original path to Git.

**Why:** Users need the unstage button to work consistently for staged renames.

## Changes

- Send both the original and current paths when toggling a renamed file
- Add regression coverage for regular and renamed path selection

## How did you test this?

- `pnpm --dir packages/ui exec vitest run src/features/task-detail/hooks/stageTogglePaths.test.ts`
- `pnpm exec biome check packages/ui/src/features/task-detail/hooks/stageTogglePaths.ts packages/ui/src/features/task-detail/hooks/stageTogglePaths.test.ts packages/ui/src/features/task-detail/hooks/useStageToggle.ts`
- `pnpm exec turbo typecheck --filter=@posthog/ui`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
