### PR TITLE
feat(sidebar): Drag to reorder nav items in customize dialog

### DIFF
--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -270,6 +270,12 @@ export interface SidebarCustomizedProperties {
   visible: boolean;
 }
 
+export interface SidebarReorderedProperties {
+  item: SidebarNavItem;
+  /** Zero-based position of the item in the nav after the drag. */
+  to_index: number;
+}
+
 export interface BrainrotActivatedProperties {
   /** Grid layout preset, e.g. "2x2". */
   layout: string;
@@ -1140,6 +1146,7 @@ export const ANALYTICS_EVENTS = {
   POSTHOG_WEB_OPENED: "PostHog web opened",
   SIDEBAR_NAV_ITEM_CLICKED: "Sidebar nav item clicked",
   SIDEBAR_CUSTOMIZED: "Sidebar customized",
+  SIDEBAR_REORDERED: "Sidebar reordered",
 
   // Permission events
   PERMISSION_RESPONDED: "Permission responded",
@@ -1300,6 +1307,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.POSTHOG_WEB_OPENED]: never;
   [ANALYTICS_EVENTS.SIDEBAR_NAV_ITEM_CLICKED]: SidebarNavItemClickedProperties;
   [ANALYTICS_EVENTS.SIDEBAR_CUSTOMIZED]: SidebarCustomizedProperties;
+  [ANALYTICS_EVENTS.SIDEBAR_REORDERED]: SidebarReorderedProperties;
 
   // Permission events
   [ANALYTICS_EVENTS.PERMISSION_RESPONDED]: PermissionRespondedProperties;

--- a/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.test.tsx
+++ b/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.test.tsx
@@ -44,7 +44,6 @@ vi.mock("@dnd-kit/react/sortable", () => ({
     isDragging: false,
   }),
 }));
-vi.mock("@dnd-kit/dom", () => ({ PointerSensor: class {} }));
 
 import {
   CUSTOMIZABLE_NAV_ITEM_IDS,
@@ -76,21 +75,36 @@ function renderDialog(available = availability()) {
   );
 }
 
-function drag(
-  sourceId: string,
-  targetId: string,
-  { cancel = false }: { cancel?: boolean } = {},
-) {
+function dragStart(sourceId: string) {
   act(() => {
     dndCapture.onDragStart?.({ operation: { source: { id: sourceId } } });
+  });
+}
+
+function dragOver(sourceId: string, targetId: string) {
+  act(() => {
     dndCapture.onDragOver?.({
       operation: { source: { id: sourceId }, target: { id: targetId } },
     });
+  });
+}
+
+function dragEnd(
+  sourceId: string,
+  { cancel = false }: { cancel?: boolean } = {},
+) {
+  act(() => {
     dndCapture.onDragEnd?.({
-      operation: { source: { id: sourceId }, target: { id: targetId } },
+      operation: { source: { id: sourceId } },
       canceled: cancel,
     });
   });
+}
+
+function rowLabels() {
+  return screen
+    .getAllByRole("checkbox")
+    .map((checkbox) => checkbox.closest("label")?.textContent);
 }
 
 describe("CustomizeSidebarDialog", () => {
@@ -142,17 +156,20 @@ describe("CustomizeSidebarDialog", () => {
     useSidebarStore.setState({ navItemOrder: ["loops", "search"] });
     renderDialog();
 
-    const labels = screen
-      .getAllByRole("checkbox")
-      .map((checkbox) => checkbox.closest("label")?.textContent);
-
-    expect(labels.slice(0, 2)).toEqual(["Loops", "Search"]);
+    expect(rowLabels().slice(0, 2)).toEqual(["Loops", "Search"]);
   });
 
-  it("dragging a row persists the new order and tracks on drop", () => {
+  it("previews on dragover and persists only on drop", () => {
     renderDialog();
 
-    drag("skills", "search");
+    dragStart("skills");
+    dragOver("skills", "search");
+
+    expect(rowLabels()[0]).toBe("Skills");
+    expect(useSidebarStore.getState().navItemOrder).toEqual([]);
+    expect(track).not.toHaveBeenCalled();
+
+    dragEnd("skills");
 
     expect(useSidebarStore.getState().navItemOrder).toEqual([
       "skills",
@@ -172,12 +189,50 @@ describe("CustomizeSidebarDialog", () => {
     });
   });
 
-  it("a canceled drag restores the order from dragstart", () => {
+  it("ignores a repeated dragover for the same source and target", () => {
     renderDialog();
 
-    drag("skills", "search", { cancel: true });
+    dragStart("skills");
+    dragOver("skills", "search");
+    dragOver("skills", "search");
+
+    expect(rowLabels()[0]).toBe("Skills");
+
+    dragEnd("skills");
+
+    expect(useSidebarStore.getState().navItemOrder[0]).toBe("skills");
+  });
+
+  it("a canceled drag drops the preview and leaves the store untouched", () => {
+    renderDialog();
+
+    dragStart("skills");
+    dragOver("skills", "search");
+    dragEnd("skills", { cancel: true });
+
+    expect(rowLabels()[0]).toBe("Search");
+    expect(useSidebarStore.getState().navItemOrder).toEqual([]);
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("a drop without movement neither persists nor tracks", () => {
+    renderDialog();
+
+    dragStart("skills");
+    dragEnd("skills");
 
     expect(useSidebarStore.getState().navItemOrder).toEqual([]);
     expect(track).not.toHaveBeenCalled();
+  });
+
+  it("reset clears the stored order back to the default", async () => {
+    const user = userEvent.setup();
+    useSidebarStore.setState({ navItemOrder: ["loops", "search"] });
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(useSidebarStore.getState().navItemOrder).toEqual([]);
+    expect(rowLabels()[0]).toBe("Search");
   });
 });

--- a/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.test.tsx
+++ b/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.test.tsx
@@ -1,12 +1,50 @@
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { Theme } from "@radix-ui/themes";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+type CapturedDragEvent = {
+  operation: { source?: { id?: string }; target?: { id?: string } };
+  canceled?: boolean;
+};
+
+const { track, dndCapture } = vi.hoisted(() => ({
+  track: vi.fn(),
+  dndCapture: {} as {
+    onDragStart?: (event: CapturedDragEvent) => void;
+    onDragOver?: (event: CapturedDragEvent) => void;
+    onDragEnd?: (event: CapturedDragEvent) => void;
+  },
+}));
 
 vi.mock("@posthog/ui/shell/analytics", () => ({ track }));
+vi.mock("@dnd-kit/react", () => ({
+  DragDropProvider: ({
+    onDragStart,
+    onDragOver,
+    onDragEnd,
+    children,
+  }: {
+    onDragStart?: (event: CapturedDragEvent) => void;
+    onDragOver?: (event: CapturedDragEvent) => void;
+    onDragEnd?: (event: CapturedDragEvent) => void;
+    children?: React.ReactNode;
+  }) => {
+    dndCapture.onDragStart = onDragStart;
+    dndCapture.onDragOver = onDragOver;
+    dndCapture.onDragEnd = onDragEnd;
+    return <>{children}</>;
+  },
+}));
+vi.mock("@dnd-kit/react/sortable", () => ({
+  useSortable: () => ({
+    ref: () => {},
+    handleRef: () => {},
+    isDragging: false,
+  }),
+}));
+vi.mock("@dnd-kit/dom", () => ({ PointerSensor: class {} }));
 
 import {
   CUSTOMIZABLE_NAV_ITEM_IDS,
@@ -38,10 +76,27 @@ function renderDialog(available = availability()) {
   );
 }
 
+function drag(
+  sourceId: string,
+  targetId: string,
+  { cancel = false }: { cancel?: boolean } = {},
+) {
+  act(() => {
+    dndCapture.onDragStart?.({ operation: { source: { id: sourceId } } });
+    dndCapture.onDragOver?.({
+      operation: { source: { id: sourceId }, target: { id: targetId } },
+    });
+    dndCapture.onDragEnd?.({
+      operation: { source: { id: sourceId }, target: { id: targetId } },
+      canceled: cancel,
+    });
+  });
+}
+
 describe("CustomizeSidebarDialog", () => {
   beforeEach(() => {
     track.mockReset();
-    useSidebarStore.setState({ navItemOverrides: {} });
+    useSidebarStore.setState({ navItemOverrides: {}, navItemOrder: [] });
   });
 
   it("unchecking a visible item demotes it and tracks the change", async () => {
@@ -81,5 +136,48 @@ describe("CustomizeSidebarDialog", () => {
     expect(
       screen.getByRole("checkbox", { name: "Configure" }),
     ).toBeInTheDocument();
+  });
+
+  it("renders rows in the stored order", () => {
+    useSidebarStore.setState({ navItemOrder: ["loops", "search"] });
+    renderDialog();
+
+    const labels = screen
+      .getAllByRole("checkbox")
+      .map((checkbox) => checkbox.closest("label")?.textContent);
+
+    expect(labels.slice(0, 2)).toEqual(["Loops", "Search"]);
+  });
+
+  it("dragging a row persists the new order and tracks on drop", () => {
+    renderDialog();
+
+    drag("skills", "search");
+
+    expect(useSidebarStore.getState().navItemOrder).toEqual([
+      "skills",
+      "search",
+      "inbox",
+      "agents",
+      "mcp-servers",
+      "command-center",
+      "contexts",
+      "activity",
+      "configure",
+      "loops",
+    ]);
+    expect(track).toHaveBeenCalledWith(ANALYTICS_EVENTS.SIDEBAR_REORDERED, {
+      item: "skills",
+      to_index: 0,
+    });
+  });
+
+  it("a canceled drag restores the order from dragstart", () => {
+    renderDialog();
+
+    drag("skills", "search", { cancel: true });
+
+    expect(useSidebarStore.getState().navItemOrder).toEqual([]);
+    expect(track).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.tsx
+++ b/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.tsx
@@ -1,4 +1,3 @@
-import { PointerSensor } from "@dnd-kit/dom";
 import { type DragDropEvents, DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import {
@@ -16,6 +15,7 @@ import {
 } from "@phosphor-icons/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import {
+  CUSTOMIZABLE_NAV_ITEMS,
   type CustomizableNavItem,
   type CustomizableNavItemId,
   isNavItemVisible,
@@ -25,7 +25,7 @@ import {
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { track } from "@posthog/ui/shell/analytics";
 import { Button, Checkbox, Dialog, Flex, Text } from "@radix-ui/themes";
-import { type RefCallback, useRef } from "react";
+import { type RefCallback, useRef, useState } from "react";
 
 const ITEM_ICONS: Record<
   CustomizableNavItemId,
@@ -68,42 +68,65 @@ export function CustomizeSidebarDialog({
   const setNavItemVisible = useSidebarStore((s) => s.setNavItemVisible);
   const setNavItemOrder = useSidebarStore((s) => s.setNavItemOrder);
 
-  const items = orderedNavItems(navItemOrder).filter(
+  // Dragover only moves this local preview. Committing to the store per
+  // dragover would serialize it to localStorage and re-render the live
+  // sidebar on every pointer move, which made dragging visibly lag; the
+  // store commits once on drop and a canceled drag just drops the preview.
+  const previewRef = useRef<readonly CustomizableNavItemId[] | null>(null);
+  const [previewOrder, setPreviewOrder] = useState<
+    readonly CustomizableNavItemId[] | null
+  >(null);
+  const updatePreview = (order: readonly CustomizableNavItemId[] | null) => {
+    previewRef.current = order;
+    setPreviewOrder(order);
+  };
+  // dragover can re-fire for the same source/target pair while the pointer
+  // sits on a row boundary; replaying the move would swap the rows back.
+  const lastMove = useRef<string | null>(null);
+
+  const items = orderedNavItems(previewOrder ?? navItemOrder).filter(
     ({ id }) => available?.[id] !== false,
   );
 
-  // Dragover persists the reorder live so the list previews it, which means a
-  // canceled drag must restore the order captured at dragstart.
-  const initialOrder = useRef<readonly CustomizableNavItemId[] | null>(null);
-
   const handleDragStart: DragDropEvents["dragstart"] = () => {
-    initialOrder.current = useSidebarStore.getState().navItemOrder;
+    lastMove.current = null;
+    updatePreview(
+      orderedNavItems(useSidebarStore.getState().navItemOrder).map(
+        (item) => item.id,
+      ),
+    );
   };
 
   const handleDragOver: DragDropEvents["dragover"] = (event) => {
     const sourceId = event.operation.source?.id;
     const targetId = event.operation.target?.id;
-    if (!sourceId || !targetId || sourceId === targetId) return;
-    const current = useSidebarStore.getState().navItemOrder;
+    const current = previewRef.current;
+    if (!current || !sourceId || !targetId || sourceId === targetId) return;
+    const moveKey = `${String(sourceId)}->${String(targetId)}`;
+    if (lastMove.current === moveKey) return;
     const next = moveNavItem(current, String(sourceId), String(targetId));
-    if (next !== current) setNavItemOrder(next);
+    if (next !== current) {
+      lastMove.current = moveKey;
+      updatePreview(next);
+    }
   };
 
   const handleDragEnd: DragDropEvents["dragend"] = (event) => {
-    const before = initialOrder.current;
-    initialOrder.current = null;
-    if (event.canceled) {
-      if (before) setNavItemOrder(before);
-      return;
-    }
-    const after = useSidebarStore.getState().navItemOrder;
-    if (before && sameOrder(before, after)) return;
-    const sourceId = event.operation.source?.id;
-    const moved = orderedNavItems(after).find(({ id }) => id === sourceId);
+    const preview = previewRef.current;
+    updatePreview(null);
+    if (event.canceled || !preview) return;
+    const stored = orderedNavItems(useSidebarStore.getState().navItemOrder).map(
+      (item) => item.id,
+    );
+    if (sameOrder(stored, preview)) return;
+    setNavItemOrder(preview);
+    const moved = CUSTOMIZABLE_NAV_ITEMS.find(
+      ({ id }) => id === event.operation.source?.id,
+    );
     if (!moved) return;
     track(ANALYTICS_EVENTS.SIDEBAR_REORDERED, {
       item: moved.analyticsId,
-      to_index: orderedNavItems(after).findIndex(({ id }) => id === moved.id),
+      to_index: preview.indexOf(moved.id),
     });
   };
 
@@ -116,16 +139,12 @@ export function CustomizeSidebarDialog({
           Unchecked items live under More.
         </Dialog.Description>
 
+        {/* Default pointer activation starts a mouse drag from the handle
+            immediately; a distance constraint here would delay pickup. */}
         <DragDropProvider
           onDragStart={handleDragStart}
           onDragOver={handleDragOver}
           onDragEnd={handleDragEnd}
-          sensors={[
-            {
-              plugin: PointerSensor,
-              options: { activationConstraints: { distance: { value: 5 } } },
-            },
-          ]}
         >
           <Flex direction="column" gap="3" mt="4">
             {items.map((item, index) => (
@@ -146,7 +165,15 @@ export function CustomizeSidebarDialog({
           </Flex>
         </DragDropProvider>
 
-        <Flex mt="4" justify="end">
+        <Flex mt="4" justify="between" align="center">
+          <Button
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={() => setNavItemOrder([])}
+          >
+            Reset
+          </Button>
           <Dialog.Close>
             <Button size="1" variant="solid">
               Done

--- a/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.tsx
+++ b/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.tsx
@@ -1,5 +1,9 @@
+import { PointerSensor } from "@dnd-kit/dom";
+import { type DragDropEvents, DragDropProvider } from "@dnd-kit/react";
+import { useSortable } from "@dnd-kit/react/sortable";
 import {
   Bell,
+  DotsSixVertical,
   EnvelopeSimple,
   HashIcon,
   Lightbulb,
@@ -12,13 +16,16 @@ import {
 } from "@phosphor-icons/react";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import {
-  CUSTOMIZABLE_NAV_ITEMS,
+  type CustomizableNavItem,
   type CustomizableNavItemId,
   isNavItemVisible,
+  moveNavItem,
+  orderedNavItems,
 } from "@posthog/ui/features/sidebar/constants";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { track } from "@posthog/ui/shell/analytics";
 import { Button, Checkbox, Dialog, Flex, Text } from "@radix-ui/themes";
+import { type RefCallback, useRef } from "react";
 
 const ITEM_ICONS: Record<
   CustomizableNavItemId,
@@ -36,6 +43,13 @@ const ITEM_ICONS: Record<
   loops: RepeatIcon,
 };
 
+function sameOrder(
+  a: readonly CustomizableNavItemId[],
+  b: readonly CustomizableNavItemId[],
+): boolean {
+  return a.length === b.length && a.every((id, i) => id === b[i]);
+}
+
 interface CustomizeSidebarDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -50,44 +64,87 @@ export function CustomizeSidebarDialog({
   available,
 }: CustomizeSidebarDialogProps) {
   const navItemOverrides = useSidebarStore((s) => s.navItemOverrides);
+  const navItemOrder = useSidebarStore((s) => s.navItemOrder);
   const setNavItemVisible = useSidebarStore((s) => s.setNavItemVisible);
+  const setNavItemOrder = useSidebarStore((s) => s.setNavItemOrder);
+
+  const items = orderedNavItems(navItemOrder).filter(
+    ({ id }) => available?.[id] !== false,
+  );
+
+  // Dragover persists the reorder live so the list previews it, which means a
+  // canceled drag must restore the order captured at dragstart.
+  const initialOrder = useRef<readonly CustomizableNavItemId[] | null>(null);
+
+  const handleDragStart: DragDropEvents["dragstart"] = () => {
+    initialOrder.current = useSidebarStore.getState().navItemOrder;
+  };
+
+  const handleDragOver: DragDropEvents["dragover"] = (event) => {
+    const sourceId = event.operation.source?.id;
+    const targetId = event.operation.target?.id;
+    if (!sourceId || !targetId || sourceId === targetId) return;
+    const current = useSidebarStore.getState().navItemOrder;
+    const next = moveNavItem(current, String(sourceId), String(targetId));
+    if (next !== current) setNavItemOrder(next);
+  };
+
+  const handleDragEnd: DragDropEvents["dragend"] = (event) => {
+    const before = initialOrder.current;
+    initialOrder.current = null;
+    if (event.canceled) {
+      if (before) setNavItemOrder(before);
+      return;
+    }
+    const after = useSidebarStore.getState().navItemOrder;
+    if (before && sameOrder(before, after)) return;
+    const sourceId = event.operation.source?.id;
+    const moved = orderedNavItems(after).find(({ id }) => id === sourceId);
+    if (!moved) return;
+    track(ANALYTICS_EVENTS.SIDEBAR_REORDERED, {
+      item: moved.analyticsId,
+      to_index: orderedNavItems(after).findIndex(({ id }) => id === moved.id),
+    });
+  };
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Content maxWidth="360px">
         <Dialog.Title>Customize sidebar</Dialog.Title>
         <Dialog.Description className="text-gray-10 text-sm">
-          Choose which items appear in your sidebar. Unchecked items live under
-          More.
+          Choose which items appear in your sidebar and drag to reorder.
+          Unchecked items live under More.
         </Dialog.Description>
 
-        <Flex direction="column" gap="3" mt="4">
-          {CUSTOMIZABLE_NAV_ITEMS.filter(
-            ({ id }) => available?.[id] !== false,
-          ).map(({ id, label, analyticsId }) => {
-            const ItemIcon = ITEM_ICONS[id];
-            const visible = isNavItemVisible(navItemOverrides, id);
-            return (
-              <Text key={id} as="label" size="2">
-                <Flex gap="2" align="center">
-                  <Checkbox
-                    checked={visible}
-                    onCheckedChange={(checked) => {
-                      const nextVisible = checked === true;
-                      setNavItemVisible(id, nextVisible);
-                      track(ANALYTICS_EVENTS.SIDEBAR_CUSTOMIZED, {
-                        item: analyticsId,
-                        visible: nextVisible,
-                      });
-                    }}
-                  />
-                  <ItemIcon size={16} />
-                  {label}
-                </Flex>
-              </Text>
-            );
-          })}
-        </Flex>
+        <DragDropProvider
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+          sensors={[
+            {
+              plugin: PointerSensor,
+              options: { activationConstraints: { distance: { value: 5 } } },
+            },
+          ]}
+        >
+          <Flex direction="column" gap="3" mt="4">
+            {items.map((item, index) => (
+              <SortableNavItemRow
+                key={item.id}
+                item={item}
+                index={index}
+                visible={isNavItemVisible(navItemOverrides, item.id)}
+                onVisibleChange={(nextVisible) => {
+                  setNavItemVisible(item.id, nextVisible);
+                  track(ANALYTICS_EVENTS.SIDEBAR_CUSTOMIZED, {
+                    item: item.analyticsId,
+                    visible: nextVisible,
+                  });
+                }}
+              />
+            ))}
+          </Flex>
+        </DragDropProvider>
 
         <Flex mt="4" justify="end">
           <Dialog.Close>
@@ -98,5 +155,49 @@ export function CustomizeSidebarDialog({
         </Flex>
       </Dialog.Content>
     </Dialog.Root>
+  );
+}
+
+function SortableNavItemRow({
+  item,
+  index,
+  visible,
+  onVisibleChange,
+}: {
+  item: CustomizableNavItem;
+  index: number;
+  visible: boolean;
+  onVisibleChange: (visible: boolean) => void;
+}) {
+  const { ref, handleRef, isDragging } = useSortable({
+    id: item.id,
+    index,
+    group: "customize-sidebar-nav",
+    transition: { duration: 200, easing: "ease" },
+  });
+  const ItemIcon = ITEM_ICONS[item.id];
+  return (
+    <div ref={ref} style={{ opacity: isDragging ? 0.5 : 1 }}>
+      <Flex gap="2" align="center">
+        <button
+          ref={handleRef as RefCallback<HTMLButtonElement>}
+          type="button"
+          title="Drag to reorder"
+          className="shrink-0 cursor-grab text-gray-9 hover:text-gray-11"
+        >
+          <DotsSixVertical size={14} />
+        </button>
+        <Text as="label" size="2" className="flex-1">
+          <Flex gap="2" align="center">
+            <Checkbox
+              checked={visible}
+              onCheckedChange={(checked) => onVisibleChange(checked === true)}
+            />
+            <ItemIcon size={16} />
+            {item.label}
+          </Flex>
+        </Text>
+      </Flex>
+    </div>
   );
 }

--- a/packages/ui/src/features/sidebar/components/SidebarNavSection.test.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarNavSection.test.tsx
@@ -96,7 +96,11 @@ describe("SidebarNavSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useAppView.mockReturnValue({ type: "home" });
-    useSidebarStore.setState({ navItemOverrides: {}, channelsEnabled: true });
+    useSidebarStore.setState({
+      navItemOverrides: {},
+      navItemOrder: [],
+      channelsEnabled: true,
+    });
   });
 
   it.each([
@@ -146,6 +150,20 @@ describe("SidebarNavSection", () => {
       expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
     },
   );
+
+  it("renders top-level items in the stored order", () => {
+    useSidebarStore.setState({ navItemOrder: ["activity", "inbox"] });
+    renderNav();
+
+    const labels = screen
+      .getAllByRole("button")
+      .map((button) => button.textContent ?? "");
+    const position = (label: string) =>
+      labels.findIndex((text) => text.includes(label));
+
+    expect(position("Activity")).toBeLessThan(position("Inbox"));
+    expect(position("Inbox")).toBeLessThan(position("Agents"));
+  });
 
   it("never lets hidden search take over the More row", () => {
     useSidebarStore.setState({ navItemOverrides: { search: false } });

--- a/packages/ui/src/features/sidebar/components/SidebarNavSection.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarNavSection.tsx
@@ -10,9 +10,9 @@ import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAll
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import {
   CUSTOMIZABLE_NAV_ITEM_IDS,
-  CUSTOMIZABLE_NAV_ITEMS,
   type CustomizableNavItemId,
   isNavItemVisible,
+  orderedNavItems,
 } from "@posthog/ui/features/sidebar/constants";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
@@ -167,6 +167,8 @@ export function SidebarNavSection({
     };
 
   const navItemOverrides = useSidebarStore((s) => s.navItemOverrides);
+  const navItemOrder = useSidebarStore((s) => s.navItemOrder);
+  const orderedItems = orderedNavItems(navItemOrder);
   const hidden = new Set<CustomizableNavItemId>(
     CUSTOMIZABLE_NAV_ITEM_IDS.filter(
       (id) => !isNavItemVisible(navItemOverrides, id),
@@ -206,7 +208,7 @@ export function SidebarNavSection({
     loops: loopsEnabled,
   };
 
-  const activeHiddenItem = CUSTOMIZABLE_NAV_ITEMS.find(
+  const activeHiddenItem = orderedItems.find(
     ({ id }) => navItemAvailable[id] && hidden.has(id) && moreItemActive[id],
   );
   const takeoverLabel =
@@ -308,10 +310,10 @@ export function SidebarNavSection({
     ),
   };
 
-  const topLevelItems = CUSTOMIZABLE_NAV_ITEMS.filter(
+  const topLevelItems = orderedItems.filter(
     ({ id }) => navItemAvailable[id] && !hidden.has(id),
   );
-  const moreItems = CUSTOMIZABLE_NAV_ITEMS.filter(
+  const moreItems = orderedItems.filter(
     ({ id }) => navItemAvailable[id] && hidden.has(id),
   );
 

--- a/packages/ui/src/features/sidebar/constants.test.ts
+++ b/packages/ui/src/features/sidebar/constants.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  CUSTOMIZABLE_NAV_ITEM_IDS,
+  moveNavItem,
+  orderedNavItems,
+  sanitizeNavItemOrder,
+} from "./constants";
+
+describe("orderedNavItems", () => {
+  it("returns the default order for an empty stored order", () => {
+    expect(orderedNavItems([]).map((item) => item.id)).toEqual(
+      CUSTOMIZABLE_NAV_ITEM_IDS,
+    );
+  });
+
+  it("puts stored ids first and appends the rest in default order", () => {
+    const ids = orderedNavItems(["loops", "search"]).map((item) => item.id);
+
+    expect(ids.slice(0, 2)).toEqual(["loops", "search"]);
+    expect(ids.slice(2)).toEqual(
+      CUSTOMIZABLE_NAV_ITEM_IDS.filter(
+        (id) => id !== "loops" && id !== "search",
+      ),
+    );
+  });
+});
+
+describe("moveNavItem", () => {
+  it("moves an item backward to the target position", () => {
+    const next = moveNavItem([], "skills", "search");
+
+    expect(next[0]).toBe("skills");
+    expect(next).toHaveLength(CUSTOMIZABLE_NAV_ITEM_IDS.length);
+  });
+
+  it("moves an item forward to the target position", () => {
+    const next = moveNavItem([], "search", "agents");
+
+    expect(next.indexOf("search")).toBe(
+      CUSTOMIZABLE_NAV_ITEM_IDS.indexOf("agents"),
+    );
+  });
+
+  it.each([
+    ["an unknown source", "retired-item", "search"],
+    ["an unknown target", "search", "retired-item"],
+    ["the same source and target", "search", "search"],
+  ])("returns the order unchanged for %s", (_label, source, target) => {
+    const order: readonly ("loops" | "search")[] = ["loops", "search"];
+
+    expect(moveNavItem(order, source, target)).toBe(order);
+  });
+});
+
+describe("sanitizeNavItemOrder", () => {
+  it.each([
+    ["a string", "corrupt"],
+    ["an object", { search: 0 }],
+    ["null", null],
+    ["a number", 7],
+  ])("returns an empty order when the value is %s", (_label, value) => {
+    expect(sanitizeNavItemOrder(value)).toEqual([]);
+  });
+
+  it("drops unknown ids, non-strings and duplicates", () => {
+    expect(
+      sanitizeNavItemOrder(["loops", "retired-item", 7, "search", "loops"]),
+    ).toEqual(["loops", "search"]);
+  });
+});

--- a/packages/ui/src/features/sidebar/constants.test.ts
+++ b/packages/ui/src/features/sidebar/constants.test.ts
@@ -13,6 +13,22 @@ describe("orderedNavItems", () => {
     );
   });
 
+  it("inserts an id missing from a full stored order after its default predecessor", () => {
+    const withoutSkills = CUSTOMIZABLE_NAV_ITEM_IDS.filter(
+      (id) => id !== "skills",
+    ).reverse();
+
+    const ids = orderedNavItems(withoutSkills).map((item) => item.id);
+
+    expect(ids.indexOf("skills")).toBe(ids.indexOf("agents") + 1);
+  });
+
+  it("inserts a missing id with no present predecessor at the start", () => {
+    const ids = orderedNavItems(["loops", "inbox"]).map((item) => item.id);
+
+    expect(ids[0]).toBe("search");
+  });
+
   it("puts stored ids first and appends the rest in default order", () => {
     const ids = orderedNavItems(["loops", "search"]).map((item) => item.id);
 

--- a/packages/ui/src/features/sidebar/constants.ts
+++ b/packages/ui/src/features/sidebar/constants.ts
@@ -88,18 +88,31 @@ export function isNavItemVisible(
 
 export type CustomizableNavItem = (typeof CUSTOMIZABLE_NAV_ITEMS)[number];
 
-/** Applies a stored drag order. Items missing from it (newly shipped, or an
- * empty order) keep their default relative position after the ordered ones. */
+/** Applies a stored drag order. Ids missing from it (newly shipped items)
+ * slot in after their nearest default predecessor instead of at the end, so
+ * users with a saved order still get new items near their intended spot. */
 export function orderedNavItems(
   order: readonly CustomizableNavItemId[],
 ): readonly CustomizableNavItem[] {
   if (order.length === 0) return CUSTOMIZABLE_NAV_ITEMS;
-  const position = new Map(order.map((id, index) => [id, index]));
-  return [...CUSTOMIZABLE_NAV_ITEMS].sort(
-    (a, b) =>
-      (position.get(a.id) ?? order.length) -
-      (position.get(b.id) ?? order.length),
-  );
+  const byId = new Map(CUSTOMIZABLE_NAV_ITEMS.map((item) => [item.id, item]));
+  const result = [...order];
+  for (const [defaultIndex, item] of CUSTOMIZABLE_NAV_ITEMS.entries()) {
+    if (result.includes(item.id)) continue;
+    let insertAt = 0;
+    for (let i = defaultIndex - 1; i >= 0; i--) {
+      const neighbor = result.indexOf(CUSTOMIZABLE_NAV_ITEMS[i].id);
+      if (neighbor !== -1) {
+        insertAt = neighbor + 1;
+        break;
+      }
+    }
+    result.splice(insertAt, 0, item.id);
+  }
+  return result.flatMap((id) => {
+    const item = byId.get(id);
+    return item ? [item] : [];
+  });
 }
 
 export function moveNavItem(

--- a/packages/ui/src/features/sidebar/constants.ts
+++ b/packages/ui/src/features/sidebar/constants.ts
@@ -86,6 +86,47 @@ export function isNavItemVisible(
   return overrides[id] ?? DEFAULT_VISIBILITY[id];
 }
 
+export type CustomizableNavItem = (typeof CUSTOMIZABLE_NAV_ITEMS)[number];
+
+/** Applies a stored drag order. Items missing from it (newly shipped, or an
+ * empty order) keep their default relative position after the ordered ones. */
+export function orderedNavItems(
+  order: readonly CustomizableNavItemId[],
+): readonly CustomizableNavItem[] {
+  if (order.length === 0) return CUSTOMIZABLE_NAV_ITEMS;
+  const position = new Map(order.map((id, index) => [id, index]));
+  return [...CUSTOMIZABLE_NAV_ITEMS].sort(
+    (a, b) =>
+      (position.get(a.id) ?? order.length) -
+      (position.get(b.id) ?? order.length),
+  );
+}
+
+export function moveNavItem(
+  order: readonly CustomizableNavItemId[],
+  sourceId: string,
+  targetId: string,
+): readonly CustomizableNavItemId[] {
+  const full = orderedNavItems(order).map((item) => item.id);
+  const ids: readonly string[] = full;
+  const from = ids.indexOf(sourceId);
+  const to = ids.indexOf(targetId);
+  if (from === -1 || to === -1 || from === to) return order;
+  const [moved] = full.splice(from, 1);
+  full.splice(to, 0, moved);
+  return full;
+}
+
+export function sanitizeNavItemOrder(value: unknown): CustomizableNavItemId[] {
+  if (!Array.isArray(value)) return [];
+  const order = new Set<CustomizableNavItemId>();
+  for (const entry of value) {
+    const id = CUSTOMIZABLE_NAV_ITEM_IDS.find((known) => known === entry);
+    if (id) order.add(id);
+  }
+  return [...order];
+}
+
 /** Keeps only known item ids with boolean values, so corrupt or stale
  * persisted state degrades to per-item defaults instead of crashing. */
 export function sanitizeNavItemOverrides(value: unknown): NavItemOverrides {

--- a/packages/ui/src/features/sidebar/sidebarStore.test.ts
+++ b/packages/ui/src/features/sidebar/sidebarStore.test.ts
@@ -4,7 +4,7 @@ import { useSidebarStore } from "./sidebarStore";
 
 describe("sidebarStore navItemOverrides", () => {
   beforeEach(() => {
-    useSidebarStore.setState({ navItemOverrides: {} });
+    useSidebarStore.setState({ navItemOverrides: {}, navItemOrder: [] });
   });
 
   it.each(
@@ -70,6 +70,38 @@ describe("sidebarStore navItemOverrides", () => {
     await useSidebarStore.persist.rehydrate();
 
     expect(useSidebarStore.getState().navItemOverrides).toEqual({});
+    localStorage.removeItem("sidebar-storage");
+  });
+
+  it("rehydration sanitizes navItemOrder to known unique ids", async () => {
+    localStorage.setItem(
+      "sidebar-storage",
+      JSON.stringify({
+        state: {
+          navItemOrder: ["loops", "retired-item", 7, "search", "loops"],
+        },
+        version: 0,
+      }),
+    );
+
+    await useSidebarStore.persist.rehydrate();
+
+    expect(useSidebarStore.getState().navItemOrder).toEqual([
+      "loops",
+      "search",
+    ]);
+    localStorage.removeItem("sidebar-storage");
+  });
+
+  it("rehydration falls back to default order when the persisted order is not an array", async () => {
+    localStorage.setItem(
+      "sidebar-storage",
+      JSON.stringify({ state: { navItemOrder: "corrupt" }, version: 0 }),
+    );
+
+    await useSidebarStore.persist.rehydrate();
+
+    expect(useSidebarStore.getState().navItemOrder).toEqual([]);
     localStorage.removeItem("sidebar-storage");
   });
 

--- a/packages/ui/src/features/sidebar/sidebarStore.ts
+++ b/packages/ui/src/features/sidebar/sidebarStore.ts
@@ -6,6 +6,7 @@ import {
   type CustomizableNavItemId,
   type NavItemOverrides,
   SIDEBAR_MIN_WIDTH,
+  sanitizeNavItemOrder,
   sanitizeNavItemOverrides,
 } from "./constants";
 
@@ -30,6 +31,9 @@ interface SidebarStoreState {
   // absent from the map follow their CUSTOMIZABLE_NAV_ITEMS defaultVisible, so newly
   // shipped moreable items keep their intended default for existing users.
   navItemOverrides: NavItemOverrides;
+  // Drag order from the Customize sidebar dialog. Empty means default order;
+  // ids absent from it (newly shipped items) render after the ordered ones.
+  navItemOrder: readonly CustomizableNavItemId[];
 }
 
 interface SidebarStoreActions {
@@ -51,6 +55,7 @@ interface SidebarStoreActions {
   toggleTaskType: (mode: WorkspaceMode) => void;
   setChannelsEnabled: (channelsEnabled: boolean) => void;
   setNavItemVisible: (item: CustomizableNavItemId, visible: boolean) => void;
+  setNavItemOrder: (order: readonly CustomizableNavItemId[]) => void;
 }
 
 type SidebarStore = SidebarStoreState & SidebarStoreActions;
@@ -72,6 +77,7 @@ export const useSidebarStore = create<SidebarStore>()(
       taskTypeFilter: [...ALL_WORKSPACE_MODES],
       channelsEnabled: false,
       navItemOverrides: {},
+      navItemOrder: [],
       setOpen: (open) => set({ open, hasUserSetOpen: true }),
       setOpenAuto: (open) =>
         set((state) => (state.hasUserSetOpen ? state : { open })),
@@ -133,6 +139,7 @@ export const useSidebarStore = create<SidebarStore>()(
         set((state) => ({
           navItemOverrides: { ...state.navItemOverrides, [item]: visible },
         })),
+      setNavItemOrder: (navItemOrder) => set({ navItemOrder }),
     }),
     {
       name: "sidebar-storage",
@@ -150,6 +157,7 @@ export const useSidebarStore = create<SidebarStore>()(
         taskTypeFilter: state.taskTypeFilter,
         channelsEnabled: state.channelsEnabled,
         navItemOverrides: state.navItemOverrides,
+        navItemOrder: state.navItemOrder,
       }),
       merge: (persisted, current) => {
         const persistedState = persisted as {
@@ -166,6 +174,7 @@ export const useSidebarStore = create<SidebarStore>()(
           taskTypeFilter?: WorkspaceMode[];
           channelsEnabled?: boolean;
           navItemOverrides?: unknown;
+          navItemOrder?: unknown;
         };
         return {
           ...current,
@@ -191,6 +200,7 @@ export const useSidebarStore = create<SidebarStore>()(
           navItemOverrides: sanitizeNavItemOverrides(
             persistedState.navItemOverrides,
           ),
+          navItemOrder: sanitizeNavItemOrder(persistedState.navItemOrder),
         };
       },
     },


### PR DESCRIPTION
## Problem

The customize sidebar dialog lets you show or hide nav items, but their order is fixed.

## Changes

Adds a drag handle to each row in the customize dialog. Dragging reorders the list live, persists the order and the sidebar nav renders in that order (hidden items keep it under More too). A canceled drag restores the order from dragstart. Reorders fire a new "Sidebar reordered" event. Stored order is sanitized on rehydrate and newly shipped items fall back to their default position.

## How did you test this?

Unit tests for the order helpers, store rehydration and the dialog drag handlers (116 sidebar tests pass), plus typecheck and Biome. Not exercised in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
