### PR TITLE
chore(ci): Mark PRs stale after 7 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Close Stale PRs
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 */12 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -17,12 +17,12 @@ jobs:
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
-          days-before-pr-stale: 30
+          days-before-pr-stale: 7
           days-before-pr-close: 7
           days-before-issue-stale: -1
           days-before-issue-close: -1
           stale-pr-label: stale
-          stale-pr-message: "This PR has had no activity for 30 days and has been marked stale. It will be closed in 7 days if no further activity occurs."
+          stale-pr-message: "This PR has had no activity for 7 days and has been marked stale. It will be closed in 7 days if no further activity occurs."
           close-pr-message: "Closing this PR due to inactivity. Feel free to reopen if you'd like to continue the work."
           exempt-pr-labels: "no stale,security"
           exempt-draft-pr: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ jobs:
           days-before-issue-stale: -1
           days-before-issue-close: -1
           stale-pr-label: stale
-          stale-pr-message: "This PR has had no activity for 7 days and has been marked stale. It will be closed in 7 days if no further activity occurs."
+          stale-pr-message: "This PR has had no activity for 7 days and has been marked stale. We are moving to the monorepo and tightening PR staleness in preparation, so it will be closed in 7 days if no further activity occurs."
           close-pr-message: "Closing this PR due to inactivity. Feel free to reopen if you'd like to continue the work."
           exempt-pr-labels: "no stale,security"
           exempt-draft-pr: false


### PR DESCRIPTION
## Problem

We are moving to the monorepo and want to tighten PR staleness in preparation, so open PRs don't carry over stale. The old policy let PRs sit 30 days before being marked stale.

## Changes

Marks PRs stale after 7 days of inactivity (was 30), keeps the 7 day close window after marking and runs the workflow every 12 hours instead of daily. Stale message updated to explain the monorepo move.

## How did you test this?

N/A, config-only change to the actions/stale schedule and thresholds.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?