### PR TITLE
Fix Home "Running" strip cards clipped on hover

### DIFF
--- a/packages/ui/src/features/home/components/HomeActiveAgentsStrip.tsx
+++ b/packages/ui/src/features/home/components/HomeActiveAgentsStrip.tsx
@@ -30,7 +30,7 @@ export function HomeActiveAgentsStrip({ agents }: HomeActiveAgentsStripProps) {
         </Text>
       </Flex>
       <ScrollArea scrollbars="horizontal">
-        <Flex gap="2" className="pb-1">
+        <Flex gap="2" className="pt-1 pb-1">
           {agents.map((agent) => {
             const task = taskById.get(agent.taskId);
             const dotColor = agent.needsPermission


### PR DESCRIPTION
## Problem

<!-- Who is this for and what problem does it solve? -->

**Why:** A task card in the Home **"Running"** agents strip was visibly clipped — the top of the card (and its title text) got cut off on hover.

The cards lift up on hover (`hover:-translate-y-px` + `hover:shadow-sm`) as an affordance, but they sat flush against the top of the horizontal `ScrollArea`, which clips vertical overflow. So the moment a card lifted, its top edge and title were cropped.

## Changes

<!-- What did you change and why? -->

Add top padding (`pt-1`) to the strip's scroll content in `HomeActiveAgentsStrip.tsx` so the lifted card and its shadow stay inside the `ScrollArea`'s clip box. One-line className change; the hover animation is preserved.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` — passes.
- `biome check` on the changed file — clean.

_Visual QA in the running app (hover a running card, confirm the top is no longer clipped) still recommended before merge._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
