### PR TITLE
feat(loops): Add stop button to loop run rows

### DIFF
--- a/packages/ui/src/features/loops/components/LoopDetailView.tsx
+++ b/packages/ui/src/features/loops/components/LoopDetailView.tsx
@@ -212,7 +212,11 @@ export function LoopDetailView({ loopId }: { loopId: string }) {
           ) : (
             <Flex direction="column" gap="2">
               {runs.map((run) => (
-                <LoopRunRow key={run.id} run={run} />
+                <LoopRunRow
+                  key={run.id}
+                  run={run}
+                  onStopped={() => void runsQuery.refetch()}
+                />
               ))}
             </Flex>
           )}

--- a/packages/ui/src/features/loops/components/LoopRunRow.tsx
+++ b/packages/ui/src/features/loops/components/LoopRunRow.tsx
@@ -6,17 +6,20 @@ import {
   type Icon,
   Lightning,
   Play,
+  Stop,
   Timer,
   Warning,
   X,
 } from "@phosphor-icons/react";
 import type { LoopSchemas } from "@posthog/api-client/loops";
 import { cn } from "@posthog/quill";
+import { StopCloudRunDialog } from "@posthog/ui/features/sessions/components/StopCloudRunDialog";
 import { Badge } from "@posthog/ui/primitives/Badge";
 import { Button } from "@posthog/ui/primitives/Button";
+import { toast } from "@posthog/ui/primitives/toast";
 import { navigateToTaskDetail } from "@posthog/ui/router/navigationBridge";
 import { Flex, Text } from "@radix-ui/themes";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 
 function statusColor(
   status: LoopSchemas.LoopRunStatusEnum,
@@ -109,10 +112,25 @@ function MetaItem({
   );
 }
 
-export function LoopRunRow({ run }: { run: LoopSchemas.LoopRun }) {
+function isStoppable(run: LoopSchemas.LoopRun): boolean {
+  return (
+    run.environment === "cloud" &&
+    (run.status === "queued" || run.status === "in_progress")
+  );
+}
+
+export function LoopRunRow({
+  run,
+  onStopped,
+}: {
+  run: LoopSchemas.LoopRun;
+  onStopped?: () => void;
+}) {
   const StatusIcon = statusIcon(run.status);
   const duration = runDuration(run);
   const triggered = Boolean(run.loop_trigger_id);
+  const stoppable = isStoppable(run);
+  const [stopOpen, setStopOpen] = useState(false);
 
   return (
     <Flex
@@ -162,15 +180,41 @@ export function LoopRunRow({ run }: { run: LoopSchemas.LoopRun }) {
           </Flex>
         ) : null}
       </Flex>
-      <Button
-        variant="soft"
-        color="gray"
-        size="1"
-        className="shrink-0"
-        onClick={() => navigateToTaskDetail(run.task_id)}
-      >
-        View run
-      </Button>
+      <Flex align="center" gap="2" className="shrink-0">
+        {stoppable ? (
+          <Button
+            variant="soft"
+            color="red"
+            size="1"
+            onClick={() => setStopOpen(true)}
+          >
+            <Stop size={12} weight="bold" />
+            Stop run
+          </Button>
+        ) : null}
+        <Button
+          variant="soft"
+          color="gray"
+          size="1"
+          onClick={() => navigateToTaskDetail(run.task_id)}
+        >
+          View run
+        </Button>
+      </Flex>
+      {stoppable || stopOpen ? (
+        <StopCloudRunDialog
+          open={stopOpen}
+          taskId={run.task_id}
+          runId={run.id}
+          title="Stop run"
+          buttonLabel="Stop run"
+          onOpenChange={setStopOpen}
+          onStopped={() => {
+            toast.success("Run stopped");
+            onStopped?.();
+          }}
+        />
+      ) : null}
     </Flex>
   );
 }


### PR DESCRIPTION
## Problem

An in-progress loop run can only be stopped by opening its task detail page. The loop detail page shows run history and lets you view a run, but there is no way to stop a run or shut down its sandbox from there.

## Changes

Active cloud runs (queued or in progress) in the run history list now show a red "Stop run" button to the left of "View run". It reuses the sessions `StopCloudRunDialog`, so stopping goes through `sessionService.stopCloudRun` with the run's task and run ids, ends the cloud session and shuts down its sandbox. On success the runs list refetches immediately instead of waiting for the 15s poll. Terminal, local-environment and not-started runs show no button.

## How did you test this?

`pnpm --filter @posthog/ui typecheck` and Biome lint on the loops feature, both clean. Not exercised against a live in-progress loop run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
