### PR TITLE
fix(tasks): refresh active cloud run on task open

### DIFF
--- a/packages/ui/src/features/task-detail/hooks/useRefreshedTask.test.tsx
+++ b/packages/ui/src/features/task-detail/hooks/useRefreshedTask.test.tsx
@@ -1,0 +1,57 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useRefreshedTask } from "./useRefreshedTask";
+
+const mocks = vi.hoisted(() => ({ getTask: vi.fn() }));
+
+vi.mock("@posthog/ui/features/auth/authClientImperative", () => ({
+  getAuthenticatedClient: vi.fn(async () => ({ getTask: mocks.getTask })),
+}));
+
+function task(runId: string, status: "failed" | "in_progress"): Task {
+  return {
+    id: "task-123",
+    title: "Cloud task",
+    description: "Keep working",
+    repository: null,
+    latest_run: {
+      id: runId,
+      task: "task-123",
+      environment: "cloud",
+      status,
+      state: {},
+    },
+  } as Task;
+}
+
+describe("useRefreshedTask", () => {
+  beforeEach(() => {
+    mocks.getTask.mockReset();
+  });
+
+  it("replaces a cached failed run with the authoritative resumed run", async () => {
+    const failedParent = task("run-parent", "failed");
+    const resumedChild = task("run-child", "in_progress");
+    mocks.getTask.mockResolvedValue(resumedChild);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () => useRefreshedTask("task-123", failedParent),
+      { wrapper },
+    );
+
+    expect(result.current.latest_run?.id).toBe("run-parent");
+    await waitFor(() => {
+      expect(result.current.latest_run?.id).toBe("run-child");
+    });
+    expect(mocks.getTask).toHaveBeenCalledWith("task-123");
+  });
+});

--- a/packages/ui/src/features/task-detail/hooks/useRefreshedTask.ts
+++ b/packages/ui/src/features/task-detail/hooks/useRefreshedTask.ts
@@ -1,0 +1,13 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { useQuery } from "@tanstack/react-query";
+import { taskDetailQuery } from "../../tasks/queries";
+
+export function useRefreshedTask(taskId: string, initialTask: Task): Task {
+  const { data } = useQuery({
+    ...taskDetailQuery(taskId),
+    initialData: initialTask,
+    refetchOnMount: "always",
+  });
+
+  return data;
+}

--- a/packages/ui/src/features/task-detail/hooks/useTaskData.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskData.ts
@@ -7,9 +7,7 @@ import { getTaskRepository } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useWorkspaceTRPC } from "@posthog/workspace-client/trpc";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
 import { cloneStore } from "../../clone/cloneStore";
-import { useTasks } from "../../tasks/useTasks";
 import { useWorkspace } from "../../workspace/useWorkspace";
 import { useRefreshedTask } from "./useRefreshedTask";
 
@@ -20,13 +18,7 @@ interface UseTaskDataParams {
 
 export function useTaskData({ taskId, initialTask }: UseTaskDataParams) {
   const trpcReact = useWorkspaceTRPC();
-  const { data: tasks = [] } = useTasks();
-  const refreshedTask = useRefreshedTask(taskId, initialTask);
-
-  const task = useMemo(
-    () => refreshedTask ?? tasks.find((t) => t.id === taskId) ?? initialTask,
-    [refreshedTask, tasks, taskId, initialTask],
-  );
+  const task = useRefreshedTask(taskId, initialTask);
 
   const workspace = useWorkspace(taskId);
   const repoPath = workspace?.folderPath ?? null;

--- a/packages/ui/src/features/task-detail/hooks/useTaskData.ts
+++ b/packages/ui/src/features/task-detail/hooks/useTaskData.ts
@@ -11,6 +11,7 @@ import { useMemo } from "react";
 import { cloneStore } from "../../clone/cloneStore";
 import { useTasks } from "../../tasks/useTasks";
 import { useWorkspace } from "../../workspace/useWorkspace";
+import { useRefreshedTask } from "./useRefreshedTask";
 
 interface UseTaskDataParams {
   taskId: string;
@@ -20,10 +21,11 @@ interface UseTaskDataParams {
 export function useTaskData({ taskId, initialTask }: UseTaskDataParams) {
   const trpcReact = useWorkspaceTRPC();
   const { data: tasks = [] } = useTasks();
+  const refreshedTask = useRefreshedTask(taskId, initialTask);
 
   const task = useMemo(
-    () => tasks.find((t) => t.id === taskId) || initialTask,
-    [tasks, taskId, initialTask],
+    () => refreshedTask ?? tasks.find((t) => t.id === taskId) ?? initialTask,
+    [refreshedTask, tasks, taskId, initialTask],
   );
 
   const workspace = useWorkspace(taskId);


### PR DESCRIPTION
## Problem

After a failed cloud run resumes into a new run, a renderer reload can keep showing the cached failed parent. The task view then remains attached to stale run state until the desktop app is restarted.

## Changes

Refresh the authoritative task detail whenever a task view mounts while retaining cached data for immediate rendering. The existing session reconciliation then switches its watcher when the latest run ID changes.