### PR TITLE
fix: clear sent messages without blocking the composer

### DIFF
--- a/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
+++ b/packages/ui/src/features/message-editor/tiptap/useTiptapEditor.ts
@@ -837,11 +837,21 @@ export function useTiptapEditor(options: UseTiptapEditorOptions) {
   }, [editor, draft]);
   const getText = useCallback(() => editor?.getText() ?? "", [editor]);
   const setContent = useCallback(
-    (text: string) => {
+    (content: string | EditorContent) => {
       if (!editor) return;
-      editor.commands.setContent(text);
+      editor.commands.setContent(
+        typeof content === "string"
+          ? content
+          : editorContentToTiptapJson(content),
+      );
+      if (typeof content !== "string") {
+        setAttachments(content.attachments ?? []);
+      }
       editor.commands.focus("end", { scrollIntoView: false });
-      draft.saveDraft(editor, attachments);
+      draft.saveDraft(
+        editor,
+        typeof content === "string" ? attachments : (content.attachments ?? []),
+      );
     },
     [editor, draft, attachments],
   );

--- a/packages/ui/src/features/message-editor/types.ts
+++ b/packages/ui/src/features/message-editor/types.ts
@@ -30,7 +30,7 @@ export interface EditorHandle {
   isEmpty: () => boolean;
   getContent: () => EditorContent;
   getText: () => string;
-  setContent: (text: string) => void;
+  setContent: (content: string | EditorContent) => void;
   /** Insert editor content (text + chips) at the cursor (end), without replacing. */
   insertEditorContent: (content: EditorContent) => void;
   insertChip: (chip: MentionChip) => void;

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -306,7 +306,6 @@ export function SessionView({
   const isCloudRun = useIsWorkspaceCloudRun(taskId);
   const editorRef = useRef<PromptInputHandle>(null);
   const sendInFlightRef = useRef(false);
-  const [isSendingPrompt, setIsSendingPrompt] = useState(false);
 
   const latestPlanTrackerRef = useRef<ReturnType<
     typeof createLatestPlanTracker
@@ -326,7 +325,7 @@ export function SessionView({
       const submittedContent = editor?.getContent() ?? null;
       if (
         editor &&
-        shouldSubmitComposerOptimistically(isCloudRun, submittedContent, text)
+        shouldSubmitComposerOptimistically(submittedContent, text)
       ) {
         const sendPromise = submitComposerPrompt(editor, submittedContent, () =>
           onSendPrompt(text),
@@ -336,7 +335,6 @@ export function SessionView({
         return;
       }
 
-      setIsSendingPrompt(true);
       try {
         if (await onSendPrompt(text)) {
           const currentEditor = editorRef.current;
@@ -349,10 +347,9 @@ export function SessionView({
         }
       } finally {
         sendInFlightRef.current = false;
-        setIsSendingPrompt(false);
       }
     },
-    [isCloudRun, onSendPrompt],
+    [onSendPrompt],
   );
 
   const handleBeforeSubmit = useCallback(
@@ -713,7 +710,7 @@ export function SessionView({
                           placeholder="Type a message... @ to mention files, ! for bash mode, / for skills"
                           disabled={!isRunning && !handoffInProgress}
                           submitDisabledExternal={
-                            handoffInProgress || !isOnline || isSendingPrompt
+                            handoffInProgress || !isOnline
                           }
                           clearOnSubmit={false}
                           submitTooltipOverride={

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -306,6 +306,7 @@ export function SessionView({
   const isCloudRun = useIsWorkspaceCloudRun(taskId);
   const editorRef = useRef<PromptInputHandle>(null);
   const sendInFlightRef = useRef(false);
+  const composerSubmissionRef = useRef(0);
 
   const latestPlanTrackerRef = useRef<ReturnType<
     typeof createLatestPlanTracker
@@ -321,14 +322,18 @@ export function SessionView({
       if (!text.trim() || sendInFlightRef.current) return;
 
       sendInFlightRef.current = true;
+      const submissionId = ++composerSubmissionRef.current;
       const editor = editorRef.current;
       const submittedContent = editor?.getContent() ?? null;
       if (
         editor &&
         shouldSubmitComposerOptimistically(submittedContent, text)
       ) {
-        const sendPromise = submitComposerPrompt(editor, submittedContent, () =>
-          onSendPrompt(text),
+        const sendPromise = submitComposerPrompt(
+          editor,
+          submittedContent,
+          () => onSendPrompt(text),
+          () => submissionId === composerSubmissionRef.current,
         );
         sendInFlightRef.current = false;
         await sendPromise;

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -32,6 +32,7 @@ import { ReasoningLevelSelector } from "@posthog/ui/features/sessions/components
 import { RawLogsView } from "@posthog/ui/features/sessions/components/raw-logs/RawLogsView";
 import { SessionResourcesBar } from "@posthog/ui/features/sessions/components/SessionResourcesBar";
 import { SteerQueueToggle } from "@posthog/ui/features/sessions/components/SteerQueueToggle";
+import { submitComposerPrompt } from "@posthog/ui/features/sessions/components/submitComposerPrompt";
 import { ThreadView } from "@posthog/ui/features/sessions/components/ThreadView";
 import { CHAT_CONTENT_MAX_WIDTH } from "@posthog/ui/features/sessions/constants";
 import { useCancelQueuedMessageEdit } from "@posthog/ui/features/sessions/hooks/useEditQueuedMessage";
@@ -302,7 +303,6 @@ export function SessionView({
   const isCloudRun = useIsWorkspaceCloudRun(taskId);
   const editorRef = useRef<PromptInputHandle>(null);
   const sendInFlightRef = useRef(false);
-  const [isSendingPrompt, setIsSendingPrompt] = useState(false);
 
   const latestPlanTrackerRef = useRef<ReturnType<
     typeof createLatestPlanTracker
@@ -318,18 +318,24 @@ export function SessionView({
       if (!text.trim() || sendInFlightRef.current) return;
 
       sendInFlightRef.current = true;
-      setIsSendingPrompt(true);
-      try {
-        if (await onSendPrompt(text)) {
-          const editor = editorRef.current;
-          if (editor && contentToXml(editor.getContent()) === text) {
-            editor.clear();
-          }
-        }
-      } finally {
+      const editor = editorRef.current;
+      const submittedContent = editor?.getContent() ?? null;
+      if (
+        editor &&
+        submittedContent &&
+        contentToXml(submittedContent) === text
+      ) {
+        const sendPromise = submitComposerPrompt(editor, submittedContent, () =>
+          onSendPrompt(text),
+        );
         sendInFlightRef.current = false;
-        setIsSendingPrompt(false);
+        await sendPromise;
+        return;
       }
+
+      const sendPromise = onSendPrompt(text);
+      sendInFlightRef.current = false;
+      await sendPromise;
     },
     [onSendPrompt],
   );
@@ -692,7 +698,7 @@ export function SessionView({
                           placeholder="Type a message... @ to mention files, ! for bash mode, / for skills"
                           disabled={!isRunning && !handoffInProgress}
                           submitDisabledExternal={
-                            handoffInProgress || !isOnline || isSendingPrompt
+                            handoffInProgress || !isOnline
                           }
                           clearOnSubmit={false}
                           submitTooltipOverride={

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -303,6 +303,7 @@ export function SessionView({
   const isCloudRun = useIsWorkspaceCloudRun(taskId);
   const editorRef = useRef<PromptInputHandle>(null);
   const sendInFlightRef = useRef(false);
+  const [isSendingPrompt, setIsSendingPrompt] = useState(false);
 
   const latestPlanTrackerRef = useRef<ReturnType<
     typeof createLatestPlanTracker
@@ -321,6 +322,7 @@ export function SessionView({
       const editor = editorRef.current;
       const submittedContent = editor?.getContent() ?? null;
       if (
+        !isCloudRun &&
         editor &&
         submittedContent &&
         contentToXml(submittedContent) === text
@@ -333,11 +335,23 @@ export function SessionView({
         return;
       }
 
-      const sendPromise = onSendPrompt(text);
-      sendInFlightRef.current = false;
-      await sendPromise;
+      setIsSendingPrompt(true);
+      try {
+        if (await onSendPrompt(text)) {
+          const currentEditor = editorRef.current;
+          if (
+            currentEditor &&
+            contentToXml(currentEditor.getContent()) === text
+          ) {
+            currentEditor.clear();
+          }
+        }
+      } finally {
+        sendInFlightRef.current = false;
+        setIsSendingPrompt(false);
+      }
     },
-    [onSendPrompt],
+    [isCloudRun, onSendPrompt],
   );
 
   const handleBeforeSubmit = useCallback(
@@ -698,7 +712,7 @@ export function SessionView({
                           placeholder="Type a message... @ to mention files, ! for bash mode, / for skills"
                           disabled={!isRunning && !handoffInProgress}
                           submitDisabledExternal={
-                            handoffInProgress || !isOnline
+                            handoffInProgress || !isOnline || isSendingPrompt
                           }
                           clearOnSubmit={false}
                           submitTooltipOverride={

--- a/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -1,5 +1,4 @@
 import { Pause, Spinner, Warning } from "@phosphor-icons/react";
-import { contentToXml } from "@posthog/core/message-editor/content";
 import {
   createLatestPlanTracker,
   SESSION_SERVICE,
@@ -32,7 +31,11 @@ import { ReasoningLevelSelector } from "@posthog/ui/features/sessions/components
 import { RawLogsView } from "@posthog/ui/features/sessions/components/raw-logs/RawLogsView";
 import { SessionResourcesBar } from "@posthog/ui/features/sessions/components/SessionResourcesBar";
 import { SteerQueueToggle } from "@posthog/ui/features/sessions/components/SteerQueueToggle";
-import { submitComposerPrompt } from "@posthog/ui/features/sessions/components/submitComposerPrompt";
+import {
+  isSubmittedContentUnchanged,
+  shouldSubmitComposerOptimistically,
+  submitComposerPrompt,
+} from "@posthog/ui/features/sessions/components/submitComposerPrompt";
 import { ThreadView } from "@posthog/ui/features/sessions/components/ThreadView";
 import { CHAT_CONTENT_MAX_WIDTH } from "@posthog/ui/features/sessions/constants";
 import { useCancelQueuedMessageEdit } from "@posthog/ui/features/sessions/hooks/useEditQueuedMessage";
@@ -322,10 +325,8 @@ export function SessionView({
       const editor = editorRef.current;
       const submittedContent = editor?.getContent() ?? null;
       if (
-        !isCloudRun &&
         editor &&
-        submittedContent &&
-        contentToXml(submittedContent) === text
+        shouldSubmitComposerOptimistically(isCloudRun, submittedContent, text)
       ) {
         const sendPromise = submitComposerPrompt(editor, submittedContent, () =>
           onSendPrompt(text),
@@ -341,7 +342,7 @@ export function SessionView({
           const currentEditor = editorRef.current;
           if (
             currentEditor &&
-            contentToXml(currentEditor.getContent()) === text
+            isSubmittedContentUnchanged(currentEditor.getContent(), text)
           ) {
             currentEditor.clear();
           }

--- a/packages/ui/src/features/sessions/components/submitComposerPrompt.test.ts
+++ b/packages/ui/src/features/sessions/components/submitComposerPrompt.test.ts
@@ -17,17 +17,11 @@ const content: EditorContent = {
   segments: [{ type: "text", text: "queued message" }],
 };
 
-it.each([
-  { isCloudRun: false, expected: true },
-  { isCloudRun: true, expected: false },
-])(
-  "returns $expected for optimistic submission when isCloudRun is $isCloudRun",
-  ({ isCloudRun, expected }) => {
-    expect(
-      shouldSubmitComposerOptimistically(isCloudRun, content, "queued message"),
-    ).toBe(expected);
-  },
-);
+it("uses optimistic submission when the composer still matches", () => {
+  expect(shouldSubmitComposerOptimistically(content, "queued message")).toBe(
+    true,
+  );
+});
 
 it("clears the submitted message before sending completes", async () => {
   const editor = createEditor();

--- a/packages/ui/src/features/sessions/components/submitComposerPrompt.test.ts
+++ b/packages/ui/src/features/sessions/components/submitComposerPrompt.test.ts
@@ -16,6 +16,7 @@ function createEditor() {
 const content: EditorContent = {
   segments: [{ type: "text", text: "queued message" }],
 };
+const canRestore = () => true;
 
 it("uses optimistic submission when the composer still matches", () => {
   expect(shouldSubmitComposerOptimistically(content, "queued message")).toBe(
@@ -33,7 +34,7 @@ it("clears the submitted message before sending completes", async () => {
       }),
   );
 
-  const submission = submitComposerPrompt(editor, content, send);
+  const submission = submitComposerPrompt(editor, content, send, canRestore);
 
   expect(editor.clear).toHaveBeenCalledOnce();
   finishSending?.(true);
@@ -43,7 +44,7 @@ it("clears the submitted message before sending completes", async () => {
 it("restores a failed message when the composer is still empty", async () => {
   const editor = createEditor();
 
-  await submitComposerPrompt(editor, content, async () => false);
+  await submitComposerPrompt(editor, content, async () => false, canRestore);
 
   expect(editor.setContent).toHaveBeenCalledWith(content);
 });
@@ -52,7 +53,24 @@ it("does not overwrite a new draft when an earlier message fails", async () => {
   const editor = createEditor();
   editor.isEmpty.mockReturnValue(false);
 
-  await submitComposerPrompt(editor, content, async () => false);
+  await submitComposerPrompt(editor, content, async () => false, canRestore);
+
+  expect(editor.setContent).not.toHaveBeenCalled();
+});
+
+it("does not restore an older message after a newer submission", async () => {
+  const editor = createEditor();
+  let isLatestSubmission = true;
+
+  const submission = submitComposerPrompt(
+    editor,
+    content,
+    async () => false,
+    () => isLatestSubmission,
+  );
+  isLatestSubmission = false;
+
+  await submission;
 
   expect(editor.setContent).not.toHaveBeenCalled();
 });

--- a/packages/ui/src/features/sessions/components/submitComposerPrompt.test.ts
+++ b/packages/ui/src/features/sessions/components/submitComposerPrompt.test.ts
@@ -1,0 +1,49 @@
+import type { EditorContent } from "@posthog/core/message-editor/content";
+import { expect, it, vi } from "vitest";
+import { submitComposerPrompt } from "./submitComposerPrompt";
+
+function createEditor() {
+  return {
+    clear: vi.fn(),
+    isEmpty: vi.fn(() => true),
+    setContent: vi.fn(),
+  };
+}
+
+const content: EditorContent = {
+  segments: [{ type: "text", text: "queued message" }],
+};
+
+it("clears the submitted message before sending completes", async () => {
+  const editor = createEditor();
+  let finishSending: ((sent: boolean) => void) | undefined;
+  const send = vi.fn(
+    () =>
+      new Promise<boolean>((resolve) => {
+        finishSending = resolve;
+      }),
+  );
+
+  const submission = submitComposerPrompt(editor, content, send);
+
+  expect(editor.clear).toHaveBeenCalledOnce();
+  finishSending?.(true);
+  await submission;
+});
+
+it("restores a failed message when the composer is still empty", async () => {
+  const editor = createEditor();
+
+  await submitComposerPrompt(editor, content, async () => false);
+
+  expect(editor.setContent).toHaveBeenCalledWith(content);
+});
+
+it("does not overwrite a new draft when an earlier message fails", async () => {
+  const editor = createEditor();
+  editor.isEmpty.mockReturnValue(false);
+
+  await submitComposerPrompt(editor, content, async () => false);
+
+  expect(editor.setContent).not.toHaveBeenCalled();
+});

--- a/packages/ui/src/features/sessions/components/submitComposerPrompt.test.ts
+++ b/packages/ui/src/features/sessions/components/submitComposerPrompt.test.ts
@@ -1,6 +1,9 @@
 import type { EditorContent } from "@posthog/core/message-editor/content";
 import { expect, it, vi } from "vitest";
-import { submitComposerPrompt } from "./submitComposerPrompt";
+import {
+  shouldSubmitComposerOptimistically,
+  submitComposerPrompt,
+} from "./submitComposerPrompt";
 
 function createEditor() {
   return {
@@ -13,6 +16,18 @@ function createEditor() {
 const content: EditorContent = {
   segments: [{ type: "text", text: "queued message" }],
 };
+
+it.each([
+  { isCloudRun: false, expected: true },
+  { isCloudRun: true, expected: false },
+])(
+  "returns $expected for optimistic submission when isCloudRun is $isCloudRun",
+  ({ isCloudRun, expected }) => {
+    expect(
+      shouldSubmitComposerOptimistically(isCloudRun, content, "queued message"),
+    ).toBe(expected);
+  },
+);
 
 it("clears the submitted message before sending completes", async () => {
   const editor = createEditor();

--- a/packages/ui/src/features/sessions/components/submitComposerPrompt.ts
+++ b/packages/ui/src/features/sessions/components/submitComposerPrompt.ts
@@ -1,7 +1,29 @@
-import type { EditorContent } from "@posthog/core/message-editor/content";
+import {
+  contentToXml,
+  type EditorContent,
+} from "@posthog/core/message-editor/content";
 import type { EditorHandle } from "@posthog/ui/features/message-editor/types";
 
 type ComposerEditor = Pick<EditorHandle, "clear" | "isEmpty" | "setContent">;
+
+export function isSubmittedContentUnchanged(
+  content: EditorContent,
+  serializedPrompt: string,
+): boolean {
+  return contentToXml(content) === serializedPrompt;
+}
+
+export function shouldSubmitComposerOptimistically(
+  isCloudRun: boolean,
+  submittedContent: EditorContent | null,
+  serializedPrompt: string,
+): submittedContent is EditorContent {
+  return (
+    !isCloudRun &&
+    submittedContent !== null &&
+    isSubmittedContentUnchanged(submittedContent, serializedPrompt)
+  );
+}
 
 export async function submitComposerPrompt(
   editor: ComposerEditor,

--- a/packages/ui/src/features/sessions/components/submitComposerPrompt.ts
+++ b/packages/ui/src/features/sessions/components/submitComposerPrompt.ts
@@ -1,0 +1,23 @@
+import type { EditorContent } from "@posthog/core/message-editor/content";
+import type { EditorHandle } from "@posthog/ui/features/message-editor/types";
+
+type ComposerEditor = Pick<EditorHandle, "clear" | "isEmpty" | "setContent">;
+
+export async function submitComposerPrompt(
+  editor: ComposerEditor,
+  submittedContent: EditorContent,
+  send: () => Promise<boolean>,
+): Promise<void> {
+  editor.clear();
+
+  try {
+    if (!(await send()) && editor.isEmpty()) {
+      editor.setContent(submittedContent);
+    }
+  } catch (error) {
+    if (editor.isEmpty()) {
+      editor.setContent(submittedContent);
+    }
+    throw error;
+  }
+}

--- a/packages/ui/src/features/sessions/components/submitComposerPrompt.ts
+++ b/packages/ui/src/features/sessions/components/submitComposerPrompt.ts
@@ -27,15 +27,16 @@ export async function submitComposerPrompt(
   editor: ComposerEditor,
   submittedContent: EditorContent,
   send: () => Promise<boolean>,
+  canRestore: () => boolean,
 ): Promise<void> {
   editor.clear();
 
   try {
-    if (!(await send()) && editor.isEmpty()) {
+    if (!(await send()) && canRestore() && editor.isEmpty()) {
       editor.setContent(submittedContent);
     }
   } catch (error) {
-    if (editor.isEmpty()) {
+    if (canRestore() && editor.isEmpty()) {
       editor.setContent(submittedContent);
     }
     throw error;

--- a/packages/ui/src/features/sessions/components/submitComposerPrompt.ts
+++ b/packages/ui/src/features/sessions/components/submitComposerPrompt.ts
@@ -14,12 +14,10 @@ export function isSubmittedContentUnchanged(
 }
 
 export function shouldSubmitComposerOptimistically(
-  isCloudRun: boolean,
   submittedContent: EditorContent | null,
   serializedPrompt: string,
 ): submittedContent is EditorContent {
   return (
-    !isCloudRun &&
     submittedContent !== null &&
     isSubmittedContentUnchanged(submittedContent, serializedPrompt)
   );


### PR DESCRIPTION
## Problem

**Why:** Messages remained in the composer until send acknowledgement after #3766, creating a visible delay for cloud tasks and preventing local tasks from queueing another message while a turn was active.

## Changes

- Clear submitted composer content immediately for cloud and local runs.
- Restore a failed submission only when it is still the latest submission and the composer remains empty, preserving newer drafts, attachments, and queued messages.
- Keep the composer available for subsequent queued messages while an earlier send is pending.

No screenshot included because this changes submission timing without altering the rendered UI.

## How did you test this?

- `pnpm --filter @posthog/ui exec vitest run src/features/sessions/components/submitComposerPrompt.test.ts`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm exec biome check packages/ui/src/features/sessions/components/SessionView.tsx packages/ui/src/features/sessions/components/submitComposerPrompt.ts packages/ui/src/features/sessions/components/submitComposerPrompt.test.ts`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
