### PR TITLE
Show stopped cloud tasks as completed

### DIFF
--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -72,7 +72,18 @@ function IconSpan({
   ariaLabel?: string;
 }) {
   if (!link) {
-    return <span className="flex items-center justify-center">{icon}</span>;
+    if (!ariaLabel) {
+      return <span className="flex items-center justify-center">{icon}</span>;
+    }
+    return (
+      <span
+        aria-label={ariaLabel}
+        className="flex items-center justify-center"
+        role="img"
+      >
+        {icon}
+      </span>
+    );
   }
   return (
     <NestedButton
@@ -163,7 +174,11 @@ function CloudStatusIcon({
         <IconSpan
           icon={<Icon size={size} weight="fill" color="var(--green-11)" />}
           link={link}
-          ariaLabel={ariaLabel}
+          ariaLabel={
+            link
+              ? `Open ${sourceLabel} thread (stopped)`
+              : `${sourceLabel} (stopped)`
+          }
         />
       </Tooltip>
     );

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -152,14 +152,28 @@ function CloudStatusIcon({
       </Tooltip>
     );
   }
-  if (taskRunStatus === "failed" || taskRunStatus === "cancelled") {
-    const statusLabel =
-      taskRunStatus === "cancelled"
-        ? `${sourceLabel} (cancelled)`
-        : `${sourceLabel} (failed)`;
+  if (taskRunStatus === "cancelled") {
     return (
       <Tooltip
-        content={link ? `Open ${sourceLabel} thread` : statusLabel}
+        content={
+          link ? `Open ${sourceLabel} thread` : `${sourceLabel} (stopped)`
+        }
+        side="right"
+      >
+        {renderIconSpan({
+          icon: <Icon size={size} color="var(--gray-9)" />,
+          link,
+          ariaLabel,
+        })}
+      </Tooltip>
+    );
+  }
+  if (taskRunStatus === "failed") {
+    return (
+      <Tooltip
+        content={
+          link ? `Open ${sourceLabel} thread` : `${sourceLabel} (failed)`
+        }
         side="right"
       >
         {renderIconSpan({

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -161,7 +161,7 @@ function CloudStatusIcon({
         side="right"
       >
         {renderIconSpan({
-          icon: <Icon size={size} color="var(--gray-9)" />,
+          icon: <Icon size={size} weight="fill" color="var(--green-11)" />,
           link,
           ariaLabel,
         })}

--- a/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -62,7 +62,7 @@ export function getOriginProductMeta(
 // clickable NestedButton that opens the originating thread externally.
 // SidebarItem renders the row as a `<button>`, so a real `<a>` or a nested
 // `<button>` here would be invalid HTML.
-function renderIconSpan({
+function IconSpan({
   icon,
   link,
   ariaLabel,
@@ -112,11 +112,11 @@ function CloudStatusIcon({
         }
         side="right"
       >
-        {renderIconSpan({
-          icon: <Icon size={size} className="ph-pulse" />,
-          link,
-          ariaLabel,
-        })}
+        <IconSpan
+          icon={<Icon size={size} className="ph-pulse" />}
+          link={link}
+          ariaLabel={ariaLabel}
+        />
       </Tooltip>
     );
   }
@@ -128,11 +128,11 @@ function CloudStatusIcon({
         }
         side="right"
       >
-        {renderIconSpan({
-          icon: <Icon size={size} weight="fill" color="var(--accent-11)" />,
-          link,
-          ariaLabel,
-        })}
+        <IconSpan
+          icon={<Icon size={size} weight="fill" color="var(--accent-11)" />}
+          link={link}
+          ariaLabel={ariaLabel}
+        />
       </Tooltip>
     );
   }
@@ -144,11 +144,11 @@ function CloudStatusIcon({
         }
         side="right"
       >
-        {renderIconSpan({
-          icon: <Icon size={size} weight="fill" color="var(--green-11)" />,
-          link,
-          ariaLabel,
-        })}
+        <IconSpan
+          icon={<Icon size={size} weight="fill" color="var(--green-11)" />}
+          link={link}
+          ariaLabel={ariaLabel}
+        />
       </Tooltip>
     );
   }
@@ -160,11 +160,11 @@ function CloudStatusIcon({
         }
         side="right"
       >
-        {renderIconSpan({
-          icon: <Icon size={size} weight="fill" color="var(--green-11)" />,
-          link,
-          ariaLabel,
-        })}
+        <IconSpan
+          icon={<Icon size={size} weight="fill" color="var(--green-11)" />}
+          link={link}
+          ariaLabel={ariaLabel}
+        />
       </Tooltip>
     );
   }
@@ -176,11 +176,11 @@ function CloudStatusIcon({
         }
         side="right"
       >
-        {renderIconSpan({
-          icon: <Icon size={size} weight="fill" color="var(--red-11)" />,
-          link,
-          ariaLabel,
-        })}
+        <IconSpan
+          icon={<Icon size={size} weight="fill" color="var(--red-11)" />}
+          link={link}
+          ariaLabel={ariaLabel}
+        />
       </Tooltip>
     );
   }
@@ -189,11 +189,7 @@ function CloudStatusIcon({
       content={link ? `Open ${sourceLabel} thread` : sourceLabel}
       side="right"
     >
-      {renderIconSpan({
-        icon: <Icon size={size} />,
-        link,
-        ariaLabel,
-      })}
+      <IconSpan icon={<Icon size={size} />} link={link} ariaLabel={ariaLabel} />
     </Tooltip>
   );
 }
@@ -365,11 +361,11 @@ export function TaskIcon({
         content={link ? `Open ${label} thread` : `From ${label}`}
         side="right"
       >
-        {renderIconSpan({
-          icon: <Icon size={size} color="var(--gray-10)" />,
-          link,
-          ariaLabel: `Open ${label} thread`,
-        })}
+        <IconSpan
+          icon={<Icon size={size} color="var(--gray-10)" />}
+          link={link}
+          ariaLabel={`Open ${label} thread`}
+        />
       </Tooltip>
     );
   }


### PR DESCRIPTION
## Problem

Stopping a cloud task is an intentional user action, but the sidebar currently presents it with the same red treatment as a failed run.

**Why:** Stopped tasks should read as successfully finished rather than errors that need attention.

## Changes

Render cancelled cloud runs with the same filled green cloud as completed runs, labelled “stopped”, while preserving the red treatment for genuine failures