### PR TITLE
test(harness): stabilize runtime cold-start test

### DIFF
--- a/packages/harness/src/runtime.test.ts
+++ b/packages/harness/src/runtime.test.ts
@@ -23,41 +23,45 @@ afterEach(async () => {
 });
 
 describe("createHarnessRuntime", () => {
-  it("returns a native Pi runtime with the PostHog model and named harness extensions", async () => {
-    vi.stubEnv("PI_OFFLINE", "1");
-    const pi = await import("@earendil-works/pi-coding-agent");
-    const cwd = await temporaryDirectory();
-    const agentDir = await temporaryDirectory();
+  it(
+    "returns a native Pi runtime with the PostHog model and named harness extensions",
+    { timeout: 15_000 },
+    async () => {
+      vi.stubEnv("PI_OFFLINE", "1");
+      const pi = await import("@earendil-works/pi-coding-agent");
+      const cwd = await temporaryDirectory();
+      const agentDir = await temporaryDirectory();
 
-    const runtime = await createHarnessRuntime({
-      agentDir,
-      authStorage: pi.AuthStorage.inMemory(),
-      cwd,
-      sessionManager: pi.SessionManager.inMemory(cwd),
-    });
+      const runtime = await createHarnessRuntime({
+        agentDir,
+        authStorage: pi.AuthStorage.inMemory(),
+        cwd,
+        sessionManager: pi.SessionManager.inMemory(cwd),
+      });
 
-    try {
-      expect(runtime).toBeInstanceOf(pi.AgentSessionRuntime);
-      expect(runtime.session.model?.provider).toBe("posthog");
-      expect(runtime.services.settingsManager.isProjectTrusted()).toBe(false);
-      expect(
-        runtime.services.resourceLoader
-          .getExtensions()
-          .extensions.map((extension) => extension.path),
-      ).toEqual(
-        expect.arrayContaining([
-          "<inline:hog-branding>",
-          "<inline:posthog-provider>",
-          "<inline:web-access>",
-          "<inline:subagent>",
-          "<inline:workflow>",
-          "<inline:mcp>",
-        ]),
-      );
-    } finally {
-      await runtime.dispose();
-    }
-  });
+      try {
+        expect(runtime).toBeInstanceOf(pi.AgentSessionRuntime);
+        expect(runtime.session.model?.provider).toBe("posthog");
+        expect(runtime.services.settingsManager.isProjectTrusted()).toBe(false);
+        expect(
+          runtime.services.resourceLoader
+            .getExtensions()
+            .extensions.map((extension) => extension.path),
+        ).toEqual(
+          expect.arrayContaining([
+            "<inline:hog-branding>",
+            "<inline:posthog-provider>",
+            "<inline:web-access>",
+            "<inline:subagent>",
+            "<inline:workflow>",
+            "<inline:mcp>",
+          ]),
+        );
+      } finally {
+        await runtime.dispose();
+      }
+    },
+  );
 
   it("keeps desktop-provided OAuth credentials in memory without touching auth.json", async () => {
     vi.stubEnv("PI_OFFLINE", "1");


### PR DESCRIPTION
## Problem

The harness runtime integration test performs a cold import and full native Pi runtime initialization. Under concurrent CI load, that valid setup can exceed Vitest's default five-second timeout and fail unrelated pull requests.

**Why:** The test needs enough time to exercise the real runtime consistently in CI without weakening timeout coverage across the rest of the harness suite.

## Changes

Give only the cold-start runtime test a 15-second timeout. All other harness tests retain Vitest's default timeout.

## How did you test this?

- `pnpm exec biome check --write packages/harness/src/runtime.test.ts`
- `pnpm --filter @posthog/shared build`
- `pnpm --filter @posthog/harness test` (661 tests passed)
- `pnpm --filter @posthog/harness typecheck`
- `git diff --check`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
