### PR TITLE
Hold channel loading state until the feed is complete so it opens at the latest message

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -696,21 +696,15 @@ export function ChannelFeedView({
     return merged;
   }, [tasks, systemMessages]);
 
-  // Open every channel at its latest message. The scroller handles the first
-  // mount itself (defaultScrollPosition), but switching channels only swaps
-  // the rows — no remount — so jump to the bottom before paint whenever the
-  // channel changes. No-ops while the loading state has the viewport unmounted.
   const viewportRef = useRef<HTMLDivElement>(null);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: channelId is the trigger — switching channels swaps the rows without a remount, so re-land at the latest message
   useLayoutEffect(() => {
     const viewport = viewportRef.current;
     if (viewport) viewport.scrollTop = viewport.scrollHeight;
   }, [channelId]);
 
-  // Hold the loading state even when some entries already exist (the "joined"
-  // opener renders as soon as the channel resolves, before the task cards):
-  // mounting the scroller around partial content spends its one-shot initial
-  // end-scroll on a near-empty list, and it never re-scrolls when the real
-  // cards arrive. Pending kickoffs bail out so an optimistic post shows now.
+  // Wait for the complete feed: the scroller's initial end-scroll fires once,
+  // so mounting around partial rows would land it short of the latest message.
   if (isLoading && pending.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center">

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -716,7 +716,11 @@ export function ChannelFeedView({
   const latestPendingId = pending[pending.length - 1]?.id;
 
   return (
-    <ChatMessageScrollerProvider defaultScrollPosition="end">
+    // Keyed by channel: switching channels swaps the content without a route
+    // remount, but the scroller only applies defaultScrollPosition once per
+    // mount — an un-keyed provider would keep the previous channel's scroll
+    // offset instead of landing at the latest message.
+    <ChatMessageScrollerProvider key={channelId} defaultScrollPosition="end">
       <FollowOwnPost latestPendingId={latestPendingId} />
       <ChatMessageScroller className="min-h-0 flex-1">
         <ChatMessageScrollerViewport>

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -629,24 +629,6 @@ function FollowOwnPost({ latestPendingId }: { latestPendingId?: string }) {
   return null;
 }
 
-// Land at the latest message when the feed swaps to another channel: the route
-// doesn't remount on a param change, so the provider's one-shot
-// defaultScrollPosition only covers the channel it mounted with. Imperative
-// rather than keying the provider — a remount would rebuild the entire feed
-// subtree on every switch. Layout effect so the jump happens in the same
-// commit as the swapped rows, before paint. Renders nothing.
-function LandAtLatestOnChannelChange({ channelId }: { channelId: string }) {
-  const { scrollToEnd } = useChatMessageScroller();
-  const prevRef = useRef(channelId);
-  useLayoutEffect(() => {
-    if (channelId !== prevRef.current) {
-      prevRef.current = channelId;
-      scrollToEnd({ behavior: "auto" });
-    }
-  }, [channelId, scrollToEnd]);
-  return null;
-}
-
 // A single feed entry, either a real task card or a synthetic system row, tagged
 // with the timestamp used to interleave the two.
 type FeedEntry =
@@ -714,6 +696,16 @@ export function ChannelFeedView({
     return merged;
   }, [tasks, systemMessages]);
 
+  // Open every channel at its latest message. The scroller handles the first
+  // mount itself (defaultScrollPosition), but switching channels only swaps
+  // the rows — no remount — so jump to the bottom before paint whenever the
+  // channel changes. No-ops while the loading state has the viewport unmounted.
+  const viewportRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current;
+    if (viewport) viewport.scrollTop = viewport.scrollHeight;
+  }, [channelId]);
+
   // Hold the loading state even when some entries already exist (the "joined"
   // opener renders as soon as the channel resolves, before the task cards):
   // mounting the scroller around partial content spends its one-shot initial
@@ -736,10 +728,9 @@ export function ChannelFeedView({
 
   return (
     <ChatMessageScrollerProvider defaultScrollPosition="end">
-      <LandAtLatestOnChannelChange channelId={channelId} />
       <FollowOwnPost latestPendingId={latestPendingId} />
       <ChatMessageScroller className="min-h-0 flex-1">
-        <ChatMessageScrollerViewport>
+        <ChatMessageScrollerViewport ref={viewportRef}>
           {/* Horizontal padding is load-bearing: ThreadItem's actions float at
               the row's top-right corner (absolute, past the row edge). Without a
               gutter they hug the scroll container and get clipped. */}

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -697,11 +697,12 @@ export function ChannelFeedView({
   }, [tasks, systemMessages]);
 
   const viewportRef = useRef<HTMLDivElement>(null);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: channelId is the trigger — switching channels swaps the rows without a remount, so re-land at the latest message
+  // biome-ignore lint/correctness/useExhaustiveDependencies: channelId is a trigger — switching channels or finishing the initial load swaps/completes the rows without a remount, so re-land at the latest message
   useLayoutEffect(() => {
+    if (isLoading) return;
     const viewport = viewportRef.current;
     if (viewport) viewport.scrollTop = viewport.scrollHeight;
-  }, [channelId]);
+  }, [channelId, isLoading]);
 
   // Wait for the complete feed: the scroller's initial end-scroll fires once,
   // so mounting around partial rows would land it short of the latest message.

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -695,7 +695,12 @@ export function ChannelFeedView({
     return merged;
   }, [tasks, systemMessages]);
 
-  if (isLoading && entries.length === 0 && pending.length === 0) {
+  // Hold the loading state even when some entries already exist (the "joined"
+  // opener renders as soon as the channel resolves, before the task cards):
+  // mounting the scroller around partial content spends its one-shot initial
+  // end-scroll on a near-empty list, and it never re-scrolls when the real
+  // cards arrive. Pending kickoffs bail out so an optimistic post shows now.
+  if (isLoading && pending.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center">
         <Spinner />

--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -59,6 +59,7 @@ import {
   memo,
   type ReactNode,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
 } from "react";
@@ -628,6 +629,24 @@ function FollowOwnPost({ latestPendingId }: { latestPendingId?: string }) {
   return null;
 }
 
+// Land at the latest message when the feed swaps to another channel: the route
+// doesn't remount on a param change, so the provider's one-shot
+// defaultScrollPosition only covers the channel it mounted with. Imperative
+// rather than keying the provider — a remount would rebuild the entire feed
+// subtree on every switch. Layout effect so the jump happens in the same
+// commit as the swapped rows, before paint. Renders nothing.
+function LandAtLatestOnChannelChange({ channelId }: { channelId: string }) {
+  const { scrollToEnd } = useChatMessageScroller();
+  const prevRef = useRef(channelId);
+  useLayoutEffect(() => {
+    if (channelId !== prevRef.current) {
+      prevRef.current = channelId;
+      scrollToEnd({ behavior: "auto" });
+    }
+  }, [channelId, scrollToEnd]);
+  return null;
+}
+
 // A single feed entry, either a real task card or a synthetic system row, tagged
 // with the timestamp used to interleave the two.
 type FeedEntry =
@@ -716,11 +735,8 @@ export function ChannelFeedView({
   const latestPendingId = pending[pending.length - 1]?.id;
 
   return (
-    // Keyed by channel: switching channels swaps the content without a route
-    // remount, but the scroller only applies defaultScrollPosition once per
-    // mount — an un-keyed provider would keep the previous channel's scroll
-    // offset instead of landing at the latest message.
-    <ChatMessageScrollerProvider key={channelId} defaultScrollPosition="end">
+    <ChatMessageScrollerProvider defaultScrollPosition="end">
+      <LandAtLatestOnChannelChange channelId={channelId} />
       <FollowOwnPost latestPendingId={latestPendingId} />
       <ChatMessageScroller className="min-h-0 flex-1">
         <ChatMessageScrollerViewport>

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -69,18 +69,26 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   const { tasks, isLoading: isLoadingFeed } = useChannelFeed(
     backendChannel?.id,
   );
-  // Until the backend channel resolves there's no feed to ask for, and the feed
-  // query is disabled — which reports isLoading:false, indistinguishable from
-  // "this channel is empty". useBackendChannel reports loading for the whole
-  // identity-resolution window (settling if the resolve fails), so fold it in:
-  // we can't call a channel empty until we know which channel it is.
-  const isLoading = isLoadingChannels || isResolvingChannel || isLoadingFeed;
   // Marking this channel read lives in ChannelHeader (rendered by every channel
   // surface), so opening Artifacts or CONTEXT.md counts as reading it too.
 
   // Durable "PostHog agent" rows (CONTEXT.md being built, …) live on the
   // backend channel — the same id the feed tasks use, not the folder id.
-  const { messages: feedMessages } = useChannelFeedMessages(backendChannel?.id);
+  const { messages: feedMessages, isLoading: isLoadingMessages } =
+    useChannelFeedMessages(backendChannel?.id);
+  // Until the backend channel resolves there's no feed to ask for, and the feed
+  // query is disabled — which reports isLoading:false, indistinguishable from
+  // "this channel is empty". useBackendChannel reports loading for the whole
+  // identity-resolution window (settling if the resolve fails), so fold it in:
+  // we can't call a channel empty until we know which channel it is. Messages
+  // loading is included so the scroller mounts once with the complete feed and
+  // its one-shot initial end-scroll lands at the latest message (it never
+  // re-fires for late-arriving rows).
+  const isLoading =
+    isLoadingChannels ||
+    isResolvingChannel ||
+    isLoadingFeed ||
+    isLoadingMessages;
   // The Slack-style "joined" opener, derived from the channel row so it renders
   // (and sorts first) even where the feed endpoint isn't deployed.
   const systemMessages = useMemo(() => {

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -80,10 +80,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   // query is disabled — which reports isLoading:false, indistinguishable from
   // "this channel is empty". useBackendChannel reports loading for the whole
   // identity-resolution window (settling if the resolve fails), so fold it in:
-  // we can't call a channel empty until we know which channel it is. Messages
-  // loading is included so the scroller mounts once with the complete feed and
-  // its one-shot initial end-scroll lands at the latest message (it never
-  // re-fires for late-arriving rows).
+  // we can't call a channel empty until we know which channel it is.
   const isLoading =
     isLoadingChannels ||
     isResolvingChannel ||


### PR DESCRIPTION
## Problem

Opening a channel from the sidebar feels slow and doesn't start you at the most recent message. The feed scroller (`ChatMessageScrollerProvider defaultScrollPosition="end"`) applies its initial end-scroll exactly once, as soon as it has any content — and by design it never re-scrolls when more rows arrive (no forced scroll). Today the scroller mounts around partial content: the synthesized "joined" opener renders the moment the backend channel resolves, while the task cards and system messages are still fetching (the loading gate also ignored `useChannelFeedMessages`' loading state). The one-shot end-scroll spends itself on that near-empty list, so the real cards land off-screen below.

## Changes

- `WebsiteChannelHome`: fold `useChannelFeedMessages`' `isLoading` (already returned, previously unused) into the feed loading gate.
- `ChannelFeedView`: scroll to the latest message on channel switch — channel-to-channel navigation swaps content without a route remount, so the scroller's one-shot `defaultScrollPosition` only covers the channel it mounted with and a revisited channel kept the previous channel's scroll offset (often the top). Implemented as a ref on the scroller viewport plus a layout effect keyed on the channel id that sets `scrollTop = scrollHeight` before paint; no remount, no extra components.
- `ChannelFeedView`: hold the loading spinner while the feed is still loading even if some entries already exist, so the scroller mounts once with the complete feed and its initial end-scroll lands at the latest message. Optimistic pending kickoffs still bail out of the spinner immediately, and warm reopens render instantly from cache with no repeat spinner.

No new scroll code — verified against the scroller engine source that `defaultScrollPosition="end"` handles the landing correctly once the mount isn't premature.

**Why:** raised in project-bluebird — opening a channel should render at the most recent message immediately instead of showing a half-loaded feed scrolled to the top.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` and `pnpm --filter @posthog/ui test` (200 files / 1755 tests pass), `pnpm lint` clean on changed files.
- Scroll/paint timing is best eyeballed live — worth a quick check in the running app that a cold channel open lands at the bottom and a reopen shows no spinner.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


