### PR TITLE
feat: honest spend attribution and context-size lens in usage display

### DIFF
--- a/packages/api-client/src/spend-analysis.ts
+++ b/packages/api-client/src/spend-analysis.ts
@@ -20,6 +20,9 @@ export interface SpendAnalysisToolRow {
   cost_usd: number;
   share_of_scoped: number;
   avg_input_tokens: number;
+  // Optional until the backend honest-attribution rollout reaches every deployment.
+  cost_attributed_usd?: number;
+  share_attributed?: number;
 }
 
 export interface SpendAnalysisModelRow {
@@ -36,6 +39,15 @@ export interface SpendAnalysisDayRow {
   cost_usd: number;
 }
 
+export interface SpendAnalysisInputSizeRow {
+  bucket: string;
+  min_input_tokens: number;
+  generation_count: number;
+  cost_usd: number;
+  share_of_scoped: number;
+  avg_cost_per_generation: number;
+}
+
 export interface SpendAnalysisBreakdown<TRow> {
   items: TRow[];
   truncated: boolean;
@@ -48,6 +60,8 @@ export interface SpendAnalysisResponse {
   by_model: SpendAnalysisBreakdown<SpendAnalysisModelRow>;
   // Optional until the backend by_day rollout reaches every deployment.
   by_day?: SpendAnalysisBreakdown<SpendAnalysisDayRow>;
+  // Optional until the backend by_input_size rollout reaches every deployment.
+  by_input_size?: SpendAnalysisBreakdown<SpendAnalysisInputSizeRow>;
   // `top_traces` is still in the backend response shape (always empty) per
   // posthog/posthog#59796. Renderer code does not consume it; left out of the
   // TS type so future readers see only what we actually use.

--- a/packages/core/src/billing/spendAnalysisTypes.ts
+++ b/packages/core/src/billing/spendAnalysisTypes.ts
@@ -20,6 +20,9 @@ export interface SpendAnalysisToolRow {
   cost_usd: number;
   share_of_scoped: number;
   avg_input_tokens: number;
+  // Optional until the backend honest-attribution rollout reaches every deployment.
+  cost_attributed_usd?: number;
+  share_attributed?: number;
 }
 
 export interface SpendAnalysisModelRow {
@@ -36,6 +39,15 @@ export interface SpendAnalysisDayRow {
   cost_usd: number;
 }
 
+export interface SpendAnalysisInputSizeRow {
+  bucket: string;
+  min_input_tokens: number;
+  generation_count: number;
+  cost_usd: number;
+  share_of_scoped: number;
+  avg_cost_per_generation: number;
+}
+
 export interface SpendAnalysisBreakdown<TRow> {
   items: TRow[];
   truncated: boolean;
@@ -48,4 +60,6 @@ export interface SpendAnalysisResponse {
   by_model: SpendAnalysisBreakdown<SpendAnalysisModelRow>;
   // Optional until the backend by_day rollout reaches every deployment.
   by_day?: SpendAnalysisBreakdown<SpendAnalysisDayRow>;
+  // Optional until the backend by_input_size rollout reaches every deployment.
+  by_input_size?: SpendAnalysisBreakdown<SpendAnalysisInputSizeRow>;
 }

--- a/packages/core/src/billing/spendSuggestions.test.ts
+++ b/packages/core/src/billing/spendSuggestions.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from "vitest";
+import type {
+  SpendAnalysisInputSizeRow,
+  SpendAnalysisResponse,
+  SpendAnalysisToolRow,
+} from "./spendAnalysisTypes";
+import { deriveSpendSuggestions } from "./spendSuggestions";
+
+function makeResponse(
+  overrides: Partial<SpendAnalysisResponse> = {},
+): SpendAnalysisResponse {
+  return {
+    summary: {
+      date_from: "2025-04-23T00:00:00Z",
+      date_to: "2025-05-23T00:00:00Z",
+      product: "posthog_code",
+      total_cost_usd: 100,
+      event_count: 1000,
+      scoped_cost_usd: 80,
+      scoped_event_count: 800,
+    },
+    by_product: { items: [], truncated: false },
+    by_tool: { items: [], truncated: false },
+    by_model: { items: [], truncated: false },
+    ...overrides,
+  };
+}
+
+function makeToolRow(
+  overrides: Partial<SpendAnalysisToolRow>,
+): SpendAnalysisToolRow {
+  return {
+    tool: "Bash",
+    generation_count: 500,
+    cost_usd: 50,
+    share_of_scoped: 0.625,
+    avg_input_tokens: 150_000,
+    ...overrides,
+  };
+}
+
+function makeInputSizeRow(
+  overrides: Partial<SpendAnalysisInputSizeRow>,
+): SpendAnalysisInputSizeRow {
+  return {
+    bucket: "<50k",
+    min_input_tokens: 0,
+    generation_count: 100,
+    cost_usd: 10,
+    share_of_scoped: 0.1,
+    avg_cost_per_generation: 0.1,
+    ...overrides,
+  };
+}
+
+describe("deriveSpendSuggestions", () => {
+  it("returns a single no-spend message when total cost is zero", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        summary: {
+          date_from: "2025-04-23T00:00:00Z",
+          date_to: "2025-05-23T00:00:00Z",
+          product: "posthog_code",
+          total_cost_usd: 0,
+          event_count: 0,
+          scoped_cost_usd: 0,
+          scoped_event_count: 0,
+        },
+      }),
+    );
+    expect(suggestions).toEqual(["No LLM spend in the selected window."]);
+  });
+
+  // The whole point of this PR: once the backend serves honest attribution,
+  // the client must use `share_attributed` and stop claiming a tool "drives"
+  // the spend, which is the co-occurrence artifact we're replacing.
+  it("uses share_attributed and avoids 'drives' wording when attribution is present", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        by_tool: {
+          items: [
+            makeToolRow({
+              cost_attributed_usd: 36,
+              share_attributed: 0.45,
+            }),
+          ],
+          truncated: false,
+        },
+      }),
+    );
+    const toolSuggestion = suggestions.find((s) => s.startsWith("Bash"));
+    expect(toolSuggestion).toContain("45%");
+    expect(toolSuggestion).not.toContain("drives");
+    expect(toolSuggestion).toContain("split across the tools it used");
+  });
+
+  // Guards the explicit backwards-compat requirement: an older backend that
+  // hasn't shipped cost_attributed_usd/share_attributed yet must still surface
+  // a top-tool suggestion, using the old share_of_scoped-based wording.
+  it("falls back to share_of_scoped and 'drives' wording when attribution fields are absent", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        by_tool: {
+          items: [makeToolRow({ share_of_scoped: 0.625 })],
+          truncated: false,
+        },
+      }),
+    );
+    const toolSuggestion = suggestions.find((s) => s.startsWith("Bash"));
+    expect(toolSuggestion).toContain("drives 63%");
+  });
+
+  it.each([
+    ["at threshold, no suggestion", 0.35, false],
+    ["above threshold, suggestion fires", 0.36, true],
+  ])(
+    "top-tool suggestion (attributed): %s",
+    (_label, shareAttributed, expectSuggestion) => {
+      const suggestions = deriveSpendSuggestions(
+        makeResponse({
+          by_tool: {
+            items: [
+              makeToolRow({
+                cost_attributed_usd: shareAttributed * 80,
+                share_attributed: shareAttributed,
+              }),
+            ],
+            truncated: false,
+          },
+        }),
+      );
+      const found = suggestions.some((s) => s.startsWith("Bash"));
+      expect(found).toBe(expectSuggestion);
+    },
+  );
+
+  it("does not add a top-tool suggestion when the top row has a null tool", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        by_tool: {
+          items: [
+            makeToolRow({
+              tool: null,
+              share_attributed: 0.9,
+              cost_attributed_usd: 72,
+            }),
+          ],
+          truncated: false,
+        },
+      }),
+    );
+    expect(suggestions.join(" ")).not.toContain("was involved in");
+  });
+
+  it("surfaces the no-tool suggestion without overstating it as a driver", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        by_tool: {
+          items: [
+            makeToolRow({ tool: "Bash", share_of_scoped: 0.5 }),
+            makeToolRow({ tool: null, share_of_scoped: 0.2 }),
+          ],
+          truncated: false,
+        },
+      }),
+    );
+    const noToolSuggestion = suggestions.find((s) => s.startsWith("20%"));
+    expect(noToolSuggestion).toContain("no tool call");
+    expect(noToolSuggestion).not.toContain("drives");
+  });
+
+  it("recommends trimming context when the >300k bucket exceeds the threshold", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        by_input_size: {
+          items: [
+            makeInputSizeRow({ bucket: "<50k", share_of_scoped: 0.1 }),
+            makeInputSizeRow({
+              bucket: ">300k",
+              min_input_tokens: 300_000,
+              share_of_scoped: 0.45,
+            }),
+          ],
+          truncated: false,
+        },
+      }),
+    );
+    const contextSuggestion = suggestions.find((s) => s.includes("300k"));
+    expect(contextSuggestion).toContain("45%");
+    expect(contextSuggestion).toContain("clear between unrelated tasks");
+  });
+
+  // The >300k bucket can stay under the bar while spend actually clusters in
+  // a smaller bucket (e.g. 200k-300k) -- the top-by-cost bucket should still
+  // trigger the suggestion using its own numbers.
+  it("falls back to the top-by-cost bucket when >300k is under threshold", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        by_input_size: {
+          items: [
+            makeInputSizeRow({ bucket: "<50k", share_of_scoped: 0.1 }),
+            makeInputSizeRow({
+              bucket: "200k-300k",
+              min_input_tokens: 200_000,
+              share_of_scoped: 0.5,
+            }),
+            makeInputSizeRow({
+              bucket: ">300k",
+              min_input_tokens: 300_000,
+              share_of_scoped: 0.2,
+            }),
+          ],
+          truncated: false,
+        },
+      }),
+    );
+    const contextSuggestion = suggestions.find((s) =>
+      s.includes("200k+ input tokens"),
+    );
+    expect(contextSuggestion).toContain("50%");
+  });
+
+  it("adds no context-size suggestion when every bucket is under threshold", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        by_input_size: {
+          items: [
+            makeInputSizeRow({ bucket: "<50k", share_of_scoped: 0.3 }),
+            makeInputSizeRow({
+              bucket: ">300k",
+              min_input_tokens: 300_000,
+              share_of_scoped: 0.3,
+            }),
+          ],
+          truncated: false,
+        },
+      }),
+    );
+    expect(
+      suggestions.some((s) => s.includes("clear between unrelated tasks")),
+    ).toBe(false);
+  });
+
+  it("adds no context-size suggestion when by_input_size is absent", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        by_tool: {
+          items: [makeToolRow({ share_of_scoped: 0.5 })],
+          truncated: false,
+        },
+      }),
+    );
+    expect(
+      suggestions.some((s) => s.includes("clear between unrelated tasks")),
+    ).toBe(false);
+  });
+
+  it("keeps the codeShare suggestion when this app dominates total spend", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        summary: {
+          date_from: "2025-04-23T00:00:00Z",
+          date_to: "2025-05-23T00:00:00Z",
+          product: "posthog_code",
+          total_cost_usd: 100,
+          event_count: 1000,
+          scoped_cost_usd: 90,
+          scoped_event_count: 900,
+        },
+      }),
+    );
+    expect(suggestions[0]).toContain("90% of your spend");
+  });
+
+  it("falls back to the generic message when no other suggestion fires", () => {
+    const suggestions = deriveSpendSuggestions(
+      makeResponse({
+        summary: {
+          date_from: "2025-04-23T00:00:00Z",
+          date_to: "2025-05-23T00:00:00Z",
+          product: "posthog_code",
+          total_cost_usd: 100,
+          event_count: 1000,
+          scoped_cost_usd: 50,
+          scoped_event_count: 500,
+        },
+      }),
+    );
+    expect(suggestions).toEqual([
+      "Your spend is fairly evenly distributed across tools. No single hotspot stands out.",
+    ]);
+  });
+});

--- a/packages/core/src/billing/spendSuggestions.ts
+++ b/packages/core/src/billing/spendSuggestions.ts
@@ -1,5 +1,85 @@
 import { formatTokens } from "./spendAnalysisFormat";
-import type { SpendAnalysisResponse } from "./spendAnalysisTypes";
+import type {
+  SpendAnalysisInputSizeRow,
+  SpendAnalysisResponse,
+} from "./spendAnalysisTypes";
+
+// A single turn often calls several tools, and the backend's `share_of_scoped`
+// splits full turn cost across every tool that turn touched -- so summing it
+// across tools exceeds 100%, and whichever tool is most ubiquitous (Bash) looks
+// artificially dominant. `share_attributed` / `cost_attributed_usd` fix this by
+// splitting each turn's cost fractionally across its tools, so they reconcile
+// to scoped spend. Prefer them once the backend serves them; fall back to the
+// old co-occurrence share otherwise.
+const TOP_TOOL_SHARE_THRESHOLD = 0.35;
+const NO_TOOL_SHARE_THRESHOLD = 0.1;
+// The largest-context bucket eating this much of scoped spend is worth calling
+// out as the primary lever -- trimming context, not switching tools.
+const LARGE_CONTEXT_SHARE_THRESHOLD = 0.4;
+const LARGEST_BUCKET_LABEL = ">300k";
+
+function hasAttributedCost(
+  row: SpendAnalysisResponse["by_tool"]["items"][number],
+): row is SpendAnalysisResponse["by_tool"]["items"][number] & {
+  cost_attributed_usd: number;
+  share_attributed: number;
+} {
+  return (
+    typeof row.cost_attributed_usd === "number" &&
+    typeof row.share_attributed === "number"
+  );
+}
+
+function topToolSuggestion(
+  toolItems: SpendAnalysisResponse["by_tool"]["items"],
+): string | null {
+  const top = toolItems[0];
+  if (!top?.tool) return null;
+
+  if (hasAttributedCost(top)) {
+    if (top.share_attributed <= TOP_TOOL_SHARE_THRESHOLD) return null;
+    return `${top.tool} was involved in ${Math.round(top.share_attributed * 100)}% of your PostHog Code spend when each turn's cost is split across the tools it used, averaging ${formatTokens(top.avg_input_tokens)} input tokens per call.`;
+  }
+
+  if (top.share_of_scoped <= TOP_TOOL_SHARE_THRESHOLD) return null;
+  return `${top.tool} drives ${Math.round(top.share_of_scoped * 100)}% of your spend in this app, averaging ${formatTokens(top.avg_input_tokens)} input tokens per call.`;
+}
+
+function noToolSuggestion(
+  toolItems: SpendAnalysisResponse["by_tool"]["items"],
+): string | null {
+  const noToolRow = toolItems.find((r) => r.tool === null);
+  if (!noToolRow || noToolRow.share_of_scoped <= NO_TOOL_SHARE_THRESHOLD) {
+    return null;
+  }
+  return `${Math.round(noToolRow.share_of_scoped * 100)}% of spend is generations with no tool call: text-only replies. Tighter prompts or stopping the agent earlier can cut this.`;
+}
+
+/** The bucket to call out: the `>300k` bucket if it clears the threshold,
+ * otherwise whichever bucket has the highest cost share (a shop can cluster in
+ * `200k-300k` without much landing in `>300k`). */
+function largestContextSuggestion(
+  rows: SpendAnalysisInputSizeRow[],
+): string | null {
+  if (rows.length === 0) return null;
+
+  const largestBucket = rows.find((r) => r.bucket === LARGEST_BUCKET_LABEL);
+  const topByCost = rows.reduce((max, r) =>
+    r.share_of_scoped > max.share_of_scoped ? r : max,
+  );
+
+  const candidate =
+    largestBucket &&
+    largestBucket.share_of_scoped > LARGE_CONTEXT_SHARE_THRESHOLD
+      ? largestBucket
+      : topByCost.share_of_scoped > LARGE_CONTEXT_SHARE_THRESHOLD
+        ? topByCost
+        : null;
+
+  if (!candidate) return null;
+
+  return `${Math.round(candidate.share_of_scoped * 100)}% of your spend comes from calls with ${formatTokens(candidate.min_input_tokens)}+ input tokens. Trimming context is your biggest lever here: clear between unrelated tasks and avoid re-reading large files or command outputs.`;
+}
 
 export function deriveSpendSuggestions(data: SpendAnalysisResponse): string[] {
   const suggestions: string[] = [];
@@ -18,20 +98,19 @@ export function deriveSpendSuggestions(data: SpendAnalysisResponse): string[] {
     );
   }
 
-  const codeTotal = summary.scoped_cost_usd;
-  if (codeTotal > 0 && toolItems.length > 0) {
-    const top = toolItems[0];
-    if (top.share_of_scoped > 0.35 && top.tool) {
-      suggestions.push(
-        `${top.tool} drives ${Math.round(top.share_of_scoped * 100)}% of your spend in this app, averaging ${formatTokens(top.avg_input_tokens)} input tokens per call.`,
-      );
-    }
-    const noToolRow = toolItems.find((r) => r.tool === null);
-    if (noToolRow && noToolRow.share_of_scoped > 0.1) {
-      suggestions.push(
-        `${Math.round(noToolRow.share_of_scoped * 100)}% is spent on generations that take no tool action: pure text replies. Consider tighter prompts or stopping the agent earlier.`,
-      );
-    }
+  if (data.by_input_size) {
+    const inputSizeSuggestion = largestContextSuggestion(
+      data.by_input_size.items,
+    );
+    if (inputSizeSuggestion) suggestions.push(inputSizeSuggestion);
+  }
+
+  if (summary.scoped_cost_usd > 0 && toolItems.length > 0) {
+    const topSuggestion = topToolSuggestion(toolItems);
+    if (topSuggestion) suggestions.push(topSuggestion);
+
+    const noToolSuggestionText = noToolSuggestion(toolItems);
+    if (noToolSuggestionText) suggestions.push(noToolSuggestionText);
   }
 
   if (suggestions.length === 0) {

--- a/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
+++ b/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
@@ -8,6 +8,7 @@ import { useMemo, useState } from "react";
 import { useSpendAnalysis } from "../useSpendAnalysis";
 import { ModelBreakdownCards } from "./ModelBreakdownCards";
 import {
+  InputSizeBreakdownCard,
   ProductBreakdownCard,
   ToolBreakdownCard,
 } from "./SpendBreakdownTables";
@@ -95,6 +96,9 @@ export function SpendAnalysisSection() {
             <ToolBreakdownCard rows={data.by_tool.items} />
             <ProductBreakdownCard rows={data.by_product.items} />
           </div>
+          {data.by_input_size && (
+            <InputSizeBreakdownCard rows={data.by_input_size.items} />
+          )}
           <SpendInsights data={data} />
         </>
       ) : null}

--- a/packages/ui/src/features/usage/components/SpendBreakdownTables.tsx
+++ b/packages/ui/src/features/usage/components/SpendBreakdownTables.tsx
@@ -1,9 +1,10 @@
-import { Stack, Wrench } from "@phosphor-icons/react";
+import { Ruler, Stack, Wrench } from "@phosphor-icons/react";
 import {
   formatTokens,
   formatUsd,
 } from "@posthog/core/billing/spendAnalysisFormat";
 import type {
+  SpendAnalysisInputSizeRow,
   SpendAnalysisProductRow,
   SpendAnalysisToolRow,
 } from "@posthog/core/billing/spendAnalysisTypes";
@@ -44,14 +45,26 @@ function BreakdownTable({
 
 export function ToolBreakdownCard({ rows }: { rows: SpendAnalysisToolRow[] }) {
   if (rows.length === 0) return null;
+  // The backend rolls out attributed cost per response, not per row: if the
+  // top row has it, every row does.
+  const hasAttributedCost = rows[0]?.cost_attributed_usd !== undefined;
+
   return (
     <UsageCard
       icon={<Wrench size={14} className="text-(--gray-9)" />}
       title="By tool"
     >
       <BreakdownTable
-        headers={["Tool", "Generations", "Avg input", "Cost"]}
-        widths={["40%", "20%", "20%", "20%"]}
+        headers={
+          hasAttributedCost
+            ? ["Tool", "Generations", "Avg input", "Cost", "Attributed"]
+            : ["Tool", "Generations", "Avg input", "Cost"]
+        }
+        widths={
+          hasAttributedCost
+            ? ["32%", "18%", "18%", "16%", "16%"]
+            : ["40%", "20%", "20%", "20%"]
+        }
       >
         {rows.slice(0, 10).map((r) => (
           <Table.Row key={r.tool ?? "(null)"}>
@@ -59,6 +72,13 @@ export function ToolBreakdownCard({ rows }: { rows: SpendAnalysisToolRow[] }) {
             <Table.Cell>{r.generation_count.toLocaleString()}</Table.Cell>
             <Table.Cell>{formatTokens(r.avg_input_tokens)}</Table.Cell>
             <Table.Cell>{formatUsd(r.cost_usd)}</Table.Cell>
+            {hasAttributedCost && (
+              <Table.Cell>
+                {r.cost_attributed_usd !== undefined
+                  ? formatUsd(r.cost_attributed_usd)
+                  : "—"}
+              </Table.Cell>
+            )}
           </Table.Row>
         ))}
       </BreakdownTable>
@@ -88,6 +108,35 @@ export function ProductBreakdownCard({
             </Table.Cell>
             <Table.Cell>{r.event_count.toLocaleString()}</Table.Cell>
             <Table.Cell>{formatUsd(r.cost_usd)}</Table.Cell>
+          </Table.Row>
+        ))}
+      </BreakdownTable>
+    </UsageCard>
+  );
+}
+
+export function InputSizeBreakdownCard({
+  rows,
+}: {
+  rows: SpendAnalysisInputSizeRow[];
+}) {
+  if (rows.length === 0) return null;
+  return (
+    <UsageCard
+      icon={<Ruler size={14} className="text-(--gray-9)" />}
+      title="By context size"
+    >
+      <BreakdownTable
+        headers={["Input tokens", "Generations", "Cost", "Share", "Avg cost"]}
+        widths={["24%", "20%", "18%", "16%", "22%"]}
+      >
+        {rows.map((r) => (
+          <Table.Row key={r.bucket}>
+            <Table.Cell>{r.bucket}</Table.Cell>
+            <Table.Cell>{r.generation_count.toLocaleString()}</Table.Cell>
+            <Table.Cell>{formatUsd(r.cost_usd)}</Table.Cell>
+            <Table.Cell>{Math.round(r.share_of_scoped * 100)}%</Table.Cell>
+            <Table.Cell>{formatUsd(r.avg_cost_per_generation)}</Table.Cell>
           </Table.Row>
         ))}
       </BreakdownTable>


### PR DESCRIPTION
## Problem

The usage banner's top-tool headline literally says "`<tool>` drives X% of your spend," computed from `share_of_scoped` in `packages/core/src/billing/spendSuggestions.ts`. That field is a co-occurrence artifact: a single turn can call several tools, and the backend attributes the full turn cost to *every* tool it touched, so whichever tool is most ubiquitous (Bash) looks artificially dominant, and the numbers don't reconcile to total spend.

This is the client half of a companion change to the posthog monorepo's `/api/llm_analytics/@me/spend/` endpoint, which adds honest attribution fields plus a genuinely new lever: spend broken down by input-context size.

## Changes

- **Types** (`packages/api-client/src/spend-analysis.ts` and `packages/core/src/billing/spendAnalysisTypes.ts`, kept in sync): added optional `cost_attributed_usd` / `share_attributed` to `SpendAnalysisToolRow` (fractional cost split across a turn's tools, reconciling to scoped spend), a new `SpendAnalysisInputSizeRow` type, and an optional `by_input_size?` breakdown on `SpendAnalysisResponse`.
- **Suggestions** (`packages/core/src/billing/spendSuggestions.ts`): the top-tool suggestion now uses `share_attributed` and is worded as co-occurrence-aware ("X was involved in N% of your spend when each turn's cost is split across the tools it used") instead of claiming a tool "drives" the spend. A new primary suggestion reads `by_input_size` and recommends trimming context (clearing between unrelated tasks, avoiding re-reads of large files/output) when the largest-context bucket or the top bucket by cost exceeds ~40% of scoped spend. The no-tool suggestion wording was tightened. All of this falls back to the previous behavior when the new fields are absent.
- **UI** (`packages/ui/src/features/usage/components/SpendBreakdownTables.tsx`, `SpendAnalysisSection.tsx`): the tool table gains an "Attributed" cost column when the field is present, and a new "By context size" table renders `by_input_size` when the backend serves it.

All new fields are optional on the client, exactly like the existing `by_day?` field, so this PR is backwards-compatible and can merge before or after the API rollout.

## How did you test this?

- `pnpm --filter @posthog/core typecheck`, `pnpm --filter @posthog/api-client typecheck`, `pnpm --filter @posthog/ui typecheck`, and a full workspace `pnpm typecheck` (24/24 tasks) all pass.
- `pnpm --filter @posthog/core test`: 2502/2502 pass, including a new `spendSuggestions.test.ts` (13 cases) covering the attributed-cost wording, the share_of_scoped/`share_attributed` fallback, the `by_input_size` threshold logic (including the `>300k`-under-threshold-but-another-bucket-over fallback), and the absent-field paths.
- `pnpm --filter @posthog/api-client test`: 130/130 pass.
- `pnpm --filter @posthog/ui test`: 2012/2012 pass.
- `biome check` on all changed files: clean.
- Full `pnpm test` (turbo, whole workspace): the only failures are in `@posthog/workspace-server` (git-network-integration and HogQL-fetch tests unrelated to this change, timing out in this sandbox with no diff in that package) — pre-existing and not touched by this PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*