### PR TITLE
fix(tasks): download artifacts without pop-ups

### DIFF
--- a/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
+++ b/packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx
@@ -52,13 +52,25 @@ const task = {
 describe("CloudArtifactDownloads", () => {
   beforeEach(() => {
     getCloudAttachmentPreviewUrl.mockReset();
+    vi.restoreAllMocks();
   });
 
   it("shows output artifacts and opens their download URL", async () => {
     getCloudAttachmentPreviewUrl.mockResolvedValue(
       "https://files.example/report.pdf",
     );
-    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    const fetchArtifact = vi
+      .spyOn(window, "fetch")
+      .mockResolvedValue(new Response("file contents"));
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:artifact");
+    const revokeObjectURL = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => undefined);
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
 
     render(
       <Theme>
@@ -70,15 +82,14 @@ describe("CloudArtifactDownloads", () => {
     expect(screen.getByText("12 KB")).toBeInTheDocument();
     expect(screen.queryByText("handoff.pack")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Download" }));
+    fireEvent.click(screen.getByText("Download"));
 
-    await waitFor(() =>
-      expect(open).toHaveBeenCalledWith(
-        "https://files.example/report.pdf",
-        "_blank",
-        "noopener,noreferrer",
-      ),
+    await waitFor(() => expect(click).toHaveBeenCalledOnce());
+    expect(fetchArtifact).toHaveBeenCalledWith(
+      "https://files.example/report.pdf",
     );
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:artifact");
     expect(getCloudAttachmentPreviewUrl).toHaveBeenCalledWith(
       "task-1",
       "run-1",

--- a/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -81,7 +81,14 @@ export function CloudArtifactDownloads({
           toast.error("This file is no longer available");
           return;
         }
-        window.open(url, "_blank", "noopener,noreferrer");
+        const response = await fetch(url);
+        if (!response.ok) throw new Error("Artifact download failed");
+        const objectUrl = URL.createObjectURL(await response.blob());
+        const anchor = document.createElement("a");
+        anchor.href = objectUrl;
+        anchor.download = artifact.name;
+        anchor.click();
+        URL.revokeObjectURL(objectUrl);
       } catch {
         toast.error("Couldn't download file");
       } finally {


### PR DESCRIPTION
## Problem

Artifact downloads were blocked in the desktop and web hosts because opening a new tab requires pop-up permission. Follow-up to #3788.

## Changes

Fetch the presigned artifact directly and trigger a local blob download with the original filename. This avoids pop-ups and keeps image artifacts from replacing the app.

## How did you test this?

- `pnpm --filter @posthog/ui exec vitest run src/features/sessions/components/CloudArtifactDownloads.test.tsx`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm biome check packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx packages/ui/src/features/sessions/components/CloudArtifactDownloads.test.tsx`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
