### PR TITLE
fix(security): Enforce CSP on sandboxed MCP app HTML

### DIFF
--- a/apps/mobile/src/features/mcp/sandbox/sandboxProxyHtml.ts
+++ b/apps/mobile/src/features/mcp/sandbox/sandboxProxyHtml.ts
@@ -47,8 +47,20 @@ export const sandboxProxyHtml = `<!DOCTYPE html>
   }
 
   var inner = document.createElement("iframe");
-  inner.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+  inner.setAttribute("sandbox", "allow-scripts allow-forms");
   document.body.appendChild(inner);
+
+  // contentWindow survives navigation, so an app that calls location.replace()
+  // would keep the bridge. Only the first load of our srcdoc may use it.
+  var appLoaded = false;
+  var bridgeClosed = false;
+  function onInnerLoad() {
+    if (!appLoaded) {
+      appLoaded = true;
+      return;
+    }
+    bridgeClosed = true;
+  }
 
   function buildAllowAttribute(permissions) {
     if (!permissions || typeof permissions !== "object") return "";
@@ -77,19 +89,16 @@ export const sandboxProxyHtml = `<!DOCTYPE html>
         var allowValue = buildAllowAttribute(params.permissions);
         if (allowValue) inner.setAttribute("allow", allowValue);
 
-        var doc = inner.contentDocument;
-        if (doc) {
-          doc.open();
-          doc.write(params.html);
-          doc.close();
-        }
+        inner.addEventListener("load", onInnerLoad);
+        inner.setAttribute("srcdoc", params.html);
       }
       return;
     }
 
     // All other host messages get relayed into the inner iframe untouched.
-    if (inner.contentWindow) {
-      inner.contentWindow.postMessage(data, location.origin || "*");
+    if (!bridgeClosed && inner.contentWindow) {
+      // An opaque origin serializes to "null", which postMessage rejects.
+      inner.contentWindow.postMessage(data, "*");
     }
   };
 
@@ -98,6 +107,7 @@ export const sandboxProxyHtml = `<!DOCTYPE html>
     var data = event.data;
     if (!data || typeof data !== "object") return;
     if (event.source !== inner.contentWindow) return;
+    if (bridgeClosed) return;
     postToHost(data);
   });
 

--- a/packages/shared/src/mcp-sandbox-proxy.test.ts
+++ b/packages/shared/src/mcp-sandbox-proxy.test.ts
@@ -20,20 +20,22 @@ describe("sandboxProxyHtml", () => {
     );
   });
 
-  it("creates inner iframe with allow-scripts, allow-same-origin, and allow-forms sandbox", () => {
+  it("creates inner iframe without allow-same-origin", () => {
     expect(sandboxProxyHtml).toContain(
-      "allow-scripts allow-same-origin allow-forms",
+      'inner.setAttribute("sandbox", "allow-scripts allow-forms")',
     );
   });
 
-  it("uses document.write to inject HTML instead of srcdoc", () => {
-    expect(sandboxProxyHtml).toContain("doc.open()");
-    expect(sandboxProxyHtml).toContain("doc.write(params.html)");
-    expect(sandboxProxyHtml).toContain("doc.close()");
+  it("uses srcdoc to inject HTML, never document.write", () => {
+    expect(sandboxProxyHtml).toContain('inner.setAttribute("srcdoc"');
+    expect(sandboxProxyHtml).not.toContain("doc.write(");
   });
 
-  it("uses location.origin for forwarding messages to inner iframe", () => {
-    expect(sandboxProxyHtml).toContain("postMessage(data, location.origin)");
+  it("forwards to the inner iframe with a wildcard target origin", () => {
+    expect(sandboxProxyHtml).toContain('postMessage(data, "*")');
+    expect(sandboxProxyHtml).not.toContain(
+      "postMessage(data, location.origin)",
+    );
   });
 
   it("builds permission policy allow attribute with cross-origin delegation", () => {
@@ -53,5 +55,24 @@ describe("sandboxProxyHtml", () => {
     expect(sandboxProxyHtml).toContain("var ");
     expect(sandboxProxyHtml).not.toContain("let ");
     expect(sandboxProxyHtml).not.toContain("const ");
+  });
+});
+
+describe("sandboxProxyHtml inner frame navigation", () => {
+  it("closes the bridge when the inner frame loads a second time", () => {
+    expect(sandboxProxyHtml).toContain(
+      'inner.addEventListener("load", onInnerLoad)',
+    );
+    expect(sandboxProxyHtml).toContain("bridgeClosed = true");
+  });
+
+  it("stops forwarding host messages once the bridge is closed", () => {
+    expect(sandboxProxyHtml).toContain(
+      "if (!bridgeClosed && inner && inner.contentWindow)",
+    );
+  });
+
+  it("drops messages relayed from a navigated inner frame", () => {
+    expect(sandboxProxyHtml).toContain("if (bridgeClosed) {");
   });
 });

--- a/packages/shared/src/mcp-sandbox-proxy.ts
+++ b/packages/shared/src/mcp-sandbox-proxy.ts
@@ -5,14 +5,9 @@
  *
  *   Host (renderer) → Outer iframe (sandbox proxy) → Inner iframe (MCP App)
  *
- * The outer iframe is served from the host's custom protocol, giving it an
- * isolated origin separate from the renderer. The inner iframe uses
- * allow-same-origin so the proxy can write HTML via document.write() — srcdoc
- * creates an opaque origin that breaks WebGL canvas operations (toDataURL) and
- * cross-origin resource access.
- *
- * Because the proxy's origin differs from the renderer's origin, the app cannot
- * traverse `window.parent.parent` to access the host's DOM, storage, or cookies.
+ * The host sandboxes the outer iframe without allow-same-origin, so both frames
+ * get opaque origins: the app cannot reach the host's DOM, storage or cookies,
+ * nor another app's frame.
  *
  * The HTML string itself is portable browser JavaScript with no host APIs; the
  * protocol that serves it is the host-specific seam.
@@ -56,8 +51,22 @@ export const sandboxProxyHtml: string = `<!DOCTYPE html>
 
       var inner = document.createElement("iframe");
       inner.style.cssText = "width:100%; height:100%; border:none;";
-      inner.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+      inner.setAttribute("sandbox", "allow-scripts allow-forms");
       document.body.appendChild(inner);
+
+      // contentWindow survives navigation, so an app that calls
+      // location.replace() would keep the bridge. Only the first load of our
+      // srcdoc may use it; any later one is the app navigating away.
+      var appLoaded = false;
+      var bridgeClosed = false;
+      function onInnerLoad() {
+        if (!appLoaded) {
+          appLoaded = true;
+          return;
+        }
+        bridgeClosed = true;
+        log("Inner frame navigated, bridge closed");
+      }
 
       // Build Permission Policy allow attribute from permissions object.
       // Maps McpUiResourcePermissions keys to Permission Policy feature names.
@@ -98,32 +107,26 @@ export const sandboxProxyHtml: string = `<!DOCTYPE html>
               inner.setAttribute("allow", allowValue);
             }
 
-            // Use document.write() instead of srcdoc to preserve origin.
-            // srcdoc creates an opaque origin that breaks WebGL canvas operations
-            // like toDataURL() and cross-origin resource access.
-            var doc = inner.contentDocument;
-            log("Writing HTML to inner iframe", {
-              htmlLength: params.html.length,
-              hasContentDocument: !!doc
+            log("Setting inner iframe srcdoc", {
+              htmlLength: params.html.length
             });
 
-            doc.open();
-            doc.write(params.html);
-            doc.close();
+            inner.addEventListener("load", onInnerLoad);
+            inner.setAttribute("srcdoc", params.html);
 
-            log("HTML written to inner iframe");
+            log("HTML handed to inner iframe");
           }
         } else {
           // Forward all other messages to inner iframe
           log("Forwarding host -> inner", {
             method: data.method,
             id: data.id,
-            hasInner: !!(inner && inner.contentWindow),
-            targetOrigin: location.origin
+            hasInner: !!(inner && inner.contentWindow)
           });
 
-          if (inner && inner.contentWindow) {
-            inner.contentWindow.postMessage(data, location.origin);
+          // An opaque origin serializes to "null", which postMessage rejects.
+          if (!bridgeClosed && inner && inner.contentWindow) {
+            inner.contentWindow.postMessage(data, "*");
           }
         }
       }
@@ -141,6 +144,12 @@ export const sandboxProxyHtml: string = `<!DOCTYPE html>
           });
           handleParentMessage(data);
         } else if (event.source === inner.contentWindow) {
+          if (bridgeClosed) {
+            log("Dropping message from navigated inner frame", {
+              method: data.method
+            });
+            return;
+          }
           log("Relaying inner -> host", {
             method: data.method,
             id: data.id,

--- a/packages/ui/src/features/mcp-apps/components/McpAppHost.tsx
+++ b/packages/ui/src/features/mcp-apps/components/McpAppHost.tsx
@@ -239,10 +239,8 @@ export function McpAppHost({
     <iframe
       ref={setIframeEl}
       src={sandboxProxyUrl}
-      // No allow-popups: app JS is same-origin with the proxy realm, so popup
-      // permission here would let it window.open() past the sandbox. Apps
-      // open links via ui/open-link, which the host scheme-validates.
-      sandbox="allow-scripts allow-same-origin allow-forms allow-presentation"
+      // allow-same-origin would resolve this frame to the host's own origin.
+      sandbox="allow-scripts allow-forms allow-presentation"
       style={{
         height: displayMode === "fullscreen" ? "100%" : `${iframeHeight}px`,
       }}

--- a/packages/ui/src/features/mcp-apps/hooks/useAppBridge.ts
+++ b/packages/ui/src/features/mcp-apps/hooks/useAppBridge.ts
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { logger } from "../../../shell/logger";
 import { useDraftStore } from "../../message-editor/draftStore";
 import type { ToolCall } from "../../sessions/types";
+import { applyCspToHtml } from "../utils/mcp-app-csp";
 import {
   computeContainerDimensions,
   INLINE_MAX_HEIGHT,
@@ -315,9 +316,8 @@ export function useAppBridge(args: UseAppBridgeArgs): UseAppBridgeReturn {
         await bridge.connect(transport);
         bridgeRef.current = bridge;
 
-        // Send resource to proxy
         await bridge.sendSandboxResourceReady({
-          html: resource.html,
+          html: applyCspToHtml(resource.html, resource.csp),
           csp: resource.csp,
           permissions: resource.permissions,
         });

--- a/packages/ui/src/features/mcp-apps/utils/mcp-app-csp.test.ts
+++ b/packages/ui/src/features/mcp-apps/utils/mcp-app-csp.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyCspToHtml,
   buildCspMetaTag,
   buildCspString,
   escapeAttr,
@@ -160,5 +161,28 @@ describe("buildCspMetaTag", () => {
     expect(tag).toContain("connect-src example.com");
     // Verify it's inside a proper attribute
     expect(tag).toMatch(/content="[^"]+"/);
+  });
+});
+
+describe("applyCspToHtml", () => {
+  it("prepends the CSP meta when there is no doctype", () => {
+    const out = applyCspToHtml("<html><body>hi</body></html>");
+    expect(out.startsWith(buildCspMetaTag())).toBe(true);
+  });
+
+  it("inserts the CSP meta after a leading doctype (no quirks mode)", () => {
+    const out = applyCspToHtml("<!doctype html><html><head></head></html>");
+    expect(out.startsWith("<!doctype html>")).toBe(true);
+    expect(out).toBe(
+      `<!doctype html>${buildCspMetaTag()}<html><head></head></html>`,
+    );
+  });
+
+  it("handles a doctype with leading whitespace and mixed case", () => {
+    const out = applyCspToHtml("  <!DOCTYPE html>\n<html></html>");
+    expect(out.startsWith("  <!DOCTYPE html>")).toBe(true);
+    expect(out.indexOf("<!DOCTYPE html>")).toBeLessThan(
+      out.indexOf(buildCspMetaTag()),
+    );
   });
 });

--- a/packages/ui/src/features/mcp-apps/utils/mcp-app-csp.ts
+++ b/packages/ui/src/features/mcp-apps/utils/mcp-app-csp.ts
@@ -83,3 +83,15 @@ export function buildCspMetaTag(csp?: McpUiResourceCsp): string {
   const cspString = buildCspString(csp);
   return `<meta http-equiv="Content-Security-Policy" content="${escapeAttr(cspString)}">`;
 }
+
+// After any doctype, which must stay first or the frame enters quirks mode.
+export function applyCspToHtml(html: string, csp?: McpUiResourceCsp): string {
+  const meta = buildCspMetaTag(csp);
+  const doctype = html.match(/^\s*<!doctype[^>]*>/i);
+  if (doctype) {
+    return (
+      html.slice(0, doctype[0].length) + meta + html.slice(doctype[0].length)
+    );
+  }
+  return meta + html;
+}


### PR DESCRIPTION
## Problem

Resolves [VERIA-354](https://veria.dev/dashboard/findings/eL4R96UpV279jBoJtn2xn): cross-platform sandbox escape in MCP UI execution.

## Changes

Drop `allow-same-origin` from the MCP app frames so they get an opaque origin instead of inheriting the web host's real origin (blob URL) or sharing one origin across apps on desktop, hand the app HTML to the inner frame via `srcdoc` since `document.write` needs same-origin access, and apply the CSP that was computed but never injected. Same change in the mobile proxy.

## How did you test this?

Unit tests in `@posthog/shared` (proxy sandbox attributes, srcdoc, target origin) and `@posthog/ui` (CSP meta placement vs doctype). Typecheck and unit suites pass for shared, ui and mobile.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

