### PR TITLE
fix(canvas): navigate share links in-app instead of via the browser

### DIFF
--- a/packages/ui/src/features/canvas/components/MentionText.test.tsx
+++ b/packages/ui/src/features/canvas/components/MentionText.test.tsx
@@ -1,6 +1,19 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MentionText } from "./MentionText";
+
+const navigateToChannelDashboard = vi.fn();
+
+vi.mock("@posthog/ui/router/navigationBridge", () => ({
+  navigateToChannel: vi.fn(),
+  navigateToChannelDashboard: (...args: unknown[]) =>
+    navigateToChannelDashboard(...args),
+  navigateToChannelTask: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("MentionText", () => {
   it("uses the shared mention styles and emphasizes the current user", () => {
@@ -40,6 +53,28 @@ describe("MentionText", () => {
       screen.getByRole("link", { name: "My @agent report" }),
     ).toHaveAttribute("href", "https://posthog.com/report");
     expect(screen.queryByText("@agent")).not.toBeInTheDocument();
+  });
+
+  it("navigates in-app instead of the browser for a canvas share link", () => {
+    render(
+      <MentionText content="[Signups](https://us.posthog.com/code/canvas/chan1/dash1) has been created" />,
+    );
+
+    const link = screen.getByRole("link", { name: "Signups" });
+    const defaultAllowed = fireEvent.click(link);
+
+    expect(defaultAllowed).toBe(false); // preventDefault was called
+    expect(navigateToChannelDashboard).toHaveBeenCalledWith("chan1", "dash1");
+  });
+
+  it("leaves an external link opening in the browser", () => {
+    render(<MentionText content="[Docs](https://example.com/guide) is here" />);
+
+    const link = screen.getByRole("link", { name: "Docs" });
+    const defaultAllowed = fireEvent.click(link);
+
+    expect(defaultAllowed).toBe(true); // default not prevented
+    expect(navigateToChannelDashboard).not.toHaveBeenCalled();
   });
 
   it("inherits the surrounding message text size", () => {

--- a/packages/ui/src/features/canvas/components/MentionText.test.tsx
+++ b/packages/ui/src/features/canvas/components/MentionText.test.tsx
@@ -63,7 +63,7 @@ describe("MentionText", () => {
     const link = screen.getByRole("link", { name: "Signups" });
     const defaultAllowed = fireEvent.click(link);
 
-    expect(defaultAllowed).toBe(false); // preventDefault was called
+    expect(defaultAllowed).toBe(false);
     expect(navigateToChannelDashboard).toHaveBeenCalledWith("chan1", "dash1");
   });
 
@@ -73,7 +73,7 @@ describe("MentionText", () => {
     const link = screen.getByRole("link", { name: "Docs" });
     const defaultAllowed = fireEvent.click(link);
 
-    expect(defaultAllowed).toBe(true); // default not prevented
+    expect(defaultAllowed).toBe(true);
     expect(navigateToChannelDashboard).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/features/canvas/components/MentionText.tsx
+++ b/packages/ui/src/features/canvas/components/MentionText.tsx
@@ -1,5 +1,6 @@
 import { splitMentionSegments } from "@posthog/shared";
 import { splitLinkSegments } from "@posthog/ui/features/canvas/utils/linkify";
+import { handleShareLinkClick } from "@posthog/ui/utils/shareLinks";
 import { Fragment, useMemo } from "react";
 import "./mention-chip.css";
 
@@ -105,6 +106,7 @@ export function MentionText({
             <a
               key={key}
               href={segment.href}
+              onClick={(event) => handleShareLinkClick(segment.href, event)}
               target="_blank"
               rel="noopener noreferrer"
               className="text-[var(--accent-11)] underline underline-offset-2 hover:text-[var(--accent-12)]"

--- a/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
+++ b/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
@@ -5,6 +5,7 @@ import { CodeBlock } from "@posthog/ui/primitives/CodeBlock";
 import { Divider } from "@posthog/ui/primitives/Divider";
 import { HighlightedCode } from "@posthog/ui/primitives/HighlightedCode";
 import { List, ListItem } from "@posthog/ui/primitives/List";
+import { handleShareLinkClick } from "@posthog/ui/utils/shareLinks";
 import { Blockquote, Checkbox, Code, Kbd, Text } from "@radix-ui/themes";
 import { memo, useMemo } from "react";
 import type { Components } from "react-markdown";
@@ -91,6 +92,7 @@ export const baseComponents: Components = {
       <a
         href={href}
         onClick={(event) => {
+          if (handleShareLinkClick(href, event)) return;
           if (!isDeeplink || !href) return;
           event.preventDefault();
           openExternalUrl(href);

--- a/packages/ui/src/utils/posthogLinks.test.ts
+++ b/packages/ui/src/utils/posthogLinks.test.ts
@@ -1,6 +1,7 @@
 import {
   canvasShareUrl,
   errorTrackingIssueUrl,
+  parseShareLink,
 } from "@posthog/ui/utils/posthogLinks";
 import { describe, expect, it, vi } from "vitest";
 
@@ -13,6 +14,52 @@ describe("canvasShareUrl", () => {
     expect(canvasShareUrl("chan/1", "dash 2", "us")).toBe(
       "https://us.posthog.com/code/canvas/chan%2F1/dash%202",
     );
+  });
+});
+
+describe("parseShareLink", () => {
+  it.each([
+    [
+      "canvas link",
+      "https://us.posthog.com/code/canvas/chan1/dash1",
+      { kind: "canvas", channelId: "chan1", dashboardId: "dash1" },
+    ],
+    [
+      "canvas link with encoded ids",
+      "https://us.posthog.com/code/canvas/chan%2F1/dash%202",
+      { kind: "canvas", channelId: "chan/1", dashboardId: "dash 2" },
+    ],
+    [
+      "channel link on the eu host",
+      "https://eu.posthog.com/code/channel/chan1",
+      { kind: "channel", channelId: "chan1" },
+    ],
+    [
+      "channel thread link",
+      "https://us.posthog.com/code/channel/chan1/tasks/task1",
+      { kind: "channel", channelId: "chan1", taskId: "task1" },
+    ],
+  ])("parses a %s", (_label, href, expected) => {
+    expect(parseShareLink(href)).toEqual(expected);
+  });
+
+  it.each([
+    ["a non-PostHog host", "https://evil.com/code/canvas/chan1/dash1"],
+    [
+      "an unrelated PostHog path",
+      "https://us.posthog.com/project/2/dashboard/1",
+    ],
+    [
+      "a canvas link missing the dashboard id",
+      "https://us.posthog.com/code/canvas/chan1",
+    ],
+    [
+      "a channel thread link with a malformed tail",
+      "https://us.posthog.com/code/channel/chan1/foo/task1",
+    ],
+    ["a malformed url", "not a url"],
+  ])("returns null for %s", (_label, href) => {
+    expect(parseShareLink(href)).toBeNull();
   });
 });
 

--- a/packages/ui/src/utils/posthogLinks.ts
+++ b/packages/ui/src/utils/posthogLinks.ts
@@ -121,17 +121,10 @@ export function channelShareUrl(
   );
 }
 
-/**
- * The in-app destination a PostHog Code share link points at — the inverse of
- * the `canvasShareUrl` / `channelShareUrl` builders above.
- */
 export type ShareLinkTarget =
   | { kind: "canvas"; channelId: string; dashboardId: string }
   | { kind: "channel"; channelId: string; taskId?: string };
 
-// Hosts we recognise as PostHog share-link origins, one per cloud region. The
-// host check keeps `parseShareLink` from hijacking unrelated links that happen
-// to share the `/code/...` path shape.
 const POSTHOG_HOSTS = new Set(
   (Object.keys(REGION_LABELS) as CloudRegion[])
     .map((region) => {
@@ -144,13 +137,6 @@ const POSTHOG_HOSTS = new Set(
     .filter(Boolean),
 );
 
-/**
- * Parse a PostHog Code share link into its in-app navigation target, or `null`
- * if it isn't one. Recognises the `/code/canvas/...` and `/code/channel/...`
- * links built above, on any region's host — the inbound deep-link handlers
- * navigate by id against the current session, so bouncing through the browser
- * to reach the app buys nothing.
- */
 export function parseShareLink(href: string): ShareLinkTarget | null {
   let url: URL;
   try {
@@ -160,8 +146,6 @@ export function parseShareLink(href: string): ShareLinkTarget | null {
   }
   if (!POSTHOG_HOSTS.has(url.host)) return null;
 
-  // Split the still-encoded pathname first, then decode each segment, so an id
-  // containing an encoded slash (`%2F`) stays a single segment.
   const segments = url.pathname
     .split("/")
     .filter(Boolean)

--- a/packages/ui/src/utils/posthogLinks.ts
+++ b/packages/ui/src/utils/posthogLinks.ts
@@ -137,16 +137,8 @@ const POSTHOG_HOSTS = new Set(
     .filter(Boolean),
 );
 
-export function parseShareLink(href: string): ShareLinkTarget | null {
-  let url: URL;
-  try {
-    url = new URL(href);
-  } catch {
-    return null;
-  }
-  if (!POSTHOG_HOSTS.has(url.host)) return null;
-
-  const segments = url.pathname
+function decodePathSegments(pathname: string): string[] {
+  return pathname
     .split("/")
     .filter(Boolean)
     .map((segment) => {
@@ -156,23 +148,39 @@ export function parseShareLink(href: string): ShareLinkTarget | null {
         return segment;
       }
     });
+}
 
-  if (segments[0] !== "code") return null;
-
-  if (segments[1] === "canvas" && segments.length === 4) {
-    return { kind: "canvas", channelId: segments[2], dashboardId: segments[3] };
+function parseCanvasShareLink(segments: string[]): ShareLinkTarget | null {
+  const [root, kind, channelId, dashboardId] = segments;
+  if (root === "code" && kind === "canvas" && segments.length === 4) {
+    return { kind: "canvas", channelId, dashboardId };
   }
-
-  if (segments[1] === "channel") {
-    if (segments.length === 3) {
-      return { kind: "channel", channelId: segments[2] };
-    }
-    if (segments.length === 5 && segments[3] === "tasks") {
-      return { kind: "channel", channelId: segments[2], taskId: segments[4] };
-    }
-  }
-
   return null;
+}
+
+function parseChannelShareLink(segments: string[]): ShareLinkTarget | null {
+  const [root, kind, channelId, maybeTasks, taskId] = segments;
+  if (root !== "code" || kind !== "channel") return null;
+  if (segments.length === 3) {
+    return { kind: "channel", channelId };
+  }
+  if (segments.length === 5 && maybeTasks === "tasks") {
+    return { kind: "channel", channelId, taskId };
+  }
+  return null;
+}
+
+export function parseShareLink(href: string): ShareLinkTarget | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  if (!POSTHOG_HOSTS.has(url.host)) return null;
+
+  const segments = decodePathSegments(url.pathname);
+  return parseCanvasShareLink(segments) ?? parseChannelShareLink(segments);
 }
 
 export function errorTrackingIssueUrl(

--- a/packages/ui/src/utils/posthogLinks.ts
+++ b/packages/ui/src/utils/posthogLinks.ts
@@ -1,4 +1,8 @@
-import type { CloudRegion } from "@posthog/shared";
+import {
+  type CloudRegion,
+  getCloudUrlFromRegion,
+  REGION_LABELS,
+} from "@posthog/shared";
 import { useAuthStore } from "@posthog/ui/features/auth/store";
 import { getPostHogUrl } from "@posthog/ui/utils/urls";
 
@@ -115,6 +119,76 @@ export function channelShareUrl(
   return getPostHogUrl(
     taskId ? `${base}/tasks/${encodeURIComponent(taskId)}` : base,
   );
+}
+
+/**
+ * The in-app destination a PostHog Code share link points at — the inverse of
+ * the `canvasShareUrl` / `channelShareUrl` builders above.
+ */
+export type ShareLinkTarget =
+  | { kind: "canvas"; channelId: string; dashboardId: string }
+  | { kind: "channel"; channelId: string; taskId?: string };
+
+// Hosts we recognise as PostHog share-link origins, one per cloud region. The
+// host check keeps `parseShareLink` from hijacking unrelated links that happen
+// to share the `/code/...` path shape.
+const POSTHOG_HOSTS = new Set(
+  (Object.keys(REGION_LABELS) as CloudRegion[])
+    .map((region) => {
+      try {
+        return new URL(getCloudUrlFromRegion(region)).host;
+      } catch {
+        return "";
+      }
+    })
+    .filter(Boolean),
+);
+
+/**
+ * Parse a PostHog Code share link into its in-app navigation target, or `null`
+ * if it isn't one. Recognises the `/code/canvas/...` and `/code/channel/...`
+ * links built above, on any region's host — the inbound deep-link handlers
+ * navigate by id against the current session, so bouncing through the browser
+ * to reach the app buys nothing.
+ */
+export function parseShareLink(href: string): ShareLinkTarget | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  if (!POSTHOG_HOSTS.has(url.host)) return null;
+
+  // Split the still-encoded pathname first, then decode each segment, so an id
+  // containing an encoded slash (`%2F`) stays a single segment.
+  const segments = url.pathname
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => {
+      try {
+        return decodeURIComponent(segment);
+      } catch {
+        return segment;
+      }
+    });
+
+  if (segments[0] !== "code") return null;
+
+  if (segments[1] === "canvas" && segments.length === 4) {
+    return { kind: "canvas", channelId: segments[2], dashboardId: segments[3] };
+  }
+
+  if (segments[1] === "channel") {
+    if (segments.length === 3) {
+      return { kind: "channel", channelId: segments[2] };
+    }
+    if (segments.length === 5 && segments[3] === "tasks") {
+      return { kind: "channel", channelId: segments[2], taskId: segments[4] };
+    }
+  }
+
+  return null;
 }
 
 export function errorTrackingIssueUrl(

--- a/packages/ui/src/utils/posthogLinks.ts
+++ b/packages/ui/src/utils/posthogLinks.ts
@@ -137,6 +137,30 @@ const POSTHOG_HOSTS = new Set(
     .filter(Boolean),
 );
 
+interface ShareLinkRoute {
+  pattern: string[];
+  build: (params: Record<string, string>) => ShareLinkTarget;
+}
+
+const SHARE_LINK_ROUTES: ShareLinkRoute[] = [
+  {
+    pattern: ["code", "canvas", ":channelId", ":dashboardId"],
+    build: ({ channelId, dashboardId }) => ({
+      kind: "canvas",
+      channelId,
+      dashboardId,
+    }),
+  },
+  {
+    pattern: ["code", "channel", ":channelId"],
+    build: ({ channelId }) => ({ kind: "channel", channelId }),
+  },
+  {
+    pattern: ["code", "channel", ":channelId", "tasks", ":taskId"],
+    build: ({ channelId, taskId }) => ({ kind: "channel", channelId, taskId }),
+  },
+];
+
 function decodePathSegments(pathname: string): string[] {
   return pathname
     .split("/")
@@ -150,24 +174,21 @@ function decodePathSegments(pathname: string): string[] {
     });
 }
 
-function parseCanvasShareLink(segments: string[]): ShareLinkTarget | null {
-  const [root, kind, channelId, dashboardId] = segments;
-  if (root === "code" && kind === "canvas" && segments.length === 4) {
-    return { kind: "canvas", channelId, dashboardId };
+function matchRoute(
+  segments: string[],
+  route: ShareLinkRoute,
+): ShareLinkTarget | null {
+  if (segments.length !== route.pattern.length) return null;
+  const params: Record<string, string> = {};
+  for (const [index, token] of route.pattern.entries()) {
+    const segment = segments[index];
+    if (token.startsWith(":")) {
+      params[token.slice(1)] = segment;
+    } else if (token !== segment) {
+      return null;
+    }
   }
-  return null;
-}
-
-function parseChannelShareLink(segments: string[]): ShareLinkTarget | null {
-  const [root, kind, channelId, maybeTasks, taskId] = segments;
-  if (root !== "code" || kind !== "channel") return null;
-  if (segments.length === 3) {
-    return { kind: "channel", channelId };
-  }
-  if (segments.length === 5 && maybeTasks === "tasks") {
-    return { kind: "channel", channelId, taskId };
-  }
-  return null;
+  return route.build(params);
 }
 
 export function parseShareLink(href: string): ShareLinkTarget | null {
@@ -180,7 +201,11 @@ export function parseShareLink(href: string): ShareLinkTarget | null {
   if (!POSTHOG_HOSTS.has(url.host)) return null;
 
   const segments = decodePathSegments(url.pathname);
-  return parseCanvasShareLink(segments) ?? parseChannelShareLink(segments);
+  for (const route of SHARE_LINK_ROUTES) {
+    const target = matchRoute(segments, route);
+    if (target) return target;
+  }
+  return null;
 }
 
 export function errorTrackingIssueUrl(

--- a/packages/ui/src/utils/shareLinks.test.ts
+++ b/packages/ui/src/utils/shareLinks.test.ts
@@ -1,7 +1,4 @@
-import {
-  handleShareLinkClick,
-  parseShareLink,
-} from "@posthog/ui/utils/shareLinks";
+import { handleShareLinkClick } from "@posthog/ui/utils/shareLinks";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const navigateToChannel = vi.fn();
@@ -17,52 +14,6 @@ vi.mock("@posthog/ui/router/navigationBridge", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-});
-
-describe("parseShareLink", () => {
-  it.each([
-    [
-      "canvas link",
-      "https://us.posthog.com/code/canvas/chan1/dash1",
-      { kind: "canvas", channelId: "chan1", dashboardId: "dash1" },
-    ],
-    [
-      "canvas link with encoded ids",
-      "https://us.posthog.com/code/canvas/chan%2F1/dash%202",
-      { kind: "canvas", channelId: "chan/1", dashboardId: "dash 2" },
-    ],
-    [
-      "channel link on the eu host",
-      "https://eu.posthog.com/code/channel/chan1",
-      { kind: "channel", channelId: "chan1" },
-    ],
-    [
-      "channel thread link",
-      "https://us.posthog.com/code/channel/chan1/tasks/task1",
-      { kind: "channel", channelId: "chan1", taskId: "task1" },
-    ],
-  ])("parses a %s", (_label, href, expected) => {
-    expect(parseShareLink(href)).toEqual(expected);
-  });
-
-  it.each([
-    ["a non-PostHog host", "https://evil.com/code/canvas/chan1/dash1"],
-    [
-      "an unrelated PostHog path",
-      "https://us.posthog.com/project/2/dashboard/1",
-    ],
-    [
-      "a canvas link missing the dashboard id",
-      "https://us.posthog.com/code/canvas/chan1",
-    ],
-    [
-      "a channel thread link with a malformed tail",
-      "https://us.posthog.com/code/channel/chan1/foo/task1",
-    ],
-    ["a malformed url", "not a url"],
-  ])("returns null for %s", (_label, href) => {
-    expect(parseShareLink(href)).toBeNull();
-  });
 });
 
 describe("handleShareLinkClick", () => {

--- a/packages/ui/src/utils/shareLinks.test.ts
+++ b/packages/ui/src/utils/shareLinks.test.ts
@@ -41,6 +41,27 @@ describe("handleShareLinkClick", () => {
     expect(navigateToChannelTask).toHaveBeenCalledWith("chan1", "task1");
   });
 
+  it.each([
+    ["meta", { metaKey: true }],
+    ["ctrl", { ctrlKey: true }],
+    ["shift", { shiftKey: true }],
+    ["a middle button", { button: 1 }],
+  ])(
+    "leaves a %s-modified click to open in a new tab/window",
+    (_label, modifier) => {
+      const event = { preventDefault: vi.fn(), ...modifier };
+
+      const handled = handleShareLinkClick(
+        "https://us.posthog.com/code/canvas/chan1/dash1",
+        event,
+      );
+
+      expect(handled).toBe(false);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(navigateToChannelDashboard).not.toHaveBeenCalled();
+    },
+  );
+
   it("leaves an external link alone", () => {
     const event = { preventDefault: vi.fn() };
 

--- a/packages/ui/src/utils/shareLinks.test.ts
+++ b/packages/ui/src/utils/shareLinks.test.ts
@@ -1,0 +1,111 @@
+import {
+  handleShareLinkClick,
+  parseShareLink,
+} from "@posthog/ui/utils/shareLinks";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigateToChannel = vi.fn();
+const navigateToChannelDashboard = vi.fn();
+const navigateToChannelTask = vi.fn();
+
+vi.mock("@posthog/ui/router/navigationBridge", () => ({
+  navigateToChannel: (...args: unknown[]) => navigateToChannel(...args),
+  navigateToChannelDashboard: (...args: unknown[]) =>
+    navigateToChannelDashboard(...args),
+  navigateToChannelTask: (...args: unknown[]) => navigateToChannelTask(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("parseShareLink", () => {
+  it.each([
+    [
+      "canvas link",
+      "https://us.posthog.com/code/canvas/chan1/dash1",
+      { kind: "canvas", channelId: "chan1", dashboardId: "dash1" },
+    ],
+    [
+      "canvas link with encoded ids",
+      "https://us.posthog.com/code/canvas/chan%2F1/dash%202",
+      { kind: "canvas", channelId: "chan/1", dashboardId: "dash 2" },
+    ],
+    [
+      "channel link on the eu host",
+      "https://eu.posthog.com/code/channel/chan1",
+      { kind: "channel", channelId: "chan1" },
+    ],
+    [
+      "channel thread link",
+      "https://us.posthog.com/code/channel/chan1/tasks/task1",
+      { kind: "channel", channelId: "chan1", taskId: "task1" },
+    ],
+  ])("parses a %s", (_label, href, expected) => {
+    expect(parseShareLink(href)).toEqual(expected);
+  });
+
+  it.each([
+    ["a non-PostHog host", "https://evil.com/code/canvas/chan1/dash1"],
+    [
+      "an unrelated PostHog path",
+      "https://us.posthog.com/project/2/dashboard/1",
+    ],
+    [
+      "a canvas link missing the dashboard id",
+      "https://us.posthog.com/code/canvas/chan1",
+    ],
+    [
+      "a channel thread link with a malformed tail",
+      "https://us.posthog.com/code/channel/chan1/foo/task1",
+    ],
+    ["a malformed url", "not a url"],
+  ])("returns null for %s", (_label, href) => {
+    expect(parseShareLink(href)).toBeNull();
+  });
+});
+
+describe("handleShareLinkClick", () => {
+  it("navigates in-app and cancels the default open for a share link", () => {
+    const event = { preventDefault: vi.fn() };
+
+    const handled = handleShareLinkClick(
+      "https://us.posthog.com/code/canvas/chan1/dash1",
+      event,
+    );
+
+    expect(handled).toBe(true);
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(navigateToChannelDashboard).toHaveBeenCalledWith("chan1", "dash1");
+  });
+
+  it("routes a channel thread link to the task navigator", () => {
+    const event = { preventDefault: vi.fn() };
+
+    handleShareLinkClick(
+      "https://us.posthog.com/code/channel/chan1/tasks/task1",
+      event,
+    );
+
+    expect(navigateToChannelTask).toHaveBeenCalledWith("chan1", "task1");
+  });
+
+  it("leaves an external link alone", () => {
+    const event = { preventDefault: vi.fn() };
+
+    const handled = handleShareLinkClick("https://example.com/docs", event);
+
+    expect(handled).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(navigateToChannel).not.toHaveBeenCalled();
+    expect(navigateToChannelDashboard).not.toHaveBeenCalled();
+    expect(navigateToChannelTask).not.toHaveBeenCalled();
+  });
+
+  it("returns false for a missing href", () => {
+    const event = { preventDefault: vi.fn() };
+
+    expect(handleShareLinkClick(undefined, event)).toBe(false);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/utils/shareLinks.ts
+++ b/packages/ui/src/utils/shareLinks.ts
@@ -23,11 +23,6 @@ export function navigateToShareTarget(target: ShareLinkTarget): void {
   }
 }
 
-/**
- * If `href` is a PostHog Code share link, navigate to it in-app and return true
- * (cancelling the click's default open-in-browser). Otherwise return false so
- * the caller lets the link open externally as usual.
- */
 export function handleShareLinkClick(
   href: string | undefined,
   event: { preventDefault: () => void },

--- a/packages/ui/src/utils/shareLinks.ts
+++ b/packages/ui/src/utils/shareLinks.ts
@@ -23,11 +23,30 @@ export function navigateToShareTarget(target: ShareLinkTarget): void {
   }
 }
 
+interface ShareLinkClickEvent {
+  preventDefault: () => void;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  button?: number;
+}
+
+function isModifiedClick(event: ShareLinkClickEvent): boolean {
+  return Boolean(
+    event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      (event.button != null && event.button !== 0),
+  );
+}
+
 export function handleShareLinkClick(
   href: string | undefined,
-  event: { preventDefault: () => void },
+  event: ShareLinkClickEvent,
 ): boolean {
-  if (!href) return false;
+  if (!href || isModifiedClick(event)) return false;
   const target = parseShareLink(href);
   if (!target) return false;
   event.preventDefault();

--- a/packages/ui/src/utils/shareLinks.ts
+++ b/packages/ui/src/utils/shareLinks.ts
@@ -1,0 +1,107 @@
+import { type CloudRegion, getCloudUrlFromRegion } from "@posthog/shared";
+import {
+  navigateToChannel,
+  navigateToChannelDashboard,
+  navigateToChannelTask,
+} from "@posthog/ui/router/navigationBridge";
+
+// The in-app destination a PostHog Code share link points at. The inverse of the
+// `canvasShareUrl` / `channelShareUrl` builders in `posthogLinks.ts`.
+export type ShareLinkTarget =
+  | { kind: "canvas"; channelId: string; dashboardId: string }
+  | { kind: "channel"; channelId: string; taskId?: string };
+
+const REGIONS: CloudRegion[] = ["us", "eu", "dev"];
+
+// Hosts we recognise as PostHog share-link origins. We match every region (not
+// just the signed-in one) so a link works in-app regardless of which instance
+// it was minted on — the inbound deep-link handlers already navigate by id
+// against the current session, so bouncing through the browser buys nothing.
+const POSTHOG_HOSTS = new Set(
+  REGIONS.map((region) => {
+    try {
+      return new URL(getCloudUrlFromRegion(region)).host;
+    } catch {
+      return "";
+    }
+  }).filter(Boolean),
+);
+
+/**
+ * Parse a PostHog Code share link into its in-app navigation target, or `null`
+ * if it isn't one. Recognises `/code/canvas/<channelId>/<dashboardId>` and
+ * `/code/channel/<channelId>[/tasks/<taskId>]` on a known PostHog host. The
+ * host check keeps us from hijacking unrelated links that happen to share the
+ * path shape.
+ */
+export function parseShareLink(href: string): ShareLinkTarget | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  if (!POSTHOG_HOSTS.has(url.host)) return null;
+
+  // Split the still-encoded pathname first, then decode each segment, so an id
+  // containing an encoded slash (`%2F`) stays a single segment.
+  const segments = url.pathname
+    .split("/")
+    .filter(Boolean)
+    .map((segment) => {
+      try {
+        return decodeURIComponent(segment);
+      } catch {
+        return segment;
+      }
+    });
+
+  if (segments[0] !== "code") return null;
+
+  if (segments[1] === "canvas" && segments.length === 4) {
+    return { kind: "canvas", channelId: segments[2], dashboardId: segments[3] };
+  }
+
+  if (segments[1] === "channel") {
+    if (segments.length === 3) {
+      return { kind: "channel", channelId: segments[2] };
+    }
+    if (segments.length === 5 && segments[3] === "tasks") {
+      return { kind: "channel", channelId: segments[2], taskId: segments[4] };
+    }
+  }
+
+  return null;
+}
+
+export function navigateToShareTarget(target: ShareLinkTarget): void {
+  switch (target.kind) {
+    case "canvas":
+      navigateToChannelDashboard(target.channelId, target.dashboardId);
+      break;
+    case "channel":
+      if (target.taskId) {
+        navigateToChannelTask(target.channelId, target.taskId);
+      } else {
+        navigateToChannel(target.channelId);
+      }
+      break;
+  }
+}
+
+/**
+ * If `href` is a PostHog Code share link, navigate to it in-app and return true
+ * (cancelling the click's default open-in-browser). Otherwise return false so
+ * the caller lets the link open externally as usual.
+ */
+export function handleShareLinkClick(
+  href: string | undefined,
+  event: { preventDefault: () => void },
+): boolean {
+  if (!href) return false;
+  const target = parseShareLink(href);
+  if (!target) return false;
+  event.preventDefault();
+  navigateToShareTarget(target);
+  return true;
+}

--- a/packages/ui/src/utils/shareLinks.ts
+++ b/packages/ui/src/utils/shareLinks.ts
@@ -1,78 +1,12 @@
-import { type CloudRegion, getCloudUrlFromRegion } from "@posthog/shared";
 import {
   navigateToChannel,
   navigateToChannelDashboard,
   navigateToChannelTask,
 } from "@posthog/ui/router/navigationBridge";
-
-// The in-app destination a PostHog Code share link points at. The inverse of the
-// `canvasShareUrl` / `channelShareUrl` builders in `posthogLinks.ts`.
-export type ShareLinkTarget =
-  | { kind: "canvas"; channelId: string; dashboardId: string }
-  | { kind: "channel"; channelId: string; taskId?: string };
-
-const REGIONS: CloudRegion[] = ["us", "eu", "dev"];
-
-// Hosts we recognise as PostHog share-link origins. We match every region (not
-// just the signed-in one) so a link works in-app regardless of which instance
-// it was minted on — the inbound deep-link handlers already navigate by id
-// against the current session, so bouncing through the browser buys nothing.
-const POSTHOG_HOSTS = new Set(
-  REGIONS.map((region) => {
-    try {
-      return new URL(getCloudUrlFromRegion(region)).host;
-    } catch {
-      return "";
-    }
-  }).filter(Boolean),
-);
-
-/**
- * Parse a PostHog Code share link into its in-app navigation target, or `null`
- * if it isn't one. Recognises `/code/canvas/<channelId>/<dashboardId>` and
- * `/code/channel/<channelId>[/tasks/<taskId>]` on a known PostHog host. The
- * host check keeps us from hijacking unrelated links that happen to share the
- * path shape.
- */
-export function parseShareLink(href: string): ShareLinkTarget | null {
-  let url: URL;
-  try {
-    url = new URL(href);
-  } catch {
-    return null;
-  }
-  if (!POSTHOG_HOSTS.has(url.host)) return null;
-
-  // Split the still-encoded pathname first, then decode each segment, so an id
-  // containing an encoded slash (`%2F`) stays a single segment.
-  const segments = url.pathname
-    .split("/")
-    .filter(Boolean)
-    .map((segment) => {
-      try {
-        return decodeURIComponent(segment);
-      } catch {
-        return segment;
-      }
-    });
-
-  if (segments[0] !== "code") return null;
-
-  if (segments[1] === "canvas" && segments.length === 4) {
-    return { kind: "canvas", channelId: segments[2], dashboardId: segments[3] };
-  }
-
-  if (segments[1] === "channel") {
-    if (segments.length === 3) {
-      return { kind: "channel", channelId: segments[2] };
-    }
-    if (segments.length === 5 && segments[3] === "tasks") {
-      return { kind: "channel", channelId: segments[2], taskId: segments[4] };
-    }
-  }
-
-  return null;
-}
+import {
+  parseShareLink,
+  type ShareLinkTarget,
+} from "@posthog/ui/utils/posthogLinks";
 
 export function navigateToShareTarget(target: ShareLinkTarget): void {
   switch (target.kind) {


### PR DESCRIPTION
## Problem

Clicking a **canvas link in a channel thread** opened PostHog Cloud in the external browser, which then deep-linked back into PostHog Code — an unnecessary round-trip, since the user is already in the app.

**Why:** reported in-app annoyance — the click flashes out to the browser and back instead of just navigating. Confirmed live on latest `main` (not a stale local version).

## Changes

The thread feed renders **server-emitted** announcement messages (e.g. "[Name](…/code/canvas/…) has been created") whose content embeds a **portable** https share link — deliberately portable so the same message works on web, Slack, and for users without the app. Those links were rendered as plain external anchors, so clicking one handed the URL to the OS browser → Cloud interstitial → `posthog-code://` back into the app.

Fix at the client render/click layer (leaving the portable stored content intact):

- New `shareLinks.ts` util — parses our own share-link URLs (`/code/canvas/<channelId>/<dashboardId>`, `/code/channel/<channelId>[/tasks/<taskId>]`) on a known PostHog host and navigates via the existing in-app router (`navigationBridge`), cancelling the default open-in-browser.
- Wired into `MentionText` (thread sidebar + channel feed / activity / intro) and `MarkdownRenderer` (agent chat). Any link that isn't a recognized share link is untouched and still opens externally.

Host matching covers all PostHog regions (not just the signed-in one), since the inbound deep-link handlers already navigate by id against the current session — so intercepting is strictly faster with the same destination.

## How did you test this?

- `pnpm --filter @posthog/ui exec vitest run src/utils/shareLinks.test.ts src/features/canvas/components/MentionText.test.tsx` → 20 passed. Covers canvas / channel / channel+task parses, encoded ids, non-PostHog host + wrong-path + malformed rejection, and click interception (preventDefault + in-app navigate) vs. external links passing through.
- Lint clean (`biome check`) and no typecheck errors in `packages/ui/src` for the changed files.
- Not yet run: full-app manual verification (build blocked in this environment on an unrelated `@posthog/agent` dist build).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*