### PR TITLE
feat(agent): add bounded local browser use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 -->
+
 # PostHog Code Development Guide
 
 `AGENTS.md` is the source of truth for architecture and development rules. `CLAUDE.md` is a symlink to this file. Edit this file only.
@@ -229,6 +231,7 @@ See [docs/conventions.md](./docs/conventions.md).
 - Use SDK types from `@anthropic-ai/claude-agent-sdk` and `@agentclientprotocol/sdk`.
 - Do not use Claude Code SDK `rawInput`. Use Zod-validated metadata.
 - User approvals are tool calls with permissions. Do not model approvals as custom methods plus notifications.
+- Keep browser and computer-use capabilities adapter-neutral unless an adapter has a documented technical constraint.
 
 ## Key Libraries
 

--- a/apps/code/runtime-dependencies.test.ts
+++ b/apps/code/runtime-dependencies.test.ts
@@ -5,6 +5,7 @@ import {
   macOnlyNativeModules,
   packagedFileGlobs,
   requiredNativeModules,
+  runtimeJavaScriptModules,
   runtimeNativeModules,
   watcherPackageFor,
 } from "./runtime-dependencies";
@@ -41,6 +42,21 @@ describe("native module globs", () => {
   it("emits a per-package glob for unscoped modules", () => {
     expect(packagedFileGlobs).toContain("node_modules/node-pty/**/*");
     expect(packagedFileGlobs).toContain("node_modules/better-sqlite3/**/*");
+  });
+
+  it("packages browser automation runtime modules", () => {
+    expect(runtimeJavaScriptModules).toEqual([
+      "@playwright/mcp",
+      "playwright",
+      "playwright-core",
+    ]);
+    expect(packagedFileGlobs).toEqual(
+      expect.arrayContaining([
+        "node_modules/@playwright/mcp/**/*",
+        "node_modules/playwright/**/*",
+        "node_modules/playwright-core/**/*",
+      ]),
+    );
   });
 });
 

--- a/apps/code/runtime-dependencies.ts
+++ b/apps/code/runtime-dependencies.ts
@@ -29,6 +29,12 @@ export const runtimeNativeModules = [
   "is-number",
 ];
 
+export const runtimeJavaScriptModules = [
+  "@playwright/mcp",
+  "playwright",
+  "playwright-core",
+];
+
 // The base native modules that must exist when packaging; a missing one is a
 // broken build, not a warning. before-pack stages these with copyRequiredDep.
 export const requiredNativeModules = [
@@ -65,6 +71,7 @@ const scopeOf = (name: string) =>
 
 export const packagedFileGlobs = [
   ...runtimeNativeModules,
+  ...runtimeJavaScriptModules,
   ...macOnlyNativeModules,
 ].map((name) => `node_modules/${scopeOf(name)}/**/*`);
 

--- a/apps/code/scripts/before-pack.ts
+++ b/apps/code/scripts/before-pack.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   macOnlyNativeModules,
   requiredNativeModules,
+  runtimeJavaScriptModules,
   runtimeNativeModules,
   watcherPackageFor,
 } from "../runtime-dependencies";
@@ -70,6 +71,10 @@ export default async function beforePack(context: BeforePackContext) {
     } else {
       copyDep(dep, rootNodeModules, localNodeModules);
     }
+  }
+
+  for (const dep of runtimeJavaScriptModules) {
+    copyRequiredDep(dep, rootNodeModules, localNodeModules);
   }
 
   const watcherPkg = watcherPackageFor(platformName, arch);

--- a/docs/BROWSER-USE.md
+++ b/docs/BROWSER-USE.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable MD013 -->
+
+# Browser use
+
+PostHog Code can give local agent sessions browser automation tools through an isolated Playwright MCP server.
+
+## Enable it
+
+1. Install Google Chrome.
+2. Open **Settings → Advanced**.
+3. Enable **Browser use**.
+4. Start a new local session.
+
+The setting applies when a session starts. Existing sessions are unchanged.
+
+## Behavior
+
+- Browser use is opt-in and disabled by default.
+- It is available only to local sessions.
+- Each session launches an isolated Chrome profile, so it does not inherit cookies or logins from the user's normal browser profile.
+- Tool calls and screenshots use the existing MCP tool-call pipeline.
+- Cloud sessions do not receive the local browser server.
+
+## Scope
+
+This feature automates websites in a dedicated Chrome window. It does not control arbitrary desktop applications or the user's existing browser windows.
+
+## Implementation
+
+The workspace session layer injects a pinned `@playwright/mcp` stdio server for every supported local agent adapter instead of maintaining a bespoke browser-control protocol. This keeps browser lifecycle, accessibility snapshots, input actions, and image responses on Playwright's supported MCP implementation while reusing PostHog Code's existing MCP tool-call and approval surfaces.

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -337,6 +337,7 @@ export interface SessionServiceDeps {
     rtkEnabledCloud?: boolean;
     spokenNotifications?: boolean;
     spokenNarrationEnabled?: boolean;
+    browserUse?: boolean;
   };
   usageLimit: { show: (...args: any[]) => any };
   readonly addDirectoryDialog: { open: boolean };
@@ -1088,14 +1089,19 @@ export class SessionService {
           this.d.log.warn("Failed to verify workspace", { taskId, err });
         });
 
-      const { customInstructions, rtkEnabledLocal, spokenNarrationEnabled } =
-        this.d.settings;
+      const {
+        customInstructions,
+        rtkEnabledLocal,
+        spokenNarrationEnabled,
+        browserUse,
+      } = this.d.settings;
       const result = await this.d.trpc.agent.reconnect.mutate({
         taskId,
         taskRunId,
         repoPath,
         rtkEnabled: rtkEnabledLocal,
         spokenNarration: spokenNarrationEnabled === true,
+        browserUse: browserUse === true,
         apiHost: auth.apiHost,
         projectId: auth.projectId,
         logUrl,
@@ -1419,6 +1425,7 @@ export class SessionService {
       customInstructions: startCustomInstructions,
       rtkEnabledLocal,
       spokenNarrationEnabled,
+      browserUse,
     } = this.d.settings;
     const preferredModel = model ?? this.d.DEFAULT_GATEWAY_MODEL;
     const result = await this.d.trpc.agent.start.mutate({
@@ -1432,6 +1439,7 @@ export class SessionService {
       customInstructions: startCustomInstructions || undefined,
       rtkEnabled: rtkEnabledLocal,
       spokenNarration: spokenNarrationEnabled === true,
+      browserUse: browserUse === true,
       effort: effortLevelSchema.safeParse(reasoningLevel).success
         ? (reasoningLevel as EffortLevel)
         : undefined,

--- a/packages/ui/src/features/sessions/sessionServiceHost.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.ts
@@ -137,6 +137,7 @@ function buildSessionServiceDeps(): SessionServiceDeps {
           ),
           import.meta.env.DEV,
         ),
+        browserUse: state.browserUse,
       };
     },
     usageLimit: {

--- a/packages/ui/src/features/settings/sections/AdvancedSettings.tsx
+++ b/packages/ui/src/features/settings/sections/AdvancedSettings.tsx
@@ -33,6 +33,8 @@ export function AdvancedSettings() {
   const setRtkEnabledLocal = useSettingsStore((s) => s.setRtkEnabledLocal);
   const rtkEnabledCloud = useSettingsStore((s) => s.rtkEnabledCloud);
   const setRtkEnabledCloud = useSettingsStore((s) => s.setRtkEnabledCloud);
+  const browserUse = useSettingsStore((s) => s.browserUse);
+  const setBrowserUse = useSettingsStore((s) => s.setBrowserUse);
   const hostTRPC = useHostTRPC();
   const { data: rtkStatus } = useQuery(hostTRPC.agent.rtkStatus.queryOptions());
   const devModeClient = useServiceOptional<DevModeClient>(DEV_MODE_CLIENT);
@@ -87,6 +89,12 @@ export function AdvancedSettings() {
             </Text>
           )}
         </Flex>
+      </SettingRow>
+      <SettingRow
+        label="Browser use"
+        description="Let local agent sessions launch an isolated Google Chrome window and interact with websites. Experimental; requires Chrome to be installed"
+      >
+        <Switch checked={browserUse} onCheckedChange={setBrowserUse} size="1" />
       </SettingRow>
       <SettingRow
         label="Reset onboarding and tours"

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -47,6 +47,7 @@ describe("feature settingsStore defaults", () => {
     expect(useSettingsStore.getState().lastUsedLocalWorkspaceMode).toBe(
       "local",
     );
+    expect(useSettingsStore.getState().browserUse).toBe(false);
   });
 });
 
@@ -220,6 +221,7 @@ describe("feature settingsStore cloud selections", () => {
     ["slotMachineMode", false, true],
     ["dismissibleUpdateBanners", false, true],
     ["showSidebarWorktrees", false, true],
+    ["browserUse", false, true],
   ] as const)("rehydrates %s", async (field, initial, persisted) => {
     getItem.mockResolvedValue(
       JSON.stringify({ state: { [field]: persisted }, version: 0 }),

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -211,12 +211,14 @@ interface SettingsStore {
   // sessions, cloud covers cloud runs.
   rtkEnabledLocal: boolean;
   rtkEnabledCloud: boolean;
+  browserUse: boolean;
   setAllowBypassPermissions: (enabled: boolean) => void;
   setPreventSleepWhileRunning: (enabled: boolean) => void;
   setDebugLogsCloudRuns: (enabled: boolean) => void;
   setAutoPublishCloudRuns: (enabled: boolean) => void;
   setRtkEnabledLocal: (enabled: boolean) => void;
   setRtkEnabledCloud: (enabled: boolean) => void;
+  setBrowserUse: (enabled: boolean) => void;
 
   // Terminal
   terminalFont: TerminalFont;
@@ -428,6 +430,7 @@ export const useSettingsStore = create<SettingsStore>()(
       autoPublishCloudRuns: true,
       rtkEnabledLocal: true,
       rtkEnabledCloud: true,
+      browserUse: false,
       setAllowBypassPermissions: (enabled) =>
         set({ allowBypassPermissions: enabled }),
       setPreventSleepWhileRunning: (enabled) =>
@@ -437,6 +440,7 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ autoPublishCloudRuns: enabled }),
       setRtkEnabledLocal: (enabled) => set({ rtkEnabledLocal: enabled }),
       setRtkEnabledCloud: (enabled) => set({ rtkEnabledCloud: enabled }),
+      setBrowserUse: (enabled) => set({ browserUse: enabled }),
 
       // Terminal
       terminalFont: "berkeley-mono",
@@ -566,6 +570,7 @@ export const useSettingsStore = create<SettingsStore>()(
         autoPublishCloudRuns: state.autoPublishCloudRuns,
         rtkEnabledLocal: state.rtkEnabledLocal,
         rtkEnabledCloud: state.rtkEnabledCloud,
+        browserUse: state.browserUse,
 
         // Terminal
         terminalFont: state.terminalFont,

--- a/packages/workspace-server/package.json
+++ b/packages/workspace-server/package.json
@@ -25,6 +25,7 @@
     "@hono/trpc-server": "catalog:",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@parcel/watcher": "catalog:",
+    "@playwright/mcp": "0.0.78",
     "@posthog/agent": "workspace:*",
     "@posthog/di": "workspace:*",
     "@posthog/enricher": "workspace:*",

--- a/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/packages/workspace-server/src/services/agent/agent.test.ts
@@ -116,6 +116,19 @@ vi.mock("@posthog/agent/adapters/claude/session/jsonl-hydration", () => ({
   hydrateSessionJsonl: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./browser-use-mcp", () => ({
+  buildBrowserUseServer: vi.fn((enabled: boolean | undefined) =>
+    enabled
+      ? {
+          name: "playwright",
+          command: process.execPath,
+          args: ["/mock/playwright-mcp/cli.js", "--isolated"],
+          env: [{ name: "ELECTRON_RUN_AS_NODE", value: "1" }],
+        }
+      : null,
+  ),
+}));
+
 vi.mock("node:fs", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:fs")>();
   return {
@@ -345,6 +358,48 @@ describe("AgentService", () => {
       expect(codexMcp).toEqual(claudeMcp);
     });
 
+    it("passes the same browser MCP server to Claude and Codex", async () => {
+      await service.startSession({
+        ...baseSessionParams,
+        taskRunId: "run-claude",
+        adapter: "claude",
+        browserUse: true,
+      });
+      await service.startSession({
+        ...baseSessionParams,
+        taskRunId: "run-codex",
+        adapter: "codex",
+        browserUse: true,
+      });
+
+      const claudeBrowserServer =
+        mockNewSession.mock.calls[0][0].mcpServers.at(-1);
+      const codexBrowserServer =
+        mockNewSession.mock.calls[1][0].mcpServers.at(-1);
+      expect(claudeBrowserServer).toMatchObject({
+        name: "playwright",
+        args: expect.arrayContaining(["--isolated"]),
+      });
+      expect(codexBrowserServer).toEqual(claudeBrowserServer);
+    });
+
+    it.each([undefined, false])(
+      "does not pass browser MCP when browserUse is %s",
+      async (browserUse) => {
+        await service.startSession({
+          ...baseSessionParams,
+          adapter: "claude",
+          browserUse,
+        });
+
+        expect(mockNewSession.mock.calls[0][0].mcpServers).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ name: "playwright" }),
+          ]),
+        );
+      },
+    );
+
     it("drops unreachable MCP servers for codex but keeps them for claude", async () => {
       vi.stubGlobal(
         "fetch",
@@ -412,6 +467,19 @@ describe("AgentService", () => {
       expect(mockNewSession).toHaveBeenCalledTimes(1);
       expect(mockNewSession.mock.calls[0][0]._meta).not.toHaveProperty(
         "spokenNarration",
+      );
+    });
+
+    it("keeps browser configuration out of adapter-specific session meta", async () => {
+      await service.startSession({
+        ...baseSessionParams,
+        adapter: "claude",
+        browserUse: true,
+      });
+
+      expect(mockNewSession).toHaveBeenCalledTimes(1);
+      expect(mockNewSession.mock.calls[0][0]._meta).not.toHaveProperty(
+        "browserUse",
       );
     });
   });

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -88,6 +88,7 @@ import type { ProcessTrackingService } from "../process-tracking/process-trackin
 import { loadSessionEnvOverrides } from "../session-env/loader";
 import { isScratchPath } from "../workspace/scratch";
 import type { AgentAuthAdapter, McpToolInstallations } from "./auth-adapter";
+import { buildBrowserUseServer } from "./browser-use-mcp";
 import { cleanupCodexHome, prepareCodexHome } from "./codex-home";
 import { discoverExternalPlugins } from "./discover-plugins";
 import {
@@ -290,6 +291,8 @@ interface SessionConfig {
   rtkEnabled?: boolean;
   /** The user's spoken-narration setting at session start. */
   spokenNarration?: boolean;
+  /** Whether local sessions may launch the isolated browser-use tools. */
+  browserUse?: boolean;
 }
 
 /** Pull the adapter's `agentCapabilities._meta.posthog.steering` from initialize. */
@@ -935,10 +938,22 @@ If a repository IS genuinely required, attach one in this priority order:
       // ("ACP connection closed") and makes the host silently fall back to a
       // Claude/Opus session. Claude connects lazily and is unaffected, so only
       // the Codex server list is pruned to the reachable ones.
-      const sessionMcpServers =
+      const reachableMcpServers =
         adapter === "codex"
           ? await this.filterReachableMcpServers(mcpServers, taskRunId)
           : mcpServers;
+      let browserUseServer: ReturnType<typeof buildBrowserUseServer> = null;
+      try {
+        browserUseServer = buildBrowserUseServer(config.browserUse, "local");
+      } catch (err) {
+        this.log.warn("Browser-use server unavailable; continuing without it", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      const sessionMcpServers = [
+        ...reachableMcpServers,
+        ...(browserUseServer ? [browserUseServer] : []),
+      ];
 
       let externalPlugins: Awaited<ReturnType<typeof discoverExternalPlugins>> =
         [];
@@ -2028,6 +2043,7 @@ For git operations while detached:
       rtkEnabled: "rtkEnabled" in params ? params.rtkEnabled : undefined,
       spokenNarration:
         "spokenNarration" in params ? params.spokenNarration : undefined,
+      browserUse: "browserUse" in params ? params.browserUse : undefined,
     };
   }
 

--- a/packages/workspace-server/src/services/agent/browser-use-mcp.test.ts
+++ b/packages/workspace-server/src/services/agent/browser-use-mcp.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { BROWSER_USE_MCP_NAME, buildBrowserUseServer } from "./browser-use-mcp";
+
+describe("buildBrowserUseServer", () => {
+  it.each([
+    { enabled: false, environment: "local" as const },
+    { enabled: true, environment: "cloud" as const },
+    { enabled: undefined, environment: "local" as const },
+  ])("returns null for $enabled in $environment", (input) => {
+    expect(buildBrowserUseServer(input.enabled, input.environment)).toBeNull();
+  });
+
+  it("builds an isolated Chrome MCP server for local sessions", () => {
+    const server = buildBrowserUseServer(true, "local");
+
+    expect(server).toMatchObject({
+      name: BROWSER_USE_MCP_NAME,
+      command: process.execPath,
+      args: expect.arrayContaining([
+        "--browser",
+        "chrome",
+        "--isolated",
+        "vision",
+      ]),
+      env: [{ name: "ELECTRON_RUN_AS_NODE", value: "1" }],
+    });
+    expect(server?.args[0]).toMatch(/@playwright[\\/]mcp[\\/]cli\.js$/);
+  });
+});

--- a/packages/workspace-server/src/services/agent/browser-use-mcp.test.ts
+++ b/packages/workspace-server/src/services/agent/browser-use-mcp.test.ts
@@ -25,5 +25,6 @@ describe("buildBrowserUseServer", () => {
       env: [{ name: "ELECTRON_RUN_AS_NODE", value: "1" }],
     });
     expect(server?.args[0]).toMatch(/@playwright[\\/]mcp[\\/]cli\.js$/);
+    expect(server?.args).toContain("omit");
   });
 });

--- a/packages/workspace-server/src/services/agent/browser-use-mcp.ts
+++ b/packages/workspace-server/src/services/agent/browser-use-mcp.ts
@@ -1,0 +1,43 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import type { McpServerStdio } from "@agentclientprotocol/sdk";
+
+export const BROWSER_USE_MCP_NAME = "playwright";
+const require = createRequire(import.meta.url);
+
+function resolvePlaywrightMcpCli(): string {
+  const packageJson = require.resolve("@playwright/mcp/package.json");
+  const cli = join(dirname(packageJson), "cli.js");
+  if (!existsSync(cli)) {
+    throw new Error(`Playwright MCP CLI not found at ${cli}`);
+  }
+  return cli;
+}
+
+export function buildBrowserUseServer(
+  enabled: boolean | undefined,
+  environment: "local" | "cloud",
+): McpServerStdio | null {
+  if (!enabled || environment !== "local") return null;
+
+  return {
+    name: BROWSER_USE_MCP_NAME,
+    command: process.execPath,
+    args: [
+      resolvePlaywrightMcpCli(),
+      "--browser",
+      "chrome",
+      "--isolated",
+      "--caps",
+      "vision",
+      "--codegen",
+      "none",
+      "--image-responses",
+      "allow",
+      "--output-mode",
+      "stdout",
+    ],
+    env: [{ name: "ELECTRON_RUN_AS_NODE", value: "1" }],
+  };
+}

--- a/packages/workspace-server/src/services/agent/browser-use-mcp.ts
+++ b/packages/workspace-server/src/services/agent/browser-use-mcp.ts
@@ -34,7 +34,7 @@ export function buildBrowserUseServer(
       "--codegen",
       "none",
       "--image-responses",
-      "allow",
+      "omit",
       "--output-mode",
       "stdout",
     ],

--- a/packages/workspace-server/src/services/agent/schemas.ts
+++ b/packages/workspace-server/src/services/agent/schemas.ts
@@ -98,6 +98,8 @@ export const startSessionInput = z.object({
    * narration off, so headless runs never load the tool.
    */
   spokenNarration: z.boolean().optional(),
+  /** Enables the isolated Playwright browser tools for local sessions. */
+  browserUse: z.boolean().optional(),
 });
 
 export type StartSessionInput = z.infer<typeof startSessionInput>;
@@ -233,6 +235,8 @@ export const reconnectSessionInput = z.object({
   rtkEnabled: z.boolean().optional(),
   /** See startSessionInput.spokenNarration. */
   spokenNarration: z.boolean().optional(),
+  /** See startSessionInput.browserUse. */
+  browserUse: z.boolean().optional(),
 });
 
 export type ReconnectSessionInput = z.infer<typeof reconnectSessionInput>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1510,6 +1510,9 @@ importers:
       '@parcel/watcher':
         specifier: 'catalog:'
         version: 2.5.6
+      '@playwright/mcp':
+        specifier: 0.0.78
+        version: 0.0.78
       '@posthog/agent':
         specifier: workspace:*
         version: link:../agent
@@ -5594,6 +5597,11 @@ packages:
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  '@playwright/mcp@0.0.78':
+    resolution: {integrity: sha512-XLTUeA6mEN9sQ+hJ4dfG8EIkDbxS0K3Trc2RBkUJuf02TgE2FQRNTMtq/aJfhyRMINsRl/Ybc4sxcWLtFn4/TQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -13114,9 +13122,19 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.62.0-alpha-1783623505000:
+    resolution: {integrity: sha512-CPJZdsA/KGT2QQlekiV6Wt+QlQrZHVSZ6oiNtOI/bYYOIVLM8jfKGWTM4zQiyd4UN+40Cq4cA6lxmZHZbtPvJQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   playwright@1.60.0:
     resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.62.0-alpha-1783623505000:
+    resolution: {integrity: sha512-6KV9h4PP3hqu4NaGdxxcijWfYh9LJcFI/R2sP4TTC4I5cFo3oRawN0ETlW5MkE3cQEgKhhoj0KUNz4sfpCT0Tg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   plist@3.1.0:
@@ -19914,6 +19932,11 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.3.6': {}
+
+  '@playwright/mcp@0.0.78':
+    dependencies:
+      playwright: 1.62.0-alpha-1783623505000
+      playwright-core: 1.62.0-alpha-1783623505000
 
   '@playwright/test@1.60.0':
     dependencies:
@@ -28712,9 +28735,17 @@ snapshots:
 
   playwright-core@1.60.0: {}
 
+  playwright-core@1.62.0-alpha-1783623505000: {}
+
   playwright@1.60.0:
     dependencies:
       playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.62.0-alpha-1783623505000:
+    dependencies:
+      playwright-core: 1.62.0-alpha-1783623505000
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## Problem

Local agents need browser automation without tying the capability to one model adapter. Image-heavy browser responses can also make long conversations exceed the gateway request limit.

## Changes

I added opt-in isolated Playwright MCP support for local adapters, packaged its runtime, and kept responses on accessibility snapshots instead of embedding screenshots in conversation history.

## How did you test this?

- Ran the focused browser MCP test.
- Ran `pnpm build`.
- Connected to the real Playwright MCP and verified navigation, snapshots, and packaged startup.
- Opened the app and checked the Advanced setting.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*