### PR TITLE
fix(tasks): avoid redundant terminal history fetches

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -5959,55 +5959,81 @@ export class SessionService {
         return;
       }
       if (resumeFromRunId) {
-        const [ancestorResult, currentRunResult] = await Promise.all([
-          authStatus.auth.client.getTaskRunSessionLogsResult(
-            taskId,
-            resumeFromRunId,
-            { limit: 100000 },
-          ),
-          authStatus.auth.client.getTaskRunSessionLogsResult(
-            taskId,
-            taskRunId,
-            { limit: 100000 },
-          ),
-        ]);
-        if (!ancestorResult.complete || !currentRunResult.complete) {
-          this.d.log.warn("Resume session log hydration was incomplete", {
-            taskId,
-            taskRunId,
-            resumeFromRunId,
-            ancestorComplete: ancestorResult.complete,
-            currentRunComplete: currentRunResult.complete,
-          });
-          return;
+        if (isTerminalStatus(runStatus)) {
+          const result =
+            await authStatus.auth.client.getTaskRunSessionLogsResult(
+              taskId,
+              taskRunId,
+              { limit: 100000 },
+            );
+          if (!result.complete) {
+            this.d.log.warn("Resume session log hydration was incomplete", {
+              taskId,
+              taskRunId,
+              resumeFromRunId,
+            });
+            return;
+          }
+          rawEntries = result.entries;
+          const markedLeafStart = rawEntries.findIndex(
+            (entry) => getEntryTaskRunMarker(entry) === taskRunId,
+          );
+          resumeLeafEntryStartIndex =
+            markedLeafStart >= 0 ? markedLeafStart : undefined;
+          liveStreamLineCount =
+            markedLeafStart >= 0
+              ? rawEntries.length - markedLeafStart
+              : rawEntries.length;
+        } else {
+          const [ancestorResult, currentRunResult] = await Promise.all([
+            authStatus.auth.client.getTaskRunSessionLogsResult(
+              taskId,
+              resumeFromRunId,
+              { limit: 100000 },
+            ),
+            authStatus.auth.client.getTaskRunSessionLogsResult(
+              taskId,
+              taskRunId,
+              { limit: 100000 },
+            ),
+          ]);
+          if (!ancestorResult.complete || !currentRunResult.complete) {
+            this.d.log.warn("Resume session log hydration was incomplete", {
+              taskId,
+              taskRunId,
+              resumeFromRunId,
+              ancestorComplete: ancestorResult.complete,
+              currentRunComplete: currentRunResult.complete,
+            });
+            return;
+          }
+          const ancestorEntries: StoredLogEntry[] = ancestorResult.entries;
+          const currentRunEntries: StoredLogEntry[] = currentRunResult.entries;
+          const ancestorKeys = ancestorEntries.map((entry) =>
+            JSON.stringify(entry),
+          );
+          const currentKeys = currentRunEntries.map((entry) =>
+            JSON.stringify(entry),
+          );
+          const overlap = suffixPrefixOverlap(ancestorKeys, currentKeys);
+          const persistedLeafEntries = currentRunEntries.slice(overlap);
+          const leafLogs = await this.fetchSessionLogs(logUrl, taskRunId);
+          const leafKeys = new Set(
+            persistedLeafEntries.map((entry) => JSON.stringify(entry)),
+          );
+          rawEntries = [
+            ...ancestorEntries,
+            ...persistedLeafEntries,
+            ...leafLogs.rawEntries.filter(
+              (entry) => !leafKeys.has(JSON.stringify(entry)),
+            ),
+          ];
+          resumeLeafEntryStartIndex = ancestorEntries.length;
+          liveStreamLineCount = Math.max(
+            leafLogs.totalLineCount,
+            persistedLeafEntries.length,
+          );
         }
-        const ancestorEntries: StoredLogEntry[] = ancestorResult.entries;
-        const currentRunEntries: StoredLogEntry[] = currentRunResult.entries;
-
-        const ancestorKeys = ancestorEntries.map((entry) =>
-          JSON.stringify(entry),
-        );
-        const currentKeys = currentRunEntries.map((entry) =>
-          JSON.stringify(entry),
-        );
-        const overlap = suffixPrefixOverlap(ancestorKeys, currentKeys);
-        const persistedLeafEntries = currentRunEntries.slice(overlap);
-        const leafLogs = await this.fetchSessionLogs(logUrl, taskRunId);
-        const leafKeys = new Set(
-          persistedLeafEntries.map((entry) => JSON.stringify(entry)),
-        );
-        rawEntries = [
-          ...ancestorEntries,
-          ...persistedLeafEntries,
-          ...leafLogs.rawEntries.filter(
-            (entry) => !leafKeys.has(JSON.stringify(entry)),
-          ),
-        ];
-        resumeLeafEntryStartIndex = ancestorEntries.length;
-        liveStreamLineCount = Math.max(
-          leafLogs.totalLineCount,
-          persistedLeafEntries.length,
-        );
       } else {
         const result = await authStatus.auth.client.getTaskRunSessionLogsResult(
           taskId,


### PR DESCRIPTION
## Problem

Opening a completed task with a long resume chain downloads overlapping history multiple times before the conversation can render.

## Changes

Completed resumed runs now hydrate from the combined session-log response once. Run markers still preserve the leaf boundary used for transcript positioning and counts. Active runs keep the existing reconciliation path.