### PR TITLE
fix(cloud-agent): use refreshed token for signed commits

### DIFF
--- a/packages/agent/src/signed-commit-artefacts.ts
+++ b/packages/agent/src/signed-commit-artefacts.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import type { SignedCommitResult } from "@posthog/git/signed-commit";
 import { PostHogAPIClient } from "./posthog-api";
+
 const SANDBOX_ENV_FILE = "/tmp/agent-env";
 
 /**

--- a/packages/agent/src/signed-commit-artefacts.ts
+++ b/packages/agent/src/signed-commit-artefacts.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import type { SignedCommitResult } from "@posthog/git/signed-commit";
 import { PostHogAPIClient } from "./posthog-api";
-import { SANDBOX_ENV_FILE } from "./utils/github-token";
+const SANDBOX_ENV_FILE = "/tmp/agent-env";
 
 /**
  * Best-effort "commit hook": after a successful signed-commit push, record one `commit`

--- a/packages/agent/src/utils/github-token.ts
+++ b/packages/agent/src/utils/github-token.ts
@@ -2,15 +2,15 @@ import { readFileSync } from "node:fs";
 import { readGithubTokenFromEnv } from "@posthog/git/signed-commit";
 
 // helpers for resolving the in-sandbox GitHub token
-// agentsh env file (NUL-delimited `key=value` pairs) that the PostHog backend
-// rewrites in place when it refreshes the sandbox's GitHub credentials
+// Dedicated agentsh credential file (NUL-delimited `key=value` pairs) that the
+// PostHog backend rewrites in place when it refreshes GitHub credentials
 // mid-session. The agent-server process env is frozen at launch, so reading
 // this live file is how in-process tools pick up a refreshed token without a
 // process restart.
-export const SANDBOX_ENV_FILE = "/tmp/agent-env";
+const SANDBOX_GITHUB_ENV_FILE = "/tmp/agent-github-env";
 
 export function readGithubTokenFromSandboxEnvFile(
-  envFilePath: string = SANDBOX_ENV_FILE,
+  envFilePath: string = SANDBOX_GITHUB_ENV_FILE,
 ): string | undefined {
   try {
     const raw = readFileSync(envFilePath, "utf8");
@@ -36,7 +36,7 @@ export function readGithubTokenFromSandboxEnvFile(
  * signed-commit tool — pick up a refreshed token without a restart.
  */
 export function resolveGithubToken(
-  envFilePath: string = SANDBOX_ENV_FILE,
+  envFilePath: string = SANDBOX_GITHUB_ENV_FILE,
 ): string | undefined {
   return (
     readGithubTokenFromSandboxEnvFile(envFilePath) ?? readGithubTokenFromEnv()


### PR DESCRIPTION
## Problem

**Why:** Long-running cloud agents need signed commits to use credentials refreshed after the agent process starts.

## Changes

Read GitHub credentials from the dedicated live credential file while keeping general sandbox metadata resolution unchanged.