### PR TITLE
fix: hide loop builder instructions from chat

### DIFF
--- a/packages/ui/src/features/loops/hooks/useLoopBuilderTask.ts
+++ b/packages/ui/src/features/loops/hooks/useLoopBuilderTask.ts
@@ -4,7 +4,7 @@ import {
   useInboxCloudTaskRunner,
 } from "@posthog/ui/features/inbox/hooks/useInboxCloudTaskRunner";
 import { useCallback, useMemo, useRef } from "react";
-import { buildLoopBuilderPrompt } from "../loopBuilderPrompt";
+import { buildLoopBuilderSystemInstructions } from "../loopBuilderPrompt";
 
 interface UseLoopBuilderTaskReturn {
   /** Start an auto-mode cloud session that builds a loop from `instructions` and navigate to it. */
@@ -30,13 +30,15 @@ export function useLoopBuilderTask(context?: {
 
   const buildInput = useCallback(
     (ctx: InboxCloudTaskInputContext): TaskCreationInput => {
-      const prompt = buildLoopBuilderPrompt({
-        instructions: instructionsRef.current,
+      const userPrompt = instructionsRef.current.trim();
+      const systemInstructions = buildLoopBuilderSystemInstructions({
+        hasSeed: !!userPrompt,
         context: contextRef.current,
       });
       return {
-        content: prompt,
-        taskDescription: prompt,
+        content: userPrompt,
+        taskDescription: userPrompt,
+        customInstructions: systemInstructions,
         // Building a loop is pure PostHog-MCP work (loops-list, integrations-list,
         // loops-create); it never touches a working tree. Run repo-less so the
         // sandbox skips the clone and isn't tied to some arbitrary default repo.

--- a/packages/ui/src/features/loops/hooks/useLoopBuilderTask.ts
+++ b/packages/ui/src/features/loops/hooks/useLoopBuilderTask.ts
@@ -31,13 +31,16 @@ export function useLoopBuilderTask(context?: {
   const buildInput = useCallback(
     (ctx: InboxCloudTaskInputContext): TaskCreationInput => {
       const userPrompt = instructionsRef.current.trim();
+      const hasSeed = !!userPrompt;
       const systemInstructions = buildLoopBuilderSystemInstructions({
-        hasSeed: !!userPrompt,
+        hasSeed,
         context: contextRef.current,
       });
+      // createTask rejects empty content and the saga drops customInstructions without message text
+      const taskContent = hasSeed ? userPrompt : "Build a loop";
       return {
-        content: userPrompt,
-        taskDescription: userPrompt,
+        content: taskContent,
+        taskDescription: taskContent,
         customInstructions: systemInstructions,
         // Building a loop is pure PostHog-MCP work (loops-list, integrations-list,
         // loops-create); it never touches a working tree. Run repo-less so the

--- a/packages/ui/src/features/loops/loopBuilderPrompt.test.ts
+++ b/packages/ui/src/features/loops/loopBuilderPrompt.test.ts
@@ -1,15 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { buildLoopBuilderPrompt } from "./loopBuilderPrompt";
+import {
+  buildLoopBuilderPrompt,
+  buildLoopBuilderSystemInstructions,
+} from "./loopBuilderPrompt";
 
 describe("buildLoopBuilderPrompt", () => {
   it("embeds the seed instructions when provided", () => {
     const prompt = buildLoopBuilderPrompt({
       instructions: "Summarize failing CI runs",
     });
+    expect(prompt).toContain("Summarize failing CI runs");
     expect(prompt).toContain(
-      "Here's what I want automated:\n\nSummarize failing CI runs",
+      "The user's message describes what they want automated.",
     );
     expect(prompt).not.toContain("Start by asking me");
+  });
+
+  it("keeps the user prompt out of system instructions", () => {
+    const instructions = buildLoopBuilderSystemInstructions({
+      hasSeed: true,
+    });
+
+    expect(instructions).toContain(
+      "The user's message describes what they want automated.",
+    );
+    expect(instructions).not.toContain("Summarize failing CI runs");
   });
 
   it.each([

--- a/packages/ui/src/features/loops/loopBuilderPrompt.ts
+++ b/packages/ui/src/features/loops/loopBuilderPrompt.ts
@@ -13,13 +13,28 @@ export function buildLoopBuilderPrompt({
 }): string {
   const seed = instructions?.trim();
 
+  return [
+    seed || undefined,
+    buildLoopBuilderSystemInstructions({ hasSeed: !!seed, context }),
+  ]
+    .filter((part): part is string => !!part)
+    .join("\n\n");
+}
+
+export function buildLoopBuilderSystemInstructions({
+  hasSeed,
+  context,
+}: {
+  hasSeed: boolean;
+  context?: { folderId: string; name: string };
+}): string {
   return `Your job in this session is to help me create a Loop for this PostHog project, then create it for me.
 
 A Loop is a named, cloud-executed agent automation: instructions the agent runs whenever a trigger fires (a schedule, a GitHub event, or an API call). Loops run unattended in a sandbox and can post results, open pull requests, and keep a context up to date.
 
 ${
-  seed
-    ? `Here's what I want automated:\n\n${seed}\n`
+  hasSeed
+    ? "The user's message describes what they want automated.\n"
     : `Start by asking me what I want automated, and offer a couple of concrete ideas.\n`
 }${
   context


### PR DESCRIPTION
## Problem

Loop builder sessions show internal builder instructions as the user message in chat.

## Changes

Before:
<img width="1932" height="2414" alt="CleanShot 2026-07-22 at 11 28 26@2x" src="https://github.com/user-attachments/assets/0fc6cc54-4e32-42bc-b633-758bfea154d0" />

After:
<img width="1908" height="2034" alt="CleanShot 2026-07-22 at 11 24 53@2x" src="https://github.com/user-attachments/assets/63e8a336-4741-4c61-a6e3-cd33140fb250" />



- Show only the prompt entered by the user
- Pass builder guidance through hidden custom instructions
- Keep context metadata available to the agent

## How did you test this?

- `pnpm exec vitest run packages/ui/src/features/loops/loopBuilderPrompt.test.ts`
- `pnpm exec biome check packages/ui/src/features/loops/loopBuilderPrompt.ts packages/ui/src/features/loops/loopBuilderPrompt.test.ts packages/ui/src/features/loops/hooks/useLoopBuilderTask.ts`
- `pnpm --filter @posthog/ui typecheck`
- Full repository typecheck attempted by pre-commit, but failed in `apps/web` on existing unresolved `@posthog/agent` and `@posthog/host-trpc` exports

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*