### PR TITLE
fix(updates): Keep bundle identity as PostHog Code

### DIFF
--- a/apps/code/README.md
+++ b/apps/code/README.md
@@ -56,7 +56,7 @@ pnpm make
 
 Output will be in:
 
-- `out/mac-arm64/PostHog.app` - Packaged app
+- `out/mac-arm64/PostHog Code.app` - Packaged app
 - `out/PostHog-Code-*.dmg` - macOS installer
 - `out/make/zip/` - ZIP archives
 

--- a/apps/code/electron-builder.ts
+++ b/apps/code/electron-builder.ts
@@ -11,8 +11,11 @@ const skipNotarize =
 const config: Configuration = {
   // Original release bundle id; changing it breaks existing installs' data dir and Keychain entries.
   appId: "com.posthog.array",
-  productName: "PostHog",
-  executableName: "PostHog",
+  // Frozen like appId: Squirrel names the installed bundle after the update
+  // payload and relaunches the pre-update path, so renaming these strands
+  // every existing install (no relaunch, dead Dock pins) — see v0.58.0.
+  productName: "PostHog Code",
+  executableName: "PostHog Code",
 
   directories: {
     output: "out",

--- a/apps/code/scripts/dev-update/build-pair.sh
+++ b/apps/code/scripts/dev-update/build-pair.sh
@@ -30,4 +30,4 @@ pnpm exec electron-builder build --mac zip --arm64 --publish never \
   -c.extraMetadata.version="$OLD_VERSION" --config electron-builder.ts
 
 echo "==> feed=$FEED_DIR"
-echo "==> app=out/mac-arm64/PostHog.app ($OLD_VERSION)"
+echo "==> app=out/mac-arm64/PostHog Code.app ($OLD_VERSION)"

--- a/apps/code/scripts/dev-update/run-from-ci.sh
+++ b/apps/code/scripts/dev-update/run-from-ci.sh
@@ -57,7 +57,7 @@ FEED_YML="$(find "$TMP/new" -name latest-mac.yml | head -1)"
 echo "==> old 1.0.0 app -> out/mac-arm64"
 rm -rf out/mac-arm64 && mkdir -p out/mac-arm64
 ditto -x -k "$OLD_ZIP" out/mac-arm64
-xattr -dr com.apple.quarantine "out/mac-arm64/PostHog.app" 2>/dev/null || true
+xattr -dr com.apple.quarantine "out/mac-arm64/PostHog Code.app" 2>/dev/null || true
 
 echo "==> new 2.0.0 feed -> out/dev-update-feed"
 rm -rf out/dev-update-feed && mkdir -p out/dev-update-feed
@@ -81,6 +81,6 @@ echo "    It swaps and relaunches into 2.0.0. Quit the app (or Ctrl+C) to finish
 echo "    App output: $APP_LOG   update log: ~/.posthog-code/logs/main.log"
 echo
 POSTHOG_E2E_UPDATE_FEED="http://127.0.0.1:$PORT" \
-  "out/mac-arm64/PostHog.app/Contents/MacOS/PostHog" >"$APP_LOG" 2>&1 || true
+  "out/mac-arm64/PostHog Code.app/Contents/MacOS/PostHog Code" >"$APP_LOG" 2>&1 || true
 
 echo "==> app exited; cleaning up"

--- a/apps/code/tests/e2e/fixtures/electron.ts
+++ b/apps/code/tests/e2e/fixtures/electron.ts
@@ -15,9 +15,9 @@ function getAppPath(): string {
   if (process.platform === "darwin") {
     const arm64Path = path.join(
       outDir,
-      "mac-arm64/PostHog.app/Contents/MacOS/PostHog",
+      "mac-arm64/PostHog Code.app/Contents/MacOS/PostHog Code",
     );
-    const x64Path = path.join(outDir, "mac/PostHog.app/Contents/MacOS/PostHog");
+    const x64Path = path.join(outDir, "mac/PostHog Code.app/Contents/MacOS/PostHog Code");
 
     if (requestedArch === "arm64") {
       if (existsSync(arm64Path)) return arm64Path;

--- a/apps/code/tests/e2e/fixtures/update.ts
+++ b/apps/code/tests/e2e/fixtures/update.ts
@@ -11,11 +11,11 @@ import path from "node:path";
 
 const OUT_DIR = path.join(__dirname, "../../../out");
 
-export const PRISTINE_APP = path.join(OUT_DIR, "mac-arm64/PostHog.app");
+export const PRISTINE_APP = path.join(OUT_DIR, "mac-arm64/PostHog Code.app");
 export const FEED_DIR = path.join(OUT_DIR, "dev-update-feed");
 export const RUN_DIR = path.join(OUT_DIR, "e2e-update-run");
-export const RUN_APP = path.join(RUN_DIR, "PostHog.app");
-export const RUN_APP_BIN = path.join(RUN_APP, "Contents/MacOS/PostHog");
+export const RUN_APP = path.join(RUN_DIR, "PostHog Code.app");
+export const RUN_APP_BIN = path.join(RUN_APP, "Contents/MacOS/PostHog Code");
 
 // The "old" side of the Forge -> electron-builder test: a real Electron Forge
 // build (v0.55.132) produced by scripts/dev-update/build-old-forge.sh. It runs


### PR DESCRIPTION
## Problem

v0.58.0 shipped the #3557 rename with `productName`/`executableName` changed to "PostHog". Squirrel.Mac names the installed bundle after the update payload and relaunches the pre-update bundle path, so every install that auto-updates gets moved to `/Applications/PostHog.app`, fails to relaunch, and leaves the old Dock pin pointing at a dead path.

## Changes

Minimal revert of the two identity fields to "PostHog Code", frozen with a comment the same way `appId` is, plus the handful of harness/docs paths that reference the built bundle. Display strings from #3557 are untouched. The next release's payload is named `PostHog Code.app` again, so v0.57.x installs update cleanly; the v0.58.0 cohort gets renamed back on their next update (one manual relaunch, same as they already hit).

Follow-ups deliberately NOT in this PR: v0.58.0 should be pulled from the update feeds so v0.57.x stragglers stop updating into the broken state, and a proper display-only rename (CFBundleDisplayName) plus Dock-pin repair can come separately.

## How did you test this?

- `tsc --noEmit` and Biome clean on the touched files.
- Not yet exercised: a packaged build + the update e2e against this branch; update e2e baseline run against renamed main is in flight (run 29901251314) to confirm the failure mode this reverts.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
