### PR TITLE
fix(message-editor): preserve comment anchors in pasted GitHub links

### DIFF
--- a/apps/mobile/src/lib/githubIssueUrl.ts
+++ b/apps/mobile/src/lib/githubIssueUrl.ts
@@ -9,23 +9,28 @@ export interface ParsedGithubIssueUrl {
 }
 
 const GITHUB_ISSUE_URL_PATTERN =
-  /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/(issues|pull)\/(\d+)(?:[/?#].*)?$/;
+  /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/(issues|pull)\/(\d+)([/?#].*)?$/;
 
 export function parseGithubIssueUrl(text: string): ParsedGithubIssueUrl | null {
   const trimmed = text.trim();
   const match = trimmed.match(GITHUB_ISSUE_URL_PATTERN);
   if (!match) return null;
 
-  const [, owner, repo, segment, rawNumber] = match;
+  const [, owner, repo, segment, rawNumber, suffix = ""] = match;
   const number = Number(rawNumber);
   if (!Number.isInteger(number) || number <= 0) return null;
 
   const kind: GithubRefKind = segment === "pull" ? "pr" : "issue";
+  // A fragment like #discussion_r123 anchors a specific comment, so keep the
+  // whole suffix — anchors such as #r123 only resolve on the /files subpage
+  // they were copied from. Without a fragment the tab/query suffix is noise.
+  const hashIndex = suffix.indexOf("#");
+  const hasFragment = hashIndex !== -1 && hashIndex < suffix.length - 1;
   return {
     kind,
     owner,
     repo,
     number,
-    normalizedUrl: `https://github.com/${owner}/${repo}/${segment}/${number}`,
+    normalizedUrl: `https://github.com/${owner}/${repo}/${segment}/${number}${hasFragment ? suffix : ""}`,
   };
 }

--- a/packages/core/src/message-editor/githubIssueUrl.test.ts
+++ b/packages/core/src/message-editor/githubIssueUrl.test.ts
@@ -55,8 +55,45 @@ describe("parseGithubIssueUrl", () => {
       },
     },
     {
-      name: "fragment is stripped from normalized URL",
+      name: "issue comment fragment is preserved",
       input: "https://github.com/PostHog/code/issues/1808#issuecomment-123",
+      expected: {
+        kind: "issue",
+        owner: "PostHog",
+        repo: "code",
+        number: 1808,
+        normalizedUrl:
+          "https://github.com/PostHog/code/issues/1808#issuecomment-123",
+      },
+    },
+    {
+      name: "PR review comment fragment is preserved",
+      input:
+        "https://github.com/PostHog/posthog/pull/72409#discussion_r3647131256",
+      expected: {
+        kind: "pr",
+        owner: "PostHog",
+        repo: "posthog",
+        number: 72409,
+        normalizedUrl:
+          "https://github.com/PostHog/posthog/pull/72409#discussion_r3647131256",
+      },
+    },
+    {
+      name: "files tab suffix is kept when a comment fragment needs it",
+      input: "https://github.com/PostHog/code/pull/1454/files#r3647131256",
+      expected: {
+        kind: "pr",
+        owner: "PostHog",
+        repo: "code",
+        number: 1454,
+        normalizedUrl:
+          "https://github.com/PostHog/code/pull/1454/files#r3647131256",
+      },
+    },
+    {
+      name: "empty fragment is stripped from normalized URL",
+      input: "https://github.com/PostHog/code/issues/1808#",
       expected: {
         kind: "issue",
         owner: "PostHog",

--- a/packages/core/src/message-editor/githubIssueUrl.ts
+++ b/packages/core/src/message-editor/githubIssueUrl.ts
@@ -11,23 +11,28 @@ export interface ParsedGithubIssueUrl {
 }
 
 const GITHUB_ISSUE_URL_PATTERN =
-  /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/(issues|pull)\/(\d+)(?:[/?#].*)?$/;
+  /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/(issues|pull)\/(\d+)([/?#].*)?$/;
 
 export function parseGithubIssueUrl(text: string): ParsedGithubIssueUrl | null {
   const trimmed = text.trim();
   const match = trimmed.match(GITHUB_ISSUE_URL_PATTERN);
   if (!match) return null;
 
-  const [, owner, repo, segment, rawNumber] = match;
+  const [, owner, repo, segment, rawNumber, suffix = ""] = match;
   const number = Number(rawNumber);
   if (!Number.isInteger(number) || number <= 0) return null;
 
   const kind: GithubRefKind = segment === "pull" ? "pr" : "issue";
+  // A fragment like #discussion_r123 anchors a specific comment, so keep the
+  // whole suffix — anchors such as #r123 only resolve on the /files subpage
+  // they were copied from. Without a fragment the tab/query suffix is noise.
+  const hashIndex = suffix.indexOf("#");
+  const hasFragment = hashIndex !== -1 && hashIndex < suffix.length - 1;
   return {
     kind,
     owner,
     repo,
     number,
-    normalizedUrl: `https://github.com/${owner}/${repo}/${segment}/${number}`,
+    normalizedUrl: `https://github.com/${owner}/${repo}/${segment}/${number}${hasFragment ? suffix : ""}`,
   };
 }


### PR DESCRIPTION
## Problem

Pasting a GitHub comment link into the composer — e.g.

```
https://github.com/PostHog/posthog/pull/72409#discussion_r3647131256
```

auto-converts it into a PR chip, but `parseGithubIssueUrl` rebuilt the chip URL from owner/repo/number only, silently dropping the `#discussion_r…` anchor. The chip's click-through and the `url="…"` attribute sent to the agent both ended up pointing at the PR itself instead of the specific comment.

## Fix

`parseGithubIssueUrl` now keeps the URL suffix on `normalizedUrl` whenever it contains a non-empty fragment. The whole suffix is preserved (path tail + query + fragment), not just the fragment, because anchors like `#r123` only resolve on the `/files` subpage they were copied from — `/pull/123#r123` would land nowhere.

Behavior without a fragment is unchanged: tab suffixes (`/files`), query strings, and trailing junk are still stripped, and `http://` is still normalized to `https://`.

`apps/mobile/src/lib/githubIssueUrl.ts` is a verbatim copy of the helper (used for PR badges and markdown link chips) and gets the identical fix to stay in sync.

## Testing

- Flipped the old "fragment is stripped" unit test to assert preservation, and added cases for the reported `#discussion_r…` link, a `/files#r…` link, and an empty `#` (still stripped).
- `pnpm --filter @posthog/core exec vitest run src/message-editor/githubIssueUrl.test.ts src/message-editor/content.test.ts` — 42 tests pass.
- `pnpm typecheck` and Biome pass (also enforced by the pre-commit hook).