### PR TITLE
fix(canvas): cap CONTEXT.md description textarea height

### DIFF
--- a/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -181,9 +181,6 @@ export function CreateChannelModal({
         id="context-description"
         autoFocus
         rows={4}
-        // quill's Textarea auto-grows with content (field-sizing) and is
-        // uncapped, so a long description would expand the dialog until the
-        // footer's Create button is pushed off-screen. Cap it and scroll within.
         className="max-h-[40vh] overflow-y-auto"
         value={description}
         placeholder={DESCRIPTION_PLACEHOLDER}

--- a/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -181,6 +181,10 @@ export function CreateChannelModal({
         id="context-description"
         autoFocus
         rows={4}
+        // quill's Textarea auto-grows with content (field-sizing) and is
+        // uncapped, so a long description would expand the dialog until the
+        // footer's Create button is pushed off-screen. Cap it and scroll within.
+        className="max-h-[40vh] overflow-y-auto"
         value={description}
         placeholder={DESCRIPTION_PLACEHOLDER}
         disabled={busy}


### PR DESCRIPTION
## Problem

When creating a channel's CONTEXT.md with an agent, the description textarea in the "Create your context.md" dialog grows without limit as you type. Because quill's `Textarea` auto-grows to fit its content (`field-sizing: content`) and has no `max-height`, a long enough description expands the modal past the viewport and pushes the footer's **Create** button off-screen — leaving ⌘/Ctrl+Enter as the only way to submit (which most users won't discover).

**Why:** reported by a user hitting this in the Channels (project-bluebird) flow — the submit button becomes unclickable for longer descriptions.

## Changes

- Cap the description `Textarea` at `40vh` with `overflow-y-auto` so it scrolls internally instead of expanding the dialog. The field is shared by both the describe-mode dialog and the create-mode step-two dialog, so both are fixed.

## How did you test this?

- Manual reasoning only — I don't have the app running in this environment. The change is a `className` on a component that already forwards `className` to the underlying quill primitive; no behavior beyond height/overflow changes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*