### PR TITLE
feat: allow deleting tasks from sidebar without archiving first

### DIFF
--- a/packages/core/src/context-menu/context-menu.test.ts
+++ b/packages/core/src/context-menu/context-menu.test.ts
@@ -142,6 +142,18 @@ describe("ContextMenuService.showTaskContextMenu", () => {
     );
   });
 
+  it("offers Delete for active tasks and resolves without an inline confirm", async () => {
+    const menu = new FakeContextMenu();
+    // dialogReturning(0) would cancel any inline confirm; Delete must resolve
+    // anyway because confirmation happens downstream in TaskDeletionService.
+    const result = makeService(menu, dialogReturning(0)).showTaskContextMenu(
+      baseTask,
+    );
+    await menu.shown;
+    findItem(menu.lastItems, "Delete").click();
+    expect(await result).toEqual({ action: { type: "delete" } });
+  });
+
   it("resolves to null when the menu is dismissed", async () => {
     const menu = new FakeContextMenu();
     const result = makeService(menu).showTaskContextMenu(baseTask);

--- a/packages/core/src/context-menu/context-menu.ts
+++ b/packages/core/src/context-menu/context-menu.ts
@@ -185,6 +185,9 @@ export class ContextMenuService {
           },
         },
       ),
+      // Confirmation is handled downstream by TaskDeletionService via
+      // confirmDeleteTask (worktree-aware wording), so no inline confirm here.
+      this.item("Delete", { type: "delete" }),
     ]);
   }
 


### PR DESCRIPTION
## Problem

Closes PostHog/posthog#76196

Deleting an active task from the sidebar currently requires archiving it first (right-click → Archive → open Archived → right-click → Delete). For a "I'm done, get this out of my list" cleanup flow, the archive detour is unnecessary friction. Tools like Cursor expose Delete directly in the sidebar context menu.

## Changes

Adds a **Delete** item to the task sidebar right-click menu, placed after "Archive prior tasks".

The diff is only +15 lines because the delete pipeline already exists end-to-end: the `taskAction` schema includes `"delete"`, `resolveTaskContextMenuIntent` maps it, `useTaskContextMenu` handles it via `deleteWithConfirm`, and `TaskDeletionService.confirmAndDelete` shows a worktree-aware confirmation dialog, unpins the task, navigates away if the task is open, deletes the worktree when present, and removes the task. This PR just exposes the menu item.

Design note: the item deliberately has **no inline `confirm` option** (unlike the archived-task menu's Delete), because confirmation is handled downstream by `confirmDeleteTask` — an inline confirm would double-prompt the user. The added test uses a cancelling dialog to lock in this behavior.

## How did you test this?

- Added a unit test in `packages/core/src/context-menu/context-menu.test.ts` verifying the Delete item appears for active tasks and resolves `{ type: "delete" }` without triggering an inline confirm dialog.
- Ran `pnpm vitest run src/context-menu/context-menu.test.ts` in `packages/core` — 11/11 tests pass (10 existing + 1 new).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?