### PR TITLE
ci(agent): verify release build before merge

### DIFF
--- a/.github/actions/build-agent-release/action.yml
+++ b/.github/actions/build-agent-release/action.yml
@@ -1,0 +1,13 @@
+name: Build agent release
+description: Build and test the agent package with all workspace dependencies
+runs:
+  using: composite
+  steps:
+    - name: Build agent and workspace dependencies
+      shell: bash
+      run: pnpm --filter @posthog/agent... run build
+
+    - name: Run agent tests
+      shell: bash
+      run: pnpm --filter @posthog/agent run test
+

--- a/.github/workflows/agent-release-verify.yml
+++ b/.github/workflows/agent-release-verify.yml
@@ -1,0 +1,41 @@
+name: Verify Agent Release
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packages/agent/**"
+      - "packages/enricher/**"
+      - "packages/git/**"
+      - "packages/harness/**"
+      - "packages/shared/**"
+      - ".github/actions/build-agent-release/**"
+      - ".github/workflows/agent-release.yml"
+      - ".github/workflows/agent-release-verify.yml"
+      - "pnpm-lock.yaml"
+
+jobs:
+  verify:
+    name: Verify agent release build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node 24
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and test agent release
+        uses: ./.github/actions/build-agent-release

--- a/.github/workflows/agent-release-verify.yml
+++ b/.github/workflows/agent-release-verify.yml
@@ -1,5 +1,8 @@
 name: Verify Agent Release
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -14,6 +17,7 @@ on:
       - ".github/workflows/agent-release.yml"
       - ".github/workflows/agent-release-verify.yml"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
 
 jobs:
   verify:

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -48,23 +48,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build shared (agent dependency)
-        run: pnpm --filter @posthog/shared run build
-
-      - name: Build git (agent dependency)
-        run: pnpm --filter @posthog/git run build
-
-      - name: Build enricher (agent dependency)
-        run: pnpm --filter @posthog/enricher run build
-
-      - name: Build harness (agent dependency)
-        run: pnpm --filter @posthog/harness run build
-
-      - name: Build the package
-        run: pnpm --filter agent run build
-
-      - name: Run tests
-        run: pnpm --filter agent run test
+      - name: Build and test agent release
+        uses: ./.github/actions/build-agent-release
 
       - name: Publish the package to npm registry
         working-directory: packages/agent


### PR DESCRIPTION
## Problem
Agent release builds can diverge from the PR build and only fail after an automated release tag is created.

## Changes
- extract the release build/test steps into a shared composite action
- run that exact action on relevant pull requests before merge
- build the complete agent workspace dependency graph instead of maintaining a manual list

## How did you test this?
- `pnpm install --frozen-lockfile`
- `pnpm --filter @posthog/agent... run build`
- `pnpm --filter @posthog/agent run test`