### PR TITLE
fix(sidebar): remove worktree name chip from task items

### DIFF
--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -12,7 +12,6 @@ import type {
   TaskGroup,
 } from "@posthog/core/sidebar/sidebarData.types";
 import { MenuLabel } from "@posthog/quill";
-import { getFileName } from "@posthog/shared";
 import { builderHog } from "@posthog/ui/assets/hedgehogs";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
@@ -92,32 +91,10 @@ function TaskRow({
   depth?: number;
 }) {
   const workspace = useWorkspace(task.id);
-  const { folders } = useFolders();
   const effectiveMode =
     workspace?.mode ??
     (task.taskRunEnvironment === "cloud" ? "cloud" : undefined);
 
-  // Chip identifying the checkout the task runs in: app-managed worktrees
-  // (worktree mode) and local tasks whose registered folder is itself a
-  // linked worktree of the group's main clone.
-  const worktreeCheckout = useMemo(() => {
-    if (workspace?.worktreePath) {
-      return {
-        name: workspace.worktreeName ?? getFileName(workspace.worktreePath),
-        path: workspace.worktreePath,
-      };
-    }
-    if (workspace?.mode === "local" && workspace.folderPath) {
-      const folder = folders.find((f) => f.path === workspace.folderPath);
-      if (folder?.mainRepoPath) {
-        return {
-          name: getFileName(workspace.folderPath),
-          path: workspace.folderPath,
-        };
-      }
-    }
-    return null;
-  }, [workspace, folders]);
   const { prState, hasDiff } = useTaskPrStatus(task);
   const isArchiving = useArchivingTasksStore((s) =>
     s.archivingTaskIds.has(task.id),
@@ -134,8 +111,6 @@ function TaskRow({
       hideHoverActions={hideHoverActions}
       isEditing={isEditing}
       workspaceMode={effectiveMode}
-      worktreeName={worktreeCheckout?.name}
-      worktreePath={worktreeCheckout?.path}
       isSuspended={task.isSuspended}
       isGenerating={task.isGenerating}
       isUnread={task.isUnread}

--- a/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -1,9 +1,4 @@
-import {
-  Archive,
-  GitFork,
-  GitPullRequest,
-  PushPin,
-} from "@phosphor-icons/react";
+import { Archive, GitPullRequest, PushPin } from "@phosphor-icons/react";
 import { parseGithubUrl } from "@posthog/git/utils";
 import type { WorkspaceMode } from "@posthog/shared";
 import { formatRelativeTimeShort } from "@posthog/shared";
@@ -34,17 +29,6 @@ function PrBadge({ url, number }: { url: string; number: number }) {
   );
 }
 
-function WorktreeChip({ name, path }: { name: string; path?: string }) {
-  return (
-    <Tooltip content={path ?? name} side="top">
-      <span className="flex h-4 max-w-[96px] shrink-0 items-center gap-0.5 rounded bg-gray-3 px-1 text-[11px] text-gray-11">
-        <GitFork size={10} weight="bold" className="shrink-0" />
-        <span className="truncate">{name}</span>
-      </span>
-    </Tooltip>
-  );
-}
-
 interface TaskItemProps {
   depth?: number;
   taskId: string;
@@ -55,10 +39,6 @@ interface TaskItemProps {
   isArchiving?: boolean;
   hideHoverActions?: boolean;
   workspaceMode?: WorkspaceMode;
-  /** Checkout name shown as a chip when the task runs in a git worktree. */
-  worktreeName?: string;
-  /** Full path of that checkout, surfaced in the chip's tooltip. */
-  worktreePath?: string;
   isGenerating?: boolean;
   isUnread?: boolean;
   isPinned?: boolean;
@@ -131,8 +111,6 @@ export function TaskItem({
   isArchiving = false,
   hideHoverActions = false,
   workspaceMode,
-  worktreeName,
-  worktreePath,
   isSuspended = false,
   isGenerating,
   isUnread,
@@ -195,14 +173,9 @@ export function TaskItem({
       />
     ) : null;
 
-  const worktreeChip = worktreeName ? (
-    <WorktreeChip name={worktreeName} path={worktreePath} />
-  ) : null;
-
   const endContent =
-    worktreeChip || prBadge || timestampNode || toolbar ? (
+    prBadge || timestampNode || toolbar ? (
       <>
-        {worktreeChip}
         {prBadge}
         {timestampNode}
         {toolbar}


### PR DESCRIPTION
## Problem

The per-task worktree name chip in the sidebar (which doubled as the branch name) took up horizontal space without a clear purpose. It's redundant now that there's a dedicated worktree dropdown, so it can go.

## Changes

Removed the `WorktreeChip` from sidebar task items along with its `worktreeName`/`worktreePath` prop plumbing and the `worktreeCheckout` computation that fed it. The separate "Worktrees" quick-start section is untouched.

## How did you test this?

`pnpm --filter @posthog/ui typecheck` (clean on touched files) and `biome lint` on both edited files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1784637393440489?thread_ts=1784637393.440489&cid=C09G8Q32R6F)*
