### PR TITLE
feat(code-review): filter files with comments

### DIFF
--- a/packages/ui/src/features/code-review/commentFileFilter.ts
+++ b/packages/ui/src/features/code-review/commentFileFilter.ts
@@ -1,0 +1,123 @@
+import type { PrCommentThread } from "@posthog/core/code-review/types";
+import type { ReactNode } from "react";
+
+export type CommentFileFilter = "none" | "commented" | "unresolved";
+
+export interface ReviewListItem {
+  key: string;
+  scrollKey?: string;
+  filePaths?: string[];
+  node: ReactNode;
+}
+
+interface CommentFileFilterState {
+  activeFilter: CommentFileFilter;
+  visibleItems: ReviewListItem[];
+  commentedFileCount: number;
+  unresolvedCommentedFileCount: number;
+}
+
+interface DeriveCommentFileFilterStateArgs {
+  items: ReviewListItem[];
+  requestedFilter: CommentFileFilter;
+  commentedFilePaths?: ReadonlySet<string>;
+  unresolvedCommentedFilePaths?: ReadonlySet<string>;
+}
+
+export function getCommentedFilePaths(threads: Map<number, PrCommentThread>): {
+  all: Set<string>;
+  unresolved: Set<string>;
+} {
+  const all = new Set<string>();
+  const unresolved = new Set<string>();
+
+  for (const thread of threads.values()) {
+    if (thread.comments.length === 0) continue;
+    all.add(thread.filePath);
+    if (!thread.isResolved) unresolved.add(thread.filePath);
+  }
+
+  return { all, unresolved };
+}
+
+export function filterReviewItemsByFilePaths(
+  items: ReviewListItem[],
+  filePaths: ReadonlySet<string>,
+): ReviewListItem[] {
+  const filteredItems: ReviewListItem[] = [];
+  let pendingSectionItems: ReviewListItem[] = [];
+
+  for (const item of items) {
+    if (!item.filePaths) {
+      pendingSectionItems = [item];
+      continue;
+    }
+
+    if (!item.filePaths.some((filePath) => filePaths.has(filePath))) continue;
+
+    filteredItems.push(...pendingSectionItems, item);
+    pendingSectionItems = [];
+  }
+
+  return filteredItems;
+}
+
+export function deriveCommentFileFilterState({
+  items,
+  requestedFilter,
+  commentedFilePaths,
+  unresolvedCommentedFilePaths,
+}: DeriveCommentFileFilterStateArgs): CommentFileFilterState {
+  if (!commentedFilePaths || !unresolvedCommentedFilePaths) {
+    return {
+      activeFilter: "none",
+      visibleItems: items,
+      commentedFileCount: 0,
+      unresolvedCommentedFileCount: 0,
+    };
+  }
+
+  const commentedItems = filterReviewItemsByFilePaths(
+    items,
+    commentedFilePaths,
+  );
+  const unresolvedCommentedItems = filterReviewItemsByFilePaths(
+    items,
+    unresolvedCommentedFilePaths,
+  );
+
+  let visibleItems: ReviewListItem[];
+  switch (requestedFilter) {
+    case "commented":
+      visibleItems = commentedItems;
+      break;
+    case "unresolved":
+      visibleItems = unresolvedCommentedItems;
+      break;
+    case "none":
+      visibleItems = items;
+      break;
+  }
+
+  return {
+    activeFilter: requestedFilter,
+    visibleItems,
+    commentedFileCount: commentedItems.filter((item) => item.filePaths).length,
+    unresolvedCommentedFileCount: unresolvedCommentedItems.filter(
+      (item) => item.filePaths,
+    ).length,
+  };
+}
+
+export function getEmptyReviewMessage(
+  commentFilter: CommentFileFilter,
+): string {
+  switch (commentFilter) {
+    case "commented":
+      return "No files with comments";
+    case "unresolved":
+      return "No files with unresolved comments";
+    case "none":
+      return "No file changes to review";
+  }
+}

--- a/packages/ui/src/features/code-review/components/CloudReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/CloudReviewPage.tsx
@@ -155,7 +155,8 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
       onCollapseFiles={collapseFiles}
       items={items}
       itemIndexByFilePath={itemIndexByFilePath}
-      commentedFilePaths={commentedFilePaths}
+      commentedFilePaths={commentedFilePaths?.all}
+      unresolvedCommentedFilePaths={commentedFilePaths?.unresolved}
       currentSignatures={currentSignatures}
       viewedRecord={viewedRecord}
       onToggleViewed={toggleViewed}

--- a/packages/ui/src/features/code-review/components/CloudReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/CloudReviewPage.tsx
@@ -11,6 +11,7 @@ import { useReviewNavigationStore } from "../reviewNavigationStore";
 import { PatchedFileDiff } from "./PatchedFileDiff";
 import {
   buildItemIndex,
+  getCommentedFilePaths,
   type ReviewListItem,
   ReviewShell,
   useReviewState,
@@ -37,8 +38,12 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
     isLoading,
   } = useCloudChangedFiles(taskId, task, isReviewOpen);
   const { commentThreads } = usePrDetails(prUrl, {
-    includeComments: isReviewOpen && showReviewComments,
+    includeComments: isReviewOpen,
   });
+  const commentedFilePaths = useMemo(
+    () => (prUrl ? getCommentedFilePaths(commentThreads) : undefined),
+    [commentThreads, prUrl],
+  );
 
   const allPaths = useMemo(() => reviewFiles.map((f) => f.path), [reviewFiles]);
 
@@ -83,6 +88,9 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
       return {
         key: file.path,
         scrollKey: file.path,
+        filePaths: [file.path, file.originalPath].filter(
+          (path): path is string => !!path,
+        ),
         node: (
           <PatchedFileDiff
             file={file}
@@ -147,6 +155,7 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
       onCollapseFiles={collapseFiles}
       items={items}
       itemIndexByFilePath={itemIndexByFilePath}
+      commentedFilePaths={commentedFilePaths}
       currentSignatures={currentSignatures}
       viewedRecord={viewedRecord}
       onToggleViewed={toggleViewed}

--- a/packages/ui/src/features/code-review/components/CloudReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/CloudReviewPage.tsx
@@ -13,7 +13,7 @@ import {
 } from "../commentFileFilter";
 import { useReviewNavigationStore } from "../reviewNavigationStore";
 import { PatchedFileDiff } from "./PatchedFileDiff";
-import { buildItemIndex, ReviewShell, useReviewState } from "./ReviewShell";
+import { ReviewShell, useReviewState } from "./ReviewShell";
 import { changedFileSignature } from "./reviewItemBuilders";
 
 interface CloudReviewPageProps {
@@ -35,12 +35,15 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
     toolCalls,
     isLoading,
   } = useCloudChangedFiles(taskId, task, isReviewOpen);
-  const { commentThreads } = usePrDetails(prUrl, {
-    includeComments: isReviewOpen,
+  const { commentThreads, commentsLoading } = usePrDetails(prUrl, {
+    includeComments: isReviewOpen && showReviewComments,
   });
   const commentedFilePaths = useMemo(
-    () => (prUrl ? getCommentedFilePaths(commentThreads) : undefined),
-    [commentThreads, prUrl],
+    () =>
+      prUrl && !commentsLoading
+        ? getCommentedFilePaths(commentThreads)
+        : undefined,
+    [commentThreads, commentsLoading, prUrl],
   );
 
   const allPaths = useMemo(() => reviewFiles.map((f) => f.path), [reviewFiles]);
@@ -117,8 +120,6 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
     toolCallFallbacks,
   ]);
 
-  const itemIndexByFilePath = useMemo(() => buildItemIndex(items), [items]);
-
   if (!prUrl && !effectiveBranch && reviewFiles.length === 0) {
     if (isRunActive) {
       return (
@@ -152,7 +153,6 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
       onUncollapseFile={uncollapseFile}
       onCollapseFiles={collapseFiles}
       items={items}
-      itemIndexByFilePath={itemIndexByFilePath}
       commentedFilePaths={commentedFilePaths?.all}
       unresolvedCommentedFilePaths={commentedFilePaths?.unresolved}
       currentSignatures={currentSignatures}

--- a/packages/ui/src/features/code-review/components/CloudReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/CloudReviewPage.tsx
@@ -7,15 +7,13 @@ import { useMemo } from "react";
 import { useDiffViewerStore } from "../../code-editor/diffViewerStore";
 import { usePrDetails } from "../../git-interaction/usePrDetails";
 import { useCloudChangedFiles } from "../../task-detail/hooks/useCloudChangedFiles";
-import { useReviewNavigationStore } from "../reviewNavigationStore";
-import { PatchedFileDiff } from "./PatchedFileDiff";
 import {
-  buildItemIndex,
   getCommentedFilePaths,
   type ReviewListItem,
-  ReviewShell,
-  useReviewState,
-} from "./ReviewShell";
+} from "../commentFileFilter";
+import { useReviewNavigationStore } from "../reviewNavigationStore";
+import { PatchedFileDiff } from "./PatchedFileDiff";
+import { buildItemIndex, ReviewShell, useReviewState } from "./ReviewShell";
 import { changedFileSignature } from "./reviewItemBuilders";
 
 interface CloudReviewPageProps {

--- a/packages/ui/src/features/code-review/components/CommentFilterSubmenu.tsx
+++ b/packages/ui/src/features/code-review/components/CommentFilterSubmenu.tsx
@@ -1,0 +1,66 @@
+import {
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+} from "@posthog/quill";
+import type { CommentFileFilter } from "../commentFileFilter";
+
+interface CommentFilterSubmenuProps {
+  commentedFileCount: number;
+  unresolvedCommentedFileCount: number;
+  commentFilter: CommentFileFilter;
+  onCommentFilterChange: (filter: CommentFileFilter) => void;
+}
+
+function getCommentFilterSuffix(commentFilter: CommentFileFilter): string {
+  switch (commentFilter) {
+    case "commented":
+      return " · All";
+    case "unresolved":
+      return " · Unresolved";
+    case "none":
+      return "";
+  }
+}
+
+export function CommentFilterSubmenu({
+  commentedFileCount,
+  unresolvedCommentedFileCount,
+  commentFilter,
+  onCommentFilterChange,
+}: CommentFilterSubmenuProps) {
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>
+        Comment filter{getCommentFilterSuffix(commentFilter)}
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent side="right" sideOffset={4}>
+        <DropdownMenuRadioGroup
+          value={commentFilter === "none" ? "" : commentFilter}
+          onValueChange={(value) =>
+            onCommentFilterChange(value as CommentFileFilter)
+          }
+        >
+          <DropdownMenuRadioItem value="commented">
+            All comments ({commentedFileCount})
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="unresolved">
+            Unresolved comments ({unresolvedCommentedFileCount})
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        {commentFilter !== "none" && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => onCommentFilterChange("none")}>
+              Clear comment filter
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}

--- a/packages/ui/src/features/code-review/components/DiffSettingsMenu.tsx
+++ b/packages/ui/src/features/code-review/components/DiffSettingsMenu.tsx
@@ -4,16 +4,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@posthog/quill";
 import { useDiffViewerStore } from "@posthog/ui/features/code-editor/diffViewerStore";
 import type { CommentFileFilter } from "../commentFileFilter";
+import { CommentFilterSubmenu } from "./CommentFilterSubmenu";
 
 interface DiffSettingsMenuProps {
   commentedFileCount: number;
@@ -87,41 +83,12 @@ export function DiffSettingsMenu({
           {showReviewComments ? "Hide review comments" : "Show review comments"}
         </DropdownMenuItem>
         {showReviewComments && onCommentFilterChange && (
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              Comment filter
-              {commentFilter === "commented"
-                ? " · All"
-                : commentFilter === "unresolved"
-                  ? " · Unresolved"
-                  : ""}
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent side="right" sideOffset={4}>
-              <DropdownMenuRadioGroup
-                value={commentFilter === "none" ? "" : commentFilter}
-                onValueChange={(value) =>
-                  onCommentFilterChange(value as CommentFileFilter)
-                }
-              >
-                <DropdownMenuRadioItem value="commented">
-                  All comments ({commentedFileCount})
-                </DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="unresolved">
-                  Unresolved comments ({unresolvedCommentedFileCount})
-                </DropdownMenuRadioItem>
-              </DropdownMenuRadioGroup>
-              {commentFilter !== "none" && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() => onCommentFilterChange("none")}
-                  >
-                    Clear comment filter
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
+          <CommentFilterSubmenu
+            commentedFileCount={commentedFileCount}
+            unresolvedCommentedFileCount={unresolvedCommentedFileCount}
+            commentFilter={commentFilter}
+            onCommentFilterChange={onCommentFilterChange}
+          />
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/packages/ui/src/features/code-review/components/DiffSettingsMenu.tsx
+++ b/packages/ui/src/features/code-review/components/DiffSettingsMenu.tsx
@@ -13,8 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@posthog/quill";
 import { useDiffViewerStore } from "@posthog/ui/features/code-editor/diffViewerStore";
-
-export type CommentFileFilter = "none" | "commented" | "unresolved";
+import type { CommentFileFilter } from "../commentFileFilter";
 
 interface DiffSettingsMenuProps {
   commentedFileCount: number;

--- a/packages/ui/src/features/code-review/components/DiffSettingsMenu.tsx
+++ b/packages/ui/src/features/code-review/components/DiffSettingsMenu.tsx
@@ -43,6 +43,12 @@ export function DiffSettingsMenu({
   const toggleShowReviewComments = useDiffViewerStore(
     (s) => s.toggleShowReviewComments,
   );
+  const handleToggleReviewComments = () => {
+    if (showReviewComments && commentFilter !== "none") {
+      onCommentFilterChange?.("none");
+    }
+    toggleShowReviewComments();
+  };
 
   return (
     <DropdownMenu>
@@ -78,10 +84,10 @@ export function DiffSettingsMenu({
           {hideWhitespaceChanges ? "Show whitespace" : "Hide whitespace"}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={toggleShowReviewComments}>
+        <DropdownMenuItem onClick={handleToggleReviewComments}>
           {showReviewComments ? "Hide review comments" : "Show review comments"}
         </DropdownMenuItem>
-        {onCommentFilterChange && (
+        {showReviewComments && onCommentFilterChange && (
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               Comment filter

--- a/packages/ui/src/features/code-review/components/DiffSettingsMenu.tsx
+++ b/packages/ui/src/features/code-review/components/DiffSettingsMenu.tsx
@@ -4,12 +4,31 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@posthog/quill";
 import { useDiffViewerStore } from "@posthog/ui/features/code-editor/diffViewerStore";
 
-export function DiffSettingsMenu() {
+export type CommentFileFilter = "none" | "commented" | "unresolved";
+
+interface DiffSettingsMenuProps {
+  commentedFileCount: number;
+  unresolvedCommentedFileCount: number;
+  commentFilter: CommentFileFilter;
+  onCommentFilterChange?: (filter: CommentFileFilter) => void;
+}
+
+export function DiffSettingsMenu({
+  commentedFileCount,
+  unresolvedCommentedFileCount,
+  commentFilter,
+  onCommentFilterChange,
+}: DiffSettingsMenuProps) {
   const wordWrap = useDiffViewerStore((s) => s.wordWrap);
   const toggleWordWrap = useDiffViewerStore((s) => s.toggleWordWrap);
   const wordDiffs = useDiffViewerStore((s) => s.wordDiffs);
@@ -31,7 +50,12 @@ export function DiffSettingsMenu() {
         render={
           <Button
             size="icon-sm"
-            aria-label="Diff settings"
+            variant={commentFilter === "none" ? "default" : "primary"}
+            aria-label={
+              commentFilter === "none"
+                ? "Diff settings"
+                : `Diff settings, ${commentFilter} comment filter active`
+            }
             className="rounded-xs"
           >
             <DotsThree size={16} weight="bold" />
@@ -57,6 +81,43 @@ export function DiffSettingsMenu() {
         <DropdownMenuItem onClick={toggleShowReviewComments}>
           {showReviewComments ? "Hide review comments" : "Show review comments"}
         </DropdownMenuItem>
+        {onCommentFilterChange && (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              Comment filter
+              {commentFilter === "commented"
+                ? " · All"
+                : commentFilter === "unresolved"
+                  ? " · Unresolved"
+                  : ""}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent side="right" sideOffset={4}>
+              <DropdownMenuRadioGroup
+                value={commentFilter === "none" ? "" : commentFilter}
+                onValueChange={(value) =>
+                  onCommentFilterChange(value as CommentFileFilter)
+                }
+              >
+                <DropdownMenuRadioItem value="commented">
+                  All comments ({commentedFileCount})
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="unresolved">
+                  Unresolved comments ({unresolvedCommentedFileCount})
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+              {commentFilter !== "none" && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => onCommentFilterChange("none")}
+                  >
+                    Clear comment filter
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/ui/src/features/code-review/components/ReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewPage.tsx
@@ -18,18 +18,16 @@ import { useCwd } from "../../sidebar/useCwd";
 import { useDiscardAllChanges } from "../../task-detail/hooks/useDiscardAllChanges";
 import { useDiscardFile } from "../../task-detail/hooks/useDiscardFile";
 import { useStageToggle } from "../../task-detail/hooks/useStageToggle";
+import {
+  getCommentedFilePaths,
+  type ReviewListItem,
+} from "../commentFileFilter";
 import { REVIEW_FILE_CACHE_TIME_MS, REVIEW_MAX_FILE_LINES } from "../constants";
 import { useEffectiveDiffSource } from "../hooks/useEffectiveDiffSource";
 import { useReviewDiffs } from "../hooks/useReviewDiffs";
 import { useReviewNavigationStore } from "../reviewNavigationStore";
 import type { DiffOptions } from "../types";
-import {
-  buildItemIndex,
-  getCommentedFilePaths,
-  type ReviewListItem,
-  ReviewShell,
-  useReviewState,
-} from "./ReviewShell";
+import { buildItemIndex, ReviewShell, useReviewState } from "./ReviewShell";
 import {
   buildPatchReviewItems,
   buildRemoteReviewItems,

--- a/packages/ui/src/features/code-review/components/ReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewPage.tsx
@@ -27,7 +27,7 @@ import { useEffectiveDiffSource } from "../hooks/useEffectiveDiffSource";
 import { useReviewDiffs } from "../hooks/useReviewDiffs";
 import { useReviewNavigationStore } from "../reviewNavigationStore";
 import type { DiffOptions } from "../types";
-import { buildItemIndex, ReviewShell, useReviewState } from "./ReviewShell";
+import { ReviewShell, useReviewState } from "./ReviewShell";
 import {
   buildPatchReviewItems,
   buildRemoteReviewItems,
@@ -108,15 +108,18 @@ export function ReviewPage({ task }: ReviewPageProps) {
   } = useEffectiveDiffSource(taskId);
 
   const showReviewComments = useDiffViewerStore((s) => s.showReviewComments);
-  const { commentThreads } = usePrDetails(prUrl, {
-    includeComments: isReviewOpen,
+  const { commentThreads, commentsLoading } = usePrDetails(prUrl, {
+    includeComments: isReviewOpen && showReviewComments,
   });
   const effectiveCommentThreads = showReviewComments
     ? commentThreads
     : undefined;
   const commentedFilePaths = useMemo(
-    () => (prUrl ? getCommentedFilePaths(commentThreads) : undefined),
-    [commentThreads, prUrl],
+    () =>
+      prUrl && !commentsLoading
+        ? getCommentedFilePaths(commentThreads)
+        : undefined,
+    [commentThreads, commentsLoading, prUrl],
   );
 
   const isLocalActive = isReviewOpen && effectiveSource === "local";
@@ -425,8 +428,6 @@ function LocalReviewContent({
     unstagedParsedFiles,
   ]);
 
-  const itemIndexByFilePath = useMemo(() => buildItemIndex(items), [items]);
-
   return (
     <ReviewShell
       task={task}
@@ -447,7 +448,6 @@ function LocalReviewContent({
       prSourceAvailable={prSourceAvailable}
       defaultBranch={defaultBranch}
       items={items}
-      itemIndexByFilePath={itemIndexByFilePath}
       commentedFilePaths={commentedFilePaths}
       unresolvedCommentedFilePaths={unresolvedCommentedFilePaths}
       currentSignatures={currentSignatures}
@@ -543,8 +543,6 @@ function RemoteReviewPage({
       taskId,
     ],
   );
-  const itemIndexByFilePath = useMemo(() => buildItemIndex(items), [items]);
-
   return (
     <ReviewShell
       task={task}
@@ -564,7 +562,6 @@ function RemoteReviewPage({
       prSourceAvailable={prSourceAvailable}
       defaultBranch={defaultBranch}
       items={items}
-      itemIndexByFilePath={itemIndexByFilePath}
       commentedFilePaths={commentedFilePaths}
       unresolvedCommentedFilePaths={unresolvedCommentedFilePaths}
       currentSignatures={currentSignatures}

--- a/packages/ui/src/features/code-review/components/ReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewPage.tsx
@@ -25,6 +25,7 @@ import { useReviewNavigationStore } from "../reviewNavigationStore";
 import type { DiffOptions } from "../types";
 import {
   buildItemIndex,
+  getCommentedFilePaths,
   type ReviewListItem,
   ReviewShell,
   useReviewState,
@@ -110,11 +111,15 @@ export function ReviewPage({ task }: ReviewPageProps) {
 
   const showReviewComments = useDiffViewerStore((s) => s.showReviewComments);
   const { commentThreads } = usePrDetails(prUrl, {
-    includeComments: isReviewOpen && showReviewComments,
+    includeComments: isReviewOpen,
   });
   const effectiveCommentThreads = showReviewComments
     ? commentThreads
     : undefined;
+  const commentedFilePaths = useMemo(
+    () => (prUrl ? getCommentedFilePaths(commentThreads) : undefined),
+    [commentThreads, prUrl],
+  );
 
   const isLocalActive = isReviewOpen && effectiveSource === "local";
 
@@ -173,6 +178,7 @@ export function ReviewPage({ task }: ReviewPageProps) {
         branchSourceAvailable={branchSourceAvailable}
         prSourceAvailable={prSourceAvailable}
         commentThreads={effectiveCommentThreads}
+        commentedFilePaths={commentedFilePaths}
       />
     );
   }
@@ -206,6 +212,7 @@ export function ReviewPage({ task }: ReviewPageProps) {
       untrackedFiles={untrackedFiles}
       stagedPathSet={stagedPathSet}
       commentThreads={effectiveCommentThreads}
+      commentedFilePaths={commentedFilePaths}
       effectiveSource={effectiveSource}
       branchSourceAvailable={branchSourceAvailable}
       prSourceAvailable={prSourceAvailable}
@@ -242,6 +249,7 @@ function LocalReviewContent({
   untrackedFiles,
   stagedPathSet,
   commentThreads,
+  commentedFilePaths,
   effectiveSource,
   branchSourceAvailable,
   prSourceAvailable,
@@ -274,6 +282,7 @@ function LocalReviewContent({
   untrackedFiles: ChangedFile[];
   stagedPathSet: Set<string>;
   commentThreads?: Map<number, PrCommentThread>;
+  commentedFilePaths?: ReadonlySet<string>;
   effectiveSource: ResolvedDiffSource;
   branchSourceAvailable: boolean;
   prSourceAvailable: boolean;
@@ -437,6 +446,7 @@ function LocalReviewContent({
       defaultBranch={defaultBranch}
       items={items}
       itemIndexByFilePath={itemIndexByFilePath}
+      commentedFilePaths={commentedFilePaths}
       currentSignatures={currentSignatures}
       viewedRecord={viewedRecord}
       onToggleViewed={toggleViewed}
@@ -455,6 +465,7 @@ function RemoteReviewPage({
   branchSourceAvailable,
   prSourceAvailable,
   commentThreads,
+  commentedFilePaths,
 }: {
   task: Task;
   repoPath: string | null;
@@ -466,6 +477,7 @@ function RemoteReviewPage({
   branchSourceAvailable: boolean;
   prSourceAvailable: boolean;
   commentThreads?: Map<number, PrCommentThread>;
+  commentedFilePaths?: ReadonlySet<string>;
 }) {
   const taskId = task.id;
   const isBranch = effectiveSource === "branch";
@@ -548,6 +560,7 @@ function RemoteReviewPage({
       defaultBranch={defaultBranch}
       items={items}
       itemIndexByFilePath={itemIndexByFilePath}
+      commentedFilePaths={commentedFilePaths}
       currentSignatures={currentSignatures}
       viewedRecord={reviewState.viewedRecord}
       onToggleViewed={reviewState.toggleViewed}

--- a/packages/ui/src/features/code-review/components/ReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewPage.tsx
@@ -178,7 +178,8 @@ export function ReviewPage({ task }: ReviewPageProps) {
         branchSourceAvailable={branchSourceAvailable}
         prSourceAvailable={prSourceAvailable}
         commentThreads={effectiveCommentThreads}
-        commentedFilePaths={commentedFilePaths}
+        commentedFilePaths={commentedFilePaths?.all}
+        unresolvedCommentedFilePaths={commentedFilePaths?.unresolved}
       />
     );
   }
@@ -212,7 +213,8 @@ export function ReviewPage({ task }: ReviewPageProps) {
       untrackedFiles={untrackedFiles}
       stagedPathSet={stagedPathSet}
       commentThreads={effectiveCommentThreads}
-      commentedFilePaths={commentedFilePaths}
+      commentedFilePaths={commentedFilePaths?.all}
+      unresolvedCommentedFilePaths={commentedFilePaths?.unresolved}
       effectiveSource={effectiveSource}
       branchSourceAvailable={branchSourceAvailable}
       prSourceAvailable={prSourceAvailable}
@@ -250,6 +252,7 @@ function LocalReviewContent({
   stagedPathSet,
   commentThreads,
   commentedFilePaths,
+  unresolvedCommentedFilePaths,
   effectiveSource,
   branchSourceAvailable,
   prSourceAvailable,
@@ -283,6 +286,7 @@ function LocalReviewContent({
   stagedPathSet: Set<string>;
   commentThreads?: Map<number, PrCommentThread>;
   commentedFilePaths?: ReadonlySet<string>;
+  unresolvedCommentedFilePaths?: ReadonlySet<string>;
   effectiveSource: ResolvedDiffSource;
   branchSourceAvailable: boolean;
   prSourceAvailable: boolean;
@@ -447,6 +451,7 @@ function LocalReviewContent({
       items={items}
       itemIndexByFilePath={itemIndexByFilePath}
       commentedFilePaths={commentedFilePaths}
+      unresolvedCommentedFilePaths={unresolvedCommentedFilePaths}
       currentSignatures={currentSignatures}
       viewedRecord={viewedRecord}
       onToggleViewed={toggleViewed}
@@ -466,6 +471,7 @@ function RemoteReviewPage({
   prSourceAvailable,
   commentThreads,
   commentedFilePaths,
+  unresolvedCommentedFilePaths,
 }: {
   task: Task;
   repoPath: string | null;
@@ -478,6 +484,7 @@ function RemoteReviewPage({
   prSourceAvailable: boolean;
   commentThreads?: Map<number, PrCommentThread>;
   commentedFilePaths?: ReadonlySet<string>;
+  unresolvedCommentedFilePaths?: ReadonlySet<string>;
 }) {
   const taskId = task.id;
   const isBranch = effectiveSource === "branch";
@@ -561,6 +568,7 @@ function RemoteReviewPage({
       items={items}
       itemIndexByFilePath={itemIndexByFilePath}
       commentedFilePaths={commentedFilePaths}
+      unresolvedCommentedFilePaths={unresolvedCommentedFilePaths}
       currentSignatures={currentSignatures}
       viewedRecord={reviewState.viewedRecord}
       onToggleViewed={reviewState.toggleViewed}

--- a/packages/ui/src/features/code-review/components/ReviewShell.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewShell.tsx
@@ -5,7 +5,14 @@ import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTask
 import { useCloudPrUrl } from "@posthog/ui/features/git-interaction/useCloudPrUrl";
 import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
 import { Flex, Spinner, Text } from "@radix-ui/themes";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { VList, type VListHandle } from "virtua";
 import {
   REVIEW_LIST_BUFFER_PX,
@@ -16,6 +23,8 @@ import { REVIEW_HOST, type ReviewHost } from "../reviewHost";
 import { useReviewNavigationStore } from "../reviewNavigationStore";
 import type { ReviewListItem, ReviewShellProps } from "../reviewShellParts";
 import {
+  buildItemIndex,
+  filterReviewItemsByFilePaths,
   findActiveScrollKey,
   findRenderedScrollAnchor,
   isFileViewed,
@@ -113,6 +122,7 @@ export function ReviewShell({
   isEmpty,
   items,
   itemIndexByFilePath,
+  commentedFilePaths,
   currentSignatures,
   viewedRecord,
   onToggleViewed,
@@ -135,6 +145,26 @@ export function ReviewShell({
   const lastActiveRef = useRef<string | null>(null);
   const pendingNavigationRef = useRef<string | null>(null);
   const navigationFrameRef = useRef<number | null>(null);
+  const [showCommentedFilesOnly, setShowCommentedFilesOnly] = useState(false);
+  const isCommentFilterActive =
+    showCommentedFilesOnly && commentedFilePaths !== undefined;
+
+  const commentedItems = useMemo(
+    () =>
+      commentedFilePaths
+        ? filterReviewItemsByFilePaths(items, commentedFilePaths)
+        : [],
+    [commentedFilePaths, items],
+  );
+  const visibleItems = isCommentFilterActive ? commentedItems : items;
+  const visibleItemIndexByFilePath = useMemo(
+    () => buildItemIndex(visibleItems),
+    [visibleItems],
+  );
+  const commentedFileCount = useMemo(
+    () => commentedItems.filter((item) => item.filePaths).length,
+    [commentedItems],
+  );
 
   const workerFactory = useCallback(
     () => reviewHost.diffWorkerFactory(),
@@ -147,12 +177,20 @@ export function ReviewShell({
   const isExpanded = reviewMode === "expanded";
 
   const viewedCount = useMemo(() => {
+    const visibleKeys = isCommentFilterActive
+      ? new Set(
+          visibleItems.flatMap((item) =>
+            item.scrollKey ? [item.scrollKey] : [],
+          ),
+        )
+      : null;
     let count = 0;
     for (const [key, sig] of currentSignatures) {
+      if (visibleKeys && !visibleKeys.has(key)) continue;
       if (isFileViewed(viewedRecord[key], sig)) count++;
     }
     return count;
-  }, [currentSignatures, viewedRecord]);
+  }, [currentSignatures, isCommentFilterActive, viewedRecord, visibleItems]);
 
   // Collapse already-viewed files on first open per task (mirrors GitHub).
   // Skips on re-opens: seededTaskRef prevents re-collapsing files the user
@@ -219,8 +257,13 @@ export function ReviewShell({
 
   useEffect(() => {
     if (!scrollRequest) return;
-    const targetIndex = itemIndexByFilePath.get(scrollRequest);
-    if (targetIndex === undefined) return;
+    const targetIndex = visibleItemIndexByFilePath.get(scrollRequest);
+    if (targetIndex === undefined) {
+      if (isCommentFilterActive && itemIndexByFilePath.has(scrollRequest)) {
+        setShowCommentedFilesOnly(false);
+      }
+      return;
+    }
 
     const currentSignature = currentSignatures.get(scrollRequest);
     const viewed =
@@ -264,7 +307,9 @@ export function ReviewShell({
     onUncollapseFile,
     scrollRequest,
     setActiveFilePath,
+    isCommentFilterActive,
     taskId,
+    visibleItemIndexByFilePath,
     viewedRecord,
   ]);
 
@@ -292,6 +337,40 @@ export function ReviewShell({
     ),
     [],
   );
+
+  let reviewContent: ReactNode;
+  if (isLoading) {
+    reviewContent = (
+      <Flex align="center" justify="center" className="min-h-0 flex-1">
+        <Spinner size="2" />
+      </Flex>
+    );
+  } else if (isEmpty || visibleItems.length === 0) {
+    reviewContent = (
+      <Flex align="center" justify="center" className="min-h-0 flex-1">
+        <Text color="gray" className="text-sm">
+          {isCommentFilterActive
+            ? "No files with comments"
+            : "No file changes to review"}
+        </Text>
+      </Flex>
+    );
+  } else {
+    reviewContent = (
+      <VList
+        ref={listRef}
+        bufferSize={REVIEW_LIST_BUFFER_PX}
+        itemSize={REVIEW_LIST_ESTIMATED_ITEM_SIZE}
+        className="pierre-scroll-root scrollbar-overlay-y min-h-0 flex-1 overflow-auto bg-(--gray-2)"
+        shift={false}
+        style={{ scrollbarGutter: "stable" }}
+        onScroll={handleScroll}
+        data={visibleItems}
+      >
+        {renderItem}
+      </VList>
+    );
+  }
 
   return (
     <WorkerPoolContextProvider
@@ -325,6 +404,13 @@ export function ReviewShell({
             taskId={taskId}
             fileCount={fileCount}
             viewedCount={viewedCount}
+            commentedFileCount={commentedFileCount}
+            showCommentedFilesOnly={isCommentFilterActive}
+            onToggleCommentedFilesOnly={
+              commentedFilePaths
+                ? () => setShowCommentedFilesOnly((current) => !current)
+                : undefined
+            }
             linesAdded={linesAdded}
             linesRemoved={linesRemoved}
             allExpanded={allExpanded}
@@ -343,38 +429,7 @@ export function ReviewShell({
               direction="column"
               className="min-w-0 flex-1"
             >
-              {isLoading ? (
-                <Flex
-                  align="center"
-                  justify="center"
-                  className="min-h-0 flex-1"
-                >
-                  <Spinner size="2" />
-                </Flex>
-              ) : isEmpty ? (
-                <Flex
-                  align="center"
-                  justify="center"
-                  className="min-h-0 flex-1"
-                >
-                  <Text color="gray" className="text-sm">
-                    No file changes to review
-                  </Text>
-                </Flex>
-              ) : (
-                <VList
-                  ref={listRef}
-                  bufferSize={REVIEW_LIST_BUFFER_PX}
-                  itemSize={REVIEW_LIST_ESTIMATED_ITEM_SIZE}
-                  className="pierre-scroll-root scrollbar-overlay-y min-h-0 flex-1 overflow-auto bg-(--gray-2)"
-                  shift={false}
-                  style={{ scrollbarGutter: "stable" }}
-                  onScroll={handleScroll}
-                  data={items}
-                >
-                  {renderItem}
-                </VList>
-              )}
+              {reviewContent}
               <PendingReviewBar taskId={taskId} />
             </Flex>
 

--- a/packages/ui/src/features/code-review/components/ReviewShell.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewShell.tsx
@@ -31,8 +31,9 @@ import {
 } from "../reviewShellParts";
 import { ReviewViewedContext } from "../reviewViewedContext";
 import { useReviewViewedStore } from "../reviewViewedStore";
+import type { CommentFileFilter } from "./DiffSettingsMenu";
 import { PendingReviewBar } from "./PendingReviewBar";
-import { type CommentFileFilter, ReviewToolbar } from "./ReviewToolbar";
+import { ReviewToolbar } from "./ReviewToolbar";
 
 // Pure helpers, hooks, types, and presentational sub-components live in
 // ../reviewShellParts. Re-exported here so consumers can import everything

--- a/packages/ui/src/features/code-review/components/ReviewShell.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewShell.tsx
@@ -32,7 +32,7 @@ import {
 import { ReviewViewedContext } from "../reviewViewedContext";
 import { useReviewViewedStore } from "../reviewViewedStore";
 import { PendingReviewBar } from "./PendingReviewBar";
-import { ReviewToolbar } from "./ReviewToolbar";
+import { type CommentFileFilter, ReviewToolbar } from "./ReviewToolbar";
 
 // Pure helpers, hooks, types, and presentational sub-components live in
 // ../reviewShellParts. Re-exported here so consumers can import everything
@@ -123,6 +123,7 @@ export function ReviewShell({
   items,
   itemIndexByFilePath,
   commentedFilePaths,
+  unresolvedCommentedFilePaths,
   currentSignatures,
   viewedRecord,
   onToggleViewed,
@@ -145,9 +146,9 @@ export function ReviewShell({
   const lastActiveRef = useRef<string | null>(null);
   const pendingNavigationRef = useRef<string | null>(null);
   const navigationFrameRef = useRef<number | null>(null);
-  const [showCommentedFilesOnly, setShowCommentedFilesOnly] = useState(false);
-  const isCommentFilterActive =
-    showCommentedFilesOnly && commentedFilePaths !== undefined;
+  const [commentFilter, setCommentFilter] = useState<CommentFileFilter>("none");
+  const activeCommentFilter =
+    commentedFilePaths && unresolvedCommentedFilePaths ? commentFilter : "none";
 
   const commentedItems = useMemo(
     () =>
@@ -156,7 +157,19 @@ export function ReviewShell({
         : [],
     [commentedFilePaths, items],
   );
-  const visibleItems = isCommentFilterActive ? commentedItems : items;
+  const unresolvedCommentedItems = useMemo(
+    () =>
+      unresolvedCommentedFilePaths
+        ? filterReviewItemsByFilePaths(items, unresolvedCommentedFilePaths)
+        : [],
+    [items, unresolvedCommentedFilePaths],
+  );
+  const visibleItems =
+    activeCommentFilter === "commented"
+      ? commentedItems
+      : activeCommentFilter === "unresolved"
+        ? unresolvedCommentedItems
+        : items;
   const visibleItemIndexByFilePath = useMemo(
     () => buildItemIndex(visibleItems),
     [visibleItems],
@@ -164,6 +177,10 @@ export function ReviewShell({
   const commentedFileCount = useMemo(
     () => commentedItems.filter((item) => item.filePaths).length,
     [commentedItems],
+  );
+  const unresolvedCommentedFileCount = useMemo(
+    () => unresolvedCommentedItems.filter((item) => item.filePaths).length,
+    [unresolvedCommentedItems],
   );
 
   const workerFactory = useCallback(
@@ -177,20 +194,21 @@ export function ReviewShell({
   const isExpanded = reviewMode === "expanded";
 
   const viewedCount = useMemo(() => {
-    const visibleKeys = isCommentFilterActive
-      ? new Set(
-          visibleItems.flatMap((item) =>
-            item.scrollKey ? [item.scrollKey] : [],
-          ),
-        )
-      : null;
+    const visibleKeys =
+      activeCommentFilter !== "none"
+        ? new Set(
+            visibleItems.flatMap((item) =>
+              item.scrollKey ? [item.scrollKey] : [],
+            ),
+          )
+        : null;
     let count = 0;
     for (const [key, sig] of currentSignatures) {
       if (visibleKeys && !visibleKeys.has(key)) continue;
       if (isFileViewed(viewedRecord[key], sig)) count++;
     }
     return count;
-  }, [currentSignatures, isCommentFilterActive, viewedRecord, visibleItems]);
+  }, [activeCommentFilter, currentSignatures, viewedRecord, visibleItems]);
 
   // Collapse already-viewed files on first open per task (mirrors GitHub).
   // Skips on re-opens: seededTaskRef prevents re-collapsing files the user
@@ -259,8 +277,11 @@ export function ReviewShell({
     if (!scrollRequest) return;
     const targetIndex = visibleItemIndexByFilePath.get(scrollRequest);
     if (targetIndex === undefined) {
-      if (isCommentFilterActive && itemIndexByFilePath.has(scrollRequest)) {
-        setShowCommentedFilesOnly(false);
+      if (
+        activeCommentFilter !== "none" &&
+        itemIndexByFilePath.has(scrollRequest)
+      ) {
+        setCommentFilter("none");
       }
       return;
     }
@@ -307,7 +328,7 @@ export function ReviewShell({
     onUncollapseFile,
     scrollRequest,
     setActiveFilePath,
-    isCommentFilterActive,
+    activeCommentFilter,
     taskId,
     visibleItemIndexByFilePath,
     viewedRecord,
@@ -349,9 +370,11 @@ export function ReviewShell({
     reviewContent = (
       <Flex align="center" justify="center" className="min-h-0 flex-1">
         <Text color="gray" className="text-sm">
-          {isCommentFilterActive
+          {activeCommentFilter === "commented"
             ? "No files with comments"
-            : "No file changes to review"}
+            : activeCommentFilter === "unresolved"
+              ? "No files with unresolved comments"
+              : "No file changes to review"}
         </Text>
       </Flex>
     );
@@ -405,10 +428,11 @@ export function ReviewShell({
             fileCount={fileCount}
             viewedCount={viewedCount}
             commentedFileCount={commentedFileCount}
-            showCommentedFilesOnly={isCommentFilterActive}
-            onToggleCommentedFilesOnly={
-              commentedFilePaths
-                ? () => setShowCommentedFilesOnly((current) => !current)
+            unresolvedCommentedFileCount={unresolvedCommentedFileCount}
+            commentFilter={activeCommentFilter}
+            onCommentFilterChange={
+              commentedFilePaths && unresolvedCommentedFilePaths
+                ? setCommentFilter
                 : undefined
             }
             linesAdded={linesAdded}

--- a/packages/ui/src/features/code-review/components/ReviewShell.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewShell.tsx
@@ -15,23 +15,27 @@ import {
 } from "react";
 import { VList, type VListHandle } from "virtua";
 import {
+  type CommentFileFilter,
+  deriveCommentFileFilterState,
+  getEmptyReviewMessage,
+  type ReviewListItem,
+} from "../commentFileFilter";
+import {
   REVIEW_LIST_BUFFER_PX,
   REVIEW_LIST_ESTIMATED_ITEM_SIZE,
 } from "../constants";
 import { useReviewDraftsStore } from "../reviewDraftsStore";
 import { REVIEW_HOST, type ReviewHost } from "../reviewHost";
 import { useReviewNavigationStore } from "../reviewNavigationStore";
-import type { ReviewListItem, ReviewShellProps } from "../reviewShellParts";
+import type { ReviewShellProps } from "../reviewShellParts";
 import {
   buildItemIndex,
-  filterReviewItemsByFilePaths,
   findActiveScrollKey,
   findRenderedScrollAnchor,
   isFileViewed,
 } from "../reviewShellParts";
 import { ReviewViewedContext } from "../reviewViewedContext";
 import { useReviewViewedStore } from "../reviewViewedStore";
-import type { CommentFileFilter } from "./DiffSettingsMenu";
 import { PendingReviewBar } from "./PendingReviewBar";
 import { ReviewToolbar } from "./ReviewToolbar";
 
@@ -44,17 +48,6 @@ export * from "../reviewShellParts";
 const SIDEBAR_MIN_WIDTH = 200;
 const SIDEBAR_MAX_WIDTH = 500;
 const SIDEBAR_DEFAULT_WIDTH = 280;
-
-function getEmptyReviewMessage(commentFilter: CommentFileFilter): string {
-  switch (commentFilter) {
-    case "commented":
-      return "No files with comments";
-    case "unresolved":
-      return "No files with unresolved comments";
-    case "none":
-      return "No file changes to review";
-  }
-}
 
 function ExpandedSidebar({ task }: { task: Task }) {
   const reviewHost = useService<ReviewHost>(REVIEW_HOST);
@@ -159,40 +152,24 @@ export function ReviewShell({
   const pendingNavigationRef = useRef<string | null>(null);
   const navigationFrameRef = useRef<number | null>(null);
   const [commentFilter, setCommentFilter] = useState<CommentFileFilter>("none");
-  const activeCommentFilter =
-    commentedFilePaths && unresolvedCommentedFilePaths ? commentFilter : "none";
-
-  const commentedItems = useMemo(
+  const {
+    activeFilter: activeCommentFilter,
+    visibleItems,
+    commentedFileCount,
+    unresolvedCommentedFileCount,
+  } = useMemo(
     () =>
-      commentedFilePaths
-        ? filterReviewItemsByFilePaths(items, commentedFilePaths)
-        : [],
-    [commentedFilePaths, items],
+      deriveCommentFileFilterState({
+        items,
+        requestedFilter: commentFilter,
+        commentedFilePaths,
+        unresolvedCommentedFilePaths,
+      }),
+    [commentFilter, commentedFilePaths, items, unresolvedCommentedFilePaths],
   );
-  const unresolvedCommentedItems = useMemo(
-    () =>
-      unresolvedCommentedFilePaths
-        ? filterReviewItemsByFilePaths(items, unresolvedCommentedFilePaths)
-        : [],
-    [items, unresolvedCommentedFilePaths],
-  );
-  const visibleItems =
-    activeCommentFilter === "commented"
-      ? commentedItems
-      : activeCommentFilter === "unresolved"
-        ? unresolvedCommentedItems
-        : items;
   const visibleItemIndexByFilePath = useMemo(
     () => buildItemIndex(visibleItems),
     [visibleItems],
-  );
-  const commentedFileCount = useMemo(
-    () => commentedItems.filter((item) => item.filePaths).length,
-    [commentedItems],
-  );
-  const unresolvedCommentedFileCount = useMemo(
-    () => unresolvedCommentedItems.filter((item) => item.filePaths).length,
-    [unresolvedCommentedItems],
   );
 
   const workerFactory = useCallback(

--- a/packages/ui/src/features/code-review/components/ReviewShell.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewShell.tsx
@@ -45,6 +45,17 @@ const SIDEBAR_MIN_WIDTH = 200;
 const SIDEBAR_MAX_WIDTH = 500;
 const SIDEBAR_DEFAULT_WIDTH = 280;
 
+function getEmptyReviewMessage(commentFilter: CommentFileFilter): string {
+  switch (commentFilter) {
+    case "commented":
+      return "No files with comments";
+    case "unresolved":
+      return "No files with unresolved comments";
+    case "none":
+      return "No file changes to review";
+  }
+}
+
 function ExpandedSidebar({ task }: { task: Task }) {
   const reviewHost = useService<ReviewHost>(REVIEW_HOST);
   const [width, setWidth] = useState(SIDEBAR_DEFAULT_WIDTH);
@@ -371,11 +382,7 @@ export function ReviewShell({
     reviewContent = (
       <Flex align="center" justify="center" className="min-h-0 flex-1">
         <Text color="gray" className="text-sm">
-          {activeCommentFilter === "commented"
-            ? "No files with comments"
-            : activeCommentFilter === "unresolved"
-              ? "No files with unresolved comments"
-              : "No file changes to review"}
+          {getEmptyReviewMessage(activeCommentFilter)}
         </Text>
       </Flex>
     );

--- a/packages/ui/src/features/code-review/components/ReviewShell.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewShell.tsx
@@ -15,7 +15,6 @@ import {
 } from "react";
 import { VList, type VListHandle } from "virtua";
 import {
-  type CommentFileFilter,
   deriveCommentFileFilterState,
   getEmptyReviewMessage,
   type ReviewListItem,
@@ -126,7 +125,6 @@ export function ReviewShell({
   isLoading,
   isEmpty,
   items,
-  itemIndexByFilePath,
   commentedFilePaths,
   unresolvedCommentedFilePaths,
   currentSignatures,
@@ -151,7 +149,12 @@ export function ReviewShell({
   const lastActiveRef = useRef<string | null>(null);
   const pendingNavigationRef = useRef<string | null>(null);
   const navigationFrameRef = useRef<number | null>(null);
-  const [commentFilter, setCommentFilter] = useState<CommentFileFilter>("none");
+  const commentFilter = useReviewNavigationStore(
+    (state) => state.commentFileFilters[taskId] ?? "none",
+  );
+  const setCommentFileFilter = useReviewNavigationStore(
+    (state) => state.setCommentFileFilter,
+  );
   const {
     activeFilter: activeCommentFilter,
     visibleItems,
@@ -265,15 +268,7 @@ export function ReviewShell({
   useEffect(() => {
     if (!scrollRequest) return;
     const targetIndex = visibleItemIndexByFilePath.get(scrollRequest);
-    if (targetIndex === undefined) {
-      if (
-        activeCommentFilter !== "none" &&
-        itemIndexByFilePath.has(scrollRequest)
-      ) {
-        setCommentFilter("none");
-      }
-      return;
-    }
+    if (targetIndex === undefined) return;
 
     const currentSignature = currentSignatures.get(scrollRequest);
     const viewed =
@@ -313,11 +308,9 @@ export function ReviewShell({
   }, [
     clearScrollRequest,
     currentSignatures,
-    itemIndexByFilePath,
     onUncollapseFile,
     scrollRequest,
     setActiveFilePath,
-    activeCommentFilter,
     taskId,
     visibleItemIndexByFilePath,
     viewedRecord,
@@ -417,7 +410,7 @@ export function ReviewShell({
             commentFilter={activeCommentFilter}
             onCommentFilterChange={
               commentedFilePaths && unresolvedCommentedFilePaths
-                ? setCommentFilter
+                ? (filter) => setCommentFileFilter(taskId, filter)
                 : undefined
             }
             linesAdded={linesAdded}

--- a/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
@@ -16,7 +16,8 @@ import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { Flex, Separator, Text } from "@radix-ui/themes";
 import { FoldVertical, Maximize, Minimize, UnfoldVertical } from "lucide-react";
 import { memo } from "react";
-import { type CommentFileFilter, DiffSettingsMenu } from "./DiffSettingsMenu";
+import type { CommentFileFilter } from "../commentFileFilter";
+import { DiffSettingsMenu } from "./DiffSettingsMenu";
 import { DiffSourceSelector } from "./DiffSourceSelector";
 
 interface ReviewToolbarProps {

--- a/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
@@ -1,13 +1,24 @@
 import {
   ArrowCounterClockwise,
   ArrowsClockwise,
+  CaretDown,
   ChatCircle,
   Columns,
   Rows,
   X,
 } from "@phosphor-icons/react";
 import type { ResolvedDiffSource } from "@posthog/core/code-review/resolveDiffSource";
-import { Button } from "@posthog/quill";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  MenuLabel,
+} from "@posthog/quill";
 import { useDiffViewerStore } from "@posthog/ui/features/code-editor/diffViewerStore";
 import {
   type ReviewMode,
@@ -25,8 +36,9 @@ interface ReviewToolbarProps {
   fileCount: number;
   viewedCount: number;
   commentedFileCount: number;
-  showCommentedFilesOnly: boolean;
-  onToggleCommentedFilesOnly?: () => void;
+  unresolvedCommentedFileCount: number;
+  commentFilter: CommentFileFilter;
+  onCommentFilterChange?: (filter: CommentFileFilter) => void;
   linesAdded: number;
   linesRemoved: number;
   allExpanded: boolean;
@@ -40,6 +52,8 @@ interface ReviewToolbarProps {
   defaultBranch?: string | null;
 }
 
+export type CommentFileFilter = "none" | "commented" | "unresolved";
+
 function formatFileCount(count: number, suffix: string): string {
   const noun = count === 1 ? "file" : "files";
   return `${count} ${noun} ${suffix}`;
@@ -50,8 +64,9 @@ export const ReviewToolbar = memo(function ReviewToolbar({
   fileCount,
   viewedCount,
   commentedFileCount,
-  showCommentedFilesOnly,
-  onToggleCommentedFilesOnly,
+  unresolvedCommentedFileCount,
+  commentFilter,
+  onCommentFilterChange,
   allExpanded,
   onExpandAll,
   onCollapseAll,
@@ -78,12 +93,21 @@ export const ReviewToolbar = memo(function ReviewToolbar({
     setReviewMode(taskId, "closed");
   };
 
-  const visibleFileCount = showCommentedFilesOnly
-    ? commentedFileCount
-    : fileCount;
-  const fileCountLabel = showCommentedFilesOnly
-    ? formatFileCount(commentedFileCount, "with comments")
-    : formatFileCount(fileCount, "changed");
+  const visibleFileCount =
+    commentFilter === "commented"
+      ? commentedFileCount
+      : commentFilter === "unresolved"
+        ? unresolvedCommentedFileCount
+        : fileCount;
+  const fileCountLabel =
+    commentFilter === "commented"
+      ? formatFileCount(commentedFileCount, "with comments")
+      : commentFilter === "unresolved"
+        ? formatFileCount(
+            unresolvedCommentedFileCount,
+            "with unresolved comments",
+          )
+        : formatFileCount(fileCount, "changed");
 
   return (
     <Flex
@@ -115,29 +139,56 @@ export const ReviewToolbar = memo(function ReviewToolbar({
       </Flex>
 
       <Flex align="center" gap="1" ml="auto">
-        {onToggleCommentedFilesOnly && (
-          <Tooltip
-            content={
-              showCommentedFilesOnly
-                ? "Show all files"
-                : `Show only files with comments (${commentedFileCount})`
-            }
-          >
-            <Button
-              size="icon-sm"
-              variant={showCommentedFilesOnly ? "primary" : "default"}
-              onClick={onToggleCommentedFilesOnly}
-              disabled={commentedFileCount === 0 && !showCommentedFilesOnly}
-              aria-label="Filter files with comments"
-              aria-pressed={showCommentedFilesOnly}
-              className="rounded-xs"
+        {onCommentFilterChange && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  size="sm"
+                  variant={commentFilter === "none" ? "default" : "primary"}
+                  aria-label="Filter files by review comments"
+                  className="rounded-xs"
+                >
+                  <ChatCircle
+                    size={14}
+                    weight={commentFilter === "none" ? "regular" : "fill"}
+                  />
+                  <CaretDown size={10} weight="bold" />
+                </Button>
+              }
+            />
+            <DropdownMenuContent
+              align="end"
+              side="bottom"
+              sideOffset={6}
+              className="min-w-[220px]"
             >
-              <ChatCircle
-                size={14}
-                weight={showCommentedFilesOnly ? "fill" : "regular"}
-              />
-            </Button>
-          </Tooltip>
+              <MenuLabel>Comment filter</MenuLabel>
+              <DropdownMenuRadioGroup
+                value={commentFilter === "none" ? "" : commentFilter}
+                onValueChange={(value) =>
+                  onCommentFilterChange(value as CommentFileFilter)
+                }
+              >
+                <DropdownMenuRadioItem value="commented">
+                  All comments ({commentedFileCount})
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="unresolved">
+                  Unresolved comments ({unresolvedCommentedFileCount})
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+              {commentFilter !== "none" && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => onCommentFilterChange("none")}
+                  >
+                    Clear comment filter
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
 
         {onRefresh && (

--- a/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
@@ -1,24 +1,12 @@
 import {
   ArrowCounterClockwise,
   ArrowsClockwise,
-  CaretDown,
-  ChatCircle,
   Columns,
   Rows,
   X,
 } from "@phosphor-icons/react";
 import type { ResolvedDiffSource } from "@posthog/core/code-review/resolveDiffSource";
-import {
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-  MenuLabel,
-} from "@posthog/quill";
+import { Button } from "@posthog/quill";
 import { useDiffViewerStore } from "@posthog/ui/features/code-editor/diffViewerStore";
 import {
   type ReviewMode,
@@ -28,7 +16,7 @@ import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { Flex, Separator, Text } from "@radix-ui/themes";
 import { FoldVertical, Maximize, Minimize, UnfoldVertical } from "lucide-react";
 import { memo } from "react";
-import { DiffSettingsMenu } from "./DiffSettingsMenu";
+import { type CommentFileFilter, DiffSettingsMenu } from "./DiffSettingsMenu";
 import { DiffSourceSelector } from "./DiffSourceSelector";
 
 interface ReviewToolbarProps {
@@ -51,8 +39,6 @@ interface ReviewToolbarProps {
   prSourceAvailable?: boolean;
   defaultBranch?: string | null;
 }
-
-export type CommentFileFilter = "none" | "commented" | "unresolved";
 
 function formatFileCount(count: number, suffix: string): string {
   const noun = count === 1 ? "file" : "files";
@@ -139,58 +125,6 @@ export const ReviewToolbar = memo(function ReviewToolbar({
       </Flex>
 
       <Flex align="center" gap="1" ml="auto">
-        {onCommentFilterChange && (
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <Button
-                  size="sm"
-                  variant={commentFilter === "none" ? "default" : "primary"}
-                  aria-label="Filter files by review comments"
-                  className="rounded-xs"
-                >
-                  <ChatCircle
-                    size={14}
-                    weight={commentFilter === "none" ? "regular" : "fill"}
-                  />
-                  <CaretDown size={10} weight="bold" />
-                </Button>
-              }
-            />
-            <DropdownMenuContent
-              align="end"
-              side="bottom"
-              sideOffset={6}
-              className="min-w-[220px]"
-            >
-              <MenuLabel>Comment filter</MenuLabel>
-              <DropdownMenuRadioGroup
-                value={commentFilter === "none" ? "" : commentFilter}
-                onValueChange={(value) =>
-                  onCommentFilterChange(value as CommentFileFilter)
-                }
-              >
-                <DropdownMenuRadioItem value="commented">
-                  All comments ({commentedFileCount})
-                </DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="unresolved">
-                  Unresolved comments ({unresolvedCommentedFileCount})
-                </DropdownMenuRadioItem>
-              </DropdownMenuRadioGroup>
-              {commentFilter !== "none" && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() => onCommentFilterChange("none")}
-                  >
-                    Clear comment filter
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
-
         {onRefresh && (
           <Tooltip content="Refresh diff">
             <Button size="icon-sm" onClick={onRefresh} className="rounded-xs">
@@ -256,7 +190,12 @@ export const ReviewToolbar = memo(function ReviewToolbar({
 
         <Separator orientation="vertical" size="1" />
 
-        <DiffSettingsMenu />
+        <DiffSettingsMenu
+          commentedFileCount={commentedFileCount}
+          unresolvedCommentedFileCount={unresolvedCommentedFileCount}
+          commentFilter={commentFilter}
+          onCommentFilterChange={onCommentFilterChange}
+        />
 
         <Tooltip content="Close review">
           <Button size="icon-sm" onClick={handleClose} className="rounded-xs">

--- a/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowCounterClockwise,
   ArrowsClockwise,
+  ChatCircle,
   Columns,
   Rows,
   X,
@@ -23,6 +24,9 @@ interface ReviewToolbarProps {
   taskId: string;
   fileCount: number;
   viewedCount: number;
+  commentedFileCount: number;
+  showCommentedFilesOnly: boolean;
+  onToggleCommentedFilesOnly?: () => void;
   linesAdded: number;
   linesRemoved: number;
   allExpanded: boolean;
@@ -36,10 +40,18 @@ interface ReviewToolbarProps {
   defaultBranch?: string | null;
 }
 
+function formatFileCount(count: number, suffix: string): string {
+  const noun = count === 1 ? "file" : "files";
+  return `${count} ${noun} ${suffix}`;
+}
+
 export const ReviewToolbar = memo(function ReviewToolbar({
   taskId,
   fileCount,
   viewedCount,
+  commentedFileCount,
+  showCommentedFilesOnly,
+  onToggleCommentedFilesOnly,
   allExpanded,
   onExpandAll,
   onCollapseAll,
@@ -66,6 +78,13 @@ export const ReviewToolbar = memo(function ReviewToolbar({
     setReviewMode(taskId, "closed");
   };
 
+  const visibleFileCount = showCommentedFilesOnly
+    ? commentedFileCount
+    : fileCount;
+  const fileCountLabel = showCommentedFilesOnly
+    ? formatFileCount(commentedFileCount, "with comments")
+    : formatFileCount(fileCount, "changed");
+
   return (
     <Flex
       id="review-toolbar"
@@ -78,12 +97,10 @@ export const ReviewToolbar = memo(function ReviewToolbar({
       className="sticky top-0 h-[32px] shrink-0 border-b border-b-(--gray-6) bg-(--color-background)"
     >
       <Flex align="center" gap="2">
-        <Text className="font-medium text-[13px]">
-          {fileCount} file{fileCount !== 1 ? "s" : ""} changed
-        </Text>
-        {fileCount > 0 && (
+        <Text className="font-medium text-[13px]">{fileCountLabel}</Text>
+        {visibleFileCount > 0 && (
           <Text className="text-(--gray-10) text-[13px]">
-            {viewedCount}/{fileCount} viewed
+            {viewedCount}/{visibleFileCount} viewed
           </Text>
         )}
         {effectiveSource && (
@@ -98,6 +115,30 @@ export const ReviewToolbar = memo(function ReviewToolbar({
       </Flex>
 
       <Flex align="center" gap="1" ml="auto">
+        {onToggleCommentedFilesOnly && (
+          <Tooltip
+            content={
+              showCommentedFilesOnly
+                ? "Show all files"
+                : `Show only files with comments (${commentedFileCount})`
+            }
+          >
+            <Button
+              size="icon-sm"
+              onClick={onToggleCommentedFilesOnly}
+              disabled={commentedFileCount === 0 && !showCommentedFilesOnly}
+              aria-label="Filter files with comments"
+              aria-pressed={showCommentedFilesOnly}
+              className={`rounded-xs ${showCommentedFilesOnly ? "bg-(--gray-4)" : ""}`}
+            >
+              <ChatCircle
+                size={14}
+                weight={showCommentedFilesOnly ? "fill" : "regular"}
+              />
+            </Button>
+          </Tooltip>
+        )}
+
         {onRefresh && (
           <Tooltip content="Refresh diff">
             <Button size="icon-sm" onClick={onRefresh} className="rounded-xs">

--- a/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
@@ -125,11 +125,12 @@ export const ReviewToolbar = memo(function ReviewToolbar({
           >
             <Button
               size="icon-sm"
+              variant={showCommentedFilesOnly ? "primary" : "default"}
               onClick={onToggleCommentedFilesOnly}
               disabled={commentedFileCount === 0 && !showCommentedFilesOnly}
               aria-label="Filter files with comments"
               aria-pressed={showCommentedFilesOnly}
-              className={`rounded-xs ${showCommentedFilesOnly ? "bg-(--gray-4)" : ""}`}
+              className="rounded-xs"
             >
               <ChatCircle
                 size={14}

--- a/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
@@ -45,6 +45,34 @@ function formatFileCount(count: number, suffix: string): string {
   return `${count} ${noun} ${suffix}`;
 }
 
+function getVisibleFileSummary(
+  commentFilter: CommentFileFilter,
+  fileCount: number,
+  commentedFileCount: number,
+  unresolvedCommentedFileCount: number,
+): { count: number; label: string } {
+  switch (commentFilter) {
+    case "commented":
+      return {
+        count: commentedFileCount,
+        label: formatFileCount(commentedFileCount, "with comments"),
+      };
+    case "unresolved":
+      return {
+        count: unresolvedCommentedFileCount,
+        label: formatFileCount(
+          unresolvedCommentedFileCount,
+          "with unresolved comments",
+        ),
+      };
+    case "none":
+      return {
+        count: fileCount,
+        label: formatFileCount(fileCount, "changed"),
+      };
+  }
+}
+
 export const ReviewToolbar = memo(function ReviewToolbar({
   taskId,
   fileCount,
@@ -79,21 +107,13 @@ export const ReviewToolbar = memo(function ReviewToolbar({
     setReviewMode(taskId, "closed");
   };
 
-  const visibleFileCount =
-    commentFilter === "commented"
-      ? commentedFileCount
-      : commentFilter === "unresolved"
-        ? unresolvedCommentedFileCount
-        : fileCount;
-  const fileCountLabel =
-    commentFilter === "commented"
-      ? formatFileCount(commentedFileCount, "with comments")
-      : commentFilter === "unresolved"
-        ? formatFileCount(
-            unresolvedCommentedFileCount,
-            "with unresolved comments",
-          )
-        : formatFileCount(fileCount, "changed");
+  const { count: visibleFileCount, label: fileCountLabel } =
+    getVisibleFileSummary(
+      commentFilter,
+      fileCount,
+      commentedFileCount,
+      unresolvedCommentedFileCount,
+    );
 
   return (
     <Flex

--- a/packages/ui/src/features/code-review/components/reviewItemBuilders.tsx
+++ b/packages/ui/src/features/code-review/components/reviewItemBuilders.tsx
@@ -7,7 +7,7 @@ import {
 import type { PrCommentThread } from "@posthog/core/code-review/types";
 import type { ChangedFile } from "@posthog/shared/domain-types";
 import { makeFileKey } from "../../git-interaction/utils/fileKey";
-import type { ReviewListItem } from "../reviewShellParts";
+import type { ReviewListItem } from "../commentFileFilter";
 import type { DiffOptions } from "../types";
 import { PatchRow, RemoteRow, UntrackedRow } from "./ReviewRows";
 

--- a/packages/ui/src/features/code-review/components/reviewItemBuilders.tsx
+++ b/packages/ui/src/features/code-review/components/reviewItemBuilders.tsx
@@ -73,6 +73,9 @@ export function buildPatchReviewItems({
     return {
       key,
       scrollKey: key,
+      filePaths: [filePath, fileDiff.prevName].filter(
+        (path): path is string => !!path,
+      ),
       node: (
         <PatchRow
           itemKey={key}
@@ -124,6 +127,7 @@ export function buildUntrackedReviewItems({
     return {
       key,
       scrollKey: key,
+      filePaths: [file.path],
       node: (
         <UntrackedRow
           itemKey={key}
@@ -167,6 +171,9 @@ export function buildRemoteReviewItems({
     return {
       key: file.path,
       scrollKey: file.path,
+      filePaths: [file.path, file.originalPath].filter(
+        (path): path is string => !!path,
+      ),
       node: (
         <RemoteRow
           file={file}

--- a/packages/ui/src/features/code-review/reviewNavigationStore.test.ts
+++ b/packages/ui/src/features/code-review/reviewNavigationStore.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useReviewNavigationStore } from "./reviewNavigationStore";
+
+describe("reviewNavigationStore", () => {
+  beforeEach(() => {
+    useReviewNavigationStore.setState({
+      activeFilePaths: {},
+      scrollRequests: {},
+      reviewModes: {},
+      commentFileFilters: {},
+    });
+  });
+
+  it("clears the comment filter when navigating to a file", () => {
+    const store = useReviewNavigationStore.getState();
+    store.setCommentFileFilter("task-1", "unresolved");
+
+    store.requestScrollToFile("task-1", "src/example.ts");
+
+    const state = useReviewNavigationStore.getState();
+    expect(state.scrollRequests["task-1"]).toBe("src/example.ts");
+    expect(state.commentFileFilters["task-1"]).toBe("none");
+  });
+});

--- a/packages/ui/src/features/code-review/reviewNavigationStore.ts
+++ b/packages/ui/src/features/code-review/reviewNavigationStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { CommentFileFilter } from "./commentFileFilter";
 
 export type ReviewMode = "closed" | "split" | "expanded";
 
@@ -6,6 +7,7 @@ interface ReviewNavigationStoreState {
   activeFilePaths: Record<string, string | null>;
   scrollRequests: Record<string, string | null>;
   reviewModes: Record<string, ReviewMode>;
+  commentFileFilters: Record<string, CommentFileFilter>;
 }
 
 interface ReviewNavigationStoreActions {
@@ -14,6 +16,7 @@ interface ReviewNavigationStoreActions {
   clearScrollRequest: (taskId: string) => void;
   clearTask: (taskId: string) => void;
   setReviewMode: (taskId: string, mode: ReviewMode) => void;
+  setCommentFileFilter: (taskId: string, filter: CommentFileFilter) => void;
   getReviewMode: (taskId: string) => ReviewMode;
 }
 
@@ -25,6 +28,7 @@ export const useReviewNavigationStore = create<ReviewNavigationStore>()(
     activeFilePaths: {},
     scrollRequests: {},
     reviewModes: {},
+    commentFileFilters: {},
 
     setActiveFilePath: (taskId, path) =>
       set((state) => ({
@@ -34,6 +38,10 @@ export const useReviewNavigationStore = create<ReviewNavigationStore>()(
     requestScrollToFile: (taskId, path) =>
       set((state) => ({
         scrollRequests: { ...state.scrollRequests, [taskId]: path },
+        commentFileFilters: {
+          ...state.commentFileFilters,
+          [taskId]: "none",
+        },
       })),
 
     clearScrollRequest: (taskId) =>
@@ -45,11 +53,23 @@ export const useReviewNavigationStore = create<ReviewNavigationStore>()(
       set((state) => ({
         activeFilePaths: { ...state.activeFilePaths, [taskId]: null },
         scrollRequests: { ...state.scrollRequests, [taskId]: null },
+        commentFileFilters: {
+          ...state.commentFileFilters,
+          [taskId]: "none",
+        },
       })),
 
     setReviewMode: (taskId, mode) =>
       set((state) => ({
         reviewModes: { ...state.reviewModes, [taskId]: mode },
+      })),
+
+    setCommentFileFilter: (taskId, filter) =>
+      set((state) => ({
+        commentFileFilters: {
+          ...state.commentFileFilters,
+          [taskId]: filter,
+        },
       })),
 
     getReviewMode: (taskId) => get().reviewModes[taskId] ?? "closed",

--- a/packages/ui/src/features/code-review/reviewShellParts.test.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.test.tsx
@@ -15,13 +15,16 @@ vi.mock("../../primitives/FileIcon", () => ({
 }));
 
 import {
-  DeferredDiffPlaceholder,
-  DiffFileHeader,
+  deriveCommentFileFilterState,
   filterReviewItemsByFilePaths,
-  findActiveScrollKey,
-  findRenderedScrollAnchor,
   getCommentedFilePaths,
   type ReviewListItem,
+} from "./commentFileFilter";
+import {
+  DeferredDiffPlaceholder,
+  DiffFileHeader,
+  findActiveScrollKey,
+  findRenderedScrollAnchor,
 } from "./reviewShellParts";
 
 type FileDiffMetadata = import("@pierre/diffs/react").FileDiffMetadata;
@@ -256,5 +259,25 @@ describe("commented file filtering", () => {
         (item) => item.key,
       ),
     ).toEqual(["section:changes", "unstaged:b.ts"]);
+  });
+
+  it("derives visible items and counts for the selected filter", () => {
+    const items: ReviewListItem[] = [
+      { key: "a.ts", filePaths: ["a.ts"], node: <span>A</span> },
+      { key: "b.ts", filePaths: ["b.ts"], node: <span>B</span> },
+      { key: "c.ts", filePaths: ["c.ts"], node: <span>C</span> },
+    ];
+
+    const state = deriveCommentFileFilterState({
+      items,
+      requestedFilter: "unresolved",
+      commentedFilePaths: new Set(["a.ts", "b.ts"]),
+      unresolvedCommentedFilePaths: new Set(["b.ts"]),
+    });
+
+    expect(state.activeFilter).toBe("unresolved");
+    expect(state.visibleItems.map((item) => item.key)).toEqual(["b.ts"]);
+    expect(state.commentedFileCount).toBe(2);
+    expect(state.unresolvedCommentedFileCount).toBe(1);
   });
 });

--- a/packages/ui/src/features/code-review/reviewShellParts.test.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.test.tsx
@@ -166,27 +166,40 @@ describe("review scroll anchors", () => {
 });
 
 describe("commented file filtering", () => {
-  it("collects paths from threads containing comments", () => {
+  it("collects paths for all and unresolved comment threads", () => {
     const commentedPaths = getCommentedFilePaths(
       new Map([
         [
           1,
           {
             filePath: "src/commented.ts",
+            isResolved: false,
             comments: [{ id: 1 }],
           },
         ],
         [
           2,
           {
+            filePath: "src/resolved.ts",
+            isResolved: true,
+            comments: [{ id: 2 }],
+          },
+        ],
+        [
+          3,
+          {
             filePath: "src/empty.ts",
+            isResolved: false,
             comments: [],
           },
         ],
       ]) as Parameters<typeof getCommentedFilePaths>[0],
     );
 
-    expect(commentedPaths).toEqual(new Set(["src/commented.ts"]));
+    expect(commentedPaths).toEqual({
+      all: new Set(["src/commented.ts", "src/resolved.ts"]),
+      unresolved: new Set(["src/commented.ts"]),
+    });
   });
 
   it("keeps matching files and their section headers", () => {

--- a/packages/ui/src/features/code-review/reviewShellParts.test.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.test.tsx
@@ -17,8 +17,11 @@ vi.mock("../../primitives/FileIcon", () => ({
 import {
   DeferredDiffPlaceholder,
   DiffFileHeader,
+  filterReviewItemsByFilePaths,
   findActiveScrollKey,
   findRenderedScrollAnchor,
+  getCommentedFilePaths,
+  type ReviewListItem,
 } from "./reviewShellParts";
 
 type FileDiffMetadata = import("@pierre/diffs/react").FileDiffMetadata;
@@ -159,5 +162,86 @@ describe("review scroll anchors", () => {
     setRect(below, 180, 260);
 
     expect(findActiveScrollKey(root)).toBe("target.ts");
+  });
+});
+
+describe("commented file filtering", () => {
+  it("collects paths from threads containing comments", () => {
+    const commentedPaths = getCommentedFilePaths(
+      new Map([
+        [
+          1,
+          {
+            filePath: "src/commented.ts",
+            comments: [{ id: 1 }],
+          },
+        ],
+        [
+          2,
+          {
+            filePath: "src/empty.ts",
+            comments: [],
+          },
+        ],
+      ]) as Parameters<typeof getCommentedFilePaths>[0],
+    );
+
+    expect(commentedPaths).toEqual(new Set(["src/commented.ts"]));
+  });
+
+  it("keeps matching files and their section headers", () => {
+    const items: ReviewListItem[] = [
+      { key: "section:staged", node: <span>Staged</span> },
+      {
+        key: "staged:a.ts",
+        filePaths: ["a.ts"],
+        node: <span>A</span>,
+      },
+      {
+        key: "staged:b.ts",
+        filePaths: ["b.ts"],
+        node: <span>B</span>,
+      },
+      { key: "section:changes", node: <span>Changes</span> },
+      {
+        key: "unstaged:c.ts",
+        filePaths: ["c.ts", "old-c.ts"],
+        node: <span>C</span>,
+      },
+    ];
+
+    expect(
+      filterReviewItemsByFilePaths(items, new Set(["b.ts", "old-c.ts"])).map(
+        (item) => item.key,
+      ),
+    ).toEqual([
+      "section:staged",
+      "staged:b.ts",
+      "section:changes",
+      "unstaged:c.ts",
+    ]);
+  });
+
+  it("drops section headers without matching files", () => {
+    const items: ReviewListItem[] = [
+      { key: "section:staged", node: <span>Staged</span> },
+      {
+        key: "staged:a.ts",
+        filePaths: ["a.ts"],
+        node: <span>A</span>,
+      },
+      { key: "section:changes", node: <span>Changes</span> },
+      {
+        key: "unstaged:b.ts",
+        filePaths: ["b.ts"],
+        node: <span>B</span>,
+      },
+    ];
+
+    expect(
+      filterReviewItemsByFilePaths(items, new Set(["b.ts"])).map(
+        (item) => item.key,
+      ),
+    ).toEqual(["section:changes", "unstaged:b.ts"]);
   });
 });

--- a/packages/ui/src/features/code-review/reviewShellParts.test.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.test.tsx
@@ -280,4 +280,18 @@ describe("commented file filtering", () => {
     expect(state.commentedFileCount).toBe(2);
     expect(state.unresolvedCommentedFileCount).toBe(1);
   });
+
+  it("keeps all files visible while comment paths are loading", () => {
+    const items: ReviewListItem[] = [
+      { key: "a.ts", filePaths: ["a.ts"], node: <span>A</span> },
+    ];
+
+    const state = deriveCommentFileFilterState({
+      items,
+      requestedFilter: "unresolved",
+    });
+
+    expect(state.activeFilter).toBe("none");
+    expect(state.visibleItems).toBe(items);
+  });
 });

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -209,7 +209,6 @@ export interface ReviewShellProps {
   isLoading: boolean;
   isEmpty: boolean;
   items: ReviewListItem[];
-  itemIndexByFilePath: Map<string, number>;
   commentedFilePaths?: ReadonlySet<string>;
   unresolvedCommentedFilePaths?: ReadonlySet<string>;
   currentSignatures: Map<string, string>;

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -16,6 +16,7 @@ import {
   splitFilePath,
   sumHunkStats,
 } from "@posthog/core/code-review/reviewShellGeometry";
+import type { PrCommentThread } from "@posthog/core/code-review/types";
 import { Badge } from "@posthog/quill";
 import type { ChangedFile, Task } from "@posthog/shared/domain-types";
 import { type ReactNode, useCallback, useMemo, useState } from "react";
@@ -208,6 +209,7 @@ export interface ReviewShellProps {
   isEmpty: boolean;
   items: ReviewListItem[];
   itemIndexByFilePath: Map<string, number>;
+  commentedFilePaths?: ReadonlySet<string>;
   currentSignatures: Map<string, string>;
   viewedRecord: Record<string, string>;
   onToggleViewed: (key: string, sig: string | null) => void;
@@ -227,7 +229,40 @@ export interface ReviewShellProps {
 export interface ReviewListItem {
   key: string;
   scrollKey?: string;
+  filePaths?: string[];
   node: ReactNode;
+}
+
+export function getCommentedFilePaths(
+  threads: Map<number, PrCommentThread>,
+): Set<string> {
+  return new Set(
+    [...threads.values()]
+      .filter((thread) => thread.comments.length > 0)
+      .map((thread) => thread.filePath),
+  );
+}
+
+export function filterReviewItemsByFilePaths(
+  items: ReviewListItem[],
+  filePaths: ReadonlySet<string>,
+): ReviewListItem[] {
+  const filteredItems: ReviewListItem[] = [];
+  let pendingSectionItems: ReviewListItem[] = [];
+
+  for (const item of items) {
+    if (!item.filePaths) {
+      pendingSectionItems = [item];
+      continue;
+    }
+
+    if (!item.filePaths.some((filePath) => filePaths.has(filePath))) continue;
+
+    filteredItems.push(...pendingSectionItems, item);
+    pendingSectionItems = [];
+  }
+
+  return filteredItems;
 }
 
 export function FileHeaderRow({

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -210,6 +210,7 @@ export interface ReviewShellProps {
   items: ReviewListItem[];
   itemIndexByFilePath: Map<string, number>;
   commentedFilePaths?: ReadonlySet<string>;
+  unresolvedCommentedFilePaths?: ReadonlySet<string>;
   currentSignatures: Map<string, string>;
   viewedRecord: Record<string, string>;
   onToggleViewed: (key: string, sig: string | null) => void;
@@ -233,14 +234,20 @@ export interface ReviewListItem {
   node: ReactNode;
 }
 
-export function getCommentedFilePaths(
-  threads: Map<number, PrCommentThread>,
-): Set<string> {
-  return new Set(
-    [...threads.values()]
-      .filter((thread) => thread.comments.length > 0)
-      .map((thread) => thread.filePath),
-  );
+export function getCommentedFilePaths(threads: Map<number, PrCommentThread>): {
+  all: Set<string>;
+  unresolved: Set<string>;
+} {
+  const all = new Set<string>();
+  const unresolved = new Set<string>();
+
+  for (const thread of threads.values()) {
+    if (thread.comments.length === 0) continue;
+    all.add(thread.filePath);
+    if (!thread.isResolved) unresolved.add(thread.filePath);
+  }
+
+  return { all, unresolved };
 }
 
 export function filterReviewItemsByFilePaths(

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -16,7 +16,6 @@ import {
   splitFilePath,
   sumHunkStats,
 } from "@posthog/core/code-review/reviewShellGeometry";
-import type { PrCommentThread } from "@posthog/core/code-review/types";
 import { Badge } from "@posthog/quill";
 import type { ChangedFile, Task } from "@posthog/shared/domain-types";
 import { type ReactNode, useCallback, useMemo, useState } from "react";
@@ -25,6 +24,7 @@ import { Tooltip } from "../../primitives/Tooltip";
 import { useThemeStore } from "../../shell/themeStore";
 import { useDiffViewerStore } from "../code-editor/diffViewerStore";
 import { computeDiffStats } from "../git-interaction/utils/diffStats";
+import type { ReviewListItem } from "./commentFileFilter";
 import { useReviewViewedContext } from "./reviewViewedContext";
 import { useReviewViewedStore } from "./reviewViewedStore";
 
@@ -33,6 +33,7 @@ export {
   buildItemIndex,
   splitFilePath,
 } from "@posthog/core/code-review/reviewShellGeometry";
+export type { ReviewListItem } from "./commentFileFilter";
 
 const STICKY_HEADER_CSS = `[data-diffs-header] { position: sticky; top: 0; z-index: 1; background: var(--gray-2); }`;
 const SCROLL_ANCHOR_SELECTOR = "[data-scroll-key]";
@@ -225,51 +226,6 @@ export interface ReviewShellProps {
   branchSourceAvailable?: boolean;
   prSourceAvailable?: boolean;
   defaultBranch?: string | null;
-}
-
-export interface ReviewListItem {
-  key: string;
-  scrollKey?: string;
-  filePaths?: string[];
-  node: ReactNode;
-}
-
-export function getCommentedFilePaths(threads: Map<number, PrCommentThread>): {
-  all: Set<string>;
-  unresolved: Set<string>;
-} {
-  const all = new Set<string>();
-  const unresolved = new Set<string>();
-
-  for (const thread of threads.values()) {
-    if (thread.comments.length === 0) continue;
-    all.add(thread.filePath);
-    if (!thread.isResolved) unresolved.add(thread.filePath);
-  }
-
-  return { all, unresolved };
-}
-
-export function filterReviewItemsByFilePaths(
-  items: ReviewListItem[],
-  filePaths: ReadonlySet<string>,
-): ReviewListItem[] {
-  const filteredItems: ReviewListItem[] = [];
-  let pendingSectionItems: ReviewListItem[] = [];
-
-  for (const item of items) {
-    if (!item.filePaths) {
-      pendingSectionItems = [item];
-      continue;
-    }
-
-    if (!item.filePaths.some((filePath) => filePaths.has(filePath))) continue;
-
-    filteredItems.push(...pendingSectionItems, item);
-    pendingSectionItems = [];
-  }
-
-  return filteredItems;
 }
 
 export function FileHeaderRow({

--- a/packages/ui/src/features/git-interaction/usePrDetails.ts
+++ b/packages/ui/src/features/git-interaction/usePrDetails.ts
@@ -85,5 +85,6 @@ export function usePrDetails(
       isLoading: metaQuery.isLoading,
     },
     commentThreads,
+    commentsLoading: commentsQuery.isLoading,
   };
 }


### PR DESCRIPTION
## Summary
- add a review toolbar filter for files with PR comments
- preserve section headers and renamed-file path matching while filtering
- keep viewed counts and file navigation consistent with the visible review list
<img width="550" height="452" alt="CleanShot 2026-07-20 at 13 01 30@2x" src="https://github.com/user-attachments/assets/216fe3f3-11cf-4d9e-8c08-8de4c6036da3" />
<img width="826" height="508" alt="CleanShot 2026-07-20 at 13 01 38@2x" src="https://github.com/user-attachments/assets/1f6c5dbf-fe98-4ecd-aa3b-5e1143466fa7" />
<img width="2676" height="606" alt="CleanShot 2026-07-20 at 13 01 44@2x" src="https://github.com/user-attachments/assets/55983f7f-ad37-4b13-9446-f926d4b58923" />
<img width="976" height="548" alt="CleanShot 2026-07-20 at 13 01 49@2x" src="https://github.com/user-attachments/assets/ae7c780e-f45a-4fb4-b1be-e0a7ac04d081" />


## Testing
- `pnpm --filter @posthog/ui exec vitest run src/features/code-review`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm exec biome check packages/ui/src/features/code-review/components/CloudReviewPage.tsx packages/ui/src/features/code-review/components/ReviewPage.tsx packages/ui/src/features/code-review/components/ReviewShell.tsx packages/ui/src/features/code-review/components/ReviewToolbar.tsx packages/ui/src/features/code-review/components/reviewItemBuilders.tsx packages/ui/src/features/code-review/reviewShellParts.tsx packages/ui/src/features/code-review/reviewShellParts.test.tsx`

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*