### PR TITLE
fix(security): Run setup discovery agent in plan mode

### DIFF
--- a/packages/agent/src/adapters/claude/session/options.ts
+++ b/packages/agent/src/adapters/claude/session/options.ts
@@ -449,7 +449,11 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     ...params.userProvidedOptions,
     betas: ["context-1m-2025-08-07"],
     systemPrompt: params.systemPrompt ?? buildSystemPrompt(),
-    settingSources: ["user", "project", "local"],
+    settingSources: params.userProvidedOptions?.settingSources ?? [
+      "user",
+      "project",
+      "local",
+    ],
     stderr: (err) => params.logger.error(err),
     cwd: params.cwd,
     includePartialMessages: true,

--- a/packages/ui/src/features/setup/setupRunServiceImpl.test.ts
+++ b/packages/ui/src/features/setup/setupRunServiceImpl.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const startMutate = vi.fn(async (_input: Record<string, unknown>) => {});
+
+vi.mock("@posthog/di/container", () => ({
+  resolveService: () => ({ agent: { start: { mutate: startMutate } } }),
+}));
+
+vi.mock("../../shell/analytics", () => ({
+  captureException: vi.fn(),
+  track: vi.fn(),
+}));
+
+import { SetupRunServiceImpl } from "./setupRunServiceImpl";
+
+describe("SetupRunServiceImpl.startAgent", () => {
+  beforeEach(() => {
+    startMutate.mockClear();
+  });
+
+  it("starts the discovery agent in plan mode, never bypassPermissions", async () => {
+    const service = new SetupRunServiceImpl();
+
+    await service.startAgent({
+      taskId: "task-1",
+      taskRunId: "run-1",
+      repoPath: "/repo",
+      apiHost: "https://us.posthog.com",
+      projectId: 1,
+      jsonSchema: {},
+    });
+
+    expect(startMutate).toHaveBeenCalledTimes(1);
+    expect(startMutate.mock.calls[0][0]).toMatchObject({
+      permissionMode: "plan",
+      disallowedTools: ["EnterPlanMode", "ExitPlanMode", "AskUserQuestion"],
+      settingSources: ["user"],
+    });
+  });
+});

--- a/packages/ui/src/features/setup/setupRunServiceImpl.ts
+++ b/packages/ui/src/features/setup/setupRunServiceImpl.ts
@@ -111,7 +111,11 @@ export class SetupRunServiceImpl implements ISetupRunService {
       repoPath: input.repoPath,
       apiHost: input.apiHost,
       projectId: input.projectId,
-      permissionMode: "bypassPermissions",
+      permissionMode: "plan",
+      // Nothing answers a permission prompt on an auto-launched run.
+      disallowedTools: ["EnterPlanMode", "ExitPlanMode", "AskUserQuestion"],
+      // Never the repo's own .claude settings: they can carry hooks.
+      settingSources: ["user"],
       jsonSchema: input.jsonSchema,
     });
   }

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -248,6 +248,7 @@ function buildClaudeCodeOptions(args: {
   effort?: EffortLevel;
   plugins: { type: "local"; path: string }[];
   disallowedTools?: string[];
+  settingSources?: ("user" | "project" | "local")[];
 }) {
   return {
     ...(args.additionalDirectories?.length && {
@@ -256,6 +257,9 @@ function buildClaudeCodeOptions(args: {
     ...(args.effort && { effort: args.effort }),
     ...(args.disallowedTools?.length && {
       disallowedTools: args.disallowedTools,
+    }),
+    ...(args.settingSources?.length && {
+      settingSources: args.settingSources,
     }),
     plugins: args.plugins,
   };
@@ -278,6 +282,7 @@ interface SessionConfig {
   systemPromptOverride?: string;
   /** Tool names denied for this session (passed to the Claude SDK). */
   disallowedTools?: string[];
+  settingSources?: ("user" | "project" | "local")[];
   /** Effort level for Claude sessions */
   effort?: EffortLevel;
   /** Model to use for the session (e.g. "claude-sonnet-4-6") */
@@ -779,6 +784,7 @@ If a repository IS genuinely required, attach one in this priority order:
       customInstructions,
       systemPromptOverride,
       disallowedTools,
+      settingSources,
       effort,
       model,
       jsonSchema,
@@ -1010,6 +1016,7 @@ If a repository IS genuinely required, attach one in this priority order:
         effort,
         plugins,
         disallowedTools,
+        settingSources,
       });
 
       let configOptions: SessionConfigOption[] | undefined;
@@ -2131,6 +2138,8 @@ For git operations while detached:
           : undefined,
       disallowedTools:
         "disallowedTools" in params ? params.disallowedTools : undefined,
+      settingSources:
+        "settingSources" in params ? params.settingSources : undefined,
       effort: "effort" in params ? params.effort : undefined,
       model: "model" in params ? params.model : undefined,
       jsonSchema: "jsonSchema" in params ? params.jsonSchema : undefined,

--- a/packages/workspace-server/src/services/agent/schemas.ts
+++ b/packages/workspace-server/src/services/agent/schemas.ts
@@ -77,6 +77,7 @@ export const startSessionInput = z.object({
    * Lets a sandboxed surface deny file/shell/network tools.
    */
   disallowedTools: z.array(z.string()).optional(),
+  settingSources: z.array(z.enum(["user", "project", "local"])).optional(),
   effort: effortLevelSchema.optional(),
   model: z.string().optional(),
   jsonSchema: z.record(z.string(), z.unknown()).nullish(),


### PR DESCRIPTION
## Problem

Resolves [VERIA-356](https://veria.dev/dashboard/findings/NA7_pukpYxnB5JD4zo4ko): RCE via automated repository setup discovery.

## Changes

Run the auto-launched discovery agent in plan mode and deny the interactive tools, so an untrusted repo can't steer it into running write/exec tools or hang it.

## How did you test this?

Unit test in `@posthog/ui` (discovery starts in plan mode with the tools denied, never bypassPermissions).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

