### PR TITLE
fix(settings): Show available update in Updates panel

### DIFF
--- a/packages/core/src/settings/updateStatus.test.ts
+++ b/packages/core/src/settings/updateStatus.test.ts
@@ -45,6 +45,41 @@ describe("deriveUpdateStatus", () => {
     });
   });
 
+  it("reports an available update with a version", () => {
+    expect(
+      deriveUpdateStatus({
+        checking: false,
+        available: true,
+        availableVersion: "1.2.3",
+      }),
+    ).toEqual({
+      message: "Update 1.2.3 available",
+      type: "success",
+      checking: false,
+    });
+  });
+
+  it("reports an available update without a version", () => {
+    expect(deriveUpdateStatus({ checking: false, available: true })).toEqual({
+      message: "Update available",
+      type: "success",
+      checking: false,
+    });
+  });
+
+  it("reports a check error", () => {
+    expect(
+      deriveUpdateStatus({
+        checking: false,
+        error: "Update check timed out. Please try again.",
+      }),
+    ).toEqual({
+      message: "Update check timed out. Please try again.",
+      type: "error",
+      checking: false,
+    });
+  });
+
   it("clears checking when finished with no other signal", () => {
     expect(deriveUpdateStatus({ checking: false })).toEqual({
       checking: false,

--- a/packages/core/src/settings/updateStatus.ts
+++ b/packages/core/src/settings/updateStatus.ts
@@ -1,9 +1,12 @@
 export interface RawUpdateStatus {
   checking?: boolean;
   downloading?: boolean;
+  available?: boolean;
   upToDate?: boolean;
   updateReady?: boolean;
   version?: string;
+  availableVersion?: string;
+  error?: string;
 }
 
 export interface DerivedUpdateStatus {
@@ -33,6 +36,18 @@ export function deriveUpdateStatus(
       type: "success",
       checking: false,
     };
+  }
+  if (status.checking === false && status.available) {
+    return {
+      message: status.availableVersion
+        ? `Update ${status.availableVersion} available`
+        : "Update available",
+      type: "success",
+      checking: false,
+    };
+  }
+  if (status.checking === false && status.error) {
+    return { message: status.error, type: "error", checking: false };
   }
   if (status.checking === false) {
     return { checking: false };


### PR DESCRIPTION
## Problem

Clicking "Check now" in Settings > Updates while an update is available leaves the row stuck on "Checking for updates...", even though the rest of the app shows the update banner.

## Changes

When a check finds an update, the updates service emits a status with `checking: false, available: true`, but `deriveUpdateStatus` had no case for it, so the stale checking message was never replaced. Added an `available` case ("Update x.y.z available") and an `error` case so async check failures (e.g. timeouts) no longer leave the row stuck either.

## How did you test this?

Unit tests for the new cases (`vitest run src/settings/updateStatus.test.ts`, 14 passed), plus full `pnpm typecheck` and Biome lint.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?