### PR TITLE
feat(inbox): add Google Search Console as a self-driving source

### DIFF
--- a/packages/shared/src/inbox-types.ts
+++ b/packages/shared/src/inbox-types.ts
@@ -11,7 +11,8 @@ export type SignalRecordKind =
   | "ticket"
   | "scanner_finding"
   | "feedback"
-  | "review";
+  | "review"
+  | "search_opportunity";
 
 /**
  * A warehouse data source the Self-driving inbox can watch. This is the single source of
@@ -48,6 +49,7 @@ const ERROR = "Surface new and reopened errors";
 const FINDING = "Surface new security and code-quality findings";
 const FEEDBACK = "Turn product feedback and feature requests into inputs";
 const REVIEW = "Monitor new app and product reviews";
+const SEARCH = "Fix pages that rank in Google but lose clicks";
 
 /** Registry of warehouse-backed inbox sources, alphabetical within each category. */
 export const EXTERNAL_INBOX_SOURCES = [
@@ -392,6 +394,16 @@ export const EXTERNAL_INBOX_SOURCES = [
     recordKind: "review",
     setup: "dynamic",
   },
+  // Search analytics
+  {
+    product: "google_search_console",
+    label: "Google Search Console",
+    description: SEARCH,
+    dwSourceType: "GoogleSearchConsole",
+    requiredTables: ["search_analytics_by_query_page"],
+    recordKind: "search_opportunity",
+    setup: "dynamic",
+  },
 ] as const satisfies readonly ExternalInboxSource[];
 
 /** Warehouse-backed source products, derived from the registry above. */
@@ -434,9 +446,13 @@ export type SourceType =
   | "session_analysis_cluster"
   | SignalRecordKind;
 
-/** Issue-like records mutate (status/votes change), so their table needs full-refresh sync. */
+/**
+ * Issue-like records mutate (status/votes change), so their table needs full-refresh sync.
+ * Tickets and search-analytics rows are append-only — existing rows never change once written —
+ * so they sync incrementally.
+ */
 export function sourceNeedsFullRefresh(recordKind: SignalRecordKind): boolean {
-  return recordKind !== "ticket";
+  return recordKind !== "ticket" && recordKind !== "search_opportunity";
 }
 
 export const EXTERNAL_INBOX_SOURCE_BY_PRODUCT: Partial<

--- a/packages/ui/src/features/inbox/components/utils/source-product-icons.tsx
+++ b/packages/ui/src/features/inbox/components/utils/source-product-icons.tsx
@@ -10,6 +10,7 @@ import {
   KanbanIcon,
   LifebuoyIcon,
   LightbulbIcon,
+  MagnifyingGlassIcon,
   MegaphoneIcon,
   ShieldIcon,
   StarIcon,
@@ -178,4 +179,9 @@ export const SOURCE_PRODUCT_META: Partial<
   },
   intercom: { Icon: ChatsIcon, color: "var(--blue-9)", label: "Intercom" },
   hubspot: { Icon: LifebuoyIcon, color: "var(--orange-9)", label: "HubSpot" },
+  google_search_console: {
+    Icon: MagnifyingGlassIcon,
+    color: "var(--sky-9)",
+    label: "Google Search Console",
+  },
 };


### PR DESCRIPTION
## Problem

Google Search Console is now a Self-driving inbox signal source (backend PR: PostHog/posthog#73079), but the inbox Sources modal had no way to turn it on or connect it.

## Changes

Registers Google Search Console in the inbox source registry so it appears as a toggle and connects through the existing generic setup form.

- `EXTERNAL_INBOX_SOURCES`: new `google_search_console` entry (watches `search_analytics_by_query_page`, `setup: "dynamic"`). The toggle card, source filter, and `SourceProduct` unions all derive from this registry, so no other wiring is needed.
- New `search_opportunity` record kind. `sourceNeedsFullRefresh` treats it as append-only (incremental sync) like tickets, because GSC's per-day search rows are immutable once written — unlike issues, which mutate and need full refresh.
- Source-product icon/label metadata (magnifying-glass icon).

No bespoke setup form: `DynamicSourceSetup` already renders the source's OAuth grant (`oauth` field, connect-by-`kind`) and property picker (`oauth-account-select`), which is exactly GSC's connect-form shape.

**Depends on PostHog/posthog#73079 shipping first.** The toggle's create call sends `source_product: "google_search_console"`, which the Signals model rejects with a 400 until that backend PR lands the enum value.

## How did you test this?

- `pnpm --filter @posthog/shared build`, `biome lint` on the changed files, and `pnpm typecheck` across the repo (24/24 packages) all pass. The unions consumed across packages type-check against the new registry entry.
- No new tests: the registry is type-enforced (a bad entry fails `typecheck`), and there is no runtime registry test to extend.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
