### PR TITLE
fix(security): Scope MCP UI resource caches by server name

### DIFF
--- a/packages/core/src/mcp-apps/mcp-apps.test.ts
+++ b/packages/core/src/mcp-apps/mcp-apps.test.ts
@@ -116,3 +116,185 @@ describe("McpAppsService config resolver", () => {
     expect(createConnection).toHaveBeenCalledTimes(2);
   });
 });
+
+const UI_MIME_TYPE = "text/html;profile=mcp-app";
+
+describe("McpAppsService resource cache isolation", () => {
+  let service: McpAppsService;
+
+  beforeEach(() => {
+    service = makeService();
+  });
+
+  function stubPerServerReads(): void {
+    vi.spyOn(internals(service), "getOrCreateConnection").mockImplementation(
+      async (serverName: string) => ({
+        name: serverName,
+        client: {
+          readResource: async () => ({
+            contents: [
+              {
+                text: `<html>${serverName}</html>`,
+                mimeType: UI_MIME_TYPE,
+              },
+            ],
+          }),
+        },
+      }),
+    );
+  }
+
+  it("does not let one server's resource satisfy another's fetch for the same URI", async () => {
+    stubPerServerReads();
+    const uri = "ui://posthog/survey-list.html";
+
+    const trusted = await service.getUiResourceByUri("posthog", uri);
+    const malicious = await service.getUiResourceByUri("evil", uri);
+
+    expect(trusted?.html).toBe("<html>posthog</html>");
+    expect(trusted?.serverName).toBe("posthog");
+    expect(malicious?.html).toBe("<html>evil</html>");
+    expect(malicious?.serverName).toBe("evil");
+  });
+
+  it("serves a cache hit only to the server that populated it", async () => {
+    const getConn = vi
+      .spyOn(internals(service), "getOrCreateConnection")
+      .mockImplementation(async (serverName: string) => ({
+        name: serverName,
+        client: {
+          readResource: async () => ({
+            contents: [
+              { text: `<html>${serverName}</html>`, mimeType: UI_MIME_TYPE },
+            ],
+          }),
+        },
+      }));
+    const uri = "ui://posthog/survey-list.html";
+
+    await service.getUiResourceByUri("posthog", uri);
+    await service.getUiResourceByUri("posthog", uri);
+    const other = await service.getUiResourceByUri("evil", uri);
+
+    expect(getConn).toHaveBeenCalledTimes(2);
+    expect(other?.serverName).toBe("evil");
+  });
+
+  it("does not share an in-flight fetch across servers for the same URI", async () => {
+    const reads: string[] = [];
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    vi.spyOn(internals(service), "getOrCreateConnection").mockImplementation(
+      async (serverName: string) => ({
+        name: serverName,
+        client: {
+          readResource: async () => {
+            reads.push(serverName);
+            await gate;
+            return {
+              contents: [
+                { text: `<html>${serverName}</html>`, mimeType: UI_MIME_TYPE },
+              ],
+            };
+          },
+        },
+      }),
+    );
+    const uri = "ui://shared/app.html";
+
+    const first = service.getUiResourceByUri("posthog", uri);
+    const other = service.getUiResourceByUri("evil", uri);
+    const joined = service.getUiResourceByUri("posthog", uri);
+    release();
+    const [r1, r2, r3] = await Promise.all([first, other, joined]);
+
+    expect(reads.filter((s) => s === "posthog")).toHaveLength(1);
+    expect(reads.filter((s) => s === "evil")).toHaveLength(1);
+    expect(r1?.serverName).toBe("posthog");
+    expect(r3?.serverName).toBe("posthog");
+    expect(r2?.serverName).toBe("evil");
+  });
+});
+
+describe("McpAppsService.proxyToolCall authorization", () => {
+  let service: McpAppsService;
+  const callTool = vi.fn(async () => ({ ok: true }));
+
+  function discoverTools(tools: unknown[]): Promise<void> {
+    vi.spyOn(internals(service), "getOrCreateConnection").mockResolvedValue({
+      name: "posthog",
+      client: {
+        listTools: async () => ({ tools }),
+        listResources: async () => ({ resources: [] }),
+        callTool,
+      },
+    });
+    service.setServerConfigs([config("posthog")]);
+    return service.handleDiscovery(["posthog"]);
+  }
+
+  beforeEach(() => {
+    service = makeService();
+    callTool.mockClear();
+  });
+
+  it("denies a tool that declares no UI metadata", async () => {
+    await discoverTools([{ name: "exec" }]);
+
+    await expect(service.proxyToolCall("posthog", "exec")).rejects.toThrow(
+      'Tool "exec" is not exposed to apps',
+    );
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("denies a tool that was never discovered", async () => {
+    await discoverTools([]);
+
+    await expect(
+      service.proxyToolCall("posthog", "delete_all"),
+    ).rejects.toThrow('Tool "delete_all" is not exposed to apps');
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it("allows a tool that opts in with ui.visibility app", async () => {
+    await discoverTools([
+      { name: "search", _meta: { ui: { visibility: ["app"] } } },
+    ]);
+
+    await expect(service.proxyToolCall("posthog", "search")).resolves.toEqual({
+      ok: true,
+    });
+    expect(callTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a tool that carries a UI association", async () => {
+    await discoverTools([
+      {
+        name: "surveys",
+        _meta: { ui: { resourceUri: "ui://posthog/s.html" } },
+      },
+    ]);
+
+    await expect(service.proxyToolCall("posthog", "surveys")).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it("still rejects a model-only tool", async () => {
+    await discoverTools([
+      {
+        name: "surveys",
+        _meta: {
+          ui: { resourceUri: "ui://posthog/s.html", visibility: ["model"] },
+        },
+      },
+    ]);
+
+    await expect(service.proxyToolCall("posthog", "surveys")).rejects.toThrow(
+      "not accessible to apps",
+    );
+    expect(callTool).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/mcp-apps/mcp-apps.ts
+++ b/packages/core/src/mcp-apps/mcp-apps.ts
@@ -64,6 +64,7 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
   private connections = new Map<string, ServerConnection>();
   private resourceCache = new Map<string, McpUiResource>();
   private toolAssociations = new Map<string, McpToolUiAssociation>();
+  private appVisibleTools = new Set<string>();
   private toolDefinitions = new Map<string, Tool>();
   private serverConfigs = new Map<string, McpServerConnectionConfig>();
   private configResolver?: (serverName: string) => Promise<void>;
@@ -81,6 +82,11 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     super();
 
     this.log = rootLogger.scope("mcp-apps-service");
+  }
+
+  // Resource URIs are server-chosen and collide across servers.
+  private cacheKey(serverName: string, resourceUri: string): string {
+    return `${serverName}\u0000${resourceUri}`;
   }
 
   /**
@@ -180,9 +186,14 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
         }
 
         const uiMeta = (tool as McpToolUiMeta)._meta?.ui;
+        const toolKey = `mcp__${serverName}__${tool.name}`;
+
+        if (uiMeta?.visibility?.includes("app")) {
+          this.appVisibleTools.add(toolKey);
+        }
+
         if (!uiMeta?.resourceUri) continue;
 
-        const toolKey = `mcp__${serverName}__${tool.name}`;
         this.toolAssociations.set(toolKey, {
           toolKey,
           serverName,
@@ -198,7 +209,10 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
         for (const resource of resourcesList.resources) {
           const meta = resource as McpResourceUiMeta;
           if (meta._meta?.ui) {
-            this.resourceMetaCache.set(resource.uri, meta);
+            this.resourceMetaCache.set(
+              this.cacheKey(serverName, resource.uri),
+              meta,
+            );
           }
         }
       }
@@ -335,7 +349,8 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     serverName: string,
     resourceUri: string,
   ): Promise<McpUiResource | null> {
-    const cached = this.resourceCache.get(resourceUri);
+    const key = this.cacheKey(serverName, resourceUri);
+    const cached = this.resourceCache.get(key);
     if (cached) {
       this.log.debug("fetchUiResourceByUri: cache hit", {
         serverName,
@@ -344,7 +359,7 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
       return cached;
     }
 
-    const pendingFetch = this.pendingFetches.get(resourceUri);
+    const pendingFetch = this.pendingFetches.get(key);
     if (pendingFetch) {
       this.log.debug("fetchUiResourceByUri: joining pending fetch", {
         serverName,
@@ -358,11 +373,11 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
       resourceUri,
     });
     const fetchPromise = this.doFetchUiResource(serverName, resourceUri);
-    this.pendingFetches.set(resourceUri, fetchPromise);
+    this.pendingFetches.set(key, fetchPromise);
     try {
       return await fetchPromise;
     } finally {
-      this.pendingFetches.delete(resourceUri);
+      this.pendingFetches.delete(key);
     }
   }
 
@@ -409,7 +424,9 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
       return null;
     }
 
-    const resourceMeta = this.resourceMetaCache.get(resourceUri);
+    const resourceMeta = this.resourceMetaCache.get(
+      this.cacheKey(serverName, resourceUri),
+    );
 
     const resource: McpUiResource = {
       uri: resourceUri,
@@ -421,7 +438,7 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
       serverName,
     };
 
-    this.resourceCache.set(resourceUri, resource);
+    this.resourceCache.set(this.cacheKey(serverName, resourceUri), resource);
     this.log.info("Lazily fetched and cached UI resource", {
       serverName,
       uri: resourceUri,
@@ -454,6 +471,10 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
       throw new Error(
         `Tool "${toolName}" is not accessible to apps (visibility: ${association.visibility.join(", ")})`,
       );
+    }
+
+    if (!association && !this.appVisibleTools.has(toolKey)) {
+      throw new Error(`Tool "${toolName}" is not exposed to apps`);
     }
 
     const conn = await this.getOrCreateConnection(serverName);
@@ -540,6 +561,7 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     this.resourceCache.clear();
     this.resourceMetaCache.clear();
     this.toolAssociations.clear();
+    this.appVisibleTools.clear();
     this.toolDefinitions.clear();
     this.pendingConnections.clear();
     this.pendingFetches.clear();
@@ -578,13 +600,17 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
       }
     }
 
-    // Only evict cached resources not referenced by remaining associations
-    const stillReferenced = new Set(
-      [...this.toolAssociations.values()].map((a) => a.resourceUri),
-    );
     for (const uri of urisToEvict) {
-      if (!stillReferenced.has(uri)) {
-        this.resourceCache.delete(uri);
+      const key = this.cacheKey(serverName, uri);
+      this.resourceCache.delete(key);
+      this.resourceMetaCache.delete(key);
+      this.pendingFetches.delete(key);
+    }
+
+    const toolKeyPrefix = `mcp__${serverName}__`;
+    for (const toolKey of this.appVisibleTools) {
+      if (toolKey.startsWith(toolKeyPrefix)) {
+        this.appVisibleTools.delete(toolKey);
       }
     }
   }
@@ -597,6 +623,7 @@ export class McpAppsService extends TypedEventEmitter<McpAppsServiceEvents> {
     this.resourceCache.clear();
     this.resourceMetaCache.clear();
     this.toolAssociations.clear();
+    this.appVisibleTools.clear();
     this.toolDefinitions.clear();
     this.serverConfigs.clear();
     this.pendingConnections.clear();


### PR DESCRIPTION
## Problem

Resolves [VERIA-352](https://veria.dev/dashboard/findings/tPnMhFxMjIxBslXpAiPOH): cross-server MCP UI cache poisoning and capability confusion.

## Changes

Key the MCP UI resource caches by (server, uri) so a malicious server can't serve HTML/metadata for a trusted server's resource, and make app tool authorization fail closed so only tools that declared a UI (or opted in with `ui.visibility` "app") can be invoked from app HTML.

## How did you test this?

Unit tests in `@posthog/core`: cross-server cache isolation, per-server in-flight dedup, and the fail-closed authorization cases.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

