### PR TITLE
fix(agent): keep cloud credentials in secondary checkouts

### DIFF
--- a/packages/agent/src/adapters/codex-app-server/spawn.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/spawn.test.ts
@@ -126,6 +126,30 @@ describe("buildAppServerArgs", () => {
     expect(args).toContain('model_verbosity="low"');
   });
 
+  it("pins the cloud BASH_ENV into tool shells for secondary checkouts", () => {
+    const args = buildAppServerArgs(
+      { binaryPath: "/bundle/codex" },
+      { IS_SANDBOX: "1", BASH_ENV: "/tmp/agentsh-bash-env.sh" },
+    );
+
+    expect(args).toContain(
+      'shell_environment_policy.set.BASH_ENV="/tmp/agentsh-bash-env.sh"',
+    );
+  });
+
+  it("does not override BASH_ENV outside a managed sandbox", () => {
+    const args = buildAppServerArgs(
+      { binaryPath: "/bundle/codex" },
+      { BASH_ENV: "/Users/example/.bash-env" },
+    );
+
+    expect(
+      args.some((arg) =>
+        arg.startsWith("shell_environment_policy.set.BASH_ENV="),
+      ),
+    ).toBe(false);
+  });
+
   it("does not set instructions at spawn (developer_instructions are per-thread)", () => {
     const args = buildAppServerArgs({
       binaryPath: "/bundle/codex",

--- a/packages/agent/src/adapters/codex-app-server/spawn.ts
+++ b/packages/agent/src/adapters/codex-app-server/spawn.ts
@@ -91,6 +91,7 @@ function tomlInlineTable(entries: Record<string, string>): string {
 
 export function buildAppServerArgs(
   options: CodexAppServerProcessOptions,
+  environment: NodeJS.ProcessEnv = process.env,
 ): string[] {
   const args: string[] = ["app-server"];
 
@@ -129,6 +130,16 @@ export function buildAppServerArgs(
   // serve — so every review 403s. Default codex's own `user` reviewer; a caller can
   // still override it via configOverrides, which the trailing loop appends last.
   args.push("-c", `approvals_reviewer="user"`);
+
+  // Codex snapshots shell state only for the thread's initial cwd. Cloud tasks
+  // can work in additional checkouts, so pin the backend-controlled BASH_ENV
+  // path into every tool shell instead of relying on snapshot restoration.
+  if (environment.IS_SANDBOX && environment.BASH_ENV) {
+    args.push(
+      "-c",
+      `shell_environment_policy.set.BASH_ENV=${tomlBasicString(environment.BASH_ENV)}`,
+    );
+  }
 
   // Disable the user's ambient ~/.codex MCP servers so the adapter only exposes
   // MCP servers PostHog injects per-thread; otherwise codex fails connecting to them.
@@ -199,7 +210,7 @@ export function spawnCodexAppServerProcess(
   }
   env.PATH = `${dirname(options.binaryPath)}${delimiter}${env.PATH ?? ""}`;
 
-  const args = buildAppServerArgs(options);
+  const args = buildAppServerArgs(options, env);
 
   logger.info("Spawning codex app-server process", {
     command: options.binaryPath,


### PR DESCRIPTION
## Problem

Cloud Codex sessions receive refreshed GitHub credentials through `BASH_ENV`, but Codex restores its captured shell snapshot only when a tool call uses the thread's initial working directory. A shell launched directly in a secondary checkout can therefore lose `gh` authentication even while the refreshed credential file is valid.

## Changes

- Pin the backend-controlled `BASH_ENV` path in Codex's shell environment policy for managed sandbox sessions.
- Pass the exact spawned process environment into argument construction.
- Leave non-sandbox Codex sessions unchanged.

The backend half of the credential refresh path is in [PostHog/posthog#72540](https://github.com/PostHog/posthog/pull/72540).
