### PR TITLE
feat(auth): support short-lived impersonated sessions

### DIFF
--- a/packages/core/src/auth/auth.test.ts
+++ b/packages/core/src/auth/auth.test.ts
@@ -79,16 +79,21 @@ const mockLogger: RootLogger = {
 function mockTokenResponse(
   overrides: {
     accessToken?: string;
-    refreshToken?: string;
+    refreshToken?: string | null;
+    expiresIn?: number;
     scopedOrgs?: string[];
   } = {},
 ) {
+  const refreshToken =
+    overrides.refreshToken === undefined
+      ? "refresh-token"
+      : overrides.refreshToken;
   return {
     success: true as const,
     data: {
       access_token: overrides.accessToken ?? "access-token",
-      refresh_token: overrides.refreshToken ?? "refresh-token",
-      expires_in: 3600,
+      ...(refreshToken ? { refresh_token: refreshToken } : {}),
+      expires_in: overrides.expiresIn ?? 3600,
       token_type: "Bearer",
       scope: "",
       scoped_organizations: overrides.scopedOrgs ?? ["org-1"],
@@ -242,7 +247,155 @@ describe("AuthService", () => {
       currentProjectId: null,
       hasCodeAccess: null,
       needsScopeReauth: false,
+      sessionType: null,
+      sessionExpiresAt: null,
+      sessionEndReason: null,
     });
+  });
+
+  it("uses an impersonated session without persisting it", async () => {
+    oauthFlow.startFlow.mockResolvedValue(
+      mockTokenResponse({ refreshToken: null }),
+    );
+    stubAuthFetch();
+
+    await service.initialize();
+    await service.login("us");
+
+    expect(service.getState()).toMatchObject({
+      status: "authenticated",
+      sessionType: "impersonated",
+      sessionExpiresAt: expect.any(Number),
+    });
+    await expect(service.getValidAccessToken()).resolves.toMatchObject({
+      accessToken: "access-token",
+    });
+    expect(sessionPort.getCurrent()).toBeNull();
+  });
+
+  it("signs out an impersonated session when a refresh is required", async () => {
+    oauthFlow.startFlow.mockResolvedValue(
+      mockTokenResponse({ refreshToken: null }),
+    );
+    stubAuthFetch();
+
+    await service.initialize();
+    await service.login("us");
+
+    await expect(service.refreshAccessToken()).rejects.toThrow(
+      "Your impersonated session has expired",
+    );
+    expect(service.getState()).toMatchObject({
+      status: "anonymous",
+      sessionType: null,
+      sessionExpiresAt: null,
+      sessionEndReason: "impersonation_expired",
+    });
+    expect(oauthFlow.refreshToken).not.toHaveBeenCalled();
+  });
+
+  it("signs out when an impersonated access token expires", async () => {
+    vi.useFakeTimers();
+    try {
+      oauthFlow.startFlow.mockResolvedValue(
+        mockTokenResponse({ refreshToken: null, expiresIn: 61 }),
+      );
+      stubAuthFetch();
+
+      await service.initialize();
+      await service.login("us");
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      await expect(service.getValidAccessToken()).resolves.toMatchObject({
+        accessToken: "access-token",
+      });
+
+      await vi.advanceTimersByTimeAsync(1_001);
+
+      expect(service.getState()).toMatchObject({
+        status: "anonymous",
+        sessionEndReason: "impersonation_expired",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not persist or extend impersonated credentials after a project change", async () => {
+    vi.useFakeTimers();
+    try {
+      oauthFlow.startFlow.mockResolvedValue(
+        mockTokenResponse({ refreshToken: null, expiresIn: 61 }),
+      );
+      stubAuthFetch({
+        orgs: {
+          "org-1": {
+            name: "Org 1",
+            projects: [
+              { id: 42, name: "Project 42" },
+              { id: 84, name: "Project 84" },
+            ],
+          },
+        },
+      });
+
+      await service.initialize();
+      await service.login("us");
+      await service.selectProject(84);
+
+      expect(service.getState().currentProjectId).toBe(84);
+      expect(sessionPort.getCurrent()).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(61_001);
+
+      expect(service.getState()).toMatchObject({
+        status: "anonymous",
+        sessionEndReason: "impersonation_expired",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not restore an impersonated session after restart", async () => {
+    oauthFlow.startFlow.mockResolvedValue(
+      mockTokenResponse({ refreshToken: null }),
+    );
+    stubAuthFetch();
+
+    await service.initialize();
+    await service.login("us");
+    service.shutdown();
+
+    service = createService();
+    service.init();
+    await service.initialize();
+
+    expect(service.getState()).toMatchObject({
+      status: "anonymous",
+      sessionType: null,
+    });
+    expect(oauthFlow.refreshToken).not.toHaveBeenCalled();
+  });
+
+  it("returns permission-denied responses without ending impersonation", async () => {
+    oauthFlow.startFlow.mockResolvedValue(
+      mockTokenResponse({ refreshToken: null }),
+    );
+    stubAuthFetch();
+
+    await service.initialize();
+    await service.login("us");
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 403 }));
+
+    const response = await service.authenticatedFetch(
+      fetch,
+      "https://us.posthog.com/api/restricted/",
+    );
+
+    expect(response.status).toBe(403);
+    expect(service.getState().status).toBe("authenticated");
+    expect(oauthFlow.refreshToken).not.toHaveBeenCalled();
   });
 
   it("requires scope reauthentication when the stored scope version is stale", async () => {
@@ -263,6 +416,9 @@ describe("AuthService", () => {
       currentProjectId: 123,
       hasCodeAccess: null,
       needsScopeReauth: true,
+      sessionType: null,
+      sessionExpiresAt: null,
+      sessionEndReason: null,
     });
   });
 
@@ -309,6 +465,24 @@ describe("AuthService", () => {
 
     expect(sessionPort.getCurrent()?.refreshTokenEncrypted).toBe(
       "rotated-refresh-token",
+    );
+  });
+
+  it("keeps the existing refresh token when the server does not rotate it", async () => {
+    seedStoredSession({ refreshToken: "existing-refresh-token" });
+    oauthFlow.refreshToken.mockResolvedValue(
+      mockTokenResponse({ refreshToken: null }),
+    );
+    stubAuthFetch();
+
+    await service.initialize();
+
+    expect(service.getState()).toMatchObject({
+      status: "authenticated",
+      sessionType: "persistent",
+    });
+    expect(sessionPort.getCurrent()?.refreshTokenEncrypted).toBe(
+      "existing-refresh-token",
     );
   });
 

--- a/packages/core/src/auth/auth.ts
+++ b/packages/core/src/auth/auth.ts
@@ -52,7 +52,8 @@ interface InMemorySession {
   accountKey: string | null;
   accessToken: string;
   accessTokenExpiresAt: number;
-  refreshToken: string;
+  refreshToken: string | null;
+  sessionType: "persistent" | "impersonated";
   cloudRegion: CloudRegion;
   orgProjectsMap: OrgProjectsMap;
   currentOrgId: string | null;
@@ -69,6 +70,7 @@ interface StoredSessionInput {
 interface TokenResponseOptions {
   cloudRegion: CloudRegion;
   selectedProjectId: number | null;
+  fallbackRefreshToken?: string;
 }
 
 @injectable()
@@ -82,10 +84,14 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     currentProjectId: null,
     hasCodeAccess: null,
     needsScopeReauth: false,
+    sessionType: null,
+    sessionExpiresAt: null,
+    sessionEndReason: null,
   };
   private session: InMemorySession | null = null;
   private initializePromise: Promise<void> | null = null;
   private refreshPromise: Promise<InMemorySession> | null = null;
+  private impersonationExpiryTimer: ReturnType<typeof setTimeout> | null = null;
   // Serializes session-state commits so overlapping selections can't
   // interleave across async encryption (see commitSessionState).
   private commitChain: Promise<void> = Promise.resolve();
@@ -157,7 +163,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   }
   async getOAuthCredentials(): Promise<{
     access: string;
-    refresh: string;
+    refresh: string | null;
     expires: number;
     region: CloudRegion;
   } | null> {
@@ -215,6 +221,13 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       init,
       initialAuth.accessToken,
     );
+
+    if (
+      response.status === 403 &&
+      this.session?.sessionType === "impersonated"
+    ) {
+      return response;
+    }
 
     if (response.status === 401 || response.status === 403) {
       const refreshedAuth = await this.refreshAccessToken();
@@ -383,11 +396,13 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     // encryption may reject). Mutate this.session, the preference, and
     // published state only after it resolves, so a rejection leaves every
     // layer on the prior session.
-    await this.persistSession({
-      refreshToken: nextSession.refreshToken,
-      cloudRegion: nextSession.cloudRegion,
-      selectedProjectId: next.currentProjectId,
-    });
+    if (nextSession.refreshToken) {
+      await this.persistSession({
+        refreshToken: nextSession.refreshToken,
+        cloudRegion: nextSession.cloudRegion,
+        selectedProjectId: next.currentProjectId,
+      });
+    }
 
     this.session = nextSession;
     this.persistProjectPreference(nextSession);
@@ -417,6 +432,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     const { cloudRegion, currentProjectId } = this.state;
 
     this.authSession.clearCurrent();
+    this.clearImpersonationExpiryTimer();
     this.session = null;
     this.setAnonymousState({ cloudRegion, currentProjectId });
     return this.getState();
@@ -538,6 +554,16 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       return currentSession;
     }
 
+    if (currentSession && !currentSession.refreshToken) {
+      if (!forceRefresh && !this.isSessionExpired(currentSession)) {
+        return currentSession;
+      }
+      this.endImpersonatedSession(currentSession);
+      throw new NotAuthenticatedError(
+        "Your impersonated session has expired. Impersonate the user again to continue.",
+      );
+    }
+
     if (this.refreshPromise) {
       return this.refreshPromise;
     }
@@ -579,6 +605,11 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
 
   private async getSessionInputForRefresh(): Promise<StoredSessionInput> {
     if (this.session) {
+      if (!this.session.refreshToken) {
+        throw new NotAuthenticatedError(
+          "Your impersonated session has expired. Impersonate the user again to continue.",
+        );
+      }
       return {
         refreshToken: this.session.refreshToken,
         cloudRegion: this.session.cloudRegion,
@@ -613,7 +644,10 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       );
 
       if (result.success && result.data) {
-        return await this.createSessionFromTokenResponse(result.data, input);
+        return await this.createSessionFromTokenResponse(result.data, {
+          ...input,
+          fallbackRefreshToken: input.refreshToken,
+        });
       }
 
       lastError = result.error || "Token refresh failed";
@@ -686,11 +720,14 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       lastSelectedOrgId: lastPrefs?.lastSelectedOrgId ?? null,
     });
 
+    const refreshToken =
+      tokenResponse.refresh_token ?? options.fallbackRefreshToken ?? null;
     const session: InMemorySession = {
       accountKey,
       accessToken: tokenResponse.access_token,
       accessTokenExpiresAt: Date.now() + tokenResponse.expires_in * 1000,
-      refreshToken: tokenResponse.refresh_token,
+      refreshToken,
+      sessionType: refreshToken ? "persistent" : "impersonated",
       cloudRegion: options.cloudRegion,
       orgProjectsMap,
       currentOrgId,
@@ -839,13 +876,18 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     session: InMemorySession,
   ): Promise<void> {
     this.persistProjectPreference(session);
-    await this.persistSession({
-      refreshToken: session.refreshToken,
-      cloudRegion: session.cloudRegion,
-      selectedProjectId: session.currentProjectId,
-    });
+    if (session.refreshToken) {
+      await this.persistSession({
+        refreshToken: session.refreshToken,
+        cloudRegion: session.cloudRegion,
+        selectedProjectId: session.currentProjectId,
+      });
+    } else {
+      this.authSession.clearCurrent();
+    }
 
     this.session = session;
+    this.scheduleImpersonationExpiry(session);
     this.updateState({
       status: "authenticated",
       bootstrapComplete: true,
@@ -854,6 +896,9 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       currentOrgId: session.currentOrgId,
       currentProjectId: session.currentProjectId,
       needsScopeReauth: false,
+      sessionType: session.sessionType,
+      sessionExpiresAt: session.accessTokenExpiresAt,
+      sessionEndReason: null,
     });
     await this.updateCodeAccessFromSession();
 
@@ -967,6 +1012,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       | "cloudRegion"
       | "currentProjectId"
       | "needsScopeReauth"
+      | "sessionEndReason"
     > = {},
   ): void {
     this.updateState({
@@ -978,6 +1024,9 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       currentProjectId: partial.currentProjectId ?? null,
       hasCodeAccess: null,
       needsScopeReauth: partial.needsScopeReauth ?? false,
+      sessionType: null,
+      sessionExpiresAt: null,
+      sessionEndReason: partial.sessionEndReason ?? null,
     });
   }
   private async updateCodeAccessFromSession(): Promise<void> {
@@ -1088,10 +1137,45 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   }
   @preDestroy()
   shutdown(): void {
+    this.clearImpersonationExpiryTimer();
     this.connectivityUnsubscribe?.();
     this.connectivityUnsubscribe = null;
     this.resumeUnsubscribe?.();
     this.resumeUnsubscribe = null;
+  }
+
+  private scheduleImpersonationExpiry(session: InMemorySession): void {
+    this.clearImpersonationExpiryTimer();
+    if (session.sessionType !== "impersonated") return;
+
+    const delayMs = Math.max(0, session.accessTokenExpiresAt - Date.now());
+    this.impersonationExpiryTimer = setTimeout(() => {
+      this.impersonationExpiryTimer = null;
+      const currentSession = this.session;
+      if (
+        currentSession?.sessionType === "impersonated" &&
+        this.isSessionExpired(currentSession)
+      ) {
+        this.endImpersonatedSession(currentSession);
+      }
+    }, delayMs);
+  }
+
+  private clearImpersonationExpiryTimer(): void {
+    if (this.impersonationExpiryTimer) {
+      clearTimeout(this.impersonationExpiryTimer);
+      this.impersonationExpiryTimer = null;
+    }
+  }
+
+  private endImpersonatedSession(session: InMemorySession): void {
+    this.clearImpersonationExpiryTimer();
+    this.session = null;
+    this.setAnonymousState({
+      cloudRegion: session.cloudRegion,
+      currentProjectId: session.currentProjectId,
+      sessionEndReason: "impersonation_expired",
+    });
   }
   private handleResume = (): void => {
     this.attemptSessionRecovery();

--- a/packages/core/src/auth/oauth.schemas.ts
+++ b/packages/core/src/auth/oauth.schemas.ts
@@ -23,7 +23,7 @@ export const oAuthTokenResponse = z.object({
   expires_in: z.number(),
   token_type: z.string(),
   scope: z.string().optional().default(""),
-  refresh_token: z.string(),
+  refresh_token: z.string().optional(),
   scoped_organizations: z.array(z.string()).optional(),
 });
 export type OAuthTokenResponse = z.infer<typeof oAuthTokenResponse>;

--- a/packages/core/src/auth/schemas.ts
+++ b/packages/core/src/auth/schemas.ts
@@ -80,6 +80,9 @@ export const authStateSchema = z.object({
   currentProjectId: z.number().nullable(),
   hasCodeAccess: z.boolean().nullable(),
   needsScopeReauth: z.boolean(),
+  sessionType: z.enum(["persistent", "impersonated"]).nullable(),
+  sessionExpiresAt: z.number().nullable(),
+  sessionEndReason: z.enum(["impersonation_expired"]).nullable().optional(),
 });
 export type AuthState = z.infer<typeof authStateSchema>;
 

--- a/packages/core/src/oauth/oauth.test.ts
+++ b/packages/core/src/oauth/oauth.test.ts
@@ -227,4 +227,29 @@ describe("OAuthService deep-link callback handler", () => {
     expect(mainWindow.restore).toHaveBeenCalled();
     expect(mainWindow.focus).toHaveBeenCalled();
   });
+
+  it("accepts a short-lived impersonated session without a refresh token", async () => {
+    const { service, getCallbackHandler } = createDeps();
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        access_token: "at",
+        expires_in: 1800,
+        token_type: "Bearer",
+        scope: "",
+      }),
+    );
+
+    const login = service.startFlow("us");
+    getCallbackHandler()?.("callback", new URLSearchParams("code=abc"));
+
+    await expect(login).resolves.toEqual({
+      success: true,
+      data: {
+        access_token: "at",
+        expires_in: 1800,
+        token_type: "Bearer",
+        scope: "",
+      },
+    });
+  });
 });

--- a/packages/core/src/oauth/oauth.ts
+++ b/packages/core/src/oauth/oauth.ts
@@ -28,10 +28,10 @@ import { OAUTH_HOST, type OAuthHost } from "./identifiers";
 import type {
   CancelFlowOutput,
   CloudRegion,
-  OAuthTokenResponse,
   RefreshTokenOutput,
   StartFlowOutput,
 } from "./schemas";
+import { type OAuthTokenResponse, oAuthTokenResponse } from "./schemas";
 
 const OAUTH_TIMEOUT_MS = 180_000; // 3 minutes
 const TOKEN_FETCH_TIMEOUT_MS = 30_000;
@@ -39,7 +39,6 @@ const DEV_CALLBACK_PORT = 8237;
 
 const NETWORK_ERROR_MESSAGE =
   "Could not connect to PostHog. Please check your internet connection and try again.";
-
 const TOKEN_FETCH_MAX_ATTEMPTS = 3;
 const TOKEN_FETCH_BACKOFF: BackoffOptions = {
   initialDelayMs: 1_000,
@@ -403,7 +402,15 @@ export class OAuthService {
       }
 
       if (response.ok) {
-        return (await response.json()) as OAuthTokenResponse;
+        const tokenResponse = oAuthTokenResponse.safeParse(
+          await response.json(),
+        );
+        if (!tokenResponse.success) {
+          throw new Error(
+            "PostHog returned an invalid authentication response. Please try again.",
+          );
+        }
+        return tokenResponse.data;
       }
 
       lastError = `Token exchange failed: ${response.status} ${response.statusText}`;

--- a/packages/ui/src/features/auth/components/AuthScreen.tsx
+++ b/packages/ui/src/features/auth/components/AuthScreen.tsx
@@ -1,9 +1,11 @@
 import { happyHog } from "@posthog/ui/assets/hedgehogs";
 import { FullScreenLayout } from "@posthog/ui/primitives/FullScreenLayout";
-import { Flex } from "@radix-ui/themes";
+import { Callout, Flex } from "@radix-ui/themes";
+import { useAuthStateValue } from "../store";
 import { SignInCard } from "./SignInCard";
 
 export function AuthScreen() {
+  const sessionEndReason = useAuthStateValue((state) => state.sessionEndReason);
   return (
     <FullScreenLayout>
       <Flex align="center" justify="center" height="100%" px="8">
@@ -20,6 +22,14 @@ export function AuthScreen() {
           >
             <Flex direction="column" align="start" gap="6" className="w-full">
               <Flex direction="column" gap="5" className="w-full">
+                {sessionEndReason === "impersonation_expired" && (
+                  <Callout.Root color="amber">
+                    <Callout.Text>
+                      Your impersonated session ended. Impersonate the user
+                      again, then sign in to continue.
+                    </Callout.Text>
+                  </Callout.Root>
+                )}
                 <SignInCard
                   hogSrc={happyHog}
                   hogMessage="Welcome back. Let's get shipping."

--- a/packages/ui/src/features/auth/store.ts
+++ b/packages/ui/src/features/auth/store.ts
@@ -13,6 +13,9 @@ export const ANONYMOUS_AUTH_STATE: AuthState = {
   currentProjectId: null,
   hasCodeAccess: null,
   needsScopeReauth: false,
+  sessionType: null,
+  sessionExpiresAt: null,
+  sessionEndReason: null,
 };
 
 interface AuthStoreState {

--- a/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
+++ b/packages/ui/src/features/sidebar/components/ProjectSwitcher.tsx
@@ -69,6 +69,8 @@ export function ProjectSwitcher() {
   };
 
   const currentOrgId = useAuthStateValue((state) => state.currentOrgId);
+  const sessionType = useAuthStateValue((state) => state.sessionType);
+  const sessionExpiresAt = useAuthStateValue((state) => state.sessionExpiresAt);
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
   const selectProjectMutation = useSelectProjectMutation();
@@ -82,6 +84,13 @@ export function ProjectSwitcher() {
     currentOrgGroup?.orgName ??
     currentProject?.organization.name ??
     "No organization";
+  const impersonationExpiry =
+    sessionType === "impersonated" && sessionExpiresAt
+      ? new Date(sessionExpiresAt).toLocaleTimeString([], {
+          hour: "numeric",
+          minute: "2-digit",
+        })
+      : null;
   const projectItems = useMemo<FlyoutItem[]>(
     () =>
       (currentOrgGroup?.projects ?? []).map((project) => ({
@@ -187,7 +196,9 @@ export function ProjectSwitcher() {
                 {currentProject?.name ?? "No project selected"}
               </ItemTitle>
               <ItemDescription className="text-[11px]">
-                {currentUser?.email ?? "No email"}
+                {impersonationExpiry
+                  ? `Impersonating until ${impersonationExpiry}`
+                  : (currentUser?.email ?? "No email")}
               </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -219,6 +230,11 @@ export function ProjectSwitcher() {
                   <ItemDescription className="text-[11px]">
                     {currentUser.email}
                   </ItemDescription>
+                  {impersonationExpiry && (
+                    <ItemDescription className="text-[11px] text-warning">
+                      Impersonated session ends at {impersonationExpiry}
+                    </ItemDescription>
+                  )}
                 </ItemContent>
               </Item>
             ) : (

--- a/packages/workspace-server/src/services/agent/auth-adapter.test.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.test.ts
@@ -26,9 +26,15 @@ function createDependencies() {
         accessToken: "fresh-access-token",
         apiHost: "https://app.posthog.com",
       }),
-      getState: vi.fn((): { currentProjectId: number | null } => ({
-        currentProjectId: 1,
-      })),
+      getState: vi.fn(
+        (): {
+          currentProjectId: number | null;
+          sessionType?: "persistent" | "impersonated" | null;
+        } => ({
+          currentProjectId: 1,
+          sessionType: "persistent",
+        }),
+      ),
       authenticatedFetch: vi
         .fn()
         .mockImplementation(
@@ -83,6 +89,8 @@ describe("AgentAuthAdapter", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_AUTH_HEADER;
   });
 
   describe("getCurrentCredentials", () => {
@@ -264,6 +272,24 @@ describe("AgentAuthAdapter", () => {
     expect(process.env.POSTHOG_PROJECT_ID).toBe("1");
     // The node-shim era prepended a shim dir here; PATH must stay untouched.
     expect(process.env.PATH).toBe(pathBefore);
+  });
+
+  it("does not export impersonated credentials to the process environment", async () => {
+    process.env.POSTHOG_API_KEY = "stale-token";
+    process.env.POSTHOG_AUTH_HEADER = "Bearer stale-token";
+    deps.authService.getState.mockReturnValue({
+      currentProjectId: 1,
+      sessionType: "impersonated",
+    });
+
+    await adapter.configureProcessEnv({
+      credentials: baseCredentials,
+      proxyUrl: "http://127.0.0.1:9999",
+      claudeCliPath: "/mock/claude-cli.js",
+    });
+
+    expect(process.env.POSTHOG_API_KEY).toBeUndefined();
+    expect(process.env.POSTHOG_AUTH_HEADER).toBeUndefined();
   });
 
   it.each([

--- a/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -185,6 +185,11 @@ export class AgentAuthAdapter {
   }
 
   private syncTokenEnvironment(token: string): void {
+    if (this.authService.getState().sessionType === "impersonated") {
+      delete process.env.POSTHOG_API_KEY;
+      delete process.env.POSTHOG_AUTH_HEADER;
+      return;
+    }
     process.env.POSTHOG_API_KEY = token;
     process.env.POSTHOG_AUTH_HEADER = `Bearer ${token}`;
   }

--- a/packages/workspace-server/src/services/agent/ports.ts
+++ b/packages/workspace-server/src/services/agent/ports.ts
@@ -61,12 +61,15 @@ export interface AgentAuth {
   getValidAccessToken(): Promise<{ accessToken: string; apiHost: string }>;
   getOAuthCredentials(): Promise<{
     access: string;
-    refresh: string;
+    refresh: string | null;
     expires: number;
     region: CloudRegion;
   } | null>;
   refreshAccessToken(): Promise<{ accessToken: string; apiHost: string }>;
-  getState(): { currentProjectId: number | null };
+  getState(): {
+    currentProjectId: number | null;
+    sessionType?: "persistent" | "impersonated" | null;
+  };
   authenticatedFetch(
     fetchImpl: AgentFetchLike,
     input: string | Request,


### PR DESCRIPTION
## Problem

PostHog intentionally issues impersonated OAuth sessions without refresh tokens so they cannot outlive the browser impersonation session. PostHog Code previously required a refresh token and failed while creating the local session.

Staff need to use PostHog Code as an impersonated user when investigating user-specific behavior without turning that short-lived authorization into a persistent login.

## Changes

Support refresh-less OAuth responses as short-lived impersonated sessions. The access token remains in memory, works for API and agent proxy requests, and is never written to the persistent auth store.

Impersonated sessions remain active through permission-denied responses, then sign out at the exact token expiry, on token rejection, when the app restarts, or when a refresh is requested. The project switcher shows when the session ends, and the sign-in screen explains how to continue after expiry.

Normal OAuth refreshes retain the existing refresh token when the server does not rotate it. Impersonated credentials are not exported to the process environment.
