### PR TITLE
fix(analytics): disable posthog-js survey rendering in the app

### DIFF
--- a/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -79,6 +79,12 @@ export function initializePostHog(sessionId?: string) {
     session_recording: {
       captureCanvas: { recordCanvas: false },
     },
+    // The shared analytics project runs many popover surveys aimed at the
+    // PostHog web app; any one without URL/event conditions would render here
+    // too. This app only submits survey responses through its own UI
+    // (captureSurveyResponse), which posthog-js survey rendering being off
+    // does not affect.
+    disable_surveys: true,
     session_idle_timeout_seconds: SESSION_IDLE_TIMEOUT_SECONDS,
     ...(sessionId ? { bootstrap: { sessionID: sessionId } } : {}),
     capture_exceptions: import.meta.env.DEV


### PR DESCRIPTION
## Problem

Popover surveys from the shared analytics project can render inside PostHog Code. The project runs a large number of launched surveys aimed at the PostHog web app, and any survey without URL or event conditions (gated only by flags/cohorts) passes eligibility inside this app too — one such survey has already been shown to users from within the app. Because the desktop app uses hash routing and its own event names, survey authors' targeting assumptions simply don't apply here, and nothing in the init config opted us out.

## Why

Raised because surveys started appearing while running the desktop app in dev; the app never intended to show posthog-js popover surveys and loose targeting on the shared project makes accidental display an ongoing risk.

## Changes

- Add `disable_surveys: true` to the shared `posthog.init` config in `packages/ui/src/shell/posthogAnalyticsImpl.ts`.

Deliberate in-app surveys are unaffected: the canvas `FeedbackModal` submits responses manually via `captureSurveyResponse` (`survey sent` capture), which does not depend on posthog-js survey rendering.

## How did you test this?

- `pnpm exec turbo typecheck --filter=@posthog/ui` (passes)
- `biome check` on the changed file (clean)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*