### PR TITLE
fix(code): restore external app icons

### DIFF
--- a/apps/code/runtime-dependencies.ts
+++ b/apps/code/runtime-dependencies.ts
@@ -37,8 +37,8 @@ export const requiredNativeModules = [
   "better-sqlite3",
 ];
 
-// file-icon (and its p-map dependency) is only used on macOS.
-export const macOnlyNativeModules = ["file-icon", "p-map"];
+// file-icon is only used on macOS.
+export const macOnlyNativeModules = ["file-icon"];
 
 // The subset that ships compiled .node binaries and must be unpacked from asar.
 const asarUnpackModules = [

--- a/apps/code/src/main/platform-adapters/electron-file-icon.test.ts
+++ b/apps/code/src/main/platform-adapters/electron-file-icon.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveMacFileIconBinary } from "./electron-file-icon";
+
+describe("resolveMacFileIconBinary", () => {
+  it("resolves the packaged extractor outside the ASAR", () => {
+    expect(
+      resolveMacFileIconBinary(
+        "/Applications/PostHog Code.app/Contents/Resources/app.asar",
+        true,
+        "/unused/node_modules/file-icon/index.js",
+      ),
+    ).toBe(
+      "/Applications/PostHog Code.app/Contents/Resources/app.asar.unpacked/node_modules/file-icon/file-icon",
+    );
+  });
+});

--- a/apps/code/src/main/platform-adapters/electron-file-icon.ts
+++ b/apps/code/src/main/platform-adapters/electron-file-icon.ts
@@ -1,19 +1,29 @@
+import { execFile } from "node:child_process";
+import path from "node:path";
 import type { IFileIcon } from "@posthog/platform/file-icon";
 import { app } from "electron";
 import { injectable } from "inversify";
 
-type FileIconModule = typeof import("file-icon");
+const FILE_ICON_MAX_BUFFER_BYTES = 100 * 1024 * 1024;
+
+export function resolveMacFileIconBinary(
+  appPath: string,
+  isPackaged: boolean,
+  modulePath: string,
+): string {
+  const resolvedModulePath = isPackaged
+    ? path.join(`${appPath}.unpacked`, "node_modules", "file-icon", "index.js")
+    : modulePath;
+  return path.join(path.dirname(resolvedModulePath), "file-icon");
+}
 
 @injectable()
 export class ElectronFileIcon implements IFileIcon {
-  private fileIconModule: FileIconModule | undefined;
-
   public async getAsDataUrl(filePath: string): Promise<string | null> {
     try {
       if (process.platform === "darwin") {
-        const mod = await this.loadFileIconModule();
-        const uint8Array = await mod.fileIconToBuffer(filePath, { size: 64 });
-        const base64 = Buffer.from(uint8Array).toString("base64");
+        const buffer = await this.getMacFileIcon(filePath);
+        const base64 = buffer.toString("base64");
         return `data:image/png;base64,${base64}`;
       }
 
@@ -25,10 +35,27 @@ export class ElectronFileIcon implements IFileIcon {
     }
   }
 
-  private async loadFileIconModule(): Promise<FileIconModule> {
-    if (!this.fileIconModule) {
-      this.fileIconModule = await import("file-icon");
-    }
-    return this.fileIconModule;
+  private getMacFileIcon(filePath: string): Promise<Buffer> {
+    const binaryPath = resolveMacFileIconBinary(
+      app.getAppPath(),
+      app.isPackaged,
+      require.resolve("file-icon"),
+    );
+    const input = JSON.stringify([{ appOrPID: filePath, size: 64 }]);
+
+    return new Promise((resolve, reject) => {
+      execFile(
+        binaryPath,
+        [input],
+        { encoding: "buffer", maxBuffer: FILE_ICON_MAX_BUFFER_BYTES },
+        (error, stdout) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(Buffer.from(stdout));
+        },
+      );
+    });
   }
 }

--- a/packages/workspace-server/src/services/external-apps/external-apps.ts
+++ b/packages/workspace-server/src/services/external-apps/external-apps.ts
@@ -380,6 +380,10 @@ export class ExternalAppsService {
       type: "terminal",
       darwin: { path: "/Applications/Ghostty.app" },
     },
+    cmux: {
+      type: "terminal",
+      darwin: { path: "/Applications/cmux.app" },
+    },
     kitty: {
       type: "terminal",
       darwin: { path: "/Applications/kitty.app" },
@@ -477,6 +481,7 @@ export class ExternalAppsService {
     alacritty: "Alacritty",
     kitty: "Kitty",
     ghostty: "Ghostty",
+    cmux: "cmux",
     hyper: "Hyper",
     tabby: "Tabby",
     rio: "Rio",


### PR DESCRIPTION
## Problem

Packaged macOS builds silently lost external application icons because the extractor depended on hoisted runtime modules and an ASAR-sensitive executable path.

## Changes

Run the bundled extractor directly from `app.asar.unpacked`, remove the unused `p-map` package, and register cmux as a detected terminal.

## How did you test this?

- Ran targeted Vitest tests and `pnpm typecheck`.
- Built the Electron package and verified native VS Code, Ghostty, cmux, and Finder icons in the running menu.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*