### PR TITLE
docs: clarify README feedback prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **[Download the latest version](https://github.com/PostHog/code/releases/latest)**
 
-Found a bug or have feedback? [Open an issue](https://github.com/PostHog/code/issues/new) on GitHub.
+Found a bug or want to share feedback? [Open an issue](https://github.com/PostHog/code/issues/new) on GitHub.
 
 # PostHog
 


### PR DESCRIPTION
## Problem

The README feedback prompt can read more naturally. This is a test PR for validating the contribution workflow.

## Changes

- Clarify the wording of the README feedback prompt.

## How did you test this?

- `git diff --check`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*