### PR TITLE
chore(deps): bump @posthog/hedgehog-mode to 0.0.53

### DIFF
--- a/apps/code/package.json
+++ b/apps/code/package.json
@@ -109,7 +109,7 @@
     "@posthog/electron-trpc": "workspace:*",
     "@posthog/enricher": "workspace:*",
     "@posthog/git": "workspace:*",
-    "@posthog/hedgehog-mode": "^0.0.48",
+    "@posthog/hedgehog-mode": "^0.0.53",
     "@posthog/host-router": "workspace:*",
     "@posthog/host-trpc": "workspace:*",
     "@posthog/platform": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/git
       '@posthog/hedgehog-mode':
-        specifier: ^0.0.48
-        version: 0.0.48(prop-types@15.8.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.0.53
+        version: 0.0.53(prop-types@15.8.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@posthog/host-router':
         specifier: workspace:*
         version: link:../../packages/host-router
@@ -5680,8 +5680,8 @@ packages:
   '@posthog/core@1.32.5':
     resolution: {integrity: sha512-Vmr6LZms7QEP1ljfTRRBVtLkeEHMrTmLECt0FXPLwUIgPwxOgvBdAYwRMWyP13WuN/XQweo1tJ9J1DxHNAF3qg==}
 
-  '@posthog/hedgehog-mode@0.0.48':
-    resolution: {integrity: sha512-CswMCbELF5De2gFDD7tyEsNiQhEivb3Mhq12RgcjAQxm1/VPD4lx2kDlpVpRv5qOJVgDVYGUFrgMWlnytNLagg==}
+  '@posthog/hedgehog-mode@0.0.53':
+    resolution: {integrity: sha512-Qyd9DckDg1Z/vT3mpKyuMemJHWpYD0k0Gob7hWCNMCDSYm/NcpDS1uX8PRoh3Z7HF2kBkZ7j6HCSUIG7Ha/j4Q==}
     engines: {node: '>=18'}
     peerDependencies:
       react: 19.2.6
@@ -20028,7 +20028,7 @@ snapshots:
     dependencies:
       '@posthog/types': 1.386.4
 
-  '@posthog/hedgehog-mode@0.0.48(prop-types@15.8.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@posthog/hedgehog-mode@0.0.53(prop-types@15.8.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       gsap: 3.14.2
       lodash: 4.17.23


### PR DESCRIPTION
## Problem

<!-- Who is this for and what problem does it solve? -->

The desktop app (`apps/code`) was pinned to `@posthog/hedgehog-mode` `^0.0.48`, five releases behind the latest published version.

## Changes

<!-- What did you change and why? -->

Bumps `@posthog/hedgehog-mode` from `0.0.48` to `0.0.53` (latest) in `apps/code`. The declared dependency ranges are identical between the two versions, so the only lockfile changes are the resolved version and its integrity hash — no transitive dependencies move.

## How did you test this?

<!-- Describe what you tested -- manual steps, automated tests, or both. -->

- Verified `0.0.53` is the latest published version on npm.
- Confirmed dependency/peer-dependency ranges are unchanged from `0.0.48`, so the lockfile edit is minimal and surgical (no unrelated churn).
- Ran `pnpm install --frozen-lockfile`, which passed its consistency gate confirming `pnpm-lock.yaml` matches `package.json`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*