### PR TITLE
feat(loops): add a default trigger to new loops

### DIFF
--- a/packages/ui/src/features/loops/components/LoopTriggerEditor.tsx
+++ b/packages/ui/src/features/loops/components/LoopTriggerEditor.tsx
@@ -18,12 +18,12 @@ import {
   type RecurringFrequency,
 } from "../loopCron";
 import {
+  defaultLoopScheduleTrigger,
   emptyLoopApiTriggerConfig,
   emptyLoopGithubTriggerConfig,
   emptyLoopScheduleTriggerConfig,
   isTriggerDraftValid,
   type LoopTriggerDraft,
-  nextDraftTriggerKey,
 } from "../loopFormTypes";
 import { LoopRepositoryPicker } from "./LoopRepositoryPicker";
 
@@ -97,15 +97,7 @@ export function LoopTriggerEditor({
   };
 
   const addTrigger = () => {
-    onChange([
-      ...triggers,
-      {
-        key: nextDraftTriggerKey(),
-        type: "schedule",
-        enabled: true,
-        config: emptyLoopScheduleTriggerConfig(),
-      },
-    ]);
+    onChange([...triggers, defaultLoopScheduleTrigger()]);
   };
 
   return (

--- a/packages/ui/src/features/loops/loopFormTypes.test.ts
+++ b/packages/ui/src/features/loops/loopFormTypes.test.ts
@@ -129,13 +129,13 @@ describe("isLoopFormValid", () => {
 });
 
 describe("emptyLoopFormValues", () => {
-  it("starts new loops with an enabled daily schedule trigger", () => {
+  it("starts new loops with an enabled weekly schedule trigger", () => {
     expect(emptyLoopFormValues().triggers).toEqual([
       {
         key: expect.any(String),
         type: "schedule",
         enabled: true,
-        config: { cron_expression: "0 9 * * *", timezone: "UTC" },
+        config: { cron_expression: "0 9 * * 1", timezone: "UTC" },
       },
     ]);
   });

--- a/packages/ui/src/features/loops/loopFormTypes.test.ts
+++ b/packages/ui/src/features/loops/loopFormTypes.test.ts
@@ -98,7 +98,7 @@ describe("isTriggerDraftValid", () => {
 
 describe("isLoopFormValid", () => {
   it("accepts a named form with instructions and no triggers", () => {
-    expect(isLoopFormValid(validFormValues())).toBe(true);
+    expect(isLoopFormValid({ ...validFormValues(), triggers: [] })).toBe(true);
   });
 
   it.each([
@@ -125,6 +125,19 @@ describe("isLoopFormValid", () => {
     },
   ])("rejects $name", ({ patch }) => {
     expect(isLoopFormValid({ ...validFormValues(), ...patch })).toBe(false);
+  });
+});
+
+describe("emptyLoopFormValues", () => {
+  it("starts new loops with an enabled daily schedule trigger", () => {
+    expect(emptyLoopFormValues().triggers).toEqual([
+      {
+        key: expect.any(String),
+        type: "schedule",
+        enabled: true,
+        config: { cron_expression: "0 9 * * *", timezone: "UTC" },
+      },
+    ]);
   });
 });
 

--- a/packages/ui/src/features/loops/loopFormTypes.ts
+++ b/packages/ui/src/features/loops/loopFormTypes.ts
@@ -45,7 +45,7 @@ export interface LoopFormValues {
 }
 
 export function emptyLoopScheduleTriggerConfig(): LoopSchemas.LoopScheduleTriggerConfig {
-  return { cron_expression: "0 9 * * *", timezone: "UTC" };
+  return { cron_expression: "0 9 * * 1", timezone: "UTC" };
 }
 
 export function emptyLoopGithubTriggerConfig(): LoopSchemas.LoopGithubTriggerConfig {

--- a/packages/ui/src/features/loops/loopFormTypes.ts
+++ b/packages/ui/src/features/loops/loopFormTypes.ts
@@ -98,6 +98,15 @@ export function nextDraftTriggerKey(): string {
   return `draft-trigger-${draftKeySeq}`;
 }
 
+export function defaultLoopScheduleTrigger(): LoopTriggerDraft {
+  return {
+    key: nextDraftTriggerKey(),
+    type: "schedule",
+    enabled: true,
+    config: emptyLoopScheduleTriggerConfig(),
+  };
+}
+
 export function emptyLoopFormValues(): LoopFormValues {
   return {
     name: "",
@@ -108,7 +117,7 @@ export function emptyLoopFormValues(): LoopFormValues {
     model: "",
     reasoningEffort: null,
     repositories: [],
-    triggers: [],
+    triggers: [defaultLoopScheduleTrigger()],
     behaviors: defaultLoopBehaviors(),
     notifications: defaultLoopNotifications(),
     contextTarget: null,


### PR DESCRIPTION
## Problem

New loop forms start without a trigger, requiring an extra click before configuring when the loop runs.

## Changes

- Start new loop drafts with an enabled weekly schedule trigger
- Reuse the same trigger factory for additional schedule triggers
- Preserve manual-only loops when the default is removed

## How did you test this?

- `pnpm --filter @posthog/ui exec vitest run src/features/loops/loopFormTypes.test.ts`
- `pnpm exec biome check packages/ui/src/features/loops/loopFormTypes.ts packages/ui/src/features/loops/loopFormTypes.test.ts packages/ui/src/features/loops/components/LoopTriggerEditor.tsx`
- `pnpm --filter @posthog/ui typecheck`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*