### PR TITLE
fix(tasks): expose artifact downloads in task conversations

### DIFF
--- a/docs/cloud-task-artifacts.md
+++ b/docs/cloud-task-artifacts.md
@@ -4,6 +4,4 @@ Cloud agents run with `/tmp/workspace` as the sandbox workspace. A repository ta
 
 Files left in the sandbox filesystem are temporary and cannot be downloaded after the sandbox is released. Agents should call the `upload_artifact` tool for every non-code deliverable they create. The tool accepts files inside the session working directory, uploads them directly to task object storage, and registers them as `output` artifacts on the task run. Registered artifacts are available through the existing task artifact download endpoint.
 
-Uploaded output files appear at the end of the task conversation, where users can download them by name.
-
 Repository changes should continue to be delivered through git rather than duplicated as task artifacts. A single uploaded artifact is limited to 30 MB.

--- a/docs/cloud-task-artifacts.md
+++ b/docs/cloud-task-artifacts.md
@@ -4,4 +4,6 @@ Cloud agents run with `/tmp/workspace` as the sandbox workspace. A repository ta
 
 Files left in the sandbox filesystem are temporary and cannot be downloaded after the sandbox is released. Agents should call the `upload_artifact` tool for every non-code deliverable they create. The tool accepts files inside the session working directory, uploads them directly to task object storage, and registers them as `output` artifacts on the task run. Registered artifacts are available through the existing task artifact download endpoint.
 
+Uploaded output files appear at the end of the task conversation, where users can download them by name.
+
 Repository changes should continue to be delivered through git rather than duplicated as task artifacts. A single uploaded artifact is limited to 30 MB.

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -4673,6 +4673,7 @@ export class SessionService {
         cloudStatus: run.status,
         cloudStage: run.stage ?? null,
         cloudOutput: run.output ?? null,
+        cloudArtifacts: run.artifacts ?? [],
         cloudErrorMessage: run.error_message,
         logUrl: run.log_url ?? session.logUrl,
       });

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -35,6 +35,7 @@ import {
   type StoredLogEntry,
   sendableQueuePrefixLength,
   sessionSupportsNativeSteer,
+  type TaskRunArtifact,
   type TaskRunStatus,
 } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -1599,7 +1600,7 @@ export class SessionService {
   /** Deduplicates concurrent manifest reads when a message renders many images. */
   private cloudAttachmentManifestRequests = new Map<
     string,
-    Promise<Array<{ id?: string; storage_path?: string }>>
+    Promise<TaskRunArtifact[]>
   >();
   private idleKilledSubscription: { unsubscribe: () => void } | null = null;
   /**
@@ -7294,22 +7295,34 @@ export class SessionService {
     }
   }
 
+  async getCloudRunArtifacts(
+    taskId: string,
+    runId: string,
+  ): Promise<TaskRunArtifact[]> {
+    const authStatus = await this.getAuthCredentialsStatus();
+    if (authStatus.kind !== "ready") return [];
+
+    return this.getCloudAttachmentManifest(
+      authStatus.auth.client,
+      `${authStatus.auth.apiHost}:${authStatus.auth.projectId}`,
+      taskId,
+      runId,
+    );
+  }
+
   private getCloudAttachmentManifest(
     client: AuthClient,
     authIdentity: string,
     taskId: string,
     runId: string,
-  ): Promise<Array<{ id?: string; storage_path?: string }>> {
+  ): Promise<TaskRunArtifact[]> {
     const key = `${authIdentity}:${taskId}:${runId}`;
     const existing = this.cloudAttachmentManifestRequests.get(key);
     if (existing) return existing;
 
     const request = client
       .getTaskRun(taskId, runId)
-      .then(
-        (run: { artifacts?: Array<{ id?: string; storage_path?: string }> }) =>
-          run.artifacts ?? [],
-      );
+      .then((run: { artifacts?: TaskRunArtifact[] }) => run.artifacts ?? []);
     this.cloudAttachmentManifestRequests.set(key, request);
 
     const clear = () => {

--- a/packages/shared/src/domain-types.ts
+++ b/packages/shared/src/domain-types.ts
@@ -3,6 +3,7 @@ import type { Adapter } from "./adapter";
 import type { AgentRuntime } from "./agent-runtime";
 import type { DismissalReasonOptionValue } from "./dismissal-reasons";
 import type { StoredLogEntry } from "./session-events";
+import type { TaskRunArtifact } from "./task";
 
 // Execution mode schema and type - shared between main and renderer
 export const executionModeSchema = z.enum([
@@ -180,6 +181,7 @@ export interface TaskRun {
   error_message: string | null;
   output: Record<string, unknown> | null; // Structured output (PR URL, commit SHA, etc.)
   state: Record<string, unknown>; // Intermediate run state (defaults to {}, never null)
+  artifacts?: TaskRunArtifact[];
   created_at: string;
   updated_at: string;
   completed_at: string | null;

--- a/packages/shared/src/sessions.ts
+++ b/packages/shared/src/sessions.ts
@@ -10,7 +10,7 @@ import type { Adapter } from "./adapter";
 import type { SkillButtonId } from "./analytics-events";
 import type { ExecutionMode } from "./exec-types";
 import type { AcpMessage } from "./session-events";
-import type { TaskRunStatus } from "./task";
+import type { TaskRunArtifact, TaskRunStatus } from "./task";
 
 export type { Adapter };
 
@@ -94,6 +94,7 @@ export interface AgentSession {
   cloudStatus?: TaskRunStatus;
   cloudStage?: string | null;
   cloudOutput?: Record<string, unknown> | null;
+  cloudArtifacts?: TaskRunArtifact[];
   cloudErrorMessage?: string | null;
   initialPrompt?: ContentBlock[];
   cloudBranch?: string | null;

--- a/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
+++ b/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
@@ -4,6 +4,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CloudArtifactDownloads } from "./CloudArtifactDownloads";
 
 const getCloudAttachmentPreviewUrl = vi.fn();
+const fetchedArtifacts = [
+  {
+    id: "output-1",
+    name: "report.pdf",
+    type: "output",
+    size: 12_000,
+    storage_path: "tasks/run-1/report.pdf",
+  },
+  {
+    id: "internal-1",
+    name: "handoff.pack",
+    type: "artifact",
+    storage_path: "tasks/run-1/handoff.pack",
+  },
+];
 
 vi.mock("@posthog/core/sessions/sessionService", () => ({
   SESSION_SERVICE: Symbol("SESSION_SERVICE"),
@@ -17,25 +32,20 @@ vi.mock("@posthog/ui/features/sessions/sessionStore", () => ({
   useSessionSelector: () => undefined,
 }));
 
+vi.mock("@posthog/ui/features/auth/store", () => ({
+  getAuthIdentity: () => "auth-1",
+  useAuthStateValue: () => "auth-1",
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: fetchedArtifacts }),
+}));
+
 const task = {
   id: "task-1",
   latest_run: {
     id: "run-1",
-    artifacts: [
-      {
-        id: "output-1",
-        name: "report.pdf",
-        type: "output",
-        size: 12_000,
-        storage_path: "tasks/run-1/report.pdf",
-      },
-      {
-        id: "internal-1",
-        name: "handoff.pack",
-        type: "artifact",
-        storage_path: "tasks/run-1/handoff.pack",
-      },
-    ],
+    status: "completed",
   },
 } as never;
 

--- a/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
+++ b/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
@@ -1,0 +1,78 @@
+import { Theme } from "@radix-ui/themes";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CloudArtifactDownloads } from "./CloudArtifactDownloads";
+
+const getCloudAttachmentPreviewUrl = vi.fn();
+
+vi.mock("@posthog/core/sessions/sessionService", () => ({
+  SESSION_SERVICE: Symbol("SESSION_SERVICE"),
+}));
+
+vi.mock("@posthog/di/react", () => ({
+  useService: () => ({ getCloudAttachmentPreviewUrl }),
+}));
+
+vi.mock("@posthog/ui/features/sessions/sessionStore", () => ({
+  useSessionSelector: () => undefined,
+}));
+
+const task = {
+  id: "task-1",
+  latest_run: {
+    id: "run-1",
+    artifacts: [
+      {
+        id: "output-1",
+        name: "report.pdf",
+        type: "output",
+        size: 12_000,
+        storage_path: "tasks/run-1/report.pdf",
+      },
+      {
+        id: "internal-1",
+        name: "handoff.pack",
+        type: "artifact",
+        storage_path: "tasks/run-1/handoff.pack",
+      },
+    ],
+  },
+} as never;
+
+describe("CloudArtifactDownloads", () => {
+  beforeEach(() => {
+    getCloudAttachmentPreviewUrl.mockReset();
+  });
+
+  it("shows output artifacts and opens their download URL", async () => {
+    getCloudAttachmentPreviewUrl.mockResolvedValue(
+      "https://files.example/report.pdf",
+    );
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    render(
+      <Theme>
+        <CloudArtifactDownloads taskId="task-1" task={task} />
+      </Theme>,
+    );
+
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
+    expect(screen.getByText("12 KB")).toBeInTheDocument();
+    expect(screen.queryByText("handoff.pack")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+
+    await waitFor(() =>
+      expect(open).toHaveBeenCalledWith(
+        "https://files.example/report.pdf",
+        "_blank",
+        "noopener,noreferrer",
+      ),
+    );
+    expect(getCloudAttachmentPreviewUrl).toHaveBeenCalledWith(
+      "task-1",
+      "run-1",
+      "output-1",
+    );
+  });
+});

--- a/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -86,7 +86,7 @@ export function CloudArtifactDownloads({
               <Flex align="center" gap="2" className="min-w-0">
                 <FileIcon filename={artifact.name} size={16} />
                 <Text className="truncate text-[13px]">{artifact.name}</Text>
-                {size && (
+                {size !== null && (
                   <Text color="gray" className="shrink-0 text-[12px]">
                     {size}
                   </Text>

--- a/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -1,0 +1,110 @@
+import { DownloadSimple } from "@phosphor-icons/react";
+import {
+  SESSION_SERVICE,
+  type SessionService,
+} from "@posthog/core/sessions/sessionService";
+import { useService } from "@posthog/di/react";
+import { Button } from "@posthog/quill";
+import type { TaskRunArtifact } from "@posthog/shared";
+import type { Task } from "@posthog/shared/domain-types";
+import { useSessionSelector } from "@posthog/ui/features/sessions/sessionStore";
+import { FileIcon } from "@posthog/ui/primitives/FileIcon";
+import { toast } from "@posthog/ui/primitives/toast";
+import { Box, Flex, Text } from "@radix-ui/themes";
+import { useCallback, useMemo, useState } from "react";
+
+function formatFileSize(size: number | undefined): string | null {
+  if (size === undefined) return null;
+  if (size < 1_000) return `${size} B`;
+  if (size < 1_000_000) return `${Math.round(size / 1_000)} KB`;
+  return `${(size / 1_000_000).toFixed(1)} MB`;
+}
+
+export function CloudArtifactDownloads({
+  taskId,
+  task,
+}: {
+  taskId: string | undefined;
+  task: Task | undefined;
+}) {
+  const sessionService = useService<SessionService>(SESSION_SERVICE);
+  const sessionArtifacts = useSessionSelector(
+    taskId,
+    (session) => session?.cloudArtifacts,
+  );
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const runId = task?.latest_run?.id;
+  const artifacts = useMemo(
+    () =>
+      (sessionArtifacts ?? task?.latest_run?.artifacts ?? []).filter(
+        (artifact) => artifact.type === "output",
+      ),
+    [sessionArtifacts, task?.latest_run?.artifacts],
+  );
+
+  const downloadArtifact = useCallback(
+    async (artifact: TaskRunArtifact): Promise<void> => {
+      if (!taskId || !runId || !artifact.id) return;
+      setDownloadingId(artifact.id);
+      try {
+        const url = await sessionService.getCloudAttachmentPreviewUrl(
+          taskId,
+          runId,
+          artifact.id,
+        );
+        if (!url) {
+          toast.error("This file is no longer available");
+          return;
+        }
+        window.open(url, "_blank", "noopener,noreferrer");
+      } catch {
+        toast.error("Couldn't download file");
+      } finally {
+        setDownloadingId(null);
+      }
+    },
+    [runId, sessionService, taskId],
+  );
+
+  if (!runId || artifacts.length === 0) return null;
+
+  return (
+    <Box className="mb-3 rounded-lg border border-gray-4 bg-gray-2 p-3">
+      <Text className="mb-2 block font-medium text-[13px]">Files</Text>
+      <Flex direction="column" gap="1">
+        {artifacts.map((artifact) => {
+          const size = formatFileSize(artifact.size);
+          const canDownload = Boolean(artifact.id);
+          return (
+            <Flex
+              key={artifact.id ?? artifact.storage_path ?? artifact.name}
+              align="center"
+              justify="between"
+              gap="3"
+              className="min-w-0 rounded-md bg-background px-2 py-1.5"
+            >
+              <Flex align="center" gap="2" className="min-w-0">
+                <FileIcon filename={artifact.name} size={16} />
+                <Text className="truncate text-[13px]">{artifact.name}</Text>
+                {size && (
+                  <Text color="gray" className="shrink-0 text-[12px]">
+                    {size}
+                  </Text>
+                )}
+              </Flex>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={!canDownload || downloadingId === artifact.id}
+                onClick={() => void downloadArtifact(artifact)}
+              >
+                <DownloadSimple size={14} />
+                {downloadingId === artifact.id ? "Opening..." : "Download"}
+              </Button>
+            </Flex>
+          );
+        })}
+      </Flex>
+    </Box>
+  );
+}

--- a/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -6,11 +6,16 @@ import {
 import { useService } from "@posthog/di/react";
 import { Button } from "@posthog/quill";
 import type { TaskRunArtifact } from "@posthog/shared";
-import type { Task } from "@posthog/shared/domain-types";
+import { isTerminalStatus, type Task } from "@posthog/shared/domain-types";
+import {
+  getAuthIdentity,
+  useAuthStateValue,
+} from "@posthog/ui/features/auth/store";
 import { useSessionSelector } from "@posthog/ui/features/sessions/sessionStore";
 import { FileIcon } from "@posthog/ui/primitives/FileIcon";
 import { toast } from "@posthog/ui/primitives/toast";
 import { Box, Flex, Text } from "@radix-ui/themes";
+import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 
 function formatFileSize(size: number | undefined): string | null {
@@ -32,14 +37,34 @@ export function CloudArtifactDownloads({
     taskId,
     (session) => session?.cloudArtifacts,
   );
+  const cloudStatus = useSessionSelector(
+    taskId,
+    (session) => session?.cloudStatus,
+  );
+  const authIdentity = useAuthStateValue(getAuthIdentity);
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const runId = task?.latest_run?.id;
+  const { data: fetchedArtifacts } = useQuery({
+    queryKey: ["cloudRunArtifacts", authIdentity, taskId, runId],
+    queryFn: () =>
+      sessionService.getCloudRunArtifacts(taskId ?? "", runId ?? ""),
+    enabled:
+      authIdentity !== null &&
+      taskId !== undefined &&
+      runId !== undefined &&
+      isTerminalStatus(cloudStatus ?? task?.latest_run?.status),
+    retry: false,
+    staleTime: Infinity,
+  });
   const artifacts = useMemo(
     () =>
-      (sessionArtifacts ?? task?.latest_run?.artifacts ?? []).filter(
-        (artifact) => artifact.type === "output",
-      ),
-    [sessionArtifacts, task?.latest_run?.artifacts],
+      (
+        fetchedArtifacts ??
+        sessionArtifacts ??
+        task?.latest_run?.artifacts ??
+        []
+      ).filter((artifact) => artifact.type === "output"),
+    [fetchedArtifacts, sessionArtifacts, task?.latest_run?.artifacts],
   );
 
   const downloadArtifact = useCallback(

--- a/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -16,6 +16,7 @@ import type {
   TurnContext,
 } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { ConversationSearchBar } from "@posthog/ui/features/sessions/components/ConversationSearchBar";
+import { CloudArtifactDownloads } from "@posthog/ui/features/sessions/components/CloudArtifactDownloads";
 import {
   PROMPT_RECALL_HINT_KEY,
   type PromptRecallHandler,
@@ -452,6 +453,7 @@ export function ConversationView({
 
   const footer = (
     <div className={compact ? "pb-1" : "pb-16"}>
+      <CloudArtifactDownloads taskId={taskId} task={task} />
       <SessionFooter
         task={task}
         isPromptPending={isPromptPending}

--- a/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -15,8 +15,8 @@ import type {
   ConversationItem,
   TurnContext,
 } from "@posthog/ui/features/sessions/components/buildConversationItems";
-import { ConversationSearchBar } from "@posthog/ui/features/sessions/components/ConversationSearchBar";
 import { CloudArtifactDownloads } from "@posthog/ui/features/sessions/components/CloudArtifactDownloads";
+import { ConversationSearchBar } from "@posthog/ui/features/sessions/components/ConversationSearchBar";
 import {
   PROMPT_RECALL_HINT_KEY,
   type PromptRecallHandler,

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -37,6 +37,7 @@ import { useSmoothedText } from "@posthog/ui/features/editor/components/useSmoot
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStore";
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { CloudArtifactDownloads } from "@posthog/ui/features/sessions/components/CloudArtifactDownloads";
 import {
   ChatMarkdown,
   ChatStreamingMarkdown,
@@ -1166,13 +1167,16 @@ function ChatThreadRenderer({
               keyboardFocusedMessageId={keyboardFocusedMessageId}
               onUserInteract={clearKeyboardFocus}
               footer={
-                <ChatThreadFooter
-                  events={footerEvents}
-                  isPromptPending={isPromptPending}
-                  promptStartedAt={promptStartedAt}
-                  task={task}
-                  taskId={taskId}
-                />
+                <>
+                  <CloudArtifactDownloads taskId={taskId} task={task} />
+                  <ChatThreadFooter
+                    events={footerEvents}
+                    isPromptPending={isPromptPending}
+                    promptStartedAt={promptStartedAt}
+                    task={task}
+                    taskId={taskId}
+                  />
+                </>
               }
             />
             <ThreadKeyboardNav


### PR DESCRIPTION
## Problem

Cloud-task agents can upload durable output artifacts, but task conversations do not expose them. Users can be told that files exist without any way to find or download them.

**Why:** Generated reports, images, and other non-code deliverables need to remain accessible after the temporary task sandbox is released.


https://github.com/user-attachments/assets/0f69f7eb-0e77-4fa3-95d3-5bcafd4d5035
