### PR TITLE
fix(agent): avoid redundant PR checkout

### DIFF
--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -3504,8 +3504,12 @@ describe("AgentServer HTTP Mode", () => {
         "https://github.com/org/repo/pull/1",
       );
       expect(prompt).toContain(
-        "gh pr checkout https://github.com/org/repo/pull/1",
+        "If it is not already checked out, check it out with `gh pr checkout https://github.com/org/repo/pull/1`",
       );
+      expect(prompt).toContain(
+        "Do not check it out again when it is already active",
+      );
+      expect(prompt).not.toContain("Check out the existing PR branch");
       expect(prompt).toContain("git_signed_commit");
       expect(prompt).toContain("Committing (signed commits required)");
       expect(prompt).not.toContain("Create a draft pull request");

--- a/packages/agent/src/server/agent-server.test.ts
+++ b/packages/agent/src/server/agent-server.test.ts
@@ -3827,13 +3827,18 @@ describe("AgentServer HTTP Mode", () => {
       expect(context).not.toContain("gh pr checkout");
     });
 
-    it("returns auto-update PR context for Slack-origin runs", () => {
+    it("avoids redundant PR checkout for auto-update runs", () => {
       process.env.POSTHOG_CODE_INTERACTION_ORIGIN = "slack";
       const s = createServer();
       const context = (s as unknown as TestableServer).buildDetectedPrContext(
         prUrl,
       );
-      expect(context).toContain(`gh pr checkout ${prUrl}`);
+      expect(context).toContain(
+        `If it is not already checked out, check it out with \`gh pr checkout ${prUrl}\``,
+      );
+      expect(context).toContain(
+        "Do not check it out again when it is already active",
+      );
       expect(context).toContain(
         "Make changes, commit, and push to that branch",
       );

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -3139,6 +3139,10 @@ export class AgentServer {
     ].join("\n");
   }
 
+  private buildExistingPrCheckoutInstruction(prUrl: string): string {
+    return `Continue working on the existing PR branch. If it is not already checked out, check it out with \`gh pr checkout ${prUrl}\`. Do not check it out again when it is already active.`;
+  }
+
   private buildDetectedPrContext(prUrl: string): string {
     if (!this.shouldAutoPublishCloudChanges()) {
       return (
@@ -3152,7 +3156,7 @@ export class AgentServer {
       `IMPORTANT — OVERRIDE PREVIOUS INSTRUCTIONS ABOUT CREATING BRANCHES/PRs.\n` +
       `You already have an open pull request: ${prUrl}\n` +
       `You MUST:\n` +
-      `1. Continue working on the existing PR branch. If it is not already checked out, check it out with \`gh pr checkout ${prUrl}\`. Do not check it out again when it is already active.\n` +
+      `1. ${this.buildExistingPrCheckoutInstruction(prUrl)}\n` +
       `2. Make changes, commit, and push to that branch\n` +
       `You MUST NOT create a new branch, close the existing PR, or create a new PR.`
     );
@@ -3283,7 +3287,7 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}
 This task already has an open pull request: ${prUrl}
 
 After completing the requested changes:
-1. Check out the existing PR branch with \`gh pr checkout ${prUrl}\`
+1. ${this.buildExistingPrCheckoutInstruction(prUrl)}
 2. Stage your changes with \`git add\`, then call the \`git_signed_commit\` tool with a clear \`message\` (do NOT use \`git commit\`/\`git push\` — they are blocked). This commits to the existing PR branch.
    - If the branch is behind its base, call the \`git_signed_merge\` tool first — it merges the base in server-side with a Verified merge commit. Only if it reports a conflict: fetch and rebase locally (\`git fetch origin <base>\`, \`git rebase origin/<base>\`, resolve, \`git rebase --continue\`), then call the \`git_signed_rewrite\` tool to force-update this same PR branch.
 3. For every PR review comment or review thread you addressed, treat the thread as done only after BOTH of these:

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -3152,7 +3152,7 @@ export class AgentServer {
       `IMPORTANT — OVERRIDE PREVIOUS INSTRUCTIONS ABOUT CREATING BRANCHES/PRs.\n` +
       `You already have an open pull request: ${prUrl}\n` +
       `You MUST:\n` +
-      `1. Check out the existing PR branch with \`gh pr checkout ${prUrl}\`\n` +
+      `1. Continue working on the existing PR branch. If it is not already checked out, check it out with \`gh pr checkout ${prUrl}\`. Do not check it out again when it is already active.\n` +
       `2. Make changes, commit, and push to that branch\n` +
       `You MUST NOT create a new branch, close the existing PR, or create a new PR.`
     );


### PR DESCRIPTION
## Problem

Cloud task follow-ups receive existing-PR instructions on every turn. The instructions required `gh pr checkout` unconditionally, so agents repeatedly checked out the same PR branch before handling each user message.

**Why:** Follow-up interactions should continue from the active branch without unnecessary repository setup or repetitive status messages.