### PR TITLE
Add share button to channel feed task messages

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -2,6 +2,7 @@ import {
   ArrowSquareOutIcon,
   ChatCircleIcon,
   GitBranchIcon,
+  LinkIcon,
   RobotIcon,
 } from "@phosphor-icons/react";
 import { taskFeedRunStatus } from "@posthog/core/canvas/channelFeed";
@@ -49,6 +50,7 @@ import type { ChannelFeedSystemMessage } from "@posthog/ui/features/canvas/hooks
 import { useChannelTaskData } from "@posthog/ui/features/canvas/hooks/useChannelTaskData";
 import { useTaskThread } from "@posthog/ui/features/canvas/hooks/useTaskThread";
 import { taskCardNavigation } from "@posthog/ui/features/canvas/taskCardNavigation";
+import { copyChannelLink } from "@posthog/ui/features/canvas/utils/copyChannelLink";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import {
   type SidebarPrState,
@@ -534,11 +536,19 @@ const FeedItem = memo(function FeedItem({
       task={task}
       actions={
         // Replying now lives in the always-visible ReplyFooter, so the hover
-        // toolbar only carries the distinct "Open task" action. Actions anchor
-        // to the row's top-right corner; a top tooltip there overhangs the panel
-        // edge and gets clipped by the scroll container, so open tooltips toward
-        // the content instead.
+        // toolbar only carries per-row actions (copy link, open task). Actions
+        // anchor to the row's top-right corner; a top tooltip there overhangs
+        // the panel edge and gets clipped by the scroll container, so open
+        // tooltips toward the content instead.
         <ThreadItemActions aria-label="Message actions" className="inset-bs-2">
+          <ThreadItemAction
+            label="Copy link to task"
+            onClick={() =>
+              void copyChannelLink(channelId, "thread_panel", task.id)
+            }
+          >
+            <LinkIcon size={15} />
+          </ThreadItemAction>
           <ThreadItemAction label="Open task" onClick={() => onOpenTask(task)}>
             <ArrowSquareOutIcon size={15} />
           </ThreadItemAction>


### PR DESCRIPTION
## Problem

Channel feed task messages had an "Open task" button but no way to share a direct link to the task from the feed — you had to open the task page to get the share button that lives there.

## Changes

- Add a "copy link to task" share button to the hover toolbar of each task message in the channel feed (`ChannelFeedView`), next to the existing "Open task" action.
- Reuses the same `copyChannelLink` util the task page's share button uses, so the copied link is identical and deep-links back into the same thread.
- Updated the now-stale toolbar comment that said it "only carries the 'Open task' action."

## How did you test this?

- `tsc --noEmit` on `@posthog/ui` — clean for the changed file (pre-existing unrelated module-resolution errors elsewhere remain).
- `biome check` on the changed file — clean.
- Existing `ChannelFeedView.test.tsx` is unaffected (it renders `TaskFeedRow`, not the `FeedItem` toolbar, and only asserts prompt expansion); the test suite has a pre-existing vitest resolution failure that reproduces identically on the unmodified branch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
