### PR TITLE
fix(security): Validate agent slug before building ingress host

### DIFF
--- a/packages/ui/src/features/agent-applications/utils/ingress.test.ts
+++ b/packages/ui/src/features/agent-applications/utils/ingress.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { agentIngressBaseUrl } from "./ingress";
+
+describe("agentIngressBaseUrl", () => {
+  it.each([
+    { slug: "my-agent", region: "us" as const },
+    { slug: "agent1", region: "us" as const },
+    { slug: "agent-builder", region: "eu" as const },
+    { slug: "a".repeat(63), region: "us" as const },
+  ])("builds a host for the valid slug $slug", ({ slug, region }) => {
+    expect(agentIngressBaseUrl(slug, region)).toBe(
+      `https://${slug}.agents.${region}.posthog.com`,
+    );
+  });
+
+  it("keeps the slug in the dev ingress path", () => {
+    expect(agentIngressBaseUrl("my-agent", "dev")).toBe(
+      "http://localhost:3030/agents/my-agent",
+    );
+  });
+
+  it.each([
+    "evil.com/x",
+    "evil.com#x",
+    "evil.com?x",
+    "a@b",
+    "a b",
+    "sub.domain",
+    "-leading",
+    "trailing-",
+    "with_underscore",
+    "a".repeat(64),
+    "",
+  ])("rejects the malformed slug %j", (slug) => {
+    expect(agentIngressBaseUrl(slug, "us")).toBeNull();
+    expect(agentIngressBaseUrl(slug, "dev")).toBeNull();
+  });
+});

--- a/packages/ui/src/features/agent-applications/utils/ingress.ts
+++ b/packages/ui/src/features/agent-applications/utils/ingress.ts
@@ -13,6 +13,9 @@ import type { CloudRegion } from "@posthog/shared";
  */
 const LOCAL_INGRESS_ORIGIN = "http://localhost:3030";
 
+// Slug reaches the host below from an attacker-controllable deep link param.
+const AGENT_SLUG_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+
 export function resolveIngressBaseUrl(
   ingressBaseUrl: string | null | undefined,
   region: CloudRegion | null,
@@ -41,7 +44,7 @@ export function agentIngressBaseUrl(
   slug: string,
   region: CloudRegion | null,
 ): string | null {
-  if (!slug || !region) return null;
+  if (!slug || !region || !AGENT_SLUG_PATTERN.test(slug)) return null;
   switch (region) {
     case "us":
       return `https://${slug}.agents.us.posthog.com`;


### PR DESCRIPTION
## Problem

Resolves [VERIA-357](https://veria.dev/dashboard/findings/wulFo1f_mrD-4iGXNGV5W): host injection in the approval deep link handler.

## Changes

Validate the agent slug as a single DNS label before it is used as the ingress host, so a malicious deep link can't redirect the bearer-authenticated request to an attacker host.

## How did you test this?

Unit tests in `@posthog/ui` (valid and malicious slugs, incl. the DNS-label boundary).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

