### PR TITLE
fix(canvas): show only team messages in thread sidebar on full task view

### DIFF
--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -482,6 +482,7 @@ function ThreadConversation({
   onToggleCollapsed,
   onOpenFull,
   showTaskSummary,
+  showAgentComms,
 }: {
   task: Task;
   channelId: string;
@@ -489,6 +490,7 @@ function ThreadConversation({
   onToggleCollapsed?: () => void;
   onOpenFull?: () => void;
   showTaskSummary: boolean;
+  showAgentComms: boolean;
 }) {
   const taskId = task.id;
   const client = useOptionalAuthenticatedClient();
@@ -557,8 +559,8 @@ function ThreadConversation({
   const timeline = useMemo(
     () =>
       buildThreadTimeline({
-        prompts: promptMsgs,
-        agentMessages: agentMsgs,
+        prompts: showAgentComms ? promptMsgs : [],
+        agentMessages: showAgentComms ? agentMsgs : [],
         humanMessages: messages.map((message) => ({
           id: message.id,
           content: message.content,
@@ -567,7 +569,7 @@ function ThreadConversation({
           value: message,
         })),
       }),
-    [promptMsgs, messages, agentMsgs],
+    [promptMsgs, messages, agentMsgs, showAgentComms],
   );
 
   const lastAgentId = agentMsgs[agentMsgs.length - 1]?.id;
@@ -680,7 +682,9 @@ function ThreadConversation({
         />
       </div>
 
-      {agentStatus && <AgentStatusLine status={agentStatus} />}
+      {showAgentComms && agentStatus && (
+        <AgentStatusLine status={agentStatus} />
+      )}
 
       <ThreadReplyComposer
         draft={draft}
@@ -704,6 +708,7 @@ export function ThreadPanel({
   onToggleCollapsed,
   onOpenFull,
   showTaskSummary = true,
+  showAgentComms = true,
 }: {
   taskId: string;
   channelId: string;
@@ -713,6 +718,7 @@ export function ThreadPanel({
   onToggleCollapsed?: () => void;
   onOpenFull?: () => void;
   showTaskSummary?: boolean;
+  showAgentComms?: boolean;
 }) {
   const { data: fetchedTask } = useQuery({
     ...taskDetailQuery(taskId),
@@ -747,6 +753,7 @@ export function ThreadPanel({
       onToggleCollapsed={onToggleCollapsed}
       onOpenFull={onOpenFull}
       showTaskSummary={showTaskSummary}
+      showAgentComms={showAgentComms}
     />
   );
 }

--- a/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
@@ -17,6 +17,7 @@ export function ThreadSidebar({
   onClose,
   onOpenFull,
   showTaskSummary,
+  showAgentComms = true,
 }: {
   taskId: string;
   channelId: string;
@@ -25,6 +26,8 @@ export function ThreadSidebar({
   onClose?: () => void;
   onOpenFull?: () => void;
   showTaskSummary?: boolean;
+  /** Show agent turns/prompts and the agent status line. Off on the full task view, where the agent session already lives next to the thread. */
+  showAgentComms?: boolean;
 }) {
   const collapsed = useThreadPanelStore((s) => s.collapsed);
   const width = useThreadPanelStore((s) => s.width);
@@ -49,6 +52,7 @@ export function ThreadSidebar({
         task={task}
         collapsed
         onToggleCollapsed={() => toggleCollapsed(false)}
+        showAgentComms={showAgentComms}
       />
     );
   }
@@ -70,6 +74,7 @@ export function ThreadSidebar({
         onToggleCollapsed={() => toggleCollapsed(true)}
         onOpenFull={onOpenFull}
         showTaskSummary={showTaskSummary}
+        showAgentComms={showAgentComms}
       />
     </ResizableSidebar>
   );

--- a/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
+++ b/packages/ui/src/router/routes/website/$channelId/tasks/$taskId.tsx
@@ -73,6 +73,7 @@ function ChannelTaskDetailRoute() {
         channelId={channelId}
         task={task}
         showTaskSummary={false}
+        showAgentComms={false}
       />
     </div>
   );


### PR DESCRIPTION
## Problem

On the full task view (`/website/$channelId/tasks/$taskId`), the right-hand thread sidebar is rendered next to `TaskDetail`, which already hosts the agent session. The sidebar's timeline interleaved agent turns and user→agent prompts with the team conversation, so expanding a task from the channel-home thread left the same agent comms duplicated across both panes — the sidebar should show only the human-to-human conversation.

## Changes

- Added a `showAgentComms` prop (default `true`) to `ThreadPanel` / `ThreadSidebar`. When `false`, it drops agent turns and user→agent prompts from the timeline and hides the agent status line.
- The channel task detail route passes `showAgentComms={false}`, so its sidebar shows only team messages.
- The channel-home thread sidebar is unchanged (still shows the full timeline).

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` — no new errors in the touched files (remaining errors are pre-existing missing-host-module resolution unrelated to this change).
- `vitest run` for `threadPanelStore.test.ts` and `WebsiteLayout.test.tsx` — pass.
- `biome check` on the three changed files — clean.

## Why

You end up with the full-screen task open and the same agent conversation duplicated in the thread sidebar; the sidebar should carry the team discussion only, since the agent session already lives in the main task pane.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*