### PR TITLE
fix(agent): Put most capable Claude at top

### DIFF
--- a/packages/agent/src/adapters/claude/session/model-config.test.ts
+++ b/packages/agent/src/adapters/claude/session/model-config.test.ts
@@ -26,8 +26,8 @@ describe("applyAvailableModelsAllowlist", () => {
         "claude-opus-4-8",
       ]).options,
     ).toEqual([
-      { value: "claude-opus-4-8", name: "Claude Opus 4.8" },
       { value: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+      { value: "claude-opus-4-8", name: "Claude Opus 4.8" },
     ]);
   });
 

--- a/packages/agent/src/gateway-models.test.ts
+++ b/packages/agent/src/gateway-models.test.ts
@@ -132,7 +132,9 @@ describe("getClaudeModelRecency", () => {
 });
 
 describe("compareModelsForPicker", () => {
-  it("groups models by family, most capable first, newest version first", () => {
+  it("groups models by family least capable first, newest version first", () => {
+    // The picker opens upward, so least-capable-first DOM order puts the most
+    // capable family (Fable) nearest the trigger — the visual top of the menu.
     // Models as the gateway might return them — arbitrary order.
     const gatewayOrder = [
       "claude-fable-5",
@@ -145,12 +147,12 @@ describe("compareModelsForPicker", () => {
     ];
     const displayed = [...gatewayOrder].sort(compareModelsForPicker);
     expect(displayed).toEqual([
-      "claude-fable-5",
-      "claude-opus-4-8",
-      "claude-opus-4-7",
+      "claude-haiku-4-5",
       "claude-sonnet-5",
       "claude-sonnet-4-6",
-      "claude-haiku-4-5",
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-fable-5",
       "claude-mystery",
     ]);
   });

--- a/packages/agent/src/gateway-models.ts
+++ b/packages/agent/src/gateway-models.ts
@@ -279,8 +279,11 @@ export function getClaudeModelRecency(modelId: string): number {
   return major * 1000 + minor;
 }
 
-// Families ordered most-capable first; unknown families sort last.
-const MODEL_FAMILY_ORDER = ["fable", "opus", "sonnet", "haiku"];
+// Families ordered least-capable first. The picker opens upward (side="top")
+// from the composer, so items later in this list render nearer the trigger and
+// read as the top of the menu — this puts the most-capable family (Fable) on
+// top. Unknown families sort after all known ones.
+const MODEL_FAMILY_ORDER = ["haiku", "sonnet", "opus", "fable"];
 
 function getModelFamilyRank(modelId: string): number {
   const id = modelId.toLowerCase();


### PR DESCRIPTION
Human tldr: Agent picker was showing Haiku first, then Sonnet, then Fable - not the most intuitively as a hierarchy.

 ---

## Problem

The Claude model picker listed families most-capable-first in the DOM. But the picker dropdown opens **upward** (`side="top"`) from the composer, so the first list item renders at the far top of the popup and the last item sits nearest the trigger where the eye lands — leaving the strongest model (Fable) visually stranded away from where you look. Raised in a Slack thread ([link](https://posthog.slack.com/archives/C09G8Q32R6F/p1784636201290769?thread_ts=1784636201.290769&cid=C09G8Q32R6F)).

## Changes

Inverted `MODEL_FAMILY_ORDER` to least-capable-first (`haiku → sonnet → opus → fable`). Because the menu opens upward, this renders Fable nearest the trigger — the visual top of the menu. Updated the picker-order unit tests to match.

## How did you test this?

`pnpm --filter @posthog/agent test` — the `compareModelsForPicker` and `applyAvailableModelsAllowlist` suites pass with the new ordering (641 tests passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1784636201290769?thread_ts=1784636201.290769&cid=C09G8Q32R6F)*
