### PR TITLE
feat(loops): Run a skill instead of instructions

### DIFF
--- a/packages/api-client/src/loops.ts
+++ b/packages/api-client/src/loops.ts
@@ -50,6 +50,7 @@ export namespace LoopSchemas {
     | "failed"
     | "cancelled";
   export type LoopRunEnvironmentEnum = "local" | "cloud";
+  export type LoopSkillSourceEnum = "user" | "repo" | "marketplace" | "codex";
 
   export type LoopRepositoryEntry = {
     github_integration_id: number;
@@ -205,6 +206,32 @@ export namespace LoopSchemas {
     created_at: string;
     updated_at: string;
     triggers: Array<LoopTrigger>;
+    /** Skill bundles attached to this loop, seeded into every fired run's sandbox.
+     * Replaced wholesale via `replaceLoopSkillBundles`, never through the loop write.
+     * Optional because a backend that predates skill bundles omits the field; treat
+     * absence as an empty list. */
+    skill_bundles?: Array<LoopSkillBundle>;
+  };
+
+  /** A skill bundle attached to a loop. `content_sha256` is the stored snapshot's
+   * digest, so a client can detect drift from the local copy of the skill. */
+  export type LoopSkillBundle = {
+    id: string;
+    skill_name: string;
+    skill_source: LoopSkillSourceEnum;
+    size: number;
+    content_sha256: string;
+    uploaded_at: string;
+  };
+
+  /** One zipped local skill in a skill-bundle replace request. */
+  export type LoopSkillBundleUpload = {
+    file_name: string;
+    skill_name: string;
+    skill_source: LoopSkillSourceEnum;
+    content_sha256: string;
+    bundle_format: "zip";
+    content_base64: string;
   };
 
   /** Request body for create (all required fields present) and partial_update
@@ -392,6 +419,8 @@ const loopRunsPath = (projectId: string, loopId: string): string =>
   `/api/projects/${projectId}/loops/${loopId}/runs/`;
 const loopPreviewPath = (projectId: string, loopId: string): string =>
   `/api/projects/${projectId}/loops/${loopId}/preview/`;
+const loopSkillBundlesPath = (projectId: string, loopId: string): string =>
+  `/api/projects/${projectId}/loops/${loopId}/skill_bundles/`;
 
 function idempotencyHeader(
   idempotencyKey: string | undefined,
@@ -579,6 +608,17 @@ export async function listLoopRuns(
 ): Promise<LoopSchemas.LoopRunPage> {
   return loopsRequest(client, "get", loopRunsPath(projectId, loopId), {
     query,
+  });
+}
+
+export async function replaceLoopSkillBundles(
+  client: ApiClient,
+  projectId: string,
+  loopId: string,
+  bundles: Array<LoopSchemas.LoopSkillBundleUpload>,
+): Promise<LoopSchemas.Loop> {
+  return loopsRequest(client, "put", loopSkillBundlesPath(projectId, loopId), {
+    body: { bundles },
   });
 }
 

--- a/packages/ui/src/features/loops/components/LoopDetailView.tsx
+++ b/packages/ui/src/features/loops/components/LoopDetailView.tsx
@@ -1,5 +1,7 @@
 import { ArrowLeftIcon, RepeatIcon } from "@phosphor-icons/react";
 import type { LoopSchemas } from "@posthog/api-client/loops";
+import { isUploadableSkillSource } from "@posthog/core/message-editor/skillTags";
+import { useHostTRPC } from "@posthog/host-router/react";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -20,6 +22,7 @@ import { useUsageLimitStore } from "@posthog/ui/features/billing/usageLimitStore
 import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
+import { Button as ActionButton } from "@posthog/ui/primitives/Button";
 import { TimezoneTimestamp } from "@posthog/ui/primitives/TimezoneTimestamp";
 import { systemTimezone } from "@posthog/ui/primitives/timezone";
 import { toast } from "@posthog/ui/primitives/toast";
@@ -28,7 +31,9 @@ import {
   navigateToLoops,
 } from "@posthog/ui/router/navigationBridge";
 import { track } from "@posthog/ui/shell/analytics";
+import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
 import { Flex, Text } from "@radix-ui/themes";
+import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { useLoop } from "../hooks/useLoop";
 import {
@@ -37,6 +42,7 @@ import {
   useUpdateLoop,
 } from "../hooks/useLoopMutations";
 import { RECENT_RUNS_LIMIT, useLoopRuns } from "../hooks/useLoopRuns";
+import { useSyncLoopSkillBundles } from "../hooks/useLoopSkillBundles";
 import {
   buildLoopEnabledToggledProps,
   buildLoopViewedProps,
@@ -51,6 +57,7 @@ import {
   summarizeNotificationDestinations,
 } from "../loopDisplay";
 import { formatLoopModel } from "../loopModels";
+import { loopSkillBundles, primaryLoopSkillBundle } from "../loopSkill";
 import { LoopLoadError } from "./LoopFallbacks";
 import { LoopRunRow } from "./LoopRunRow";
 
@@ -430,6 +437,12 @@ function ConfigSummarySection({ loop }: { loop: LoopSchemas.Loop }) {
             .join(" · ")}
         </SummaryRow>
 
+        {loopSkillBundles(loop).length > 0 ? (
+          <SummaryRow label="Skill">
+            <LoopSkillSummary loop={loop} />
+          </SummaryRow>
+        ) : null}
+
         <SummaryRow label="Repository">
           {loop.repositories.length > 0
             ? loop.repositories.map((repo) => repo.full_name).join(", ")
@@ -465,8 +478,91 @@ function ConfigSummarySection({ loop }: { loop: LoopSchemas.Loop }) {
   );
 }
 
+function LoopSkillSummary({ loop }: { loop: LoopSchemas.Loop }) {
+  const { localWorkspaces } = useHostCapabilities();
+  const trpc = useHostTRPC();
+  const { data: localSkillData } = useQuery({
+    ...trpc.skills.list.queryOptions(),
+    enabled: localWorkspaces,
+  });
+  const syncSkillBundles = useSyncLoopSkillBundles();
+
+  const primary = primaryLoopSkillBundle(loop);
+  if (!primary) return null;
+  const dependencyCount = loopSkillBundles(loop).length - 1;
+
+  // The one-click refresh must be unambiguous about which skill it snapshots: it
+  // requires exactly one local skill matching the stored name AND source, so a
+  // same-named skill from another source (say, an opened repo) can never silently
+  // replace the loop's snapshot. Ambiguous cases go through the edit form, where
+  // the picker shows each candidate.
+  const candidates = (localSkillData ?? []).filter(
+    (skill) =>
+      skill.name === primary.skill_name &&
+      skill.source === primary.skill_source,
+  );
+  const localMatch = candidates.length === 1 ? candidates[0] : undefined;
+  const updateDisabledReason = !localWorkspaces
+    ? "updating the snapshot needs the desktop app"
+    : localMatch
+      ? null
+      : candidates.length > 1
+        ? `several local skills are named ${primary.skill_name}; pick the right one from the edit form`
+        : `no local ${primary.skill_source} skill named ${primary.skill_name} was found on this machine`;
+
+  const handleUpdate = () => {
+    if (!localMatch || !isUploadableSkillSource(localMatch.source)) return;
+    syncSkillBundles.mutate(
+      {
+        loopId: loop.id,
+        skill: {
+          name: localMatch.name,
+          source: localMatch.source,
+          path: localMatch.path,
+        },
+      },
+      {
+        onSuccess: () => toast.success("Skill snapshot updated"),
+        onError: (error) =>
+          toast.error("Failed to update the skill snapshot", {
+            description: error.message,
+          }),
+      },
+    );
+  };
+
+  return (
+    <Flex align="center" gap="2" wrap="wrap">
+      <Text className="text-[12.5px] text-gray-12">
+        {primary.skill_name}
+        {dependencyCount > 0
+          ? ` (+${dependencyCount} ${dependencyCount === 1 ? "dependency" : "dependencies"})`
+          : ""}
+      </Text>
+      <Text
+        className="text-[11px] text-gray-10"
+        title={new Date(primary.uploaded_at).toLocaleString()}
+      >
+        Snapshot {primary.content_sha256.slice(0, 8)}
+      </Text>
+      <ActionButton
+        variant="soft"
+        color="gray"
+        size="1"
+        loading={syncSkillBundles.isPending}
+        disabled={syncSkillBundles.isPending || !!updateDisabledReason}
+        disabledReason={updateDisabledReason}
+        onClick={handleUpdate}
+      >
+        Update from local skill
+      </ActionButton>
+    </Flex>
+  );
+}
+
 function InstructionsSection({ loop }: { loop: LoopSchemas.Loop }) {
   const updateLoop = useUpdateLoop(loop.id);
+  const primarySkill = primaryLoopSkillBundle(loop);
   const [draft, setDraft] = useState<string | null>(null);
   // Escape reverts and blurs; skip the resulting onBlur save.
   const skipCommit = useRef(false);
@@ -528,6 +624,13 @@ function InstructionsSection({ loop }: { loop: LoopSchemas.Loop }) {
           }
         }}
       />
+      {primarySkill ? (
+        <Text className="text-[11px] text-gray-10 leading-snug">
+          This loop runs the {primarySkill.skill_name} skill: the leading /
+          {primarySkill.skill_name} line invokes its attached snapshot. Editing
+          here changes only the text; use Edit to change or detach the skill.
+        </Text>
+      ) : null}
     </Flex>
   );
 }

--- a/packages/ui/src/features/loops/components/LoopForm.tsx
+++ b/packages/ui/src/features/loops/components/LoopForm.tsx
@@ -17,10 +17,18 @@ import {
   navigateToLoops,
 } from "@posthog/ui/router/navigationBridge";
 import { track } from "@posthog/ui/shell/analytics";
-import { Box, Flex, Text, TextArea, TextField } from "@radix-ui/themes";
+import { Box, Flex, Text, TextField } from "@radix-ui/themes";
 import { type ReactNode, useEffect, useState } from "react";
 import { useAuthStateValue } from "../../auth/store";
-import { useCreateLoop, useUpdateLoop } from "../hooks/useLoopMutations";
+import {
+  useCreateLoop,
+  useDeleteLoop,
+  useUpdateLoop,
+} from "../hooks/useLoopMutations";
+import {
+  useBundleLocalSkill,
+  useReplaceLoopSkillBundles,
+} from "../hooks/useLoopSkillBundles";
 import { buildLoopSavedProps } from "../loopAnalytics";
 import { summarizeTrigger } from "../loopDisplay";
 import { useLoopDraftStore } from "../loopDraftStore";
@@ -36,12 +44,14 @@ import {
   normalizeLoopFormValues,
 } from "../loopFormTypes";
 import { formatLoopModel } from "../loopModels";
+import { buildSkillInstructions, loopSkillBundles } from "../loopSkill";
 import { LoopBehaviorFields } from "./LoopBehaviorFields";
 import { LoopContextFields } from "./LoopContextFields";
 import { Field } from "./LoopFormPrimitives";
 import { LoopModelFields } from "./LoopModelFields";
 import { LoopNotificationsFields } from "./LoopNotificationsFields";
 import { LoopRepositoryPicker } from "./LoopRepositoryPicker";
+import { LoopInstructionsFields } from "./LoopSkillFields";
 import { LoopTriggerEditor } from "./LoopTriggerEditor";
 
 const VISIBILITY_OPTIONS: {
@@ -102,13 +112,21 @@ export function LoopForm({ loop }: LoopFormProps) {
 
   const createLoop = useCreateLoop();
   const updateLoop = useUpdateLoop(loop?.id ?? "");
-  const isSubmitting = isEdit ? updateLoop.isPending : createLoop.isPending;
+  const deleteLoop = useDeleteLoop();
+  const bundleSkill = useBundleLocalSkill();
+  const replaceSkillBundles = useReplaceLoopSkillBundles();
+  const isSubmitting =
+    (isEdit ? updateLoop.isPending : createLoop.isPending) ||
+    bundleSkill.isPending ||
+    replaceSkillBundles.isPending ||
+    deleteLoop.isPending;
   const canSubmit = isLoopFormValid(values) && !isSubmitting;
 
   // Per-step gate for the Next button. The final Create button is gated on the
   // whole form being valid, so jumping between steps can't submit a bad loop.
   const stepComplete = [
-    !!values.name.trim() && !!values.instructions.trim(),
+    !!values.name.trim() &&
+      (values.skill !== null || !!values.instructions.trim()),
     values.triggers.every(isTriggerDraftValid),
     true,
     isLoopFormValid(values),
@@ -140,16 +158,72 @@ export function LoopForm({ loop }: LoopFormProps) {
   const handleSubmit = async () => {
     if (!canSubmit) return;
     const body = formValuesToLoopWrite(values);
-    try {
-      if (isEdit) {
-        const updated = await updateLoop.mutateAsync(body);
-        track(ANALYTICS_EVENTS.LOOP_UPDATED, buildLoopSavedProps(updated));
-        navigateToLoopDetail(updated.id);
-      } else {
-        const created = await createLoop.mutateAsync(body);
-        track(ANALYTICS_EVENTS.LOOP_CREATED, buildLoopSavedProps(created));
-        navigateToLoopDetail(created.id);
+
+    // Bundling runs before anything is persisted: a missing or broken local
+    // skill fails here with no partial state, instead of leaving a saved loop
+    // whose `/skill-name` instructions have no matching bundle.
+    let uploads: LoopSchemas.LoopSkillBundleUpload[] | null = null;
+    if (values.skill?.kind === "local") {
+      try {
+        uploads = await bundleSkill.mutateAsync(values.skill);
+      } catch (error) {
+        toast.error("Failed to bundle the skill", {
+          description: error instanceof Error ? error.message : undefined,
+        });
+        return;
       }
+    }
+
+    try {
+      const saved = isEdit
+        ? await updateLoop.mutateAsync(body)
+        : await createLoop.mutateAsync(body);
+      track(
+        isEdit ? ANALYTICS_EVENTS.LOOP_UPDATED : ANALYTICS_EVENTS.LOOP_CREATED,
+        buildLoopSavedProps(saved),
+      );
+      const needsDetach =
+        values.skill === null && loopSkillBundles(saved).length > 0;
+      if (uploads || needsDetach) {
+        try {
+          await replaceSkillBundles.mutateAsync({
+            loopId: saved.id,
+            uploads: uploads ?? [],
+          });
+        } catch (error) {
+          const description =
+            error instanceof Error ? error.message : undefined;
+          if (!isEdit) {
+            // Roll the just-created loop back rather than leaving one that
+            // fires `/skill-name` with no bundle behind it. If the rollback
+            // itself fails, an orphaned loop exists — say so instead of
+            // pretending nothing was created.
+            try {
+              await deleteLoop.mutateAsync(saved.id);
+              toast.error("Failed to create loop", { description });
+            } catch {
+              toast.error("Loop created, but attaching its skill failed", {
+                description: [
+                  description,
+                  `Delete "${saved.name}" or re-save it from Edit.`,
+                ]
+                  .filter(Boolean)
+                  .join(" "),
+              });
+            }
+            return;
+          }
+          // Keep the form open with its state intact: saving again retries
+          // both the loop write and the skill upload.
+          toast.error("Loop saved, but updating its skill failed", {
+            description: [description, "Save again to retry."]
+              .filter(Boolean)
+              .join(" "),
+          });
+          return;
+        }
+      }
+      navigateToLoopDetail(saved.id);
     } catch (error) {
       const safetyLimit =
         error instanceof LoopsApiError ? error.safetyLimit : null;
@@ -207,15 +281,11 @@ export function LoopForm({ loop }: LoopFormProps) {
                   onChange={(e) => patch({ description: e.target.value })}
                 />
               </Field>
-              <Field label="Instructions" required>
-                <TextArea
-                  value={values.instructions}
-                  placeholder="Summarize failing CI runs from the last 24 hours and post the summary to #eng-standup."
-                  disabled={isSubmitting}
-                  className="min-h-[220px] text-[13px] leading-relaxed"
-                  onChange={(e) => patch({ instructions: e.target.value })}
-                />
-              </Field>
+              <LoopInstructionsFields
+                values={values}
+                disabled={isSubmitting}
+                onPatch={patch}
+              />
             </Step>
           ) : null}
 
@@ -548,7 +618,11 @@ function ReviewList({
       />
       <ReviewRow
         label="Prompt"
-        value={values.instructions.trim() || "No prompt"}
+        value={
+          values.skill
+            ? buildSkillInstructions(values.skill.name, values.skillContext)
+            : values.instructions.trim() || "No prompt"
+        }
         multiline
       />
       <ReviewRow

--- a/packages/ui/src/features/loops/components/LoopSkillFields.tsx
+++ b/packages/ui/src/features/loops/components/LoopSkillFields.tsx
@@ -1,0 +1,278 @@
+import { CaretDown } from "@phosphor-icons/react";
+import { isUploadableSkillSource } from "@posthog/core/message-editor/skillTags";
+import { useHostTRPC } from "@posthog/host-router/react";
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+  Button as QuillButton,
+} from "@posthog/quill";
+import { SettingsOptionSelect } from "@posthog/ui/features/settings/SettingsOptionSelect";
+import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
+import { TextArea } from "@radix-ui/themes";
+import { useQuery } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+import type { LoopFormValues } from "../loopFormTypes";
+import type { LoopSkillDraft } from "../loopSkill";
+import { Field } from "./LoopFormPrimitives";
+
+const ATTACHED_OPTION_VALUE = "attached-snapshot";
+
+interface PickableSkill {
+  name: string;
+  source: LoopSkillDraft["source"];
+  path: string;
+  repoName?: string;
+}
+
+/** Same-named skills from different sources must be tellable apart in the picker,
+ * or the user can't know which one the loop will snapshot. */
+function pickableSkillLabel(
+  skill: PickableSkill,
+  duplicatedNames: Set<string>,
+): string {
+  if (!duplicatedNames.has(skill.name)) return skill.name;
+  const origin = skill.repoName
+    ? `${skill.source}: ${skill.repoName}`
+    : skill.source;
+  return `${skill.name} (${origin})`;
+}
+
+interface SkillOption {
+  value: string;
+  label: string;
+}
+
+/** Searchable skill picker, same quill Combobox shape as the repository picker
+ * on the new-task page. Items are the (unique) labels so cmdk's filter matches
+ * what the user sees. */
+function SkillCombobox({
+  options,
+  selectedValue,
+  disabled,
+  onValueChange,
+}: {
+  options: SkillOption[];
+  selectedValue: string;
+  disabled: boolean;
+  onValueChange: (value: string) => void;
+}) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const selectedLabel =
+    options.find((option) => option.value === selectedValue)?.label ?? null;
+
+  return (
+    <Combobox
+      items={options.map((option) => option.label)}
+      value={selectedLabel}
+      onValueChange={(label) => {
+        const picked = options.find((option) => option.label === label);
+        if (picked) {
+          onValueChange(picked.value);
+        }
+      }}
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+          setSearchQuery("");
+        }
+      }}
+      inputValue={searchQuery}
+      onInputValueChange={setSearchQuery}
+      disabled={disabled}
+    >
+      <ComboboxTrigger
+        render={
+          <QuillButton
+            ref={triggerRef}
+            variant="outline"
+            size="sm"
+            disabled={disabled}
+            aria-label="Skill"
+            className="w-full justify-between"
+          >
+            <span className="min-w-0 truncate">
+              {selectedLabel ?? "Pick a skill…"}
+            </span>
+            <CaretDown size={10} weight="bold" className="shrink-0" />
+          </QuillButton>
+        }
+      />
+      <ComboboxContent
+        anchor={triggerRef}
+        side="bottom"
+        sideOffset={6}
+        className="min-w-[280px]"
+      >
+        <ComboboxInput placeholder="Search skills..." />
+        <ComboboxEmpty>No skills found.</ComboboxEmpty>
+        <ComboboxList>
+          {(label: string) => (
+            <ComboboxItem key={label} value={label}>
+              {label}
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+export function LoopInstructionsFields({
+  values,
+  disabled,
+  onPatch,
+}: {
+  values: LoopFormValues;
+  disabled: boolean;
+  onPatch: (next: Partial<LoopFormValues>) => void;
+}) {
+  const { localWorkspaces } = useHostCapabilities();
+  const trpc = useHostTRPC();
+  const lastSkill = useRef<LoopSkillDraft | null>(values.skill);
+  const { data: localSkillData } = useQuery({
+    ...trpc.skills.list.queryOptions(),
+    enabled: localWorkspaces,
+  });
+  const localSkills: PickableSkill[] = (localSkillData ?? []).flatMap(
+    (skill) =>
+      isUploadableSkillSource(skill.source)
+        ? [
+            {
+              name: skill.name,
+              source: skill.source,
+              path: skill.path,
+              repoName: skill.repoName,
+            },
+          ]
+        : [],
+  );
+  const nameCounts = new Map<string, number>();
+  for (const skill of localSkills) {
+    nameCounts.set(skill.name, (nameCounts.get(skill.name) ?? 0) + 1);
+  }
+  const duplicatedNames = new Set(
+    [...nameCounts].flatMap(([name, count]) => (count > 1 ? [name] : [])),
+  );
+
+  const skill = values.skill;
+  const skillUnavailableHint = localWorkspaces
+    ? "No local skills found. Create one under Settings → Skills first."
+    : "Picking a skill needs the desktop app, where your local skills live.";
+
+  const selectedValue =
+    skill?.kind === "local" ? skill.path : skill ? ATTACHED_OPTION_VALUE : "";
+  const skillOptions = [
+    ...(skill?.kind === "attached" &&
+    !localSkills.some((local) => local.name === skill.name)
+      ? [
+          {
+            value: ATTACHED_OPTION_VALUE,
+            label: `${skill.name} (attached snapshot)`,
+          },
+        ]
+      : []),
+    ...localSkills.map((local) => ({
+      value: local.path,
+      label:
+        skill?.kind === "attached" && local.name === skill.name
+          ? `${pickableSkillLabel(local, duplicatedNames)} (pick again to refresh the snapshot)`
+          : pickableSkillLabel(local, duplicatedNames),
+    })),
+  ];
+
+  const handleModeChange = (mode: string) => {
+    if (mode === "skill") {
+      // Restore whatever was picked before the toggle away; defaulting to the
+      // first local skill would silently swap the loop onto an unrelated one.
+      const restored =
+        lastSkill.current ??
+        (localSkills[0] ? { kind: "local" as const, ...localSkills[0] } : null);
+      if (!restored) return;
+      onPatch({ skill: restored });
+    } else {
+      if (skill) {
+        lastSkill.current = skill;
+      }
+      onPatch({ skill: null });
+    }
+  };
+
+  const handleSkillChange = (value: string) => {
+    if (value === ATTACHED_OPTION_VALUE) return;
+    const picked = localSkills.find((local) => local.path === value);
+    if (picked) {
+      const draft: LoopSkillDraft = { kind: "local", ...picked };
+      lastSkill.current = draft;
+      onPatch({ skill: draft });
+    }
+  };
+
+  return (
+    <>
+      <Field label="Prompt source" required>
+        <SettingsOptionSelect
+          ariaLabel="Prompt source"
+          value={skill ? "skill" : "instructions"}
+          disabled={disabled}
+          options={[
+            { value: "instructions", label: "Write instructions" },
+            { value: "skill", label: "Run a skill" },
+          ]}
+          onValueChange={handleModeChange}
+        />
+        {!skill && localSkills.length === 0 ? (
+          <span className="text-[11px] text-gray-10 leading-snug">
+            {skillUnavailableHint}
+          </span>
+        ) : null}
+      </Field>
+
+      {skill ? (
+        <>
+          <Field
+            label="Skill"
+            required
+            hint="The skill is snapshotted when you save; every run installs that snapshot into its sandbox."
+          >
+            <SkillCombobox
+              options={skillOptions}
+              selectedValue={selectedValue}
+              disabled={disabled}
+              onValueChange={handleSkillChange}
+            />
+          </Field>
+          <Field
+            label="Additional context"
+            hint="Optional extra instructions appended after the skill invocation on every run."
+          >
+            <TextArea
+              value={values.skillContext}
+              placeholder="Only check the release workflow and post the summary to #eng-standup."
+              disabled={disabled}
+              className="min-h-[120px] text-[13px] leading-relaxed"
+              onChange={(e) => onPatch({ skillContext: e.target.value })}
+            />
+          </Field>
+        </>
+      ) : (
+        <Field label="Instructions" required>
+          <TextArea
+            value={values.instructions}
+            placeholder="Summarize failing CI runs from the last 24 hours and post the summary to #eng-standup."
+            disabled={disabled}
+            className="min-h-[220px] text-[13px] leading-relaxed"
+            onChange={(e) => onPatch({ instructions: e.target.value })}
+          />
+        </Field>
+      )}
+    </>
+  );
+}

--- a/packages/ui/src/features/loops/hooks/useLoopSkillBundles.ts
+++ b/packages/ui/src/features/loops/hooks/useLoopSkillBundles.ts
@@ -1,0 +1,130 @@
+import {
+  type LoopSchemas,
+  replaceLoopSkillBundles,
+} from "@posthog/api-client/loops";
+import { useHostTRPCClient } from "@posthog/host-router/react";
+import {
+  type QueryClient,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { isTrustedSkillDependency } from "../loopSkill";
+import { loopsKeys } from "./loopsKeys";
+import { useLoopsClient } from "./useLoopsClient";
+
+function applyLoopToCache(
+  queryClient: QueryClient,
+  projectId: string | null,
+  loop: LoopSchemas.Loop,
+): void {
+  queryClient.setQueryData(loopsKeys.detail(projectId, loop.id), loop);
+  void queryClient.invalidateQueries({ queryKey: loopsKeys.list(projectId) });
+}
+
+export interface LoopLocalSkillRef {
+  name: string;
+  source: LoopSchemas.LoopSkillSourceEnum;
+  path: string;
+}
+
+type HostClient = ReturnType<typeof useHostTRPCClient>;
+
+async function buildSkillUploads(
+  hostClient: HostClient,
+  skill: LoopLocalSkillRef,
+): Promise<LoopSchemas.LoopSkillBundleUpload[]> {
+  const refs = await hostClient.skills.resolveDependencies.query([skill]);
+  const dependencies = refs.filter((ref) => ref.name !== skill.name);
+  const untrusted = dependencies.find(
+    (dep) => !isTrustedSkillDependency(dep, skill),
+  );
+  if (untrusted) {
+    throw new Error(
+      `The ${skill.name} skill references /${untrusted.name}, which resolved to a skill ` +
+        `outside its own scope (${untrusted.source}: ${untrusted.path}). Install ` +
+        `${untrusted.name} alongside ${skill.name} and retry.`,
+    );
+  }
+  const ordered = [skill, ...dependencies];
+  const bundles = await Promise.all(
+    ordered.map((ref) => hostClient.skills.bundleLocal.query(ref)),
+  );
+  return bundles.map((bundle) => ({
+    file_name: bundle.fileName,
+    skill_name: bundle.name,
+    skill_source: bundle.source,
+    content_sha256: bundle.contentSha256,
+    bundle_format: "zip" as const,
+    content_base64: bundle.contentBase64,
+  }));
+}
+
+/**
+ * Bundles a local skill plus its skill dependencies via workspace-server into
+ * upload payloads. Host-only: nothing is persisted anywhere, so callers can run
+ * it before writing the loop and fail fast with no partial state.
+ */
+export function useBundleLocalSkill() {
+  const hostClient = useHostTRPCClient();
+  return useMutation<
+    LoopSchemas.LoopSkillBundleUpload[],
+    Error,
+    LoopLocalSkillRef
+  >({
+    mutationFn: (skill) => buildSkillUploads(hostClient, skill),
+  });
+}
+
+/** Replaces a loop's stored bundles wholesale; an empty list detaches them all. */
+export function useReplaceLoopSkillBundles() {
+  const loopsClient = useLoopsClient();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    LoopSchemas.Loop,
+    Error,
+    { loopId: string; uploads: LoopSchemas.LoopSkillBundleUpload[] }
+  >({
+    mutationFn: async ({ loopId, uploads }) => {
+      if (!loopsClient) throw new Error("Not authenticated");
+      return await replaceLoopSkillBundles(
+        loopsClient.client,
+        loopsClient.projectId,
+        loopId,
+        uploads,
+      );
+    },
+    onSuccess: (loop) =>
+      applyLoopToCache(queryClient, loopsClient?.projectId ?? null, loop),
+  });
+}
+
+/**
+ * Bundle-and-replace in one step, for refreshing an existing loop's snapshot
+ * from the detail page. Detaching (null skill) never touches the host, so it
+ * also works on hosts without a local filesystem.
+ */
+export function useSyncLoopSkillBundles() {
+  const loopsClient = useLoopsClient();
+  const hostClient = useHostTRPCClient();
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    LoopSchemas.Loop,
+    Error,
+    { loopId: string; skill: LoopLocalSkillRef | null }
+  >({
+    mutationFn: async ({ loopId, skill }) => {
+      if (!loopsClient) throw new Error("Not authenticated");
+      const uploads = skill ? await buildSkillUploads(hostClient, skill) : [];
+      return await replaceLoopSkillBundles(
+        loopsClient.client,
+        loopsClient.projectId,
+        loopId,
+        uploads,
+      );
+    },
+    onSuccess: (loop) =>
+      applyLoopToCache(queryClient, loopsClient?.projectId ?? null, loop),
+  });
+}

--- a/packages/ui/src/features/loops/loopFormTypes.test.ts
+++ b/packages/ui/src/features/loops/loopFormTypes.test.ts
@@ -207,6 +207,44 @@ describe("formValuesToLoopWrite", () => {
   });
 });
 
+function baseLoop(): LoopSchemas.Loop {
+  return {
+    id: "loop-1",
+    team_id: 1,
+    created_by_id: 1,
+    name: "Digest",
+    description: "daily",
+    visibility: "team",
+    instructions: "Summarize.",
+    runtime_adapter: "claude",
+    model: "claude-sonnet-5",
+    reasoning_effort: "medium",
+    repositories: [],
+    sandbox_environment_id: null,
+    enabled: true,
+    disabled_reason: null,
+    overlap_policy: "skip",
+    behaviors: defaultLoopBehaviors(),
+    connectors: { mcp_installation_ids: [], posthog_mcp_scopes: "read_only" },
+    notifications: {
+      push: { enabled: false, events: [], params: {} },
+      email: { enabled: false, events: [], params: {} },
+      slack: { enabled: false, events: [], params: {} },
+    },
+    context_target: null,
+    internal: false,
+    origin_product: "user_created",
+    last_run_at: null,
+    last_run_status: null,
+    last_error: null,
+    consecutive_failures: 0,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-01T00:00:00Z",
+    triggers: [],
+    skill_bundles: [],
+  };
+}
+
 describe("loopToFormValues round trip", () => {
   it("maps a loop back into form values that write the same shape", () => {
     const loop = {
@@ -260,6 +298,7 @@ describe("loopToFormValues round trip", () => {
           updated_at: "2026-07-01T00:00:00Z",
         },
       ],
+      skill_bundles: [],
     } satisfies LoopSchemas.Loop;
 
     const values = loopToFormValues(loop);
@@ -290,6 +329,96 @@ describe("loopToFormValues round trip", () => {
         config: { cron_expression: "0 9 * * *", timezone: "UTC" },
       },
     ]);
+  });
+});
+
+describe("skill-driven loops", () => {
+  it("derives instructions from the skill and context on write", () => {
+    const write = formValuesToLoopWrite({
+      ...validFormValues(),
+      instructions: "stale free text",
+      skill: {
+        kind: "local",
+        name: "weekly-report",
+        source: "user",
+        path: "/skills/weekly-report",
+      },
+      skillContext: "Focus on churn.",
+    });
+    expect(write.instructions).toBe("/weekly-report\n\nFocus on churn.");
+  });
+
+  it("derives a bare invocation when the context is empty", () => {
+    const write = formValuesToLoopWrite({
+      ...validFormValues(),
+      skill: {
+        kind: "local",
+        name: "weekly-report",
+        source: "user",
+        path: "/skills/weekly-report",
+      },
+      skillContext: "  ",
+    });
+    expect(write.instructions).toBe("/weekly-report");
+  });
+
+  it.each([
+    {
+      name: "skill with no instructions",
+      skill: true,
+      instructions: "",
+      expected: true,
+    },
+    {
+      name: "no skill and no instructions",
+      skill: false,
+      instructions: "",
+      expected: false,
+    },
+    {
+      name: "no skill with instructions",
+      skill: false,
+      instructions: "Do it.",
+      expected: true,
+    },
+  ])(
+    "isLoopFormValid: $name → $expected",
+    ({ skill, instructions, expected }) => {
+      expect(
+        isLoopFormValid({
+          ...validFormValues(),
+          instructions,
+          skill: skill
+            ? { kind: "local", name: "s", source: "user", path: "/s" }
+            : null,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("maps an attached bundle back into an attached skill draft with its context", () => {
+    const bundle: LoopSchemas.LoopSkillBundle = {
+      id: "b1",
+      skill_name: "weekly-report",
+      skill_source: "user",
+      size: 10,
+      content_sha256: "a".repeat(64),
+      uploaded_at: "2026-07-01T00:00:00Z",
+    };
+    const loop = {
+      ...baseLoop(),
+      instructions: "/weekly-report\n\nFocus on churn.",
+      skill_bundles: [bundle],
+    };
+
+    const values = loopToFormValues(loop);
+    expect(values.skill).toEqual({
+      kind: "attached",
+      name: "weekly-report",
+      source: "user",
+    });
+    expect(values.skillContext).toBe("Focus on churn.");
+    expect(formValuesToLoopWrite(values).instructions).toBe(loop.instructions);
   });
 });
 

--- a/packages/ui/src/features/loops/loopFormTypes.ts
+++ b/packages/ui/src/features/loops/loopFormTypes.ts
@@ -1,5 +1,11 @@
 import type { LoopSchemas } from "@posthog/api-client/loops";
 import { systemTimezone } from "@posthog/ui/primitives/timezone";
+import {
+  buildSkillInstructions,
+  type LoopSkillDraft,
+  parseSkillContext,
+  primaryLoopSkillBundle,
+} from "./loopSkill";
 
 /**
  * A trigger row in the create/edit form. `key` is a client-only stable
@@ -30,6 +36,12 @@ export interface LoopFormValues {
   description: string;
   visibility: LoopSchemas.LoopVisibilityEnum;
   instructions: string;
+  /** When set, the loop runs this skill instead of free-form instructions;
+   * `instructions` is derived as `/skill-name` plus `skillContext` on save. */
+  skill: LoopSkillDraft | null;
+  /** Optional free text appended after the skill invocation. Only meaningful
+   * when `skill` is set. */
+  skillContext: string;
   runtimeAdapter: LoopSchemas.LoopRuntimeAdapterEnum;
   model: string;
   reasoningEffort: LoopSchemas.LoopReasoningEffortEnum | null;
@@ -129,6 +141,8 @@ export function emptyLoopFormValues(): LoopFormValues {
     description: "",
     visibility: "personal",
     instructions: "",
+    skill: null,
+    skillContext: "",
     runtimeAdapter: "claude",
     model: "",
     reasoningEffort: null,
@@ -153,11 +167,22 @@ export function normalizeLoopFormValues(
 }
 
 export function loopToFormValues(loop: LoopSchemas.Loop): LoopFormValues {
+  const primaryBundle = primaryLoopSkillBundle(loop);
   return {
     name: loop.name,
     description: loop.description,
     visibility: loop.visibility,
     instructions: loop.instructions,
+    skill: primaryBundle
+      ? {
+          kind: "attached",
+          name: primaryBundle.skill_name,
+          source: primaryBundle.skill_source,
+        }
+      : null,
+    skillContext: primaryBundle
+      ? parseSkillContext(loop.instructions, primaryBundle.skill_name)
+      : "",
     runtimeAdapter: loop.runtime_adapter,
     model: loop.model,
     reasoningEffort: loop.reasoning_effort,
@@ -188,7 +213,9 @@ export function formValuesToLoopWrite(
     name: values.name.trim(),
     description: values.description.trim(),
     visibility: values.visibility,
-    instructions: values.instructions,
+    instructions: values.skill
+      ? buildSkillInstructions(values.skill.name, values.skillContext)
+      : values.instructions,
     runtime_adapter: values.runtimeAdapter,
     model: values.model.trim(),
     reasoning_effort: values.reasoningEffort,
@@ -212,7 +239,10 @@ export function formValuesToLoopWrite(
 }
 
 export function isLoopFormValid(values: LoopFormValues): boolean {
-  if (!values.name.trim() || !values.instructions.trim()) {
+  if (!values.name.trim()) {
+    return false;
+  }
+  if (!values.skill && !values.instructions.trim()) {
     return false;
   }
   if (values.contextTarget && values.visibility !== "team") {

--- a/packages/ui/src/features/loops/loopSkill.test.ts
+++ b/packages/ui/src/features/loops/loopSkill.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSkillInstructions,
+  isTrustedSkillDependency,
+  parseSkillContext,
+} from "./loopSkill";
+
+describe("buildSkillInstructions", () => {
+  it.each([
+    { context: "", expected: "/deploy-checks" },
+    { context: "   ", expected: "/deploy-checks" },
+    {
+      context: "Focus on the checkout flow.",
+      expected: "/deploy-checks\n\nFocus on the checkout flow.",
+    },
+  ])("context $context → $expected", ({ context, expected }) => {
+    expect(buildSkillInstructions("deploy-checks", context)).toBe(expected);
+  });
+});
+
+describe("isTrustedSkillDependency", () => {
+  const repoPrimary = {
+    source: "repo" as const,
+    path: "/work/app/.claude/skills/deploy-checks",
+  };
+
+  it.each([
+    {
+      name: "user dependency of a repo skill is rejected",
+      // A repository's SKILL.md controls dependency names; trusting user skills
+      // here would let it exfiltrate the user's private machine-level skills.
+      dep: { source: "user" as const, path: "/home/me/.claude/skills/helper" },
+      primary: repoPrimary,
+      expected: false,
+    },
+    {
+      name: "user dependency of a user skill is trusted",
+      dep: { source: "user" as const, path: "/home/me/.claude/skills/helper" },
+      primary: {
+        source: "user" as const,
+        path: "/home/me/.claude/skills/deploy-checks",
+      },
+      expected: true,
+    },
+    {
+      name: "sibling from the same repo skills dir is trusted",
+      dep: { source: "repo" as const, path: "/work/app/.claude/skills/helper" },
+      primary: repoPrimary,
+      expected: true,
+    },
+    {
+      name: "same-source skill from another repo is rejected",
+      dep: {
+        source: "repo" as const,
+        path: "/work/other-repo/.claude/skills/helper",
+      },
+      primary: repoPrimary,
+      expected: false,
+    },
+    {
+      name: "cross-source non-user match is rejected",
+      dep: {
+        source: "marketplace" as const,
+        path: "/plugins/x/skills/helper",
+      },
+      primary: repoPrimary,
+      expected: false,
+    },
+    {
+      name: "windows-style sibling paths are compared by directory",
+      dep: {
+        source: "repo" as const,
+        path: "C:\\app\\.claude\\skills\\helper",
+      },
+      primary: {
+        source: "repo" as const,
+        path: "C:\\app\\.claude\\skills\\deploy-checks",
+      },
+      expected: true,
+    },
+  ])("$name", ({ dep, primary, expected }) => {
+    expect(isTrustedSkillDependency(dep, primary)).toBe(expected);
+  });
+});
+
+describe("parseSkillContext", () => {
+  it.each([
+    { name: "bare invocation", instructions: "/deploy-checks", expected: "" },
+    {
+      name: "invocation with context",
+      instructions: "/deploy-checks\n\nFocus on churn.",
+      expected: "Focus on churn.",
+    },
+    {
+      name: "invocation with single-newline context",
+      instructions: "/deploy-checks\nFocus on churn.",
+      expected: "Focus on churn.",
+    },
+    {
+      name: "drifted instructions are returned whole",
+      instructions: "Do the deploy checks manually.",
+      expected: "Do the deploy checks manually.",
+    },
+    {
+      name: "prefix-only slash word is not treated as the invocation",
+      instructions: "/deploy-checks-extra\n\nMore.",
+      expected: "/deploy-checks-extra\n\nMore.",
+    },
+  ])("$name", ({ instructions, expected }) => {
+    expect(parseSkillContext(instructions, "deploy-checks")).toBe(expected);
+  });
+});

--- a/packages/ui/src/features/loops/loopSkill.ts
+++ b/packages/ui/src/features/loops/loopSkill.ts
@@ -1,0 +1,87 @@
+import type { LoopSchemas } from "@posthog/api-client/loops";
+
+/**
+ * The skill driving a loop's instructions in the form. `attached` is the
+ * server-stored snapshot (edit mode, unchanged on save); `local` is a skill
+ * picked from this machine, bundled and uploaded on save.
+ */
+export type LoopSkillDraft =
+  | {
+      kind: "attached";
+      name: string;
+      source: LoopSchemas.LoopSkillSourceEnum;
+    }
+  | {
+      kind: "local";
+      name: string;
+      source: LoopSchemas.LoopSkillSourceEnum;
+      path: string;
+    };
+
+export function buildSkillInstructions(
+  skillName: string,
+  context: string,
+): string {
+  const invocation = `/${skillName}`;
+  const trimmed = context.trim();
+  return trimmed ? `${invocation}\n\n${trimmed}` : invocation;
+}
+
+/**
+ * The free-text context of skill-driven instructions: everything after the
+ * leading `/skill-name` line. Instructions that drifted from that shape are
+ * returned whole so nothing the user wrote is hidden.
+ */
+export function parseSkillContext(
+  instructions: string,
+  skillName: string,
+): string {
+  const invocation = `/${skillName}`;
+  const trimmed = instructions.trim();
+  if (trimmed === invocation) return "";
+  if (trimmed.startsWith(`${invocation}\n`)) {
+    return trimmed.slice(invocation.length).trim();
+  }
+  return trimmed;
+}
+
+function parentDir(skillPath: string): string {
+  const separatorIndex = Math.max(
+    skillPath.lastIndexOf("/"),
+    skillPath.lastIndexOf("\\"),
+  );
+  return separatorIndex > 0 ? skillPath.slice(0, separatorIndex) : skillPath;
+}
+
+/**
+ * Whether a resolved skill dependency may ride along in a loop's bundle set.
+ * Dependency names come from the referencing skill's SKILL.md, which for a repo
+ * skill is repository-controlled — so only same-source siblings from the same
+ * skills directory are trusted. Anything looser leaks: a cross-directory match
+ * lets another repo shadow the dependency, and trusting user skills from a repo
+ * primary would let a repository declare likely user-skill names and silently
+ * upload the user's private machine-level skills.
+ */
+export function isTrustedSkillDependency(
+  dep: { source: LoopSchemas.LoopSkillSourceEnum; path: string },
+  primary: { source: LoopSchemas.LoopSkillSourceEnum; path: string },
+): boolean {
+  return (
+    dep.source === primary.source &&
+    parentDir(dep.path) === parentDir(primary.path)
+  );
+}
+
+/** The loop's attached bundles, tolerating a backend that predates the field. */
+export function loopSkillBundles(
+  loop: LoopSchemas.Loop,
+): LoopSchemas.LoopSkillBundle[] {
+  return loop.skill_bundles ?? [];
+}
+
+/** The bundle whose skill the loop's instructions invoke; dependency bundles follow it. */
+export function primaryLoopSkillBundle(
+  loop: LoopSchemas.Loop,
+): LoopSchemas.LoopSkillBundle | null {
+  return loopSkillBundles(loop)[0] ?? null;
+}

--- a/packages/workspace-server/src/services/skills/skill-bundler.ts
+++ b/packages/workspace-server/src/services/skills/skill-bundler.ts
@@ -23,7 +23,19 @@ function getSafeSkillFileName(name: string): string {
 }
 
 async function assertSkillRoot(skillPath: string): Promise<string> {
-  const root = await fs.promises.realpath(path.resolve(skillPath));
+  const lexical = path.resolve(skillPath);
+  const parentReal = await fs.promises.realpath(path.dirname(lexical));
+  const root = await fs.promises.realpath(lexical);
+  // A symlinked skill root bundles whatever it points at, so a repository could
+  // commit `.claude/skills/foo -> ~/.claude/skills/foo` and exfiltrate a
+  // directory from outside the repo into an uploaded bundle. Only the skill
+  // directory itself must be real; symlinked ancestors (e.g. /tmp on macOS)
+  // stay legal.
+  if (root !== path.join(parentReal, path.basename(lexical))) {
+    throw new Error(
+      "Local skill bundle root must be a real directory, not a symlink",
+    );
+  }
   const skillMdPath = path.join(root, "SKILL.md");
   const stat = await fs.promises.stat(skillMdPath);
   if (!stat.isFile()) {

--- a/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/packages/workspace-server/src/services/skills/skills.test.ts
@@ -502,6 +502,60 @@ describe("write-path guard", () => {
     ).rejects.toThrow("not a known skill directory");
   });
 
+  it("rejects a repo skill reached through a symlinked skills directory", async () => {
+    // The leaf check alone misses this: a repo committing `.claude/skills`
+    // itself as a symlink makes every skill under it resolve outside the repo.
+    const outside = path.join(root, "outside-skills");
+    await createSkill(outside, "escapee");
+    await rm(repoSkillsDir, { recursive: true, force: true });
+    await symlink(outside, repoSkillsDir, "dir");
+    const service = makeService();
+
+    await expect(
+      service.bundleLocalSkill({
+        name: "escapee",
+        source: "repo",
+        path: path.join(repoSkillsDir, "escapee"),
+      }),
+    ).rejects.toThrow("resolves outside its repository");
+  });
+
+  it("rejects a symlinked repo skill root", async () => {
+    // A repository could commit `.claude/skills/foo` as a symlink to a
+    // directory outside the repo; bundling must refuse to follow it rather
+    // than upload the external target.
+    const target = await createSkill(root, "linked");
+    const linkPath = path.join(repoSkillsDir, "linked");
+    await symlink(target, linkPath, "dir");
+    const service = makeService();
+
+    await expect(
+      service.bundleLocalSkill({
+        name: "linked",
+        source: "repo",
+        path: linkPath,
+      }),
+    ).rejects.toThrow("resolves outside its repository");
+  });
+
+  it("rejects a symlinked skill root outside repo roots", async () => {
+    // Non-repo roots have no repository anchor, so the bundler's own
+    // leaf-symlink check is the guard there.
+    const target = await createSkill(root, "linked");
+    await mkdir(userSkillsHome.dir, { recursive: true });
+    const linkPath = path.join(userSkillsHome.dir, "linked");
+    await symlink(target, linkPath, "dir");
+    const service = makeService();
+
+    await expect(
+      service.bundleLocalSkill({
+        name: "linked",
+        source: "user",
+        path: linkPath,
+      }),
+    ).rejects.toThrow("not a symlink");
+  });
+
   it.each([
     ["bundled skill", () => path.join(pluginPath, "skills", "bundled-skill")],
     ["arbitrary directory", () => path.join(root, "rogue")],

--- a/packages/workspace-server/src/services/skills/skills.ts
+++ b/packages/workspace-server/src/services/skills/skills.ts
@@ -499,11 +499,39 @@ export class SkillsService {
     input: BundleLocalSkillInput,
   ): Promise<BundleLocalSkillOutput> {
     const skillDir = await this.resolveKnownSkillDir(input.path);
+    await this.assertRepoSkillStaysInRepo(skillDir);
     return bundleLocalSkill({
       name: input.name,
       source: input.source,
       skillPath: skillDir,
     });
+  }
+
+  /**
+   * A repository can commit any ancestor of its skills (`.claude` or
+   * `.claude/skills`) as a symlink pointing outside the repo, which passes the
+   * lexical known-root check and the bundler's leaf-symlink check yet bundles
+   * an external directory. Uploads must stay inside the real repository, so
+   * anchor the check on the workspace folder itself — the one path segment a
+   * repo author cannot control.
+   */
+  private async assertRepoSkillStaysInRepo(skillDir: string): Promise<void> {
+    const parent = path.dirname(skillDir);
+    const folders = await this.folders.getFolders();
+    const owningFolder = folders.find(
+      (folder) =>
+        path.resolve(path.join(folder.path, ".claude", "skills")) === parent,
+    );
+    if (!owningFolder) return;
+    const [realSkill, realFolder] = await Promise.all([
+      fs.promises.realpath(skillDir),
+      fs.promises.realpath(path.resolve(owningFolder.path)),
+    ]);
+    if (!realSkill.startsWith(realFolder + path.sep)) {
+      throw new Error(
+        "Access denied: repository skill resolves outside its repository",
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

A loop's prompt is a free-form instructions blob. Teams that already maintain skills have no way to point a loop at one, so the same playbook gets pasted into instructions and drifts from the skill.

## Changes

The loop form's prompt step gains a source choice: write instructions or run a skill. Picking a local skill zips it (plus its skill dependencies) via workspace-server on save and uploads the set through the new `PUT /loops/{id}/skill_bundles/` endpoint, and the loop's instructions become `/skill-name` plus an optional context field. The backend seeds those bundles into every fired run, where the sandbox agent-server already installs `skill_bundle` artifacts.

The loop detail page shows the attached skill with its snapshot digest and an "Update from local skill" button to re-snapshot after editing the skill. On hosts without a local filesystem (web) the picker is hidden; an attached skill can still be kept or detached.

Requires PostHog/posthog#73069 to be deployed first; until then the skill_bundles endpoint 404s and `loop.skill_bundles` is absent.

## How did you test this?

Unit tests for the new instruction build/parse helpers and the form round-trip (skill mode validity, derived instructions, attached-snapshot mapping) via `pnpm --filter @posthog/ui test`. Full `pnpm typecheck` and Biome lint are clean. Not exercised against a live backend since the API only exists in the paired posthog PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
