### PR TITLE
Add a persisted "mode after plan approval" setting

### DIFF
--- a/packages/ui/src/features/permissions/PlanApprovalSelector.test.tsx
+++ b/packages/ui/src/features/permissions/PlanApprovalSelector.test.tsx
@@ -53,27 +53,49 @@ function renderSelector(options: PermissionOption[]) {
 describe("PlanApprovalSelector", () => {
   beforeEach(() => {
     // Reset the remembered choice so tests don't leak through persistence.
-    useSettingsStore.setState({ lastPlanApprovalMode: null });
+    useSettingsStore.setState({
+      lastPlanApprovalMode: null,
+      defaultPlanApprovalMode: "last_used",
+    });
   });
 
   it.each([
     {
       label: "there is no prior or remembered mode",
       lastMode: null,
+      defaultMode: "last_used",
       options: [AUTO, ACCEPT_EDITS, DEFAULT_MODE, REJECT],
       expected: "auto",
     },
     {
       label: "a last choice is remembered",
       lastMode: "acceptEdits",
+      defaultMode: "last_used",
+      options: [AUTO, ACCEPT_EDITS, DEFAULT_MODE],
+      expected: "acceptEdits",
+    },
+    {
+      label: "a pinned default mode overrides the remembered choice",
+      lastMode: "acceptEdits",
+      defaultMode: "auto",
+      options: [AUTO, ACCEPT_EDITS, DEFAULT_MODE],
+      expected: "auto",
+    },
+    {
+      label: "the pinned default mode isn't offered",
+      lastMode: "acceptEdits",
+      defaultMode: "bypassPermissions",
       options: [AUTO, ACCEPT_EDITS, DEFAULT_MODE],
       expected: "acceptEdits",
     },
   ] as const)(
     "defaults to $expected when $label",
-    async ({ lastMode, options, expected }) => {
+    async ({ lastMode, defaultMode, options, expected }) => {
       const user = userEvent.setup();
-      useSettingsStore.setState({ lastPlanApprovalMode: lastMode });
+      useSettingsStore.setState({
+        lastPlanApprovalMode: lastMode,
+        defaultPlanApprovalMode: defaultMode,
+      });
       const { onSelect } = renderSelector([...options]);
 
       await user.click(screen.getByText("Approve and proceed"));

--- a/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
+++ b/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
@@ -5,7 +5,10 @@ import type {
 import type { ExecutionMode } from "@posthog/shared";
 import { ModeSelector } from "@posthog/ui/features/message-editor/components/ModeSelector";
 import { MODE_LABELS } from "@posthog/ui/features/sessions/modeStyles";
-import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import {
+  type DefaultPlanApprovalMode,
+  useSettingsStore,
+} from "@posthog/ui/features/settings/settingsStore";
 import {
   ActionSelector,
   InlineEditableText,
@@ -29,6 +32,32 @@ function hasCustomInput(option: PermissionOption): boolean {
   return (
     (option._meta as { customInput?: boolean } | null | undefined)
       ?.customInput === true
+  );
+}
+
+// Resolution order: a pinned default mode (if configured and offered), else
+// the mode last approved with (remembered preference), then "auto", then
+// manual-approve, then any single-use mode, then the first.
+function resolveInitialPlanApprovalMode(
+  approveOptions: PermissionOption[],
+  defaultApprovalMode: DefaultPlanApprovalMode,
+  lastApprovalMode: ExecutionMode | null,
+): string | undefined {
+  const has = (id: string) => approveOptions.some((o) => o.optionId === id);
+
+  if (defaultApprovalMode !== "last_used" && has(defaultApprovalMode)) {
+    return defaultApprovalMode;
+  }
+  if (lastApprovalMode && has(lastApprovalMode)) {
+    return lastApprovalMode;
+  }
+  if (has("auto")) {
+    return "auto";
+  }
+  return (
+    approveOptions.find((o) => o.optionId === "default")?.optionId ??
+    approveOptions.find((o) => o.kind === "allow_once")?.optionId ??
+    approveOptions[0]?.optionId
   );
 }
 
@@ -81,24 +110,15 @@ export function PlanApprovalSelector({
     (s) => s.defaultPlanApprovalMode,
   );
 
-  // Resolution order: a pinned default mode (if configured and offered), else
-  // the mode last approved with (remembered preference), then "auto", then
-  // manual-approve, then any single-use mode, then the first.
-  const initialMode = useMemo(() => {
-    const has = (id: string) => approveOptions.some((o) => o.optionId === id);
-    return (
-      (defaultApprovalMode !== "last_used" && has(defaultApprovalMode)
-        ? defaultApprovalMode
-        : undefined) ??
-      (lastApprovalMode && has(lastApprovalMode)
-        ? lastApprovalMode
-        : undefined) ??
-      (has("auto") ? "auto" : undefined) ??
-      approveOptions.find((o) => o.optionId === "default")?.optionId ??
-      approveOptions.find((o) => o.kind === "allow_once")?.optionId ??
-      approveOptions[0]?.optionId
-    );
-  }, [approveOptions, lastApprovalMode, defaultApprovalMode]);
+  const initialMode = useMemo(
+    () =>
+      resolveInitialPlanApprovalMode(
+        approveOptions,
+        defaultApprovalMode,
+        lastApprovalMode,
+      ),
+    [approveOptions, lastApprovalMode, defaultApprovalMode],
+  );
 
   const [selectedMode, setSelectedMode] = useState(initialMode);
   const [selectedIndex, setSelectedIndex] = useState(0);

--- a/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
+++ b/packages/ui/src/features/permissions/PlanApprovalSelector.tsx
@@ -77,12 +77,19 @@ export function PlanApprovalSelector({
   const setLastApprovalMode = useSettingsStore(
     (s) => s.setLastPlanApprovalMode,
   );
+  const defaultApprovalMode = useSettingsStore(
+    (s) => s.defaultPlanApprovalMode,
+  );
 
-  // Resolution order: the mode last approved with (remembered preference),
-  // then "auto", then manual-approve, then any single-use mode, then the first.
+  // Resolution order: a pinned default mode (if configured and offered), else
+  // the mode last approved with (remembered preference), then "auto", then
+  // manual-approve, then any single-use mode, then the first.
   const initialMode = useMemo(() => {
     const has = (id: string) => approveOptions.some((o) => o.optionId === id);
     return (
+      (defaultApprovalMode !== "last_used" && has(defaultApprovalMode)
+        ? defaultApprovalMode
+        : undefined) ??
       (lastApprovalMode && has(lastApprovalMode)
         ? lastApprovalMode
         : undefined) ??
@@ -91,7 +98,7 @@ export function PlanApprovalSelector({
       approveOptions.find((o) => o.kind === "allow_once")?.optionId ??
       approveOptions[0]?.optionId
     );
-  }, [approveOptions, lastApprovalMode]);
+  }, [approveOptions, lastApprovalMode, defaultApprovalMode]);
 
   const [selectedMode, setSelectedMode] = useState(initialMode);
   const [selectedIndex, setSelectedIndex] = useState(0);

--- a/packages/ui/src/features/sessions/modeStyles.tsx
+++ b/packages/ui/src/features/sessions/modeStyles.tsx
@@ -7,6 +7,7 @@ import {
   Robot,
   ShieldCheck,
 } from "@phosphor-icons/react";
+import type { ExecutionMode } from "@posthog/shared";
 
 export interface ModeStyle {
   icon: React.ReactNode;
@@ -66,3 +67,14 @@ export const MODE_LABELS: Record<string, string> = {
   "read-only": "Read-only",
   "full-access": "Full access",
 };
+
+// Concrete modes `buildExitPlanModePermissionOptions` (packages/agent) can
+// offer when a plan is approved, excluding "plan" itself. Kept here, next to
+// the label map settings/approval UI already share, so both pick modes from
+// one list.
+export const PLAN_APPROVAL_MODES: readonly ExecutionMode[] = [
+  "auto",
+  "default",
+  "acceptEdits",
+  "bypassPermissions",
+];

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -7,7 +7,10 @@ import {
   COLLAPSE_MODE_OPTIONS,
   type CollapseMode,
 } from "@posthog/ui/features/sessions/components/new-thread/conversationThreadConfig";
-import { MODE_LABELS } from "@posthog/ui/features/sessions/modeStyles";
+import {
+  MODE_LABELS,
+  PLAN_APPROVAL_MODES,
+} from "@posthog/ui/features/sessions/modeStyles";
 import { SettingRow } from "@posthog/ui/features/settings/SettingRow";
 import {
   type AutoConvertLongText,
@@ -330,14 +333,11 @@ export function GeneralSettings() {
           <Select.Trigger className="min-w-[100px]" />
           <Select.Content>
             <Select.Item value="last_used">Last used</Select.Item>
-            <Select.Item value="auto">{MODE_LABELS.auto}</Select.Item>
-            <Select.Item value="default">{MODE_LABELS.default}</Select.Item>
-            <Select.Item value="acceptEdits">
-              {MODE_LABELS.acceptEdits}
-            </Select.Item>
-            <Select.Item value="bypassPermissions">
-              {MODE_LABELS.bypassPermissions}
-            </Select.Item>
+            {PLAN_APPROVAL_MODES.map((mode) => (
+              <Select.Item key={mode} value={mode}>
+                {MODE_LABELS[mode]}
+              </Select.Item>
+            ))}
           </Select.Content>
         </Select.Root>
       </SettingRow>

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -7,11 +7,13 @@ import {
   COLLAPSE_MODE_OPTIONS,
   type CollapseMode,
 } from "@posthog/ui/features/sessions/components/new-thread/conversationThreadConfig";
+import { MODE_LABELS } from "@posthog/ui/features/sessions/modeStyles";
 import { SettingRow } from "@posthog/ui/features/settings/SettingRow";
 import {
   type AutoConvertLongText,
   type DefaultInitialTaskMode,
   type DefaultMessagingMode,
+  type DefaultPlanApprovalMode,
   type DefaultReasoningEffort,
   type DiffOpenMode,
   type SendMessagesWith,
@@ -77,6 +79,7 @@ export function GeneralSettings() {
     autoConvertLongText,
     defaultInitialTaskMode,
     defaultMessagingMode,
+    defaultPlanApprovalMode,
     defaultReasoningEffort,
     diffOpenMode,
     sendMessagesWith,
@@ -87,6 +90,7 @@ export function GeneralSettings() {
     setAutoConvertLongText,
     setDefaultInitialTaskMode,
     setDefaultMessagingMode,
+    setDefaultPlanApprovalMode,
     setDefaultReasoningEffort,
     setDiffOpenMode,
     setSendMessagesWith,
@@ -144,6 +148,18 @@ export function GeneralSettings() {
       setDefaultInitialTaskMode(value);
     },
     [defaultInitialTaskMode, setDefaultInitialTaskMode],
+  );
+
+  const handleDefaultPlanApprovalModeChange = useCallback(
+    (value: DefaultPlanApprovalMode) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "default_plan_approval_mode",
+        new_value: value,
+        old_value: defaultPlanApprovalMode,
+      });
+      setDefaultPlanApprovalMode(value);
+    },
+    [defaultPlanApprovalMode, setDefaultPlanApprovalMode],
   );
 
   const handleDefaultMessagingModeChange = useCallback(
@@ -294,6 +310,34 @@ export function GeneralSettings() {
           <Select.Content>
             <Select.Item value="plan">Plan</Select.Item>
             <Select.Item value="last_used">Last used</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </SettingRow>
+
+      <SettingRow
+        label="Mode after plan approval"
+        description="Choose whether approving a plan always resumes in a specific mode, or remembers your last choice"
+      >
+        <Select.Root
+          value={defaultPlanApprovalMode}
+          onValueChange={(value) =>
+            handleDefaultPlanApprovalModeChange(
+              value as DefaultPlanApprovalMode,
+            )
+          }
+          size="1"
+        >
+          <Select.Trigger className="min-w-[100px]" />
+          <Select.Content>
+            <Select.Item value="last_used">Last used</Select.Item>
+            <Select.Item value="auto">{MODE_LABELS.auto}</Select.Item>
+            <Select.Item value="default">{MODE_LABELS.default}</Select.Item>
+            <Select.Item value="acceptEdits">
+              {MODE_LABELS.acceptEdits}
+            </Select.Item>
+            <Select.Item value="bypassPermissions">
+              {MODE_LABELS.bypassPermissions}
+            </Select.Item>
           </Select.Content>
         </Select.Root>
       </SettingRow>

--- a/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/packages/ui/src/features/settings/settingsStore.test.ts
@@ -220,6 +220,7 @@ describe("feature settingsStore cloud selections", () => {
     ["slotMachineMode", false, true],
     ["dismissibleUpdateBanners", false, true],
     ["showSidebarWorktrees", false, true],
+    ["defaultPlanApprovalMode", "last_used", "auto"],
   ] as const)("rehydrates %s", async (field, initial, persisted) => {
     getItem.mockResolvedValue(
       JSON.stringify({ state: { [field]: persisted }, version: 0 }),

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -16,6 +16,7 @@ export type LocalWorkspaceMode = "worktree" | "local";
 export const DEFAULT_WORKSPACE_MODE: WorkspaceMode = "cloud";
 export type AgentAdapter = Adapter;
 export type DefaultInitialTaskMode = "plan" | "last_used";
+export type DefaultPlanApprovalMode = ExecutionMode | "last_used";
 export type DefaultMessagingMode = "queue" | "steer";
 export type DefaultReasoningEffort =
   | "low"
@@ -117,6 +118,9 @@ interface SettingsStore {
   lastUsedInitialTaskMode: ExecutionMode;
   // Mode last chosen when approving a plan; pre-selected on the next approval.
   lastPlanApprovalMode: ExecutionMode | null;
+  // Pins plan approval to always pre-select a specific mode, overriding
+  // lastPlanApprovalMode; "last_used" preserves the old sticky behavior.
+  defaultPlanApprovalMode: DefaultPlanApprovalMode;
   defaultReasoningEffort: DefaultReasoningEffort;
   defaultMessagingMode: DefaultMessagingMode;
   setDefaultMessagingMode: (mode: DefaultMessagingMode) => void;
@@ -140,6 +144,7 @@ interface SettingsStore {
   setDefaultInitialTaskMode: (mode: DefaultInitialTaskMode) => void;
   setLastUsedInitialTaskMode: (mode: ExecutionMode) => void;
   setLastPlanApprovalMode: (mode: ExecutionMode) => void;
+  setDefaultPlanApprovalMode: (mode: DefaultPlanApprovalMode) => void;
   setDefaultReasoningEffort: (effort: DefaultReasoningEffort) => void;
 
   // Notifications
@@ -306,6 +311,7 @@ export const useSettingsStore = create<SettingsStore>()(
       defaultInitialTaskMode: "plan",
       lastUsedInitialTaskMode: "plan",
       lastPlanApprovalMode: null,
+      defaultPlanApprovalMode: "last_used",
       defaultReasoningEffort: "last_used",
       defaultMessagingMode: "queue",
       setDefaultRunMode: (mode) => set({ defaultRunMode: mode }),
@@ -348,6 +354,8 @@ export const useSettingsStore = create<SettingsStore>()(
       setLastUsedInitialTaskMode: (mode) =>
         set({ lastUsedInitialTaskMode: mode }),
       setLastPlanApprovalMode: (mode) => set({ lastPlanApprovalMode: mode }),
+      setDefaultPlanApprovalMode: (mode) =>
+        set({ defaultPlanApprovalMode: mode }),
       setDefaultReasoningEffort: (effort) =>
         set({ defaultReasoningEffort: effort }),
       setDefaultMessagingMode: (mode) => set({ defaultMessagingMode: mode }),
@@ -531,6 +539,7 @@ export const useSettingsStore = create<SettingsStore>()(
         defaultInitialTaskMode: state.defaultInitialTaskMode,
         lastUsedInitialTaskMode: state.lastUsedInitialTaskMode,
         lastPlanApprovalMode: state.lastPlanApprovalMode,
+        defaultPlanApprovalMode: state.defaultPlanApprovalMode,
         defaultReasoningEffort: state.defaultReasoningEffort,
         defaultMessagingMode: state.defaultMessagingMode,
 


### PR DESCRIPTION
## Problem

Approving a plan pre-selects a continue-mode that's either a sticky "last used" choice or a hardcoded "auto" fallback — there's no way to pin a specific mode as the permanent default. Pick a different mode once (e.g. for one sensitive plan), and every future plan approval silently defaults to that mode too.

<img width="859" height="194" alt="Screenshot 2026-07-22 at 4 16 23 PM" src="https://github.com/user-attachments/assets/d164d243-1d36-476d-a38d-da2c0f09bc17" />

## Changes

- Adds `defaultPlanApprovalMode` to the settings store (`packages/ui/src/features/settings/settingsStore.ts`), default `"last_used"` (fully backward compatible).
- Exposes it as "Mode after plan approval" in Settings → General, right below "Initial task mode" (`GeneralSettings.tsx`).
- `PlanApprovalSelector` now resolves its pre-selected mode from this pinned setting first, falling back to the existing remembered/last-used chain when it's `"last_used"` or the pinned mode isn't offered.
- Since both the Claude and Codex adapters route their plan-approval prompt through this same shared UI component, the change covers both without touching `packages/agent` or `packages/core`.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` and `pnpm --filter @posthog/ui test` (added cases to `settingsStore.test.ts` and `PlanApprovalSelector.test.tsx` covering persistence round-trip and the pinned-mode-overrides-remembered-mode / pinned-mode-not-offered branches) — all passing.
- `biome check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*