### PR TITLE
fix: keep subagent spinner and footer live while a subagent runs

### DIFF
--- a/packages/agent/src/adapters/codex-app-server/mapping.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/mapping.test.ts
@@ -262,6 +262,49 @@ describe("mapAppServerNotification", () => {
     });
   });
 
+  it("maps a started wait tool call so the UI shows the main thread waiting on its subagents", () => {
+    const result = mapAppServerNotification(
+      "s-1",
+      APP_SERVER_NOTIFICATIONS.ITEM_STARTED,
+      {
+        item: {
+          type: "collabAgentToolCall",
+          id: "wait-1",
+          tool: "wait",
+          status: "inProgress",
+          senderThreadId: "main-thread",
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      sessionId: "s-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "wait-1",
+        title: "Wait for subagents",
+        kind: "other",
+        status: "in_progress",
+        rawInput: {},
+        _meta: { posthog: { toolName: "wait_agent" } },
+      },
+    });
+  });
+
+  it("still drops closeAgent lifecycle events", () => {
+    expect(
+      mapAppServerNotification("s-1", APP_SERVER_NOTIFICATIONS.ITEM_STARTED, {
+        item: {
+          type: "collabAgentToolCall",
+          id: "close-1",
+          tool: "closeAgent",
+          status: "inProgress",
+          senderThreadId: "main-thread",
+        },
+      }),
+    ).toBeNull();
+  });
+
   it("keeps a completed spawn tool call terminal while its subagent is running", () => {
     const result = mapAppServerNotification(
       "s-1",

--- a/packages/agent/src/adapters/codex-app-server/mapping.ts
+++ b/packages/agent/src/adapters/codex-app-server/mapping.ts
@@ -411,7 +411,7 @@ function describeTool(item: AppServerItem): ToolDescriptor | null {
         output: dynamicToolText(item.contentItems),
       };
     case "collabAgentToolCall":
-      if (item.tool === "wait" || item.tool === "closeAgent") {
+      if (item.tool === "closeAgent") {
         return null;
       }
       return {

--- a/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -15,6 +15,7 @@ import type {
   ConversationItem,
   TurnContext,
 } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { conversationHasActiveSubagent } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { ConversationSearchBar } from "@posthog/ui/features/sessions/components/ConversationSearchBar";
 import {
   PROMPT_RECALL_HINT_KEY,
@@ -195,6 +196,15 @@ export function ConversationView({
         isCloud,
       }),
     [conversationItems, optimisticItems, isCloud],
+  );
+
+  // A subagent keeps running detached after the parent prompt completes; keep the
+  // footer's generating indicator alive until its nested child work settles. This
+  // is display-only: the prompt-lifecycle gates (queue/steer) still read the raw
+  // `isPromptPending`, so a follow-up message sends instead of queueing.
+  const footerPromptPending = useMemo(
+    () => !!isPromptPending || conversationHasActiveSubagent(items),
+    [isPromptPending, items],
   );
 
   // Fold each completed turn's tool-call work into a collapsible chip, and emit
@@ -454,7 +464,7 @@ export function ConversationView({
     <div className={compact ? "pb-1" : "pb-16"}>
       <SessionFooter
         task={task}
-        isPromptPending={isPromptPending}
+        isPromptPending={footerPromptPending}
         promptStartedAt={promptStartedAt}
         lastGenerationDuration={
           lastTurnInfo?.isComplete

--- a/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -1,9 +1,10 @@
 import { makeAttachmentUri } from "@posthog/core/sessions/promptContent";
-import type { AcpMessage } from "@posthog/shared";
+import { type AcpMessage, posthogToolMeta } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
 import {
   buildConversationItems,
   type ConversationItem,
+  conversationHasActiveSubagent,
 } from "./buildConversationItems";
 
 function consoleMsg(ts: number, message: string, level = "info"): AcpMessage {
@@ -950,6 +951,139 @@ describe("buildConversationItems", () => {
 
       expect(lastTurnInfo?.isComplete).toBe(true);
       expect(lastTurnInfo?.durationMs).toBeGreaterThan(0);
+    });
+  });
+
+  describe("active subagent detection", () => {
+    const spawnMsg = (ts: number, toolCallId: string): AcpMessage => ({
+      type: "acp_message",
+      ts,
+      message: {
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId,
+            kind: "other",
+            status: "in_progress",
+            title: "Do the thing",
+            _meta: posthogToolMeta({ toolName: "Task" }),
+          },
+        },
+      },
+    });
+
+    const spawnUpdate = (
+      ts: number,
+      toolCallId: string,
+      status: string,
+    ): AcpMessage => ({
+      type: "acp_message",
+      ts,
+      message: {
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          update: { sessionUpdate: "tool_call_update", toolCallId, status },
+        },
+      },
+    });
+
+    const childToolMsg = (
+      ts: number,
+      toolCallId: string,
+      parentId: string,
+      status: string,
+    ): AcpMessage => ({
+      type: "acp_message",
+      ts,
+      message: {
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "tool_call",
+            toolCallId,
+            kind: "execute",
+            status,
+            title: toolCallId,
+            _meta: posthogToolMeta({
+              toolName: "Bash",
+              parentToolCallId: parentId,
+            }),
+          },
+        },
+      },
+    });
+
+    const childToolUpdate = (
+      ts: number,
+      toolCallId: string,
+      status: string,
+    ): AcpMessage => ({
+      type: "acp_message",
+      ts,
+      message: {
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          update: { sessionUpdate: "tool_call_update", toolCallId, status },
+        },
+      },
+    });
+
+    it("reports an active subagent while a child tool call is in_progress", () => {
+      // Claude: the subagent's nested tool calls stream within the parent turn,
+      // before the prompt response settles it. The spawn row is already marked
+      // completed (its result is being assembled), but a child is mid-flight.
+      const events = [
+        userPromptMsg(1, 1, "go"),
+        spawnMsg(2, "spawn-1"),
+        spawnUpdate(3, "spawn-1", "completed"),
+        childToolMsg(4, "child-1", "spawn-1", "in_progress"),
+      ];
+
+      const { items } = buildConversationItems(events, true);
+      expect(conversationHasActiveSubagent(items)).toBe(true);
+    });
+
+    it("still reports active after the parent turn ends but a child is in_flight (detached subagent)", () => {
+      const events = [
+        userPromptMsg(1, 1, "go"),
+        spawnMsg(2, "spawn-1"),
+        childToolMsg(3, "child-1", "spawn-1", "in_progress"),
+        spawnUpdate(4, "spawn-1", "completed"),
+        promptResponseMsg(5, 1),
+      ];
+
+      const { items } = buildConversationItems(events, false);
+      expect(conversationHasActiveSubagent(items)).toBe(true);
+    });
+
+    it("clears once every child tool call has settled", () => {
+      const events = [
+        userPromptMsg(1, 1, "go"),
+        spawnMsg(2, "spawn-1"),
+        childToolMsg(3, "child-1", "spawn-1", "in_progress"),
+        childToolUpdate(4, "child-1", "completed"),
+        spawnUpdate(5, "spawn-1", "completed"),
+        promptResponseMsg(6, 1),
+      ];
+
+      const { items } = buildConversationItems(events, false);
+      expect(conversationHasActiveSubagent(items)).toBe(false);
+    });
+
+    it("ignores a non-subagent tool call with no children", () => {
+      const events = [
+        userPromptMsg(1, 1, "go"),
+        childToolMsg(2, "t1", "nonexistent-parent", "in_progress"),
+        promptResponseMsg(3, 1),
+      ];
+
+      const { items } = buildConversationItems(events, false);
+      expect(conversationHasActiveSubagent(items)).toBe(false);
     });
   });
 });

--- a/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -13,6 +13,7 @@ import {
   isJsonRpcNotification,
   isJsonRpcRequest,
   isJsonRpcResponse,
+  readAgentToolName,
   readParentToolCallId,
   type UserShellExecuteParams,
 } from "@posthog/shared";
@@ -31,6 +32,7 @@ import {
   type SkillButtonId,
 } from "@posthog/ui/features/skill-buttons/prompts";
 import type { Step, StepStatus } from "@posthog/ui/primitives/StepList";
+import { SUBAGENT_SPAWN_TOOL_NAMES } from "./session-update/collaborationTools";
 import type { RenderItem } from "./session-update/SessionUpdateView";
 
 export interface TurnContext {
@@ -163,6 +165,56 @@ const TERMINAL_TOOL_STATUSES = new Set(["completed", "failed", "cancelled"]);
 
 function isTerminalToolStatus(status: string | null | undefined): boolean {
   return status != null && TERMINAL_TOOL_STATUSES.has(status);
+}
+
+/**
+ * Whether a subagent spawn (Task/Agent tool call) still has work in flight.
+ * The parent turn ends when the spawn tool call returns, but the subagent keeps
+ * running detached; its nested tool calls arrive as children on the spawn's
+ * `TurnContext`. Without this check the spawn row's spinner stops the moment
+ * the parent turn completes, making the conversation look done mid-subagent.
+ */
+export function hasActiveSubagent(
+  context: Pick<TurnContext, "toolCalls" | "childItems">,
+  spawnToolCallId: string,
+): boolean {
+  const children = context.childItems.get(spawnToolCallId);
+  if (!children?.length) return false;
+  for (const child of children) {
+    if (child.type !== "session_update") continue;
+    if (child.update.sessionUpdate !== "tool_call") continue;
+    const resolved = child.update.toolCallId
+      ? context.toolCalls.get(child.update.toolCallId)
+      : undefined;
+    const status = resolved?.status ?? child.update.status;
+    if (!isTerminalToolStatus(status)) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether any subagent anywhere in the conversation still has work in flight.
+ * Drives the footer's generating indicator after the parent prompt has
+ * completed but a detached subagent is still running.
+ */
+export function conversationHasActiveSubagent(
+  items: ConversationItem[],
+): boolean {
+  for (const item of items) {
+    if (item.type !== "session_update") continue;
+    if (item.update.sessionUpdate !== "tool_call") continue;
+    if (!isSubagentSpawnUpdate(item.update)) continue;
+    if (hasActiveSubagent(item.turnContext, item.update.toolCallId))
+      return true;
+  }
+  return false;
+}
+
+function isSubagentSpawnUpdate(
+  update: RenderItem,
+): update is Extract<RenderItem, { sessionUpdate: "tool_call" }> {
+  if (update.sessionUpdate !== "tool_call") return false;
+  return SUBAGENT_SPAWN_TOOL_NAMES.has(readAgentToolName(update._meta) ?? "");
 }
 
 function isThoughtItem(

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
@@ -1,5 +1,6 @@
 import type { AcpMessage } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
+import { conversationHasActiveSubagent } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { SessionFooter } from "@posthog/ui/features/sessions/components/SessionFooter";
 import { useContextUsage } from "@posthog/ui/features/sessions/hooks/useContextUsage";
 import { useConversationItems } from "@posthog/ui/features/sessions/hooks/useConversationItems";
@@ -37,18 +38,24 @@ export function ChatThreadFooter({
 }: ChatThreadFooterProps) {
   const showDebugLogs = useSettingsStore((s) => s.debugLogsCloudRuns);
   const contextUsage = useContextUsage(events);
-  const { lastTurnInfo, isCompacting, completedToolCallCount } =
+  const { items, lastTurnInfo, isCompacting, completedToolCallCount } =
     useConversationItems(events, isPromptPending, { showDebugLogs });
   const pendingPermissions = usePendingPermissionsForTask(taskId ?? "");
   const queuedCount = useQueuedMessagesForTask(taskId).length;
   const session = useSessionForTask(taskId);
   const pausedDurationMs = session?.pausedDurationMs ?? 0;
 
+  // Keep the generating indicator alive while a detached subagent is still
+  // running after the parent prompt completed. Display-only; the prompt
+  // lifecycle (queue/steer) still reads the raw `isPromptPending`.
+  const footerPromptPending =
+    !!isPromptPending || conversationHasActiveSubagent(items);
+
   return (
     <div className="pt-1">
       <SessionFooter
         task={task}
-        isPromptPending={isPromptPending}
+        isPromptPending={footerPromptPending}
         promptStartedAt={promptStartedAt}
         lastGenerationDuration={
           lastTurnInfo?.isComplete

--- a/packages/ui/src/features/sessions/components/chat-thread/ToolGroup.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ToolGroup.tsx
@@ -10,7 +10,9 @@ import { readAgentToolName } from "@posthog/shared";
 import type { ToolCall } from "@posthog/ui/features/sessions/types";
 import { memo } from "react";
 import type { ConversationItem } from "../buildConversationItems";
+import { hasActiveSubagent } from "../buildConversationItems";
 import { grouping } from "../new-thread/conversationThreadConfig";
+import { isSubagentSpawnTool } from "../session-update/collaborationTools";
 import { SessionUpdateView } from "../session-update/SessionUpdateView";
 import { iconForToolCall } from "../session-update/toolCallUtils";
 
@@ -64,13 +66,18 @@ function friendlyName(key: string): string {
 }
 
 export function isToolActive(item: ToolGroupItem["tools"][number]): boolean {
-  const { toolCall } = resolveTool(item);
+  const { toolCall, toolName } = resolveTool(item);
+  if (item.turnContext.turnCancelled) return false;
+
   const incomplete =
     toolCall.status === "pending" || toolCall.status === "in_progress";
+  if (incomplete && !item.turnContext.turnComplete) return true;
+
+  // The spawn settled and the parent turn ended, but the subagent keeps running
+  // detached — keep the group live on its nested child work.
   return (
-    incomplete &&
-    !item.turnContext.turnCancelled &&
-    !item.turnContext.turnComplete
+    isSubagentSpawnTool(toolName) &&
+    hasActiveSubagent(item.turnContext, toolCall.toolCallId)
   );
 }
 

--- a/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
+++ b/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
@@ -1,6 +1,7 @@
 import type { Icon } from "@phosphor-icons/react";
 import { readAgentToolName, readMcpToolDescriptor } from "@posthog/shared";
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { hasActiveSubagent } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import {
   buildDoneLabel,
   type CollapseMode,
@@ -140,6 +141,7 @@ function summarize(items: ConversationItem[]): GroupSummary {
   let liveLabel: string | null = null;
   let lastToolStatus: string | undefined;
   let trailingThoughtStreaming = false;
+  let subagentActive = false;
   const icons: GroupIconEntry[] = [];
   const seenIcons = new Set<string>();
 
@@ -160,6 +162,15 @@ function summarize(items: ConversationItem[]): GroupSummary {
       if (name && grouping.subagentToolNames.has(name)) {
         counts.subagents++;
         addIcon(SUBAGENT_ICON, "subagent");
+        // A settled spawn with the parent turn complete can still have a detached
+        // subagent running in its children — that keeps the chip live.
+        if (
+          !subagentActive &&
+          update.toolCallId &&
+          hasActiveSubagent(item.turnContext, update.toolCallId)
+        ) {
+          subagentActive = true;
+        }
       } else if (readMcpToolDescriptor(update._meta)) {
         counts.other++;
         addIcon(MCP_ICON, "mcp");
@@ -211,6 +222,7 @@ function summarize(items: ConversationItem[]): GroupSummary {
   if (trailingThoughtStreaming) liveLabel = "Thinking…";
   const active =
     trailingThoughtStreaming ||
+    subagentActive ||
     lastToolStatus === "pending" ||
     lastToolStatus === "in_progress";
   const hasCountableWork =

--- a/packages/ui/src/features/sessions/components/session-update/SubagentToolView.test.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/SubagentToolView.test.tsx
@@ -1,0 +1,100 @@
+import { posthogToolMeta } from "@posthog/shared";
+import type {
+  ConversationSessionUpdate,
+  ToolCall,
+} from "@posthog/ui/features/sessions/types";
+import { Theme } from "@radix-ui/themes";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ConversationItem, TurnContext } from "../buildConversationItems";
+import { SubagentToolView } from "./SubagentToolView";
+
+// The legacy thread path (no ChatThreadChrome provider) renders the bespoke
+// bordered box; that's enough to assert the spinner vs. robot-icon swap.
+function makeTurnContext(
+  spawnId: string,
+  children: ConversationItem[],
+): TurnContext {
+  const toolCalls = new Map<string, ToolCall>();
+  for (const child of children) {
+    if (child.type !== "session_update") continue;
+    const update = child.update as ConversationSessionUpdate;
+    if (update.sessionUpdate === "tool_call" && update.toolCallId) {
+      toolCalls.set(update.toolCallId, update as unknown as ToolCall);
+    }
+  }
+  return {
+    toolCalls,
+    childItems: new Map([[spawnId, children]]),
+    turnCancelled: false,
+    turnComplete: true,
+  };
+}
+
+function childToolCall(
+  id: string,
+  parentId: string,
+  status: ToolCall["status"],
+): ConversationItem {
+  return {
+    type: "session_update",
+    id,
+    update: {
+      sessionUpdate: "tool_call",
+      toolCallId: id,
+      kind: "execute",
+      status,
+      title: id,
+      _meta: posthogToolMeta({ toolName: "Bash", parentToolCallId: parentId }),
+    },
+    turnContext: {} as TurnContext,
+  };
+}
+
+function renderView(
+  toolCall: ToolCall,
+  turnContext: TurnContext,
+  childItems: ConversationItem[],
+) {
+  return render(
+    <Theme>
+      <SubagentToolView
+        toolCall={toolCall}
+        turnComplete
+        childItems={childItems}
+        turnContext={turnContext}
+      />
+    </Theme>,
+  );
+}
+
+describe("SubagentToolView", () => {
+  const spawnToolCall: ToolCall = {
+    toolCallId: "spawn-1",
+    title: "Do the thing",
+    kind: "other",
+    status: "completed",
+    _meta: posthogToolMeta({ toolName: "Task" }),
+  };
+
+  it("shows the robot icon (no spinner) once the subagent and its children are done", () => {
+    const children = [childToolCall("child-1", "spawn-1", "completed")];
+    const turnContext = makeTurnContext("spawn-1", children);
+    const { container } = renderView(spawnToolCall, turnContext, children);
+
+    // DotsCircleSpinner renders braille-dot frames (class `ph-dots-frame`) only
+    // while loading; otherwise LoadingIcon shows the Robot <svg>. A settled
+    // subagent shows no spinner frames.
+    expect(container.querySelector(".ph-dots-frame")).toBeNull();
+  });
+
+  it("keeps the spinner while a child tool call is in_progress even though the turn is complete", () => {
+    const children = [childToolCall("child-1", "spawn-1", "in_progress")];
+    const turnContext = makeTurnContext("spawn-1", children);
+    const { container } = renderView(spawnToolCall, turnContext, children);
+
+    // The spawn is `completed` and `turnComplete` is true, but a child is still
+    // in flight — the spinner must stay up so the row doesn't read as done.
+    expect(container.querySelector(".ph-dots-frame")).not.toBeNull();
+  });
+});

--- a/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
@@ -13,6 +13,7 @@ import {
 import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import { useState } from "react";
 import type { ConversationItem, TurnContext } from "../buildConversationItems";
+import { hasActiveSubagent } from "../buildConversationItems";
 import { useChatThreadChrome } from "../chat-thread/chatThreadChrome";
 import { SessionUpdateView } from "./SessionUpdateView";
 import { ToolRow } from "./ToolRow";
@@ -40,6 +41,10 @@ export function SubagentToolView({
     turnCancelled,
     turnComplete,
   );
+  // The parent turn completes when the spawn tool call returns, but the subagent
+  // keeps running detached. Keep the spinner alive while any of its child tool
+  // calls are non-terminal, or the row reads as done mid-subagent.
+  const subagentActive = hasActiveSubagent(turnContext, toolCall.toolCallId);
   const chatChrome = useChatThreadChrome();
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -75,7 +80,7 @@ export function SubagentToolView({
                   <span className="flex items-center">
                     <LoadingIcon
                       icon={Robot}
-                      isLoading={isLoading}
+                      isLoading={isLoading || subagentActive}
                       className="text-gray-10"
                     />
                   </span>
@@ -124,14 +129,17 @@ export function SubagentToolView({
             <TooltipTrigger
               render={
                 <span className="flex items-center">
-                  <LoadingIcon icon={Robot} isLoading={isLoading} />
+                  <LoadingIcon
+                    icon={Robot}
+                    isLoading={isLoading || subagentActive}
+                  />
                 </span>
               }
             />
             <TooltipContent side="top">Delegated to a subagent</TooltipContent>
           </Tooltip>
         }
-        isLoading={isLoading}
+        isLoading={isLoading || subagentActive}
         isFailed={isFailed}
         wasCancelled={wasCancelled}
         content={childContent}


### PR DESCRIPTION
## Problem

When a sub-agent (Task/Agent tool call) is running, the conversation UI sometimes looked done while the sub-agent was still working. Two faces:

1. The sub-agent row's spinner stopped once the parent turn completed (or once the spawn tool call settled), even though the sub-agent kept running.
2. The footer's "Generating…" indicator stopped for the same reason.

This affects both the Claude and Codex adapters.

## Changes

Derive live state from the sub-agent's own nested child tool calls instead of the parent turn's `turnComplete` / the spawn's own status:

- `SubagentToolView` keeps its spinner while any child tool call is non-terminal, even after the parent turn completes.
- New-thread `ToolGroup` / chip summary stay "Using" while a sub-agent in the group has active children.
- Both footers (legacy `ConversationView` and `ChatThreadFooter`) keep the generating indicator alive via a new `conversationHasActiveSubagent` helper.

Display-only: the prompt-lifecycle gates (message queue / steer) still read the raw `isPromptPending`, so a follow-up message sends rather than queuing while a detached sub-agent finishes.

Also restores Codex's `wait` collab-agent event ("Waiting for subagents" row) that PR #3522 had hidden alongside `closeAgent`; `closeAgent` stays hidden as lifecycle noise.

## How did you test this?

- New unit tests in `buildConversationItems.test.ts` for `conversationHasActiveSubagent` (active child, detached sub-agent after turn end, clears on settle, ignores non-subagent).
- New `SubagentToolView.test.tsx` asserting the spinner stays up while a child is `in_progress` with `turnComplete=true`, and clears when settled.
- `pnpm --filter @posthog/ui exec vitest run src/features/sessions/` (467 passing)
- `pnpm --filter agent exec vitest run src/adapters/codex-app-server/mapping.test.ts` (39 passing)
- `pnpm --filter @posthog/ui typecheck`, `biome lint` on changed files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*