### PR TITLE
feat: filter viewed code review files

### DIFF
--- a/packages/ui/src/features/code-review/commentFileFilter.ts
+++ b/packages/ui/src/features/code-review/commentFileFilter.ts
@@ -62,6 +62,52 @@ export function filterReviewItemsByFilePaths(
   return filteredItems;
 }
 
+export function filterReviewItemsByViewedState(
+  items: ReviewListItem[],
+  currentSignatures: ReadonlyMap<string, string>,
+  viewedRecord: Readonly<Record<string, string>>,
+): ReviewListItem[] {
+  const filteredItems: ReviewListItem[] = [];
+  let pendingSectionItems: ReviewListItem[] = [];
+
+  for (const item of items) {
+    if (!item.filePaths) {
+      pendingSectionItems = [item];
+      continue;
+    }
+
+    const signature = item.scrollKey
+      ? currentSignatures.get(item.scrollKey)
+      : undefined;
+    if (
+      signature !== undefined &&
+      item.scrollKey !== undefined &&
+      viewedRecord[item.scrollKey] === signature
+    ) {
+      continue;
+    }
+
+    filteredItems.push(...pendingSectionItems, item);
+    pendingSectionItems = [];
+  }
+
+  return filteredItems;
+}
+
+export function resolveVisibleActiveFilePath(
+  items: ReviewListItem[],
+  activeFilePath: string | null,
+): string | null {
+  if (
+    activeFilePath &&
+    items.some((item) => item.filePaths?.includes(activeFilePath))
+  ) {
+    return activeFilePath;
+  }
+
+  return items.find((item) => item.scrollKey)?.scrollKey ?? null;
+}
+
 export function deriveCommentFileFilterState({
   items,
   requestedFilter,

--- a/packages/ui/src/features/code-review/components/DiffSettingsMenu.tsx
+++ b/packages/ui/src/features/code-review/components/DiffSettingsMenu.tsx
@@ -16,6 +16,8 @@ interface DiffSettingsMenuProps {
   unresolvedCommentedFileCount: number;
   commentFilter: CommentFileFilter;
   onCommentFilterChange?: (filter: CommentFileFilter) => void;
+  hideViewedFiles: boolean;
+  onHideViewedFilesChange: (hideViewed: boolean) => void;
 }
 
 export function DiffSettingsMenu({
@@ -23,6 +25,8 @@ export function DiffSettingsMenu({
   unresolvedCommentedFileCount,
   commentFilter,
   onCommentFilterChange,
+  hideViewedFiles,
+  onHideViewedFilesChange,
 }: DiffSettingsMenuProps) {
   const wordWrap = useDiffViewerStore((s) => s.wordWrap);
   const toggleWordWrap = useDiffViewerStore((s) => s.toggleWordWrap);
@@ -79,6 +83,11 @@ export function DiffSettingsMenu({
           {hideWhitespaceChanges ? "Show whitespace" : "Hide whitespace"}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={() => onHideViewedFilesChange(!hideViewedFiles)}
+        >
+          {hideViewedFiles ? "Show viewed files" : "Hide viewed files"}
+        </DropdownMenuItem>
         <DropdownMenuItem onClick={handleToggleReviewComments}>
           {showReviewComments ? "Hide review comments" : "Show review comments"}
         </DropdownMenuItem>

--- a/packages/ui/src/features/code-review/components/ReviewShell.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewShell.tsx
@@ -16,8 +16,10 @@ import {
 import { VList, type VListHandle } from "virtua";
 import {
   deriveCommentFileFilterState,
+  filterReviewItemsByViewedState,
   getEmptyReviewMessage,
   type ReviewListItem,
+  resolveVisibleActiveFilePath,
 } from "../commentFileFilter";
 import {
   REVIEW_LIST_BUFFER_PX,
@@ -29,7 +31,6 @@ import { useReviewNavigationStore } from "../reviewNavigationStore";
 import type { ReviewShellProps } from "../reviewShellParts";
 import {
   buildItemIndex,
-  filterReviewItemsByViewedState,
   findActiveScrollKey,
   findRenderedScrollAnchor,
   isFileViewed,
@@ -272,7 +273,27 @@ export function ReviewShell({
   const setActiveFilePath = useReviewNavigationStore(
     (s) => s.setActiveFilePath,
   );
+  const activeFilePath = useReviewNavigationStore(
+    (s) => s.activeFilePaths[taskId] ?? null,
+  );
   const clearTask = useReviewNavigationStore((s) => s.clearTask);
+
+  useEffect(() => {
+    if (!hideViewedFiles || !activeFilePath) return;
+    const nextActiveFilePath = resolveVisibleActiveFilePath(
+      filteredItems,
+      activeFilePath,
+    );
+    if (nextActiveFilePath === activeFilePath) return;
+    lastActiveRef.current = nextActiveFilePath;
+    setActiveFilePath(taskId, nextActiveFilePath);
+  }, [
+    activeFilePath,
+    filteredItems,
+    hideViewedFiles,
+    setActiveFilePath,
+    taskId,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/packages/ui/src/features/code-review/components/ReviewShell.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewShell.tsx
@@ -29,6 +29,7 @@ import { useReviewNavigationStore } from "../reviewNavigationStore";
 import type { ReviewShellProps } from "../reviewShellParts";
 import {
   buildItemIndex,
+  filterReviewItemsByViewedState,
   findActiveScrollKey,
   findRenderedScrollAnchor,
   isFileViewed,
@@ -155,6 +156,12 @@ export function ReviewShell({
   const setCommentFileFilter = useReviewNavigationStore(
     (state) => state.setCommentFileFilter,
   );
+  const hideViewedFiles = useReviewNavigationStore(
+    (state) => state.hideViewedFiles[taskId] ?? false,
+  );
+  const setHideViewedFiles = useReviewNavigationStore(
+    (state) => state.setHideViewedFiles,
+  );
   const {
     activeFilter: activeCommentFilter,
     visibleItems,
@@ -170,9 +177,21 @@ export function ReviewShell({
       }),
     [commentFilter, commentedFilePaths, items, unresolvedCommentedFilePaths],
   );
+  const filteredItems = useMemo(() => {
+    if (!hideViewedFiles) return visibleItems;
+    return filterReviewItemsByViewedState(
+      visibleItems,
+      currentSignatures,
+      viewedRecord,
+    );
+  }, [currentSignatures, hideViewedFiles, viewedRecord, visibleItems]);
+  const filteredFileCount = useMemo(
+    () => filteredItems.filter((item) => item.filePaths).length,
+    [filteredItems],
+  );
   const visibleItemIndexByFilePath = useMemo(
-    () => buildItemIndex(visibleItems),
-    [visibleItems],
+    () => buildItemIndex(filteredItems),
+    [filteredItems],
   );
 
   const workerFactory = useCallback(
@@ -348,11 +367,13 @@ export function ReviewShell({
         <Spinner size="2" />
       </Flex>
     );
-  } else if (isEmpty || visibleItems.length === 0) {
+  } else if (isEmpty || filteredItems.length === 0) {
     reviewContent = (
       <Flex align="center" justify="center" className="min-h-0 flex-1">
         <Text color="gray" className="text-sm">
-          {getEmptyReviewMessage(activeCommentFilter)}
+          {hideViewedFiles
+            ? "No unviewed file changes"
+            : getEmptyReviewMessage(activeCommentFilter)}
         </Text>
       </Flex>
     );
@@ -366,7 +387,7 @@ export function ReviewShell({
         shift={false}
         style={{ scrollbarGutter: "stable" }}
         onScroll={handleScroll}
-        data={visibleItems}
+        data={filteredItems}
       >
         {renderItem}
       </VList>
@@ -412,6 +433,11 @@ export function ReviewShell({
               commentedFilePaths && unresolvedCommentedFilePaths
                 ? (filter) => setCommentFileFilter(taskId, filter)
                 : undefined
+            }
+            hideViewedFiles={hideViewedFiles}
+            filteredFileCount={filteredFileCount}
+            onHideViewedFilesChange={(hideViewed) =>
+              setHideViewedFiles(taskId, hideViewed)
             }
             linesAdded={linesAdded}
             linesRemoved={linesRemoved}

--- a/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewToolbar.tsx
@@ -28,6 +28,9 @@ interface ReviewToolbarProps {
   unresolvedCommentedFileCount: number;
   commentFilter: CommentFileFilter;
   onCommentFilterChange?: (filter: CommentFileFilter) => void;
+  hideViewedFiles: boolean;
+  filteredFileCount: number;
+  onHideViewedFilesChange: (hideViewed: boolean) => void;
   linesAdded: number;
   linesRemoved: number;
   allExpanded: boolean;
@@ -82,6 +85,9 @@ export const ReviewToolbar = memo(function ReviewToolbar({
   unresolvedCommentedFileCount,
   commentFilter,
   onCommentFilterChange,
+  hideViewedFiles,
+  filteredFileCount,
+  onHideViewedFilesChange,
   allExpanded,
   onExpandAll,
   onCollapseAll,
@@ -108,13 +114,18 @@ export const ReviewToolbar = memo(function ReviewToolbar({
     setReviewMode(taskId, "closed");
   };
 
-  const { count: visibleFileCount, label: fileCountLabel } =
-    getVisibleFileSummary(
-      commentFilter,
-      fileCount,
-      commentedFileCount,
-      unresolvedCommentedFileCount,
-    );
+  const visibleFileSummary = getVisibleFileSummary(
+    commentFilter,
+    fileCount,
+    commentedFileCount,
+    unresolvedCommentedFileCount,
+  );
+  const visibleFileCount = hideViewedFiles
+    ? filteredFileCount
+    : visibleFileSummary.count;
+  const fileCountLabel = hideViewedFiles
+    ? formatFileCount(filteredFileCount, "not viewed")
+    : visibleFileSummary.label;
 
   return (
     <Flex
@@ -129,7 +140,7 @@ export const ReviewToolbar = memo(function ReviewToolbar({
     >
       <Flex align="center" gap="2">
         <Text className="font-medium text-[13px]">{fileCountLabel}</Text>
-        {visibleFileCount > 0 && (
+        {!hideViewedFiles && visibleFileCount > 0 && (
           <Text className="text-(--gray-10) text-[13px]">
             {viewedCount}/{visibleFileCount} viewed
           </Text>
@@ -216,6 +227,8 @@ export const ReviewToolbar = memo(function ReviewToolbar({
           unresolvedCommentedFileCount={unresolvedCommentedFileCount}
           commentFilter={commentFilter}
           onCommentFilterChange={onCommentFilterChange}
+          hideViewedFiles={hideViewedFiles}
+          onHideViewedFilesChange={onHideViewedFilesChange}
         />
 
         <Tooltip content="Close review">

--- a/packages/ui/src/features/code-review/reviewNavigationStore.test.ts
+++ b/packages/ui/src/features/code-review/reviewNavigationStore.test.ts
@@ -9,6 +9,7 @@ describe("reviewNavigationStore", () => {
       reviewModes: {},
       selectedPrUrls: {},
       commentFileFilters: {},
+      hideViewedFiles: {},
     });
   });
 
@@ -26,6 +27,20 @@ describe("reviewNavigationStore", () => {
     expect(
       useReviewNavigationStore.getState().selectedPrUrls["task-1"],
     ).toBeUndefined();
+  });
+
+  it("stores and clears the viewed-file filter per task", () => {
+    const store = useReviewNavigationStore.getState();
+    store.setHideViewedFiles("task-1", true);
+
+    expect(useReviewNavigationStore.getState().hideViewedFiles["task-1"]).toBe(
+      true,
+    );
+
+    store.clearTask("task-1");
+    expect(useReviewNavigationStore.getState().hideViewedFiles["task-1"]).toBe(
+      false,
+    );
   });
 
   it("clears the comment filter when navigating to a file", () => {

--- a/packages/ui/src/features/code-review/reviewNavigationStore.ts
+++ b/packages/ui/src/features/code-review/reviewNavigationStore.ts
@@ -9,6 +9,7 @@ interface ReviewNavigationStoreState {
   reviewModes: Record<string, ReviewMode>;
   selectedPrUrls: Record<string, string | undefined>;
   commentFileFilters: Record<string, CommentFileFilter>;
+  hideViewedFiles: Record<string, boolean>;
 }
 
 interface ReviewNavigationStoreActions {
@@ -19,6 +20,7 @@ interface ReviewNavigationStoreActions {
   setReviewMode: (taskId: string, mode: ReviewMode) => void;
   setSelectedPrUrl: (taskId: string, url: string) => void;
   setCommentFileFilter: (taskId: string, filter: CommentFileFilter) => void;
+  setHideViewedFiles: (taskId: string, hideViewed: boolean) => void;
   getReviewMode: (taskId: string) => ReviewMode;
 }
 
@@ -32,6 +34,7 @@ export const useReviewNavigationStore = create<ReviewNavigationStore>()(
     reviewModes: {},
     selectedPrUrls: {},
     commentFileFilters: {},
+    hideViewedFiles: {},
 
     setActiveFilePath: (taskId, path) =>
       set((state) => ({
@@ -45,6 +48,7 @@ export const useReviewNavigationStore = create<ReviewNavigationStore>()(
           ...state.commentFileFilters,
           [taskId]: "none",
         },
+        hideViewedFiles: { ...state.hideViewedFiles, [taskId]: false },
       })),
 
     clearScrollRequest: (taskId) =>
@@ -61,6 +65,7 @@ export const useReviewNavigationStore = create<ReviewNavigationStore>()(
           [taskId]: "none",
         },
         selectedPrUrls: { ...state.selectedPrUrls, [taskId]: undefined },
+        hideViewedFiles: { ...state.hideViewedFiles, [taskId]: false },
       })),
 
     setReviewMode: (taskId, mode) =>
@@ -84,6 +89,14 @@ export const useReviewNavigationStore = create<ReviewNavigationStore>()(
         commentFileFilters: {
           ...state.commentFileFilters,
           [taskId]: filter,
+        },
+      })),
+
+    setHideViewedFiles: (taskId, hideViewed) =>
+      set((state) => ({
+        hideViewedFiles: {
+          ...state.hideViewedFiles,
+          [taskId]: hideViewed,
         },
       })),
 

--- a/packages/ui/src/features/code-review/reviewShellParts.test.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.test.tsx
@@ -23,6 +23,7 @@ import {
 import {
   DeferredDiffPlaceholder,
   DiffFileHeader,
+  filterReviewItemsByViewedState,
   findActiveScrollKey,
   findRenderedScrollAnchor,
 } from "./reviewShellParts";
@@ -169,6 +170,36 @@ describe("review scroll anchors", () => {
 });
 
 describe("commented file filtering", () => {
+  it("keeps only unviewed files and their section headers", () => {
+    const items: ReviewListItem[] = [
+      { key: "section:staged", node: <span>Staged</span> },
+      {
+        key: "staged:a.ts",
+        scrollKey: "staged:a.ts",
+        filePaths: ["a.ts"],
+        node: <span>A</span>,
+      },
+      { key: "section:changes", node: <span>Changes</span> },
+      {
+        key: "unstaged:b.ts",
+        scrollKey: "unstaged:b.ts",
+        filePaths: ["b.ts"],
+        node: <span>B</span>,
+      },
+    ];
+
+    expect(
+      filterReviewItemsByViewedState(
+        items,
+        new Map([
+          ["staged:a.ts", "signature-a"],
+          ["unstaged:b.ts", "signature-b"],
+        ]),
+        { "staged:a.ts": "signature-a" },
+      ).map((item) => item.key),
+    ).toEqual(["section:changes", "unstaged:b.ts"]);
+  });
+
   it("collects paths for all and unresolved comment threads", () => {
     const commentedPaths = getCommentedFilePaths(
       new Map([

--- a/packages/ui/src/features/code-review/reviewShellParts.test.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.test.tsx
@@ -17,13 +17,14 @@ vi.mock("../../primitives/FileIcon", () => ({
 import {
   deriveCommentFileFilterState,
   filterReviewItemsByFilePaths,
+  filterReviewItemsByViewedState,
   getCommentedFilePaths,
   type ReviewListItem,
+  resolveVisibleActiveFilePath,
 } from "./commentFileFilter";
 import {
   DeferredDiffPlaceholder,
   DiffFileHeader,
-  filterReviewItemsByViewedState,
   findActiveScrollKey,
   findRenderedScrollAnchor,
 } from "./reviewShellParts";
@@ -198,6 +199,22 @@ describe("commented file filtering", () => {
         { "staged:a.ts": "signature-a" },
       ).map((item) => item.key),
     ).toEqual(["section:changes", "unstaged:b.ts"]);
+  });
+
+  it("selects the first visible file when the active file is filtered out", () => {
+    const items: ReviewListItem[] = [
+      { key: "section:changes", node: <span>Changes</span> },
+      {
+        key: "b.ts",
+        scrollKey: "b.ts",
+        filePaths: ["b.ts", "old-b.ts"],
+        node: <span>B</span>,
+      },
+    ];
+
+    expect(resolveVisibleActiveFilePath(items, "a.ts")).toBe("b.ts");
+    expect(resolveVisibleActiveFilePath(items, "old-b.ts")).toBe("old-b.ts");
+    expect(resolveVisibleActiveFilePath([], "a.ts")).toBeNull();
   });
 
   it("collects paths for all and unresolved comment threads", () => {

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -301,6 +301,38 @@ export function isFileViewed(
   return storedSig === currentSig;
 }
 
+export function filterReviewItemsByViewedState(
+  items: ReviewListItem[],
+  currentSignatures: ReadonlyMap<string, string>,
+  viewedRecord: Readonly<Record<string, string>>,
+): ReviewListItem[] {
+  const filteredItems: ReviewListItem[] = [];
+  let pendingSectionItems: ReviewListItem[] = [];
+
+  for (const item of items) {
+    if (!item.filePaths) {
+      pendingSectionItems = [item];
+      continue;
+    }
+
+    const signature = item.scrollKey
+      ? currentSignatures.get(item.scrollKey)
+      : undefined;
+    if (
+      signature !== undefined &&
+      item.scrollKey !== undefined &&
+      isFileViewed(viewedRecord[item.scrollKey], signature)
+    ) {
+      continue;
+    }
+
+    filteredItems.push(...pendingSectionItems, item);
+    pendingSectionItems = [];
+  }
+
+  return filteredItems;
+}
+
 function ViewedCheckbox({ viewedKey }: { viewedKey: string }) {
   const ctx = useReviewViewedContext();
   if (!ctx) return null;

--- a/packages/ui/src/features/code-review/reviewShellParts.tsx
+++ b/packages/ui/src/features/code-review/reviewShellParts.tsx
@@ -301,38 +301,6 @@ export function isFileViewed(
   return storedSig === currentSig;
 }
 
-export function filterReviewItemsByViewedState(
-  items: ReviewListItem[],
-  currentSignatures: ReadonlyMap<string, string>,
-  viewedRecord: Readonly<Record<string, string>>,
-): ReviewListItem[] {
-  const filteredItems: ReviewListItem[] = [];
-  let pendingSectionItems: ReviewListItem[] = [];
-
-  for (const item of items) {
-    if (!item.filePaths) {
-      pendingSectionItems = [item];
-      continue;
-    }
-
-    const signature = item.scrollKey
-      ? currentSignatures.get(item.scrollKey)
-      : undefined;
-    if (
-      signature !== undefined &&
-      item.scrollKey !== undefined &&
-      isFileViewed(viewedRecord[item.scrollKey], signature)
-    ) {
-      continue;
-    }
-
-    filteredItems.push(...pendingSectionItems, item);
-    pendingSectionItems = [];
-  }
-
-  return filteredItems;
-}
-
 function ViewedCheckbox({ viewedKey }: { viewedKey: string }) {
   const ctx = useReviewViewedContext();
   if (!ctx) return null;


### PR DESCRIPTION
## Problem

Code reviews with many files make it hard to focus on changes that still need review.

## Changes

<img width="1286" height="572" alt="CleanShot 2026-07-24 at 14 32 48@2x" src="https://github.com/user-attachments/assets/6724ae92-820c-4abf-aa35-ea0dff980ce1" />
<img width="1298" height="586" alt="CleanShot 2026-07-24 at 14 33 12@2x" src="https://github.com/user-attachments/assets/1449d373-dc5a-4d20-8d04-c973be4b817b" />


- Add a Hide viewed files option to diff settings
- Combine viewed-state filtering with comment filters
- Preserve section headers and clear filters for direct file navigation

## How did you test this?

- Ran the `@posthog/ui` test suite: 2,115 tests passed
- Ran Biome checks on all changed files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*