### PR TITLE
fix(shortcuts): bind Steer/Queue toggle to Ctrl+S instead of Cmd+S

### DIFF
--- a/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -32,7 +32,7 @@ export const SHORTCUTS = {
   MESSAGE_JUMP: "mod+j",
   BLUR: "escape",
   SUBMIT_BLUR: "mod+enter",
-  SWITCH_MESSAGING_MODE: "mod+s",
+  SWITCH_MESSAGING_MODE: "ctrl+s",
   RELOAD_WINDOW: "mod+shift+r",
   ZOOM_IN: "mod+=",
   ZOOM_OUT: "mod+-",


### PR DESCRIPTION
## Problem

The Steer/Queue messaging-mode toggle was bound to `Cmd+S` on macOS (via `"mod+s"`), which conflicts with the platform's save convention and is inconsistent across platforms. The toggle should use the literal Control key on all platforms.

## Changes

- Bind `SWITCH_MESSAGING_MODE` to `ctrl+s` instead of `mod+s` in `packages/ui/src/features/command/keyboard-shortcuts.ts`, so the toggle listens for Control/Ctrl+S everywhere instead of Cmd+S on macOS. The hotkey hint in the Steer/Queue tooltip updates automatically via `formatHotkey`.
