### PR TITLE
feat(mobile): show warehouse-backed sources in inbox Source filter (port #3597)

### DIFF
--- a/apps/mobile/src/features/inbox/components/FilterSheet.test.ts
+++ b/apps/mobile/src/features/inbox/components/FilterSheet.test.ts
@@ -1,0 +1,18 @@
+import { EXTERNAL_INBOX_SOURCES } from "@posthog/shared";
+import { describe, expect, it } from "vitest";
+import { SOURCE_PRODUCT_OPTIONS } from "./FilterSheet";
+
+describe("SOURCE_PRODUCT_OPTIONS", () => {
+  it("includes every warehouse-backed source from the shared registry", () => {
+    const values = new Set(SOURCE_PRODUCT_OPTIONS.map((o) => o.value));
+    for (const source of EXTERNAL_INBOX_SOURCES) {
+      expect(values.has(source.product)).toBe(true);
+    }
+  });
+
+  it("keeps the native products", () => {
+    const values = SOURCE_PRODUCT_OPTIONS.map((o) => o.value);
+    expect(values).toContain("session_replay");
+    expect(values).toContain("signals_scout");
+  });
+});

--- a/apps/mobile/src/features/inbox/components/FilterSheet.tsx
+++ b/apps/mobile/src/features/inbox/components/FilterSheet.tsx
@@ -1,4 +1,5 @@
 import { Text } from "@components/text";
+import { EXTERNAL_INBOX_SOURCES } from "@posthog/shared";
 import { Check } from "phosphor-react-native";
 import { Modal, Pressable, ScrollView, View } from "react-native";
 import { useScreenInsets } from "@/hooks/useScreenInsets";
@@ -68,17 +69,19 @@ function usePriorityDotColors(): Record<SignalReportPriority, string> {
   };
 }
 
-const SOURCE_PRODUCT_OPTIONS: { value: SourceProduct; label: string }[] = [
-  { value: "session_replay", label: "Session replay" },
-  { value: "error_tracking", label: "Error tracking" },
-  { value: "llm_analytics", label: "AI observability" },
-  { value: "github", label: "GitHub" },
-  { value: "linear", label: "Linear" },
-  { value: "zendesk", label: "Zendesk" },
-  { value: "conversations", label: "Conversations" },
-  { value: "signals_scout", label: "Scout" },
-  { value: "health_checks", label: "Health checks" },
-];
+export const SOURCE_PRODUCT_OPTIONS: { value: SourceProduct; label: string }[] =
+  [
+    { value: "session_replay", label: "Session replay" },
+    { value: "error_tracking", label: "Error tracking" },
+    { value: "llm_analytics", label: "AI observability" },
+    { value: "conversations", label: "Conversations" },
+    { value: "signals_scout", label: "Scout" },
+    { value: "health_checks", label: "Health checks" },
+    ...EXTERNAL_INBOX_SOURCES.map((source) => ({
+      value: source.product,
+      label: source.label,
+    })),
+  ];
 
 function SectionHeader({ title }: { title: string }) {
   return (

--- a/apps/mobile/src/features/inbox/components/SignalCard.tsx
+++ b/apps/mobile/src/features/inbox/components/SignalCard.tsx
@@ -1,5 +1,9 @@
 import { Text } from "@components/text";
 import {
+  EXTERNAL_INBOX_SOURCE_BY_PRODUCT,
+  type SourceProduct,
+} from "@posthog/shared";
+import {
   ArrowSquareOut,
   Bug,
   CaretDown,
@@ -11,6 +15,7 @@ import {
   FirstAid,
   GithubLogo,
   LinkSimple,
+  Plug,
   Question,
   Robot,
   WarningCircle,
@@ -22,44 +27,9 @@ import { formatRelativeTime } from "@/lib/format";
 import { openExternalUrl } from "@/lib/openExternalUrl";
 import { useThemeColors } from "@/lib/theme";
 import type { Signal, SignalFindingContent } from "../types";
+import { sourceLine } from "../utils";
 
 const COLLAPSE_THRESHOLD = 280;
-
-const ERROR_TRACKING_TYPE_LABELS: Record<string, string> = {
-  issue_created: "New issue",
-  issue_reopened: "Issue reopened",
-  issue_spiking: "Volume spike",
-};
-
-function sourceLine(signal: Signal): string {
-  const { source_product, source_type } = signal;
-  if (source_product === "error_tracking") {
-    const label =
-      ERROR_TRACKING_TYPE_LABELS[source_type] ?? source_type.replace(/_/g, " ");
-    return `Error tracking · ${label}`;
-  }
-  if (source_product === "session_replay" && source_type === "session_problem")
-    return "Session replay · Session problem";
-  if (source_product === "llm_analytics" && source_type === "evaluation")
-    return "AI observability · Evaluation";
-  if (source_product === "zendesk" && source_type === "ticket")
-    return "Zendesk · Ticket";
-  if (source_product === "github" && source_type === "issue")
-    return "GitHub · Issue";
-  if (source_product === "linear" && source_type === "issue")
-    return "Linear · Issue";
-  if (
-    source_product === "signals_scout" &&
-    source_type === "cross_source_issue"
-  )
-    return "Scout · Cross-source issue";
-  if (source_product === "signals_scout") return "Scout";
-  if (source_product === "health_checks" && source_type === "health_issue")
-    return "Health checks · Issue";
-  const product = source_product.replace(/_/g, " ");
-  const type = source_type.replace(/_/g, " ");
-  return `${product} · ${type}`;
-}
 
 function SourceIcon({
   product,
@@ -88,6 +58,8 @@ function SourceIcon({
     case "health_checks":
       return <FirstAid size={size} color={color} />;
     default:
+      if (EXTERNAL_INBOX_SOURCE_BY_PRODUCT[product as SourceProduct])
+        return <Plug size={size} color={color} />;
       return <WarningCircle size={size} color={color} />;
   }
 }

--- a/apps/mobile/src/features/inbox/stores/inboxFilterStore.test.ts
+++ b/apps/mobile/src/features/inbox/stores/inboxFilterStore.test.ts
@@ -15,7 +15,7 @@ describe("inboxFilterStore", () => {
     useInboxFilterStore.getState().resetFilters();
   });
 
-  it.each<SourceProduct>(["signals_scout", "error_tracking", "github"])(
+  it.each<SourceProduct>(["signals_scout", "error_tracking", "sentry"])(
     "toggles %s in and out of the source filter",
     (source) => {
       const { toggleSourceProduct } = useInboxFilterStore.getState();

--- a/apps/mobile/src/features/inbox/stores/inboxFilterStore.ts
+++ b/apps/mobile/src/features/inbox/stores/inboxFilterStore.ts
@@ -1,3 +1,4 @@
+import type { SourceProduct } from "@posthog/shared";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
@@ -14,16 +15,7 @@ type SortField = Extract<
 
 type SortDirection = "asc" | "desc";
 
-export type SourceProduct =
-  | "conversations"
-  | "error_tracking"
-  | "github"
-  | "health_checks"
-  | "linear"
-  | "llm_analytics"
-  | "session_replay"
-  | "signals_scout"
-  | "zendesk";
+export type { SourceProduct };
 
 export const DEFAULT_STATUS_FILTER: SignalReportStatus[] = [
   "ready",

--- a/apps/mobile/src/features/inbox/utils.test.ts
+++ b/apps/mobile/src/features/inbox/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type {
   AvailableSuggestedReviewer,
+  Signal,
   SignalReport,
   SignalReportOrderingField,
   SignalReportStatus,
@@ -17,8 +18,22 @@ import {
   isRestorableReport,
   orderSuggestedReviewers,
   reviewerMatchesAvailable,
+  sourceLine,
   toSuggestedReviewerWriteContent,
 } from "./utils";
+
+function signal(source_product: string, source_type: string): Signal {
+  return {
+    signal_id: "s1",
+    content: "",
+    source_product,
+    source_type,
+    source_id: "id",
+    weight: 1,
+    timestamp: "",
+    extra: {},
+  };
+}
 
 function reviewer(login: string, uuid?: string): SuggestedReviewer {
   return {
@@ -435,6 +450,24 @@ describe("dismissalReasonLabel", () => {
     { value: "totally_unknown_code", expected: "totally_unknown_code" },
   ])("maps $value", ({ value, expected }) => {
     expect(dismissalReasonLabel(value)).toBe(expected);
+  });
+});
+
+describe("sourceLine", () => {
+  it.each([
+    {
+      product: "error_tracking",
+      type: "issue_created",
+      expected: "Error tracking · New issue",
+    },
+    { product: "sentry", type: "issue", expected: "Sentry · issue" },
+    {
+      product: "mystery_source",
+      type: "thing",
+      expected: "mystery source · thing",
+    },
+  ])("labels $product", ({ product, type, expected }) => {
+    expect(sourceLine(signal(product, type))).toBe(expected);
   });
 });
 

--- a/apps/mobile/src/features/inbox/utils.ts
+++ b/apps/mobile/src/features/inbox/utils.ts
@@ -1,8 +1,13 @@
+import {
+  EXTERNAL_INBOX_SOURCE_BY_PRODUCT,
+  type SourceProduct,
+} from "@posthog/shared";
 import { differenceInHours, format, formatDistanceToNow } from "date-fns";
 import type { InboxViewedProperties } from "@/lib/analytics";
 import { DISMISSAL_REASON_OPTIONS } from "./constants";
 import type {
   AvailableSuggestedReviewer,
+  Signal,
   SignalReport,
   SignalReportOrderingField,
   SignalReportPriority,
@@ -10,6 +15,44 @@ import type {
   SuggestedReviewer,
   SuggestedReviewerWriteEntry,
 } from "./types";
+
+const ERROR_TRACKING_TYPE_LABELS: Record<string, string> = {
+  issue_created: "New issue",
+  issue_reopened: "Issue reopened",
+  issue_spiking: "Volume spike",
+};
+
+export function sourceLine(signal: Signal): string {
+  const { source_product, source_type } = signal;
+  if (source_product === "error_tracking") {
+    const label =
+      ERROR_TRACKING_TYPE_LABELS[source_type] ?? source_type.replace(/_/g, " ");
+    return `Error tracking · ${label}`;
+  }
+  if (source_product === "session_replay" && source_type === "session_problem")
+    return "Session replay · Session problem";
+  if (source_product === "llm_analytics" && source_type === "evaluation")
+    return "AI observability · Evaluation";
+  if (source_product === "zendesk" && source_type === "ticket")
+    return "Zendesk · Ticket";
+  if (source_product === "github" && source_type === "issue")
+    return "GitHub · Issue";
+  if (source_product === "linear" && source_type === "issue")
+    return "Linear · Issue";
+  if (
+    source_product === "signals_scout" &&
+    source_type === "cross_source_issue"
+  )
+    return "Scout · Cross-source issue";
+  if (source_product === "signals_scout") return "Scout";
+  if (source_product === "health_checks" && source_type === "health_issue")
+    return "Health checks · Issue";
+  const warehouseSource =
+    EXTERNAL_INBOX_SOURCE_BY_PRODUCT[source_product as SourceProduct];
+  const product = warehouseSource?.label ?? source_product.replace(/_/g, " ");
+  const type = source_type.replace(/_/g, " ");
+  return `${product} · ${type}`;
+}
 
 const SIGNAL_SUMMARY_SECTION_HEADERS = [
   "What's happening",


### PR DESCRIPTION
## Problem

Desktop PR #3597 expanded the self-driving inbox to recognize ~30 warehouse-backed signal sources (Sentry, Zendesk, Postgres, Hubspot, etc.) on top of the PostHog-native products. The **mobile** app was never updated: its inbox Source filter and signal cards only handled the ~9 native products, so signals originating from warehouse sources could not be filtered by source and rendered with a crude fallback label and no proper icon.

**Why:** bring the mobile inbox viewing/filtering surface to parity with desktop so warehouse-backed signals are filterable and correctly labelled/iconed.

## Changes

Mobile-only (`apps/mobile`); no desktop or shared-package changes.

- `FilterSheet.tsx` — the Source filter's warehouse entries are now derived from the shared `EXTERNAL_INBOX_SOURCES` registry (native products first, then the registry spread), mirroring desktop's `INBOX_SOURCE_OPTIONS`, instead of a hardcoded native-only list.
- `SignalCard.tsx` — warehouse sources get a sensible label from the shared registry and fall back to a generic `Plug` icon (mobile has no per-source icon assets; matches desktop's `PlugIcon` fallback). The pure `sourceLine` helper moved into the inbox `utils.ts`.
- `inboxFilterStore.ts` — re-exports the shared `SourceProduct` union instead of a local hardcoded copy, so the wider set typechecks.

This ports only the inbox viewing/filtering surface. The desktop "self-driving sources" setup/config modal is intentionally **not** ported — mobile has no source-connection flow.

## How did you test this?

- `pnpm --filter mobile test` — 458 passing, including new unit tests for the widened source filter (`inboxFilterStore.test.ts`), the derived options list (`FilterSheet.test.ts`), and the `sourceLine` label helper incl. warehouse + unknown fallbacks (`utils.test.ts`).
- `tsc --noEmit` on `apps/mobile` — no errors in the changed files.
- `biome check` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
