### PR TITLE
fix(code): restore zoom after external resize

### DIFF
--- a/apps/code/snapshots.yml
+++ b/apps/code/snapshots.yml
@@ -27,7 +27,7 @@ snapshots:
     archive-archivedtasksview--many-tasks--dark:
         hash: v1.k4693efd2.40d24f07a24c6400c32ae68b39fd908a056beb5dc6df8bcb237ec2ab2b494f4a.l2vjfSQDalCPRtDNV7pbfTKGlMsQoI81jI-UdJfLHWE
     archive-archivedtasksview--many-tasks--light:
-        hash: v1.k4693efd2.52ec9963bfe6f248ffcdaa4c26945d2b7e303115825b65d978aa5aefd4af1007.ZLtOfTZUrznhYeB-N2SIHzQWRzF6TDSaipNkfd8uzjM
+        hash: v1.k4693efd2.74c25b303262f2d4c0f22890d351e76f482827548548f7c023bc309327c927b8.DP9VVrvBz1naIJMwHORkfqm69BlO785ulOt4o6zFs94
     archive-archivedtasksview--mixed-modes--dark:
         hash: v1.k4693efd2.d94039b8cc17a4ad1b720364f41fee58a4843aa9a901443997ba62602f698794.441LWZhT-2WQZJHni4LoOgQsOSr2O103NZOk1pF8ME4
     archive-archivedtasksview--mixed-modes--light:

--- a/apps/code/src/main/zoom.test.ts
+++ b/apps/code/src/main/zoom.test.ts
@@ -28,6 +28,10 @@ class FakeWebContents extends EventEmitter {
     return this.destroyed;
   }
 
+  public getZoomLevel(): number {
+    return this.zoomLevel;
+  }
+
   public setZoomLevel(level: number): void {
     this.setZoomLevelCalls.push(level);
     this.zoomLevel = level;
@@ -98,7 +102,6 @@ describe("window zoom", () => {
 
     window.webContents.emit("zoom-changed", { preventDefault: vi.fn() }, "in");
     vi.runAllTimers();
-    vi.advanceTimersByTime(5 * 60 * 1000);
     window.webContents.zoomLevel = 0;
 
     window.emit("resize");
@@ -166,17 +169,29 @@ describe("window zoom", () => {
     },
   );
 
-  it("debounces repeated resize restorations", () => {
+  it("skips redundant restoration during a resize storm", () => {
     const window = createWindow();
     setupWindowZoom(window);
-    window.webContents.zoomLevel = 0;
+    window.webContents.zoomLevel = 0.5;
 
     window.emit("resize");
+    vi.runAllTimers();
+    vi.advanceTimersByTime(16);
     window.emit("resize");
-    window.emit("resized");
+    vi.runAllTimers();
+    const callsBeforeReset = [...window.webContents.setZoomLevelCalls];
+
+    window.webContents.zoomLevel = 0;
+    window.emit("resize");
     vi.runAllTimers();
 
-    expect(window.webContents.setZoomLevelCalls).toEqual([0.5]);
+    expect({
+      callsBeforeReset,
+      callsAfterReset: window.webContents.setZoomLevelCalls,
+    }).toEqual({
+      callsBeforeReset: [],
+      callsAfterReset: [0.5],
+    });
   });
 
   it("ignores queued zoom work after the window is destroyed", () => {

--- a/apps/code/src/main/zoom.test.ts
+++ b/apps/code/src/main/zoom.test.ts
@@ -85,34 +85,29 @@ describe("window zoom", () => {
     expect(window.webContents.zoomLevel).toBe(0.5);
   });
 
-  it("restores the persisted level after task navigation", () => {
+  it("restores the current level after an external window resize", () => {
     const window = createWindow();
     setupWindowZoom(window);
+
+    window.webContents.emit("zoom-changed", { preventDefault: vi.fn() }, "in");
+    vi.runAllTimers();
+    vi.advanceTimersByTime(5 * 60 * 1000);
     window.webContents.zoomLevel = 0;
 
-    window.webContents.emit(
-      "did-navigate-in-page",
-      {},
-      "file:///app/tasks/next-task",
-      true,
-    );
+    window.emit("resize");
+    vi.runAllTimers();
+    const restoredZoomLevel = window.webContents.zoomLevel;
+    adjustWindowZoom(window, 0.5);
 
-    expect(window.webContents.zoomLevel).toBe(0.5);
-  });
-
-  it("ignores in-page navigation inside subframes", () => {
-    const window = createWindow();
-    setupWindowZoom(window);
-    window.webContents.zoomLevel = 0;
-
-    window.webContents.emit(
-      "did-navigate-in-page",
-      {},
-      "file:///embedded-content",
-      false,
-    );
-
-    expect(window.webContents.zoomLevel).toBe(0);
+    expect({
+      restoredZoomLevel,
+      zoomLevel: window.webContents.zoomLevel,
+      saved: store.save.mock.calls,
+    }).toEqual({
+      restoredZoomLevel: 1,
+      zoomLevel: 1.5,
+      saved: [[1], [1.5]],
+    });
   });
 
   it.each([

--- a/apps/code/src/main/zoom.test.ts
+++ b/apps/code/src/main/zoom.test.ts
@@ -85,6 +85,36 @@ describe("window zoom", () => {
     expect(window.webContents.zoomLevel).toBe(0.5);
   });
 
+  it("restores the persisted level after task navigation", () => {
+    const window = createWindow();
+    setupWindowZoom(window);
+    window.webContents.zoomLevel = 0;
+
+    window.webContents.emit(
+      "did-navigate-in-page",
+      {},
+      "file:///app/tasks/next-task",
+      true,
+    );
+
+    expect(window.webContents.zoomLevel).toBe(0.5);
+  });
+
+  it("ignores in-page navigation inside subframes", () => {
+    const window = createWindow();
+    setupWindowZoom(window);
+    window.webContents.zoomLevel = 0;
+
+    window.webContents.emit(
+      "did-navigate-in-page",
+      {},
+      "file:///embedded-content",
+      false,
+    );
+
+    expect(window.webContents.zoomLevel).toBe(0);
+  });
+
   it.each([
     ["in", 1],
     ["out", 0],

--- a/apps/code/src/main/zoom.test.ts
+++ b/apps/code/src/main/zoom.test.ts
@@ -20,9 +20,16 @@ vi.mock("./utils/store", () => ({
 import { adjustWindowZoom, restoreWindowZoom, setupWindowZoom } from "./zoom";
 
 class FakeWebContents extends EventEmitter {
+  public destroyed = false;
+  public readonly setZoomLevelCalls: number[] = [];
   public zoomLevel = 0;
 
+  public isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
   public setZoomLevel(level: number): void {
+    this.setZoomLevelCalls.push(level);
     this.zoomLevel = level;
   }
 }
@@ -135,20 +142,58 @@ describe("window zoom", () => {
     },
   );
 
-  it("keeps wheel zoom after resizing", () => {
+  it.each(["resize", "resized"] as const)(
+    "keeps wheel zoom after %s",
+    (resizeEvent) => {
+      const window = createWindow();
+      setupWindowZoom(window);
+
+      window.webContents.emit(
+        "zoom-changed",
+        { preventDefault: vi.fn() },
+        "in",
+      );
+      window.emit(resizeEvent);
+      vi.runAllTimers();
+
+      expect({
+        zoomLevel: window.webContents.zoomLevel,
+        saved: store.save.mock.calls,
+      }).toEqual({
+        zoomLevel: 1,
+        saved: [[1]],
+      });
+    },
+  );
+
+  it("debounces repeated resize restorations", () => {
+    const window = createWindow();
+    setupWindowZoom(window);
+    window.webContents.zoomLevel = 0;
+
+    window.emit("resize");
+    window.emit("resize");
+    window.emit("resized");
+    vi.runAllTimers();
+
+    expect(window.webContents.setZoomLevelCalls).toEqual([0.5]);
+  });
+
+  it("ignores queued zoom work after the window is destroyed", () => {
     const window = createWindow();
     setupWindowZoom(window);
 
     window.webContents.emit("zoom-changed", { preventDefault: vi.fn() }, "in");
-    window.emit("resized");
+    window.emit("resize");
+    window.webContents.destroyed = true;
     vi.runAllTimers();
 
     expect({
-      zoomLevel: window.webContents.zoomLevel,
+      zoomLevelCalls: window.webContents.setZoomLevelCalls,
       saved: store.save.mock.calls,
     }).toEqual({
-      zoomLevel: 1,
-      saved: [[1]],
+      zoomLevelCalls: [],
+      saved: [],
     });
   });
 

--- a/apps/code/src/main/zoom.ts
+++ b/apps/code/src/main/zoom.ts
@@ -6,6 +6,7 @@ const ZOOM_MIN = -3;
 const ZOOM_MAX = 3;
 
 interface ZoomWebContents {
+  isDestroyed(): boolean;
   on(event: "did-finish-load", listener: () => void): void;
   on(
     event: "zoom-changed",
@@ -63,6 +64,7 @@ function runAfterWheelZoom(window: ZoomWindow, action: () => void): void {
 }
 
 export function setWindowZoom(window: ZoomWindow, level: number): void {
+  if (window.webContents.isDestroyed()) return;
   const nextLevel = clampZoomLevel(level);
   const state = zoomStates.get(window);
   if (state) state.currentZoomLevel = nextLevel;
@@ -83,6 +85,7 @@ export function adjustWindowZoom(
 
 export function restoreWindowZoom(window: ZoomWindow): void {
   runAfterWheelZoom(window, () => {
+    if (window.webContents.isDestroyed()) return;
     window.webContents.setZoomLevel(getCurrentZoomLevel(window));
   });
 }

--- a/apps/code/src/main/zoom.ts
+++ b/apps/code/src/main/zoom.ts
@@ -6,6 +6,7 @@ const ZOOM_MIN = -3;
 const ZOOM_MAX = 3;
 
 interface ZoomWebContents {
+  getZoomLevel(): number;
   isDestroyed(): boolean;
   on(event: "did-finish-load", listener: () => void): void;
   on(
@@ -86,7 +87,10 @@ export function adjustWindowZoom(
 export function restoreWindowZoom(window: ZoomWindow): void {
   runAfterWheelZoom(window, () => {
     if (window.webContents.isDestroyed()) return;
-    window.webContents.setZoomLevel(getCurrentZoomLevel(window));
+    const zoomLevel = getCurrentZoomLevel(window);
+    if (window.webContents.getZoomLevel() !== zoomLevel) {
+      window.webContents.setZoomLevel(zoomLevel);
+    }
   });
 }
 

--- a/apps/code/src/main/zoom.ts
+++ b/apps/code/src/main/zoom.ts
@@ -8,6 +8,10 @@ const ZOOM_MAX = 3;
 interface ZoomWebContents {
   on(event: "did-finish-load", listener: () => void): void;
   on(
+    event: "did-navigate-in-page",
+    listener: (event: unknown, url: string, isMainFrame: boolean) => void,
+  ): void;
+  on(
     event: "zoom-changed",
     listener: (
       event: { preventDefault(): void },
@@ -105,6 +109,9 @@ export function setupWindowZoom(window: ZoomWindow): void {
   };
 
   window.webContents.on("did-finish-load", () => restoreWindowZoom(window));
+  window.webContents.on("did-navigate-in-page", (_event, _url, isMainFrame) => {
+    if (isMainFrame) restoreWindowZoom(window);
+  });
   window.webContents.on("zoom-changed", (event, zoomDirection) => {
     event.preventDefault();
     state.wheelZoomDelta += zoomDirection === "in" ? ZOOM_STEP : -ZOOM_STEP;

--- a/apps/code/src/main/zoom.ts
+++ b/apps/code/src/main/zoom.ts
@@ -8,10 +8,6 @@ const ZOOM_MAX = 3;
 interface ZoomWebContents {
   on(event: "did-finish-load", listener: () => void): void;
   on(
-    event: "did-navigate-in-page",
-    listener: (event: unknown, url: string, isMainFrame: boolean) => void,
-  ): void;
-  on(
     event: "zoom-changed",
     listener: (
       event: { preventDefault(): void },
@@ -27,6 +23,7 @@ interface ZoomWindow {
       | "enter-full-screen"
       | "leave-full-screen"
       | "maximize"
+      | "resize"
       | "resized"
       | "unmaximize",
     listener: () => void,
@@ -109,9 +106,6 @@ export function setupWindowZoom(window: ZoomWindow): void {
   };
 
   window.webContents.on("did-finish-load", () => restoreWindowZoom(window));
-  window.webContents.on("did-navigate-in-page", (_event, _url, isMainFrame) => {
-    if (isMainFrame) restoreWindowZoom(window);
-  });
   window.webContents.on("zoom-changed", (event, zoomDirection) => {
     event.preventDefault();
     state.wheelZoomDelta += zoomDirection === "in" ? ZOOM_STEP : -ZOOM_STEP;
@@ -127,6 +121,7 @@ export function setupWindowZoom(window: ZoomWindow): void {
 
   window.on("maximize", scheduleRestore);
   window.on("unmaximize", scheduleRestore);
+  window.on("resize", scheduleRestore);
   window.on("resized", scheduleRestore);
   window.on("enter-full-screen", scheduleRestore);
   window.on("leave-full-screen", scheduleRestore);


### PR DESCRIPTION
## Problem

External window managers such as Magnet or Rectangle can resize the Electron window without emitting the manual-resize completion event. Chromium can reset the visible zoom to 100% while the app still tracks the previous level, so the next zoom input jumps from a stale baseline.

**Why:** Window snapping should not change the visible app zoom or desynchronise it from the stored level.

Closes #2959

## Changes

Restore the current in-memory zoom after every Electron `resize` event, but only call `setZoomLevel` when Chromium has diverged from it. Ignore queued work after renderer teardown and keep wheel zoom changes serialized with restoration.

## How did you test this?

- Added regression coverage for delayed external resets, spaced resize storms, both resize event variants, wheel zoom races, and renderer teardown.
- `pnpm --filter code exec vitest run src/main/zoom.test.ts`
- `pnpm turbo typecheck --filter=@posthog/code`
- `pnpm exec biome check apps/code/src/main/zoom.ts apps/code/src/main/zoom.test.ts`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
