### PR TITLE
feat: support shared local MCP configuration

### DIFF
--- a/apps/code/src/renderer/di/container.ts
+++ b/apps/code/src/renderer/di/container.ts
@@ -399,10 +399,13 @@ container.bind(CODE_REVIEW_WORKSPACE_CLIENT).toConstantValue({
 } satisfies CodeReviewWorkspaceClient);
 container.bind(REVERT_HUNK_SERVICE).to(RevertHunkService).inSingletonScope();
 
-// local MCP servers (~/.claude.json), read for cloud-import classification
+// local MCP servers, read for cloud-import classification
 container.bind(LOCAL_MCP_WORKSPACE_CLIENT).toConstantValue({
   listLocalMcpServers: (cwd?: string) =>
     trpcClient.localMcp.list.query({ cwd }),
+  getLocalMcpConfig: () => trpcClient.localMcp.config.query(),
+  updateLocalMcpConfig: (content: string) =>
+    trpcClient.localMcp.updateConfig.mutate({ content }),
 } satisfies LocalMcpWorkspaceClient);
 
 // skills (team publish/install reach workspace-server through this slice)

--- a/packages/agent/src/adapters/claude/session/mcp-config.test.ts
+++ b/packages/agent/src/adapters/claude/session/mcp-config.test.ts
@@ -3,9 +3,51 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  loadPostHogCodeMcpServers,
   loadUserClaudeJsonMcpServerEntries,
   loadUserClaudeJsonMcpServers,
+  toAcpMcpServers,
 } from "./mcp-config";
+
+describe("loadPostHogCodeMcpServers", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "posthog-mcp-test-"));
+    fs.mkdirSync(path.join(tmpHome, ".posthog-code"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("loads only transports shared by Claude and Codex", () => {
+    fs.writeFileSync(
+      path.join(tmpHome, ".posthog-code", "mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          command: { command: "npx", args: ["server"] },
+          remote: { type: "http", url: "https://mcp.example.com" },
+          legacy: { type: "sse", url: "https://sse.example.com" },
+        },
+      }),
+    );
+
+    expect(Object.keys(loadPostHogCodeMcpServers(undefined, tmpHome))).toEqual([
+      "command",
+      "remote",
+    ]);
+  });
+
+  it("returns empty for missing or invalid config", () => {
+    expect(loadPostHogCodeMcpServers(undefined, tmpHome)).toEqual({});
+    fs.writeFileSync(
+      path.join(tmpHome, ".posthog-code", "mcp.json"),
+      "invalid",
+    );
+    expect(loadPostHogCodeMcpServers(undefined, tmpHome)).toEqual({});
+  });
+});
 
 describe("loadUserClaudeJsonMcpServers", () => {
   let tmpHome: string;
@@ -111,6 +153,44 @@ describe("loadUserClaudeJsonMcpServers", () => {
       else process.env.CLAUDE_CONFIG_DIR = original;
       fs.rmSync(altDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("toAcpMcpServers", () => {
+  it("preserves stdio and HTTP server credentials for another local adapter", () => {
+    expect(
+      toAcpMcpServers({
+        filesystem: {
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem"],
+          env: { ROOT: "/workspace" },
+        },
+        observability: {
+          type: "http",
+          url: "https://mcp.example.com/mcp",
+          headers: { Authorization: "Bearer secret" },
+        },
+      }),
+    ).toEqual([
+      {
+        name: "filesystem",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem"],
+        env: [{ name: "ROOT", value: "/workspace" }],
+      },
+      {
+        name: "observability",
+        type: "http",
+        url: "https://mcp.example.com/mcp",
+        headers: [{ name: "Authorization", value: "Bearer secret" }],
+      },
+    ]);
+  });
+
+  it("drops local entries with an unsupported transport", () => {
+    expect(
+      toAcpMcpServers({ invalid: { type: "websocket" } as never }),
+    ).toEqual([]);
   });
 });
 

--- a/packages/agent/src/adapters/claude/session/mcp-config.ts
+++ b/packages/agent/src/adapters/claude/session/mcp-config.ts
@@ -1,12 +1,16 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { NewSessionRequest } from "@agentclientprotocol/sdk";
+import type { McpServer, NewSessionRequest } from "@agentclientprotocol/sdk";
 import type { McpServerConfig } from "@anthropic-ai/claude-agent-sdk";
 import type {
   LocalMcpServerDescriptor,
   LocalMcpServerScope,
   LocalMcpTransport,
+} from "@posthog/shared";
+import {
+  parsePostHogMcpServers,
+  validatePostHogMcpConfig,
 } from "@posthog/shared";
 import type { Logger } from "../../../utils/logger";
 
@@ -83,6 +87,83 @@ export function loadUserClaudeJsonMcpServers(
     servers[entry.name] = entry.config;
   }
   return servers;
+}
+
+export function loadPostHogCodeMcpServers(
+  logger?: Logger,
+  homeDir: string = os.homedir(),
+): Record<string, McpServerConfig> {
+  const configPath = path.join(homeDir, ".posthog-code", "mcp.json");
+  let parsed: { mcpServers?: unknown };
+  try {
+    parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      logger?.warn("Failed to parse PostHog Code MCP config", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return {};
+  }
+  const servers: Record<string, McpServerConfig> = {};
+  const issues = validatePostHogMcpConfig(parsed);
+  if (issues.length > 0) {
+    logger?.warn("Ignoring invalid PostHog Code MCP configuration", { issues });
+  }
+  for (const entry of parsePostHogMcpServers(parsed)) {
+    if (entry.config) servers[entry.name] = entry.config as McpServerConfig;
+  }
+  return servers;
+}
+
+/**
+ * Converts local Claude config entries into ACP's transport-neutral MCP shape.
+ * This lets non-Claude adapters use the same explicit local configuration
+ * without inheriting ambient agent configuration or plugins.
+ */
+export function toAcpMcpServers(
+  servers: Record<string, McpServerConfig>,
+): McpServer[] {
+  const result: McpServer[] = [];
+  for (const [name, config] of Object.entries(servers)) {
+    const transport = parseClaudeJsonTransport(config);
+    switch (transport.kind) {
+      case "http":
+        result.push({
+          name,
+          type: "http",
+          url: transport.url,
+          headers: Object.entries(transport.headers ?? {}).map(
+            ([headerName, value]) => ({ name: headerName, value }),
+          ),
+        });
+        break;
+      case "sse":
+        result.push({
+          name,
+          type: "sse",
+          url: transport.url,
+          headers: Object.entries(transport.headers ?? {}).map(
+            ([headerName, value]) => ({ name: headerName, value }),
+          ),
+        });
+        break;
+      case "stdio":
+        result.push({
+          name,
+          command: transport.command,
+          args: transport.args ?? [],
+          env: Object.entries(transport.env ?? {}).map(([envName, value]) => ({
+            name: envName,
+            value,
+          })),
+        });
+        break;
+      default:
+        break;
+    }
+  }
+  return result;
 }
 
 export function sanitizeHeaders(

--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -29,7 +29,7 @@ import {
 import { type CodeExecutionMode, toSdkPermissionMode } from "../tools";
 import type { EffortLevel } from "../types";
 import { buildAppendedInstructions } from "./instructions";
-import { loadUserClaudeJsonMcpServers } from "./mcp-config";
+import { loadPostHogCodeMcpServers } from "./mcp-config";
 import { DEFAULT_MODEL, FALLBACK_MODEL } from "./models";
 import { createRtkRewriteHook, resolveRtkPrefix } from "./rtk";
 import type { SettingsManager } from "./settings";
@@ -140,10 +140,10 @@ export function buildSystemPrompt(
 function buildMcpServers(
   userServers: Record<string, McpServerConfig> | undefined,
   acpServers: Record<string, McpServerConfig>,
-  projectScopedServers: Record<string, McpServerConfig>,
+  posthogCodeServers: Record<string, McpServerConfig>,
 ): Record<string, McpServerConfig> {
   return {
-    ...projectScopedServers,
+    ...posthogCodeServers,
     ...(userServers || {}),
     ...acpServers,
   };
@@ -465,7 +465,7 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     mcpServers: buildMcpServers(
       params.userProvidedOptions?.mcpServers,
       params.mcpServers,
-      loadUserClaudeJsonMcpServers(params.cwd, params.logger),
+      loadPostHogCodeMcpServers(params.logger),
     ),
     env: buildEnvironment(params.gatewayEnv),
     hooks: buildHooks(

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -51,6 +51,10 @@ import {
   emptyBaseline,
   estimateTokens,
 } from "../claude/context-breakdown";
+import {
+  loadPostHogCodeMcpServers,
+  toAcpMcpServers,
+} from "../claude/session/mcp-config";
 import { isLocalSkillCommandChunk } from "../local-skill";
 import { resolveSpokenNarration } from "../session-meta";
 import {
@@ -540,8 +544,15 @@ export class CodexAppServerAgent extends BaseAcpAgent {
           { message },
         ),
     );
+    const localMcpServers = toAcpMcpServers(
+      loadPostHogCodeMcpServers(this.logger),
+    );
     const mcpServers = toCodexMcpServers(
-      [...(params.mcpServers ?? []), ...(localTools ? [localTools] : [])],
+      [
+        ...localMcpServers,
+        ...(params.mcpServers ?? []),
+        ...(localTools ? [localTools] : []),
+      ],
       { gatePosthogExec: true },
     );
     const config = buildThreadConfig(mcpServers, params.additionalDirectories);

--- a/packages/agent/src/adapters/codex-app-server/mcp-config.test.ts
+++ b/packages/agent/src/adapters/codex-app-server/mcp-config.test.ts
@@ -23,6 +23,7 @@ describe("toCodexMcpServers", () => {
 
     expect(toCodexMcpServers(servers)).toEqual({
       posthog: {
+        enabled: true,
         command: "node",
         args: ["server.js"],
         env: { TOKEN: "abc", BASE: "http://x" },
@@ -36,7 +37,7 @@ describe("toCodexMcpServers", () => {
     ] as unknown as McpServer[];
 
     expect(toCodexMcpServers(servers)).toEqual({
-      bare: { command: "run", args: [] },
+      bare: { enabled: true, command: "run", args: [] },
     });
   });
 
@@ -52,6 +53,7 @@ describe("toCodexMcpServers", () => {
 
     expect(toCodexMcpServers(servers)).toEqual({
       remote: {
+        enabled: true,
         url: "https://mcp.example/mcp",
         http_headers: { Authorization: "Bearer t" },
       },
@@ -74,10 +76,11 @@ describe("toCodexMcpServers", () => {
 
     expect(toCodexMcpServers(servers, { gatePosthogExec: true })).toEqual({
       posthog_cloud: {
+        enabled: true,
         url: "https://mcp.example/mcp",
         tools: { exec: { approval_mode: "prompt" } },
       },
-      other: { url: "https://other.example/mcp" },
+      other: { enabled: true, url: "https://other.example/mcp" },
     });
   });
 
@@ -91,7 +94,7 @@ describe("toCodexMcpServers", () => {
     ] as unknown as McpServer[];
 
     expect(toCodexMcpServers(servers)).toEqual({
-      posthog: { url: "https://mcp.example/mcp" },
+      posthog: { enabled: true, url: "https://mcp.example/mcp" },
     });
   });
 });

--- a/packages/agent/src/adapters/codex-app-server/mcp-config.ts
+++ b/packages/agent/src/adapters/codex-app-server/mcp-config.ts
@@ -6,6 +6,7 @@ interface CodexMcpServerToolConfig {
 }
 
 interface CodexMcpServerPolicyConfig {
+  enabled: true;
   tools?: Record<string, CodexMcpServerToolConfig>;
 }
 
@@ -42,11 +43,13 @@ export function toCodexMcpServers(
     // `approval_mode: "prompt"` makes codex ask before every exec call; the
     // per-sub-tool regex filtering happens in the adapter's approval handlers,
     // which auto-accept calls the session's permission policy does not gate.
-    const policy =
+    const policy: CodexMcpServerPolicyConfig = { enabled: true };
+    if (
       options?.gatePosthogExec &&
       isPostHogExecDescriptor({ server: server.name, tool: "exec" })
-        ? { tools: { exec: { approval_mode: "prompt" as const } } }
-        : {};
+    ) {
+      policy.tools = { exec: { approval_mode: "prompt" } };
+    }
     if ("command" in server && server.command) {
       const env = pairsToRecord(server.env);
       out[server.name] = {

--- a/packages/core/src/local-mcp/localMcpImport.test.ts
+++ b/packages/core/src/local-mcp/localMcpImport.test.ts
@@ -177,6 +177,11 @@ describe("LocalMcpImportService", () => {
   it("classifies everything the workspace client reports, passing cwd through", async () => {
     const listed: Array<string | undefined> = [];
     const workspace: LocalMcpWorkspaceClient = {
+      getLocalMcpConfig: async () => ({ path: "/config", content: null }),
+      updateLocalMcpConfig: async (content) => ({
+        path: "/config",
+        content,
+      }),
       listLocalMcpServers: async (cwd) => {
         listed.push(cwd);
         return [
@@ -195,6 +200,24 @@ describe("LocalMcpImportService", () => {
       ["server", "importable"],
       ["local", "requires_desktop"],
     ]);
+  });
+
+  it("delegates config reads and writes to the workspace boundary", async () => {
+    const workspace: LocalMcpWorkspaceClient = {
+      listLocalMcpServers: async () => [],
+      getLocalMcpConfig: async () => ({ path: "/config", content: "old" }),
+      updateLocalMcpConfig: async (content) => ({ path: "/config", content }),
+    };
+    const service = new LocalMcpImportService(workspace);
+
+    await expect(service.getConfigFile()).resolves.toEqual({
+      path: "/config",
+      content: "old",
+    });
+    await expect(service.updateConfigFile("new")).resolves.toEqual({
+      path: "/config",
+      content: "new",
+    });
   });
 });
 

--- a/packages/core/src/local-mcp/localMcpImport.ts
+++ b/packages/core/src/local-mcp/localMcpImport.ts
@@ -11,6 +11,10 @@ import { LOCAL_MCP_WORKSPACE_CLIENT } from "./identifiers";
 /** The slice of workspace-server this service needs, bound by the host. */
 export interface LocalMcpWorkspaceClient {
   listLocalMcpServers(cwd?: string): Promise<LocalMcpServerDescriptor[]>;
+  getLocalMcpConfig(): Promise<{ path: string; content: string | null }>;
+  updateLocalMcpConfig(
+    content: string,
+  ): Promise<{ path: string; content: string | null }>;
 }
 
 export type LocalMcpCloudAvailability =
@@ -199,13 +203,22 @@ export class LocalMcpImportService {
 
   /**
    * Classifies the user's local MCP servers by whether they can be imported
-   * into a cloud sandbox. `cwd` picks up ~/.claude.json project-scoped
-   * servers for that checkout in addition to user-scoped ones.
+   * into a cloud sandbox.
    */
   async getCloudAvailability(
     cwd?: string,
   ): Promise<LocalMcpCloudClassification[]> {
     const servers = await this.workspace.listLocalMcpServers(cwd);
     return servers.map(classifyLocalMcpServer);
+  }
+
+  async getConfigFile(): Promise<{ path: string; content: string | null }> {
+    return this.workspace.getLocalMcpConfig();
+  }
+
+  async updateConfigFile(
+    content: string,
+  ): Promise<{ path: string; content: string | null }> {
+    return this.workspace.updateLocalMcpConfig(content);
   }
 }

--- a/packages/host-router/src/routers/local-mcp.router.ts
+++ b/packages/host-router/src/routers/local-mcp.router.ts
@@ -6,6 +6,8 @@ import {
 import {
   listLocalMcpServersInput,
   listLocalMcpServersOutput,
+  localMcpConfigFileOutput,
+  updateLocalMcpConfigFileInput,
 } from "@posthog/workspace-server/services/local-mcp/schemas";
 
 export const localMcpRouter = router({
@@ -16,5 +18,18 @@ export const localMcpRouter = router({
       ctx.container
         .get<LocalMcpService>(LOCAL_MCP_SERVICE)
         .listServers(input.cwd),
+    ),
+  config: publicProcedure
+    .output(localMcpConfigFileOutput)
+    .query(({ ctx }) =>
+      ctx.container.get<LocalMcpService>(LOCAL_MCP_SERVICE).getConfigFile(),
+    ),
+  updateConfig: publicProcedure
+    .input(updateLocalMcpConfigFileInput)
+    .output(localMcpConfigFileOutput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<LocalMcpService>(LOCAL_MCP_SERVICE)
+        .updateConfigFile(input.content),
     ),
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -166,6 +166,12 @@ export type {
   LocalMcpServerDescriptor,
   LocalMcpServerScope,
   LocalMcpTransport,
+  ParsedPostHogMcpServer,
+  PostHogMcpServerConfig,
+} from "./local-mcp-domain";
+export {
+  parsePostHogMcpServers,
+  validatePostHogMcpConfig,
 } from "./local-mcp-domain";
 export {
   formatMention,

--- a/packages/shared/src/local-mcp-domain.test.ts
+++ b/packages/shared/src/local-mcp-domain.test.ts
@@ -65,6 +65,11 @@ describe("parsePostHogMcpServers", () => {
 });
 
 describe("validatePostHogMcpConfig", () => {
+  it("accepts an empty object as an empty configuration", () => {
+    expect(validatePostHogMcpConfig({})).toEqual([]);
+    expect(parsePostHogMcpServers({})).toEqual([]);
+  });
+
   it("reports invalid roots and named server entries", () => {
     expect(validatePostHogMcpConfig(null)).toEqual([
       "Configuration must be a JSON object",

--- a/packages/shared/src/local-mcp-domain.test.ts
+++ b/packages/shared/src/local-mcp-domain.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  parsePostHogMcpServers,
+  validatePostHogMcpConfig,
+} from "./local-mcp-domain";
+
+describe("parsePostHogMcpServers", () => {
+  it("validates the shared stdio and HTTP configuration", () => {
+    expect(
+      parsePostHogMcpServers({
+        mcpServers: {
+          command: {
+            command: "npx",
+            args: ["server"],
+            env: { TOKEN: "secret" },
+          },
+          remote: {
+            type: "http",
+            url: "https://mcp.example.com",
+            headers: { Authorization: "Bearer secret" },
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        name: "command",
+        config: {
+          type: "stdio",
+          command: "npx",
+          args: ["server"],
+          env: { TOKEN: "secret" },
+        },
+      },
+      {
+        name: "remote",
+        config: {
+          type: "http",
+          url: "https://mcp.example.com",
+          headers: { Authorization: "Bearer secret" },
+        },
+      },
+    ]);
+  });
+
+  it.each([
+    { name: "array root", value: [] },
+    { name: "array server map", value: { mcpServers: [] } },
+  ])("rejects an $name", ({ value }) => {
+    expect(parsePostHogMcpServers(value)).toEqual([]);
+  });
+
+  it.each([
+    { name: "unsupported transport", config: { type: "sse", url: "x" } },
+    { name: "non-string argument", config: { command: "x", args: [1] } },
+    { name: "non-string environment", config: { command: "x", env: { A: 1 } } },
+    {
+      name: "non-string header",
+      config: { type: "http", url: "x", headers: { A: 1 } },
+    },
+  ])("retains the name of an invalid $name", ({ config }) => {
+    expect(parsePostHogMcpServers({ mcpServers: { broken: config } })).toEqual([
+      { name: "broken", config: null },
+    ]);
+  });
+});
+
+describe("validatePostHogMcpConfig", () => {
+  it("reports invalid roots and named server entries", () => {
+    expect(validatePostHogMcpConfig(null)).toEqual([
+      "Configuration must be a JSON object",
+    ]);
+    expect(validatePostHogMcpConfig({ mcpServers: [] })).toEqual([
+      "mcpServers must be an object",
+    ]);
+    expect(
+      validatePostHogMcpConfig({
+        mcpServers: { broken: { type: "sse", url: "https://example.com" } },
+      }),
+    ).toEqual(["Invalid MCP server configuration: broken"]);
+  });
+});

--- a/packages/shared/src/local-mcp-domain.ts
+++ b/packages/shared/src/local-mcp-domain.ts
@@ -1,9 +1,8 @@
 // Host-agnostic shapes for the user's locally configured MCP servers
-// (~/.claude.json) as they relate to cloud task runs. The workspace-server
+// (~/.posthog-code/mcp.json) as they relate to task runs. The workspace-server
 // reads the config from disk; @posthog/core classifies each server by whether
 // it can be imported into a cloud sandbox.
 
-/** Where a local MCP server definition came from in ~/.claude.json. */
 export type LocalMcpServerScope = "user" | "project";
 
 /**
@@ -15,6 +14,100 @@ export type LocalMcpTransport =
   | { type: "http" | "sse"; url: string; headers?: Record<string, string> }
   | { type: "stdio"; command: string; args?: string[] }
   | { type: "unknown" };
+
+export type PostHogMcpServerConfig =
+  | {
+      type?: "stdio";
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+    }
+  | {
+      type: "http";
+      url: string;
+      headers?: Record<string, string>;
+    };
+
+export interface ParsedPostHogMcpServer {
+  name: string;
+  config: PostHogMcpServerConfig | null;
+}
+
+function stringRecord(value: unknown): Record<string, string> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const entries = Object.entries(value);
+  if (entries.some(([, entry]) => typeof entry !== "string")) return null;
+  return Object.fromEntries(entries) as Record<string, string>;
+}
+
+export function parsePostHogMcpServers(
+  value: unknown,
+): ParsedPostHogMcpServer[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  const servers = (value as { mcpServers?: unknown }).mcpServers;
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
+    return [];
+  }
+
+  return Object.entries(servers).map(([name, raw]) => {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return { name, config: null };
+    }
+    const config = raw as Record<string, unknown>;
+    if (config.type === "http" && typeof config.url === "string") {
+      const headers =
+        config.headers === undefined ? undefined : stringRecord(config.headers);
+      if (headers === null) return { name, config: null };
+      return {
+        name,
+        config: {
+          type: "http" as const,
+          url: config.url,
+          ...(headers !== undefined ? { headers } : {}),
+        },
+      };
+    }
+    if (
+      (config.type === undefined || config.type === "stdio") &&
+      typeof config.command === "string"
+    ) {
+      const args = config.args;
+      const env =
+        config.env === undefined ? undefined : stringRecord(config.env);
+      if (
+        (args !== undefined &&
+          (!Array.isArray(args) ||
+            args.some((entry) => typeof entry !== "string"))) ||
+        env === null
+      ) {
+        return { name, config: null };
+      }
+      return {
+        name,
+        config: {
+          type: "stdio" as const,
+          command: config.command,
+          ...(args !== undefined ? { args: args as string[] } : {}),
+          ...(env !== undefined ? { env } : {}),
+        },
+      };
+    }
+    return { name, config: null };
+  });
+}
+
+export function validatePostHogMcpConfig(value: unknown): string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return ["Configuration must be a JSON object"];
+  }
+  const servers = (value as { mcpServers?: unknown }).mcpServers;
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
+    return ["mcpServers must be an object"];
+  }
+  return parsePostHogMcpServers(value)
+    .filter((entry) => entry.config === null)
+    .map((entry) => `Invalid MCP server configuration: ${entry.name}`);
+}
 
 /**
  * A locally configured MCP server as reported by the workspace-server.

--- a/packages/shared/src/local-mcp-domain.ts
+++ b/packages/shared/src/local-mcp-domain.ts
@@ -101,6 +101,9 @@ export function validatePostHogMcpConfig(value: unknown): string[] {
     return ["Configuration must be a JSON object"];
   }
   const servers = (value as { mcpServers?: unknown }).mcpServers;
+  if (servers === undefined) {
+    return [];
+  }
   if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
     return ["mcpServers must be an object"];
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "0.22.1",
     "@base-ui/react": "^1.3.0",
+    "@codemirror/commands": "6.8.1",
     "@codemirror/lang-angular": "^0.1.4",
     "@codemirror/lang-cpp": "^6.0.3",
     "@codemirror/lang-css": "^6.3.1",

--- a/packages/ui/src/features/local-mcp/LocalMcpRailSection.tsx
+++ b/packages/ui/src/features/local-mcp/LocalMcpRailSection.tsx
@@ -1,37 +1,33 @@
-import { Plugs } from "@phosphor-icons/react";
+import { FolderOpen, Plugs } from "@phosphor-icons/react";
 import type { LocalMcpCloudClassification } from "@posthog/core/local-mcp/localMcpImport";
-import { Flex, Text } from "@radix-ui/themes";
+import { Button, Flex, Text } from "@radix-ui/themes";
 
-const AVAILABILITY_LABELS: Record<
-  LocalMcpCloudClassification["availability"],
-  string
-> = {
-  importable: "Available in cloud",
-  requires_desktop: "Relayed via your machine",
-  built_in: "Built into cloud runs",
-  unsupported: "Not available in cloud",
-};
+function transportLabel(server: LocalMcpCloudClassification): string {
+  if (server.reason === "reserved_name") return "Reserved name";
+  if (server.reason === "stdio_transport") return "Local command";
+  if (server.reason === "public_url" || server.reason === "private_url") {
+    return "HTTP server";
+  }
+  return "Unsupported configuration";
+}
 
 interface LocalMcpRailSectionProps {
   servers: LocalMcpCloudClassification[];
   search: string;
+  onOpenConfig: () => void;
 }
 
-/**
- * Rail section listing the user's local (~/.claude.json) MCP servers and
- * whether each will be available inside cloud task runs. Purely
- * informational: these servers are configured outside the app, so the rows
- * open no detail view.
- */
+/** Local PostHog Code MCP servers shared by local agent adapters. */
 export function LocalMcpRailSection({
   servers,
   search,
+  onOpenConfig,
 }: LocalMcpRailSectionProps) {
   const query = search.trim().toLowerCase();
   const visible = query
     ? servers.filter((server) => server.name.toLowerCase().includes(query))
     : servers;
-  if (visible.length === 0) return null;
+  if (visible.length === 0 && query) return null;
 
   return (
     <>
@@ -46,16 +42,20 @@ export function LocalMcpRailSection({
         <Text
           color="gray"
           className="font-medium text-[10px] uppercase leading-none"
-          title="MCP servers from ~/.claude.json on this machine"
+          title="MCP servers from ~/.posthog-code/mcp.json on this machine"
         >
           Local
         </Text>
-        <Text
+        <Button
+          variant="ghost"
           color="gray"
-          className="rounded-[10px] bg-(--gray-4) px-[6px] py-[1px] text-[10px] leading-none"
+          size="1"
+          title="Open local MCP configuration"
+          aria-label="Open local MCP configuration"
+          onClick={onOpenConfig}
         >
-          {visible.length}
-        </Text>
+          <FolderOpen size={12} />
+        </Button>
       </Flex>
       {visible.map((server) => (
         <div
@@ -74,11 +74,16 @@ export function LocalMcpRailSection({
               {server.name}
             </Text>
             <Text color="gray" truncate className="text-[10px] leading-none">
-              {AVAILABILITY_LABELS[server.availability]}
+              {transportLabel(server)}
             </Text>
           </Flex>
         </div>
       ))}
+      {visible.length === 0 && (
+        <Text color="gray" className="px-2 py-1 text-[11px]">
+          No local servers configured.
+        </Text>
+      )}
     </>
   );
 }

--- a/packages/ui/src/features/local-mcp/useLocalMcpCloudServers.test.tsx
+++ b/packages/ui/src/features/local-mcp/useLocalMcpCloudServers.test.tsx
@@ -19,7 +19,10 @@ vi.mock("../feature-flags/useFeatureFlag", () => ({
   useFeatureFlag: () => mocks.flagEnabled,
 }));
 
-import { useLocalMcpCloudServers } from "./useLocalMcpCloudServers";
+import {
+  useLocalMcpCloudServers,
+  useLocalMcpServers,
+} from "./useLocalMcpCloudServers";
 
 function wrapper({ children }: { children: ReactNode }) {
   const queryClient = new QueryClient({
@@ -43,7 +46,7 @@ describe("useLocalMcpCloudServers", () => {
     mocks.getCloudAvailability.mockResolvedValue([server]);
   });
 
-  it("does not inspect local MCP servers while the feature flag is disabled", () => {
+  it("does not import local MCP servers into cloud while the flag is disabled", () => {
     const { result } = renderHook(() => useLocalMcpCloudServers(true), {
       wrapper,
     });
@@ -52,9 +55,8 @@ describe("useLocalMcpCloudServers", () => {
     expect(mocks.getCloudAvailability).not.toHaveBeenCalled();
   });
 
-  it("returns local MCP servers while the feature flag is enabled", async () => {
+  it("returns local MCP servers for cloud while the flag is enabled", async () => {
     mocks.flagEnabled = true;
-
     const { result } = renderHook(() => useLocalMcpCloudServers(true), {
       wrapper,
     });
@@ -64,16 +66,20 @@ describe("useLocalMcpCloudServers", () => {
     );
   });
 
-  it("hides cached local MCP servers when the feature flag is disabled", async () => {
-    mocks.flagEnabled = true;
+  it("always returns local MCP servers for the settings page", async () => {
+    const { result } = renderHook(() => useLocalMcpServers(true), { wrapper });
+
+    await waitFor(() => expect(result.current.servers).toEqual([server]));
+  });
+
+  it("hides cached local MCP servers when disabled", async () => {
     const { result, rerender } = renderHook(
-      () => useLocalMcpCloudServers(true),
-      { wrapper },
+      ({ enabled }) => useLocalMcpServers(enabled),
+      { wrapper, initialProps: { enabled: true } },
     );
     await waitFor(() => expect(result.current.servers).toEqual([server]));
 
-    mocks.flagEnabled = false;
-    rerender();
+    rerender({ enabled: false });
 
     expect(result.current).toEqual({ servers: [], isLoading: false });
   });

--- a/packages/ui/src/features/local-mcp/useLocalMcpCloudServers.ts
+++ b/packages/ui/src/features/local-mcp/useLocalMcpCloudServers.ts
@@ -19,28 +19,38 @@ export interface LocalMcpCloudServersResult {
 }
 
 /**
- * The user's local (~/.claude.json) MCP servers classified by cloud
+ * The user's local (~/.posthog-code/mcp.json) MCP servers classified by cloud
  * availability. Empty on hosts without a local workspace (web/mobile — the
- * service is only bound on desktop) and while the feature flag is off.
+ * service is only bound on desktop).
  */
-export function useLocalMcpCloudServers(
-  enabled: boolean,
-): LocalMcpCloudServersResult {
+function useLocalMcpServersQuery(enabled: boolean): LocalMcpCloudServersResult {
   const service = useServiceOptional<LocalMcpImportService>(
     LOCAL_MCP_IMPORT_SERVICE,
   );
-  const flagEnabled = useFeatureFlag(LOCAL_MCP_IMPORT_FLAG);
-  const queryEnabled = enabled && flagEnabled && !!service;
+  const queryEnabled = enabled && !!service;
 
   const query = useQuery({
     queryKey: ["local-mcp-cloud-availability"],
     queryFn: () => (service ? service.getCloudAvailability() : NO_SERVERS),
     enabled: queryEnabled,
-    staleTime: 30_000,
+    refetchOnWindowFocus: true,
   });
 
   return {
     servers: queryEnabled ? (query.data ?? NO_SERVERS) : NO_SERVERS,
     isLoading: queryEnabled && query.isLoading,
   };
+}
+
+export function useLocalMcpServers(
+  enabled: boolean,
+): LocalMcpCloudServersResult {
+  return useLocalMcpServersQuery(enabled);
+}
+
+export function useLocalMcpCloudServers(
+  enabled: boolean,
+): LocalMcpCloudServersResult {
+  const flagEnabled = useFeatureFlag(LOCAL_MCP_IMPORT_FLAG);
+  return useLocalMcpServersQuery(enabled && flagEnabled);
 }

--- a/packages/ui/src/features/mcp-servers/components/McpServersView.tsx
+++ b/packages/ui/src/features/mcp-servers/components/McpServersView.tsx
@@ -2,7 +2,7 @@ import type {
   McpRecommendedServer,
   McpServerInstallation,
 } from "@posthog/api-client/posthog-client";
-import { useLocalMcpCloudServers } from "@posthog/ui/features/local-mcp/useLocalMcpCloudServers";
+import { useLocalMcpServers } from "@posthog/ui/features/local-mcp/useLocalMcpCloudServers";
 import { AddCustomServerForm } from "@posthog/ui/features/mcp-server-manager/AddCustomServerForm";
 import { MarketplaceView } from "@posthog/ui/features/mcp-servers/components/parts/MarketplaceView";
 import { McpInstalledRail } from "@posthog/ui/features/mcp-servers/components/parts/McpInstalledRail";
@@ -18,13 +18,15 @@ import {
 } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { LocalMcpConfigView } from "./parts/LocalMcpConfigView";
 import { ServerDetailView } from "./parts/ServerDetailView";
 
 type SceneView =
   | { kind: "marketplace" }
   | { kind: "detail-installation"; installationId: string }
   | { kind: "detail-template"; templateId: string }
-  | { kind: "add-custom" };
+  | { kind: "add-custom" }
+  | { kind: "local-config"; openKey: number };
 
 export function McpServersView() {
   const queryClient = useQueryClient();
@@ -59,11 +61,14 @@ export function McpServersView() {
     reauthorizePending,
   } = useMcpServers();
 
-  const { servers: localServers } = useLocalMcpCloudServers(true);
+  const { servers: localServers } = useLocalMcpServers(true);
 
   useEffect(() => {
     const refreshMcpState = () => {
       queryClient.invalidateQueries({ queryKey: ["mcp"] });
+      queryClient.invalidateQueries({
+        queryKey: ["local-mcp-cloud-availability"],
+      });
     };
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") refreshMcpState();
@@ -185,6 +190,10 @@ export function McpServersView() {
       );
     }
 
+    if (view.kind === "local-config") {
+      return <LocalMcpConfigView openKey={view.openKey} />;
+    }
+
     if (
       view.kind === "detail-installation" ||
       view.kind === "detail-template"
@@ -264,6 +273,12 @@ export function McpServersView() {
         localServers={localServers}
         selectedInstallationId={selectedInstallationId}
         onAddCustom={() => setView({ kind: "add-custom" })}
+        onOpenLocalConfig={() =>
+          setView((current) => ({
+            kind: "local-config",
+            openKey: current.kind === "local-config" ? current.openKey + 1 : 1,
+          }))
+        }
         onSelectInstallation={(installationId) =>
           setView({ kind: "detail-installation", installationId })
         }

--- a/packages/ui/src/features/mcp-servers/components/parts/LocalMcpConfigView.test.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/LocalMcpConfigView.test.tsx
@@ -1,0 +1,103 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getConfigFile: vi.fn(),
+  updateConfigFile: vi.fn(),
+}));
+
+vi.mock("@posthog/di/react", () => ({
+  useService: () => mocks,
+}));
+
+vi.mock("@posthog/ui/features/skills/SkillCodeEditor", () => ({
+  SkillCodeEditor: ({
+    initialContent,
+    onDocChanged,
+  }: {
+    initialContent: string;
+    onDocChanged: (content: string) => void;
+  }) => (
+    <textarea
+      aria-label="MCP config"
+      defaultValue={initialContent}
+      onChange={(event) => onDocChanged(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock("@posthog/ui/primitives/toast", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { LocalMcpConfigView } from "./LocalMcpConfigView";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("LocalMcpConfigView", () => {
+  beforeEach(() => {
+    mocks.getConfigFile.mockReset();
+    mocks.updateConfigFile.mockReset();
+    mocks.getConfigFile.mockResolvedValue({
+      path: "/home/user/.posthog-code/mcp.json",
+      content: '{"mcpServers":{}}',
+    });
+    mocks.updateConfigFile.mockImplementation(async (content: string) => ({
+      path: "/home/user/.posthog-code/mcp.json",
+      content,
+    }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("flushes an edit when navigating away before the debounce", async () => {
+    const view = render(<LocalMcpConfigView openKey={1} />, { wrapper });
+    const editor = await screen.findByLabelText("MCP config");
+    vi.useFakeTimers();
+
+    fireEvent.change(editor, { target: { value: "changed" } });
+    act(() => vi.advanceTimersByTime(499));
+    expect(mocks.updateConfigFile).not.toHaveBeenCalled();
+
+    view.unmount();
+    expect(mocks.updateConfigFile).toHaveBeenCalledWith("changed");
+  });
+
+  it("autosaves invalid JSON and announces the invalid state", async () => {
+    render(<LocalMcpConfigView openKey={1} />, { wrapper });
+    const editor = await screen.findByLabelText("MCP config");
+
+    fireEvent.change(editor, { target: { value: "{ invalid" } });
+
+    await waitFor(() =>
+      expect(mocks.updateConfigFile).toHaveBeenCalledWith("{ invalid"),
+    );
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Saved, invalid JSON",
+    );
+  });
+
+  it("shows a read error without exposing an empty editable config", async () => {
+    mocks.getConfigFile.mockRejectedValue(new Error("read failed"));
+
+    render(<LocalMcpConfigView openKey={1} />, { wrapper });
+
+    expect(await screen.findByText("read failed")).toBeVisible();
+    expect(screen.queryByLabelText("MCP config")).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/features/mcp-servers/components/parts/LocalMcpConfigView.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/LocalMcpConfigView.tsx
@@ -8,7 +8,7 @@ import { Box, Button, Flex, Spinner, Text } from "@radix-ui/themes";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 
-const EMPTY_CONFIG = '{\n  "mcpServers": {}\n}\n';
+const EMPTY_CONFIG = "{}\n";
 
 function validationMessage(content: string): string | null {
   try {

--- a/packages/ui/src/features/mcp-servers/components/parts/LocalMcpConfigView.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/LocalMcpConfigView.tsx
@@ -1,0 +1,184 @@
+import { LOCAL_MCP_IMPORT_SERVICE } from "@posthog/core/local-mcp/identifiers";
+import type { LocalMcpImportService } from "@posthog/core/local-mcp/localMcpImport";
+import { useService } from "@posthog/di/react";
+import { validatePostHogMcpConfig } from "@posthog/shared";
+import { SkillCodeEditor } from "@posthog/ui/features/skills/SkillCodeEditor";
+import { toast } from "@posthog/ui/primitives/toast";
+import { Box, Button, Flex, Spinner, Text } from "@radix-ui/themes";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+
+const EMPTY_CONFIG = '{\n  "mcpServers": {}\n}\n';
+
+function validationMessage(content: string): string | null {
+  try {
+    const issues = validatePostHogMcpConfig(JSON.parse(content));
+    return issues[0] ?? null;
+  } catch {
+    return "invalid JSON";
+  }
+}
+
+function saveStatus(
+  isPending: boolean,
+  draft: string,
+  savedContent: string,
+  failedContent: string | null,
+): string {
+  const validationError = validationMessage(draft);
+  if (failedContent === draft) return "Could not save";
+  if (validationError && (isPending || draft !== savedContent)) {
+    return `${validationError}, saving…`;
+  }
+  if (validationError) return `Saved, ${validationError}`;
+  if (isPending) return "Saving…";
+  if (draft === savedContent) return "Saved";
+  return "Saving…";
+}
+
+export function LocalMcpConfigView({ openKey }: { openKey: number }) {
+  const service = useService<LocalMcpImportService>(LOCAL_MCP_IMPORT_SERVICE);
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["local-mcp-config", openKey],
+    queryFn: () => service.getConfigFile(),
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading) {
+    return (
+      <Flex align="center" justify="center" py="6">
+        <Spinner size="2" />
+      </Flex>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Flex direction="column" align="center" gap="3" py="6">
+        <Text color="red" className="text-sm">
+          {error.message || "Failed to read local MCP configuration"}
+        </Text>
+        <Button variant="outline" size="1" onClick={() => refetch()}>
+          Retry
+        </Button>
+      </Flex>
+    );
+  }
+
+  return (
+    <LocalMcpConfigEditor
+      path={data?.path ?? "~/.posthog-code/mcp.json"}
+      initialContent={data?.content ?? EMPTY_CONFIG}
+    />
+  );
+}
+
+function LocalMcpConfigEditor({
+  path,
+  initialContent,
+}: {
+  path: string;
+  initialContent: string;
+}) {
+  const service = useService<LocalMcpImportService>(LOCAL_MCP_IMPORT_SERVICE);
+  const queryClient = useQueryClient();
+  const [draft, setDraft] = useState(initialContent);
+  const [savedContent, setSavedContent] = useState(initialContent);
+  const [failedContent, setFailedContent] = useState<string | null>(null);
+  const draftRef = useRef(draft);
+  const savedContentRef = useRef(savedContent);
+  draftRef.current = draft;
+  savedContentRef.current = savedContent;
+  const validationError = validationMessage(draft);
+  const statusIsDangerous = validationError !== null || failedContent === draft;
+  const saveConfig = useMutation({
+    mutationFn: (content: string) => service.updateConfigFile(content),
+    retry: 1,
+    onSuccess: (saved) => {
+      const content = saved.content ?? EMPTY_CONFIG;
+      setSavedContent(content);
+      setFailedContent(null);
+      queryClient.invalidateQueries({
+        queryKey: ["local-mcp-cloud-availability"],
+      });
+    },
+    onError: (error, content) => {
+      setFailedContent(content);
+      toast.error(error.message || "Failed to save local MCP configuration");
+    },
+  });
+
+  useEffect(() => {
+    if (
+      draft === savedContent ||
+      draft === failedContent ||
+      saveConfig.isPending
+    ) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      saveConfig.mutate(draft);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [draft, failedContent, saveConfig, savedContent]);
+
+  useEffect(
+    () => () => {
+      const latestDraft = draftRef.current;
+      if (latestDraft === savedContentRef.current) return;
+      void service.updateConfigFile(latestDraft).catch((error) => {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Failed to save local MCP configuration",
+        );
+      });
+    },
+    [service],
+  );
+
+  return (
+    <Flex direction="column" gap="3" className="h-full min-h-[600px]">
+      <Flex align="center" justify="between">
+        <Flex direction="column" gap="1">
+          <Text className="font-medium">Local MCP configuration</Text>
+          <Text color="gray" className="text-sm">
+            {path}
+          </Text>
+          <Text color="gray" className="text-xs">
+            Shared by local Claude and Codex agents. Supports stdio and HTTP.
+          </Text>
+        </Flex>
+        <Text
+          role="status"
+          aria-live="polite"
+          color={statusIsDangerous ? "red" : "gray"}
+          className="font-medium text-xs"
+        >
+          {saveStatus(saveConfig.isPending, draft, savedContent, failedContent)}
+        </Text>
+        {failedContent === draft && (
+          <Button
+            variant="outline"
+            color="red"
+            size="1"
+            onClick={() => saveConfig.mutate(draft)}
+          >
+            Retry
+          </Button>
+        )}
+      </Flex>
+      <Box className="min-h-0 flex-1 overflow-hidden rounded border border-gray-6">
+        <SkillCodeEditor
+          initialContent={initialContent}
+          filePath={path}
+          onDocChanged={(content) => {
+            setDraft(content);
+            setFailedContent(null);
+          }}
+        />
+      </Box>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/mcp-servers/components/parts/McpInstalledRail.tsx
+++ b/packages/ui/src/features/mcp-servers/components/parts/McpInstalledRail.tsx
@@ -28,6 +28,7 @@ interface McpInstalledRailProps {
   localServers: LocalMcpCloudClassification[];
   selectedInstallationId: string | null;
   onAddCustom: () => void;
+  onOpenLocalConfig: () => void;
   onSelectInstallation: (installationId: string) => void;
 }
 
@@ -37,6 +38,7 @@ export function McpInstalledRail({
   localServers,
   selectedInstallationId,
   onAddCustom,
+  onOpenLocalConfig,
   onSelectInstallation,
 }: McpInstalledRailProps) {
   const [search, setSearch] = useState("");
@@ -185,7 +187,11 @@ export function McpInstalledRail({
               );
             })
           )}
-          <LocalMcpRailSection servers={localServers} search={search} />
+          <LocalMcpRailSection
+            servers={localServers}
+            search={search}
+            onOpenConfig={onOpenLocalConfig}
+          />
         </Flex>
       </ScrollArea>
     </aside>

--- a/packages/ui/src/features/skills/SkillCodeEditor.tsx
+++ b/packages/ui/src/features/skills/SkillCodeEditor.tsx
@@ -1,4 +1,10 @@
-import { EditorView } from "@codemirror/view";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentWithTab,
+} from "@codemirror/commands";
+import { EditorView, keymap } from "@codemirror/view";
 import { useMemo, useRef } from "react";
 import { useCodeMirror } from "../code-editor/hooks/useCodeMirror";
 import { useEditorExtensions } from "../code-editor/hooks/useEditorExtensions";
@@ -23,6 +29,8 @@ export function SkillCodeEditor({
   const extensions = useMemo(
     () => [
       ...baseExtensions,
+      history(),
+      keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
       EditorView.updateListener.of((update) => {
         if (update.docChanged) {
           onDocChangedRef.current(update.state.doc.toString());

--- a/packages/workspace-server/src/services/local-mcp/identifiers.ts
+++ b/packages/workspace-server/src/services/local-mcp/identifiers.ts
@@ -4,8 +4,10 @@ export const LOCAL_MCP_SERVICE = Symbol.for("posthog.workspace.localMcp");
 
 export interface LocalMcpService {
   /**
-   * Lists the user's locally configured MCP servers (~/.claude.json), merging
-   * the project-scoped section for `cwd` over the user-scoped one when given.
+   * Lists the user's locally configured MCP servers
+   * (~/.posthog-code/mcp.json).
    */
   listServers(cwd?: string): Promise<LocalMcpServerDescriptor[]>;
+  getConfigFile(): Promise<{ path: string; content: string | null }>;
+  updateConfigFile(content: string): Promise<{ path: string; content: string }>;
 }

--- a/packages/workspace-server/src/services/local-mcp/local-mcp.test.ts
+++ b/packages/workspace-server/src/services/local-mcp/local-mcp.test.ts
@@ -1,4 +1,11 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -7,8 +14,13 @@ import { LocalMcpServiceImpl } from "./local-mcp";
 let home: string;
 let originalHome: string | undefined;
 
-async function writeClaudeJson(data: unknown) {
-  await writeFile(path.join(home, ".claude.json"), JSON.stringify(data));
+function mcpConfigPath(): string {
+  return path.join(home, ".posthog-code", "mcp.json");
+}
+
+async function writeMcpConfig(data: unknown) {
+  await mkdir(path.dirname(mcpConfigPath()), { recursive: true });
+  await writeFile(mcpConfigPath(), JSON.stringify(data));
 }
 
 beforeEach(async () => {
@@ -23,16 +35,17 @@ afterEach(async () => {
 });
 
 describe("LocalMcpServiceImpl.listServers", () => {
-  it("returns empty when ~/.claude.json is missing or malformed", async () => {
+  it("returns empty when the config is missing or malformed", async () => {
     const service = new LocalMcpServiceImpl();
     expect(await service.listServers()).toEqual([]);
 
-    await writeFile(path.join(home, ".claude.json"), "not json");
+    await mkdir(path.dirname(mcpConfigPath()), { recursive: true });
+    await writeFile(mcpConfigPath(), "not json");
     expect(await service.listServers()).toEqual([]);
   });
 
-  it("normalizes http, sse, and stdio servers with their scope", async () => {
-    await writeClaudeJson({
+  it("normalizes shared HTTP and stdio transports", async () => {
+    await writeMcpConfig({
       mcpServers: {
         grafana: {
           type: "http",
@@ -47,16 +60,9 @@ describe("LocalMcpServiceImpl.listServers", () => {
           env: { SECRET: "do-not-leak" },
         },
       },
-      projects: {
-        "/repo": {
-          mcpServers: {
-            docs: { type: "http", url: "http://localhost:3001/mcp" },
-          },
-        },
-      },
     });
 
-    const servers = await new LocalMcpServiceImpl().listServers("/repo");
+    const servers = await new LocalMcpServiceImpl().listServers();
 
     expect(servers).toEqual([
       {
@@ -71,7 +77,7 @@ describe("LocalMcpServiceImpl.listServers", () => {
       {
         name: "legacy",
         scope: "user",
-        transport: { type: "sse", url: "https://sse.example.com/mcp" },
+        transport: { type: "unknown" },
       },
       {
         name: "playwright",
@@ -82,28 +88,7 @@ describe("LocalMcpServiceImpl.listServers", () => {
           args: ["@playwright/mcp@latest"],
         },
       },
-      {
-        name: "docs",
-        scope: "project",
-        transport: { type: "http", url: "http://localhost:3001/mcp" },
-      },
     ]);
-  });
-
-  it("omits project-scoped servers when no cwd is given", async () => {
-    await writeClaudeJson({
-      mcpServers: { top: { type: "http", url: "https://a.example.com" } },
-      projects: {
-        "/repo": {
-          mcpServers: {
-            scoped: { type: "http", url: "https://b.example.com" },
-          },
-        },
-      },
-    });
-
-    const servers = await new LocalMcpServiceImpl().listServers();
-    expect(servers.map((s) => s.name)).toEqual(["top"]);
   });
 
   it.each([
@@ -113,18 +98,75 @@ describe("LocalMcpServiceImpl.listServers", () => {
       transport: { type: "stdio", command: "uvx", args: ["some-mcp"] },
     },
     {
-      name: "bare url without type is read as http",
+      name: "bare url without type is unknown",
       config: { url: "https://bare.example.com/mcp" },
-      transport: { type: "http", url: "https://bare.example.com/mcp" },
+      transport: { type: "unknown" },
     },
     {
       name: "unrecognized shape is unknown",
       config: { type: "websocket", endpoint: "wss://x" },
       transport: { type: "unknown" },
     },
+    {
+      name: "non-object config is unknown",
+      config: null,
+      transport: { type: "unknown" },
+    },
   ])("$name", async ({ config, transport }) => {
-    await writeClaudeJson({ mcpServers: { server: config } });
+    await writeMcpConfig({ mcpServers: { server: config } });
     const servers = await new LocalMcpServiceImpl().listServers();
     expect(servers).toEqual([{ name: "server", scope: "user", transport }]);
   });
+});
+
+describe("LocalMcpServiceImpl.getConfigFile", () => {
+  it("returns the local config path and its content when present", async () => {
+    await writeMcpConfig({ mcpServers: {} });
+
+    await expect(new LocalMcpServiceImpl().getConfigFile()).resolves.toEqual({
+      path: mcpConfigPath(),
+      content: JSON.stringify({ mcpServers: {} }),
+    });
+  });
+
+  it("reports a missing local config without failing", async () => {
+    await expect(new LocalMcpServiceImpl().getConfigFile()).resolves.toEqual({
+      path: mcpConfigPath(),
+      content: null,
+    });
+  });
+});
+
+describe("LocalMcpServiceImpl.updateConfigFile", () => {
+  it("saves the exact content, including invalid JSON", async () => {
+    const content = "{ invalid json";
+
+    await expect(
+      new LocalMcpServiceImpl().updateConfigFile(content),
+    ).resolves.toEqual({ path: mcpConfigPath(), content });
+    await expect(readFile(mcpConfigPath(), "utf8")).resolves.toBe(content);
+  });
+
+  it("serializes concurrent saves so the latest content wins", async () => {
+    const service = new LocalMcpServiceImpl();
+    await Promise.all([
+      service.updateConfigFile("first"),
+      service.updateConfigFile("second"),
+    ]);
+
+    await expect(readFile(mcpConfigPath(), "utf8")).resolves.toBe("second");
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "restricts config and directory permissions",
+    async () => {
+      await new LocalMcpServiceImpl().updateConfigFile("secret");
+
+      const fileMode = (await stat(mcpConfigPath())).mode & 0o777;
+      const directoryMode =
+        (await stat(path.dirname(mcpConfigPath()))).mode & 0o777;
+      expect(fileMode).toBe(0o600);
+      expect(directoryMode).toBe(0o700);
+    },
+  );
 });

--- a/packages/workspace-server/src/services/local-mcp/local-mcp.ts
+++ b/packages/workspace-server/src/services/local-mcp/local-mcp.ts
@@ -1,11 +1,103 @@
-import { loadUserClaudeJsonMcpServerDescriptors } from "@posthog/agent/adapters/claude/session/mcp-config";
-import type { LocalMcpServerDescriptor } from "@posthog/shared";
+import { randomUUID } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type {
+  LocalMcpServerDescriptor,
+  LocalMcpTransport,
+  PostHogMcpServerConfig,
+} from "@posthog/shared";
+import { parsePostHogMcpServers } from "@posthog/shared";
 import { injectable } from "inversify";
 import type { LocalMcpService } from "./identifiers";
 
+function configPath(): string {
+  return join(homedir(), ".posthog-code", "mcp.json");
+}
+
+function normalizeConfig(
+  config: PostHogMcpServerConfig | null,
+): LocalMcpTransport {
+  if (config?.type === "http") {
+    return {
+      type: "http",
+      url: config.url,
+      headers: config.headers,
+    };
+  }
+  if (config && "command" in config) {
+    return {
+      type: "stdio",
+      command: config.command,
+      args: config.args,
+    };
+  }
+  return { type: "unknown" };
+}
+
 @injectable()
 export class LocalMcpServiceImpl implements LocalMcpService {
-  async listServers(cwd?: string): Promise<LocalMcpServerDescriptor[]> {
-    return loadUserClaudeJsonMcpServerDescriptors(cwd);
+  private updateQueue: Promise<unknown> = Promise.resolve();
+
+  async listServers(): Promise<LocalMcpServerDescriptor[]> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readFile(configPath(), "utf8"));
+    } catch {
+      return [];
+    }
+    return parsePostHogMcpServers(parsed).map((entry) => ({
+      name: entry.name,
+      scope: "user" as const,
+      transport: normalizeConfig(entry.config),
+    }));
+  }
+
+  async getConfigFile(): Promise<{ path: string; content: string | null }> {
+    const path = configPath();
+    try {
+      return { path, content: await readFile(path, "utf8") };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { path, content: null };
+      }
+      throw error;
+    }
+  }
+
+  async updateConfigFile(
+    content: string,
+  ): Promise<{ path: string; content: string }> {
+    const update = this.updateQueue.then(() => this.writeConfigFile(content));
+    this.updateQueue = update.catch(() => undefined);
+    return update;
+  }
+
+  private async writeConfigFile(
+    content: string,
+  ): Promise<{ path: string; content: string }> {
+    const path = configPath();
+    const directory = dirname(path);
+    const temporaryPath = join(directory, `.mcp-${randomUUID()}.tmp`);
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await chmod(directory, 0o700);
+    try {
+      await writeFile(temporaryPath, content, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      await rename(temporaryPath, path);
+      await chmod(path, 0o600);
+    } finally {
+      await rm(temporaryPath, { force: true });
+    }
+    return { path, content };
   }
 }

--- a/packages/workspace-server/src/services/local-mcp/schemas.ts
+++ b/packages/workspace-server/src/services/local-mcp/schemas.ts
@@ -32,3 +32,10 @@ export const listLocalMcpServersInput = z.object({
 export const listLocalMcpServersOutput = z.array(
   localMcpServerDescriptorSchema,
 );
+
+export const localMcpConfigFileOutput = z.object({
+  path: z.string(),
+  content: z.string().nullable(),
+});
+
+export const updateLocalMcpConfigFileInput = z.object({ content: z.string() });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1199,6 +1199,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@codemirror/commands':
+        specifier: 6.8.1
+        version: 6.8.1
       '@codemirror/lang-angular':
         specifier: ^0.1.4
         version: 0.1.4
@@ -2611,6 +2614,9 @@ packages:
 
   '@codemirror/autocomplete@6.20.0':
     resolution: {integrity: sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==}
+
+  '@codemirror/commands@6.8.1':
+    resolution: {integrity: sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==}
 
   '@codemirror/lang-angular@0.1.4':
     resolution: {integrity: sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==}
@@ -16891,6 +16897,13 @@ snapshots:
   '@borewit/text-codec@0.2.2': {}
 
   '@codemirror/autocomplete@6.20.0':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.17
+      '@lezer/common': 1.5.1
+
+  '@codemirror/commands@6.8.1':
     dependencies:
       '@codemirror/language': 6.12.2
       '@codemirror/state': 6.5.4


### PR DESCRIPTION
## Problem

There is no visible way in the Posthog Desktop UI to configure local MCP servers. It just reads from a local ./claude but no way to see what is configured

## Changes
<img width="590" height="508" alt="CleanShot 2026-07-24 at 16 09 42@2x" src="https://github.com/user-attachments/assets/03ae2b37-992a-4e55-8572-f0cd68bad172" />

<img width="2538" height="1600" alt="CleanShot 2026-07-24 at 16 05 22@2x" src="https://github.com/user-attachments/assets/d0b1081e-2e4a-4e25-8c52-7a92e6bfb706" />
<img width="2510" height="1448" alt="CleanShot 2026-07-24 at 16 06 13@2x" src="https://github.com/user-attachments/assets/fff643dd-a063-487a-b8db-2ba4285ad0fc" />
<img width="2112" height="1136" alt="CleanShot 2026-07-24 at 16 06 36@2x" src="https://github.com/user-attachments/assets/d36441e3-43a7-446c-b923-360beec4a94c" />
<img width="2064" height="1176" alt="CleanShot 2026-07-24 at 16 06 41@2x" src="https://github.com/user-attachments/assets/de7121e7-cd8e-49f7-b02e-332f21d1b1ca" />


Only affects local runs

- add `~/.posthog-code/mcp.json` for shared stdio and HTTP MCP servers
- surface and autosave the config from the MCP settings page
- inject supported servers into both local adapters
- validate unsupported entries, secure file writes, and keep cloud import feature-gated

## How did you test this?

- 198 focused package tests
- 7 UI tests
- `pnpm --filter @posthog/agent build`
- affected package and desktop typechecks
- repository commit hook full typecheck
- live Electron MCP settings flow over CDP

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*