### PR TITLE
fix(cloud-agent): fall back to legacy env file for github token

### DIFF
--- a/packages/agent/src/utils/github-token.test.ts
+++ b/packages/agent/src/utils/github-token.test.ts
@@ -66,11 +66,28 @@ describe("github-token", () => {
       expect(resolveGithubToken(path)).toBe("ghs_fromfile");
     });
 
-    it("falls back to the process env when the sandbox file is absent", () => {
+    it("prefers the github env file over the legacy env file", () => {
+      const githubPath = writeEnvFile("GH_TOKEN=ghs_github\0");
+      const legacyPath = writeEnvFile("GH_TOKEN=ghs_legacy\0");
+      expect(resolveGithubToken(githubPath, legacyPath)).toBe("ghs_github");
+    });
+
+    it("falls back to the legacy env file when the github env file is absent", () => {
       vi.stubEnv("GH_TOKEN", "ghs_fromprocess");
-      expect(resolveGithubToken("/nonexistent/agent-env")).toBe(
-        "ghs_fromprocess",
-      );
+      const legacyPath = writeEnvFile("GH_TOKEN=ghs_legacy\0");
+      expect(
+        resolveGithubToken("/nonexistent/agent-github-env", legacyPath),
+      ).toBe("ghs_legacy");
+    });
+
+    it("falls back to the process env when both sandbox files are absent", () => {
+      vi.stubEnv("GH_TOKEN", "ghs_fromprocess");
+      expect(
+        resolveGithubToken(
+          "/nonexistent/agent-github-env",
+          "/nonexistent/agent-env",
+        ),
+      ).toBe("ghs_fromprocess");
     });
   });
 });

--- a/packages/agent/src/utils/github-token.ts
+++ b/packages/agent/src/utils/github-token.ts
@@ -8,6 +8,11 @@ import { readGithubTokenFromEnv } from "@posthog/git/signed-commit";
 // this live file is how in-process tools pick up a refreshed token without a
 // process restart.
 const SANDBOX_GITHUB_ENV_FILE = "/tmp/agent-github-env";
+// Legacy pre-split file. Before GitHub credentials got their own file, the
+// backend refreshed them in place here. Kept as a fallback so that during a
+// mixed-version rollout (new agent, old backend that only writes this file) we
+// still read a live, refreshed token instead of the frozen process env.
+const SANDBOX_LEGACY_ENV_FILE = "/tmp/agent-env";
 
 export function readGithubTokenFromSandboxEnvFile(
   envFilePath: string = SANDBOX_GITHUB_ENV_FILE,
@@ -31,14 +36,21 @@ export function readGithubTokenFromSandboxEnvFile(
 
 /** The GitHub token available to the sandbox, if any.
  *
- * Prefers the live agentsh env file (refreshed in place mid-session) over the
- * process env (frozen at launch) so long-running in-process tools — e.g. the
- * signed-commit tool — pick up a refreshed token without a restart.
+ * Precedence: the dedicated live credential file, then the legacy live file,
+ * then the process env (frozen at launch). Reading a live file first is how
+ * long-running in-process tools — e.g. the signed-commit tool — pick up a
+ * refreshed token without a restart. The legacy fallback covers a mixed-version
+ * rollout where an older backend still refreshes credentials only into
+ * `/tmp/agent-env`; without it the reader would drop straight to the frozen
+ * process env and sign commits with an expired or previous actor's token.
  */
 export function resolveGithubToken(
-  envFilePath: string = SANDBOX_GITHUB_ENV_FILE,
+  githubEnvFilePath: string = SANDBOX_GITHUB_ENV_FILE,
+  legacyEnvFilePath: string = SANDBOX_LEGACY_ENV_FILE,
 ): string | undefined {
   return (
-    readGithubTokenFromSandboxEnvFile(envFilePath) ?? readGithubTokenFromEnv()
+    readGithubTokenFromSandboxEnvFile(githubEnvFilePath) ??
+    readGithubTokenFromSandboxEnvFile(legacyEnvFilePath) ??
+    readGithubTokenFromEnv()
   );
 }


### PR DESCRIPTION
## Problem

Follow-up to #3652 (already merged), which pointed the in-sandbox GitHub token reader at the backend's dedicated credential file. A review comment flagged a mixed-version rollout gap: the agent and the backend deploy independently, so a **new agent** can run against an **older backend** that still refreshes GitHub credentials only into the legacy `/tmp/agent-env`. In that window the reader looked only at `/tmp/agent-github-env` and, finding it absent, dropped straight to the process env frozen at launch — so a signed commit could use an expired or previous actor's token.

**Why:** keep signed commits using a live, refreshed token across the rollout window regardless of which backend version a sandbox is paired with, avoiding the `Bad credentials (HTTP 401)` failure #3652 addressed.

## Changes

`resolveGithubToken` now chains the reads: dedicated `/tmp/agent-github-env` → legacy `/tmp/agent-env` (live-refreshed by older backends) → process env as a last resort. Under the current backend the legacy file excludes the token, so the dedicated file still wins; under an older backend the legacy fallback picks up the fresh token instead of the frozen one.

## How did you test this?

- `pnpm --filter @posthog/agent... build` (includes `tsc` typecheck) — passes
- `pnpm --filter @posthog/agent exec vitest run src/utils/github-token.test.ts` — 9 tests pass, including new cases for github-over-legacy precedence and legacy fallback
- `biome check` on the changed files — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*