### PR TITLE
fix(security): Keep OAuth token out of terminal environments

### DIFF
--- a/packages/workspace-server/src/services/agent/auth-adapter.test.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.test.ts
@@ -250,6 +250,8 @@ describe("AgentAuthAdapter", () => {
 
   it("configures environment using the gateway proxy and current token", async () => {
     const pathBefore = process.env.PATH;
+    delete process.env.POSTHOG_API_KEY;
+    delete process.env.POSTHOG_AUTH_HEADER;
 
     await adapter.configureProcessEnv({
       credentials: baseCredentials,
@@ -257,8 +259,8 @@ describe("AgentAuthAdapter", () => {
       claudeCliPath: "/mock/claude-cli.js",
     });
 
-    expect(process.env.POSTHOG_API_KEY).toBe("test-access-token");
-    expect(process.env.POSTHOG_AUTH_HEADER).toBe("Bearer test-access-token");
+    expect(process.env.POSTHOG_API_KEY).toBeUndefined();
+    expect(process.env.POSTHOG_AUTH_HEADER).toBeUndefined();
     expect(process.env.LLM_GATEWAY_URL).toBe("http://127.0.0.1:9999");
     expect(process.env.CLAUDE_CODE_EXECUTABLE).toBe("/mock/claude-cli.js");
     expect(process.env.POSTHOG_PROJECT_ID).toBe("1");

--- a/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -184,20 +184,13 @@ export class AgentAuthAdapter {
     }
   }
 
-  private syncTokenEnvironment(token: string): void {
-    process.env.POSTHOG_API_KEY = token;
-    process.env.POSTHOG_AUTH_HEADER = `Bearer ${token}`;
-  }
-
   private async getValidToken(): Promise<string> {
     const { accessToken } = await this.authService.getValidAccessToken();
-    this.syncTokenEnvironment(accessToken);
     return accessToken;
   }
 
   private async refreshToken(): Promise<string> {
     const { accessToken } = await this.authService.refreshAccessToken();
-    this.syncTokenEnvironment(accessToken);
     return accessToken;
   }
 

--- a/packages/workspace-server/src/services/shell/shell.test.ts
+++ b/packages/workspace-server/src/services/shell/shell.test.ts
@@ -192,6 +192,42 @@ describe("ShellService.createSession workspace env", () => {
       restoreEnv("POSTHOG_CODE_INTERNAL_CHILD", saved.internalChild);
     }
   });
+
+  it.each(["POSTHOG_API_KEY", "POSTHOG_AUTH_HEADER", "LLM_GATEWAY_URL"])(
+    "strips the credential var %s so repo scripts cannot read it",
+    async (key) => {
+      const saved = process.env[key];
+      process.env[key] = "secret-value";
+      try {
+        const { service } = createWorktreeTaskService("/does/not/exist");
+
+        await service.createSession({
+          sessionId: "session-1",
+          taskId: "task-1",
+        });
+
+        expect(spawnedEnv()[key]).toBeUndefined();
+      } finally {
+        restoreEnv(key, saved);
+      }
+    },
+  );
+
+  it("strips credential vars even when supplied via additionalEnv", async () => {
+    const { service } = createWorktreeTaskService("/does/not/exist");
+
+    await service.createSession({
+      sessionId: "session-1",
+      taskId: "task-1",
+      additionalEnv: {
+        POSTHOG_API_KEY: "leaked",
+        LLM_GATEWAY_URL: "http://127.0.0.1:9999/token",
+      },
+    });
+
+    expect(spawnedEnv().POSTHOG_API_KEY).toBeUndefined();
+    expect(spawnedEnv().LLM_GATEWAY_URL).toBeUndefined();
+  });
 });
 
 describe("ShellService.execute", () => {

--- a/packages/workspace-server/src/services/shell/shell.ts
+++ b/packages/workspace-server/src/services/shell/shell.ts
@@ -38,6 +38,12 @@ declare module "node-pty" {
 const PTY_ENCODING = "utf8";
 const DESTROYED_EXIT_CODE = 130;
 
+const CREDENTIAL_ENV_KEYS = [
+  "POSTHOG_API_KEY",
+  "POSTHOG_AUTH_HEADER",
+  "LLM_GATEWAY_URL",
+];
+
 export interface ShellSession {
   pty: pty.IPty;
   exitPromise: Promise<{ exitCode: number }>;
@@ -92,6 +98,11 @@ function buildShellEnv(
     FORCE_COLOR: "3",
     ...additionalEnv,
   });
+
+  // After additionalEnv, so a caller cannot reintroduce one.
+  for (const key of CREDENTIAL_ENV_KEYS) {
+    delete env[key];
+  }
 
   return env;
 }


### PR DESCRIPTION
## Problem

Resolves [VERIA-351](https://veria.dev/dashboard/findings/vnGQA59w9b-fBGOFMjzFE): OAuth access token leak in terminal shell environments.

## Changes

Stop writing the OAuth token to the shared process env, and scrub the credential vars from the shell/pty env so repo scripts can't read them.

## How did you test this?

Unit tests in `@posthog/workspace-server` (shell env scrubbing, incl. via `additionalEnv`, and the auth adapter).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

