### PR TITLE
feat(sidebar): user-set task labels with priority sort

### DIFF
--- a/apps/code/src/main/platform-adapters/electron-context-menu.ts
+++ b/apps/code/src/main/platform-adapters/electron-context-menu.ts
@@ -29,6 +29,11 @@ function toElectronItem(item: ContextMenuItem): MenuItemConstructorOptions {
     enabled: action.enabled ?? true,
     accelerator: action.accelerator,
   };
+  // Electron only renders a checkmark on checkbox/radio items.
+  if (action.checked !== undefined) {
+    options.type = "checkbox";
+    options.checked = action.checked;
+  }
   if (action.icon) {
     options.icon = resizeIcon(action.icon);
   }

--- a/apps/web/src/web-host-router.ts
+++ b/apps/web/src/web-host-router.ts
@@ -13,6 +13,7 @@ import {
   type CloudRegion,
   getCloudUrlFromRegion,
   tabsSnapshotSchema,
+  taskLabelSchema,
 } from "@posthog/shared";
 import { getAuthenticatedClient } from "@posthog/ui/features/auth/authClientImperative";
 import { z } from "zod";
@@ -318,6 +319,11 @@ const workspaceStubRouter = router({
   togglePin: publicProcedure
     .input(z.object({ taskId: z.string() }))
     .mutation(({ input }) => webTaskMetadataStore.togglePin(input.taskId)),
+  setTaskLabel: publicProcedure
+    .input(z.object({ taskId: z.string(), label: taskLabelSchema.nullable() }))
+    .mutation(({ input }) =>
+      webTaskMetadataStore.setLabel(input.taskId, input.label),
+    ),
   markViewed: publicProcedure
     .input(z.object({ taskId: z.string() }))
     .mutation(({ input }) => {

--- a/apps/web/src/web-task-metadata-store.ts
+++ b/apps/web/src/web-task-metadata-store.ts
@@ -1,3 +1,4 @@
+import { type TaskLabel, taskLabelSchema } from "@posthog/shared";
 import { z } from "zod";
 import { createRecordStore } from "./web-local-store";
 
@@ -11,6 +12,8 @@ const taskMetadataSchema = z.object({
   pinnedAt: z.string().nullable(),
   lastViewedAt: z.string().nullable(),
   lastActivityAt: z.string().nullable(),
+  // catch(null) so rows persisted before labels shipped aren't shed on load.
+  label: taskLabelSchema.nullable().catch(null),
 });
 
 export type TaskMetadata = z.infer<typeof taskMetadataSchema>;
@@ -19,6 +22,7 @@ const EMPTY: TaskMetadata = {
   pinnedAt: null,
   lastViewedAt: null,
   lastActivityAt: null,
+  label: null,
 };
 
 const store = createRecordStore(
@@ -61,6 +65,14 @@ export const webTaskMetadataStore = {
 
   markActivity(taskId: string): void {
     update(taskId, { lastActivityAt: new Date().toISOString() });
+  },
+
+  setLabel(
+    taskId: string,
+    label: TaskLabel | null,
+  ): { label: TaskLabel | null } {
+    update(taskId, { label });
+    return { label };
   },
 
   remove(taskId: string): void {

--- a/packages/core/src/context-menu/context-menu.test.ts
+++ b/packages/core/src/context-menu/context-menu.test.ts
@@ -142,6 +142,58 @@ describe("ContextMenuService.showTaskContextMenu", () => {
     );
   });
 
+  it("offers a Label submenu with every label plus None, checking the current one", async () => {
+    const menu = new FakeContextMenu();
+    makeService(menu).showTaskContextMenu({
+      ...baseTask,
+      currentLabel: "active",
+    });
+    await menu.shown;
+    const submenu = findItem(menu.lastItems, "Label").submenu ?? [];
+    expect(labels(submenu)).toEqual([
+      "High priority",
+      "Active",
+      "Deprioritized",
+      "Done",
+      "None",
+    ]);
+    expect(findItem(submenu, "Active").checked).toBe(true);
+    expect(findItem(submenu, "High priority").checked).toBe(false);
+    expect(findItem(submenu, "None").checked).toBe(false);
+  });
+
+  it("checks None in the Label submenu when the task is unlabeled", async () => {
+    const menu = new FakeContextMenu();
+    makeService(menu).showTaskContextMenu({ ...baseTask, currentLabel: null });
+    await menu.shown;
+    const submenu = findItem(menu.lastItems, "Label").submenu ?? [];
+    expect(findItem(submenu, "None").checked).toBe(true);
+  });
+
+  it("resolves set-label with the clicked label, and null for None", async () => {
+    const pick = new FakeContextMenu();
+    const picked = makeService(pick).showTaskContextMenu(baseTask);
+    await pick.shown;
+    findItem(
+      findItem(pick.lastItems, "Label").submenu ?? [],
+      "High priority",
+    ).click();
+    expect(await picked).toEqual({
+      action: { type: "set-label", label: "high-priority" },
+    });
+
+    const clear = new FakeContextMenu();
+    const cleared = makeService(clear).showTaskContextMenu({
+      ...baseTask,
+      currentLabel: "done",
+    });
+    await clear.shown;
+    findItem(findItem(clear.lastItems, "Label").submenu ?? [], "None").click();
+    expect(await cleared).toEqual({
+      action: { type: "set-label", label: null },
+    });
+  });
+
   it("resolves to null when the menu is dismissed", async () => {
     const menu = new FakeContextMenu();
     const result = makeService(menu).showTaskContextMenu(baseTask);

--- a/packages/core/src/context-menu/context-menu.ts
+++ b/packages/core/src/context-menu/context-menu.ts
@@ -4,6 +4,7 @@ import {
   type IContextMenu,
 } from "@posthog/platform/context-menu";
 import { DIALOG_SERVICE, type IDialog } from "@posthog/platform/dialog";
+import { TASK_LABEL_META, TASK_LABELS } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import {
   CONTEXT_MENU_EXTERNAL_APPS_SERVICE,
@@ -40,6 +41,7 @@ import type {
   ConfirmOptions,
   MenuItemDef,
   SeparatorDef,
+  SubmenuItemDef,
 } from "./types";
 
 @injectable()
@@ -118,6 +120,7 @@ export class ContextMenuService {
       isInCommandCenter,
       hasEmptyCommandCenterCell,
       channels,
+      currentLabel,
     } = input;
     const { apps, lastUsedAppId } = await this.getExternalAppsData();
     const hasPath = worktreePath || folderPath;
@@ -139,9 +142,28 @@ export class ContextMenuService {
           ]
         : [];
 
+    // Radio-style label picker: every label plus "None", the current one checked.
+    const labelSubmenu: SubmenuItemDef<TaskAction> = {
+      type: "submenu",
+      label: "Label",
+      items: [
+        ...TASK_LABELS.map((label) => ({
+          label: TASK_LABEL_META[label].displayName,
+          checked: (currentLabel ?? null) === label,
+          action: { type: "set-label" as const, label },
+        })),
+        {
+          label: "None",
+          checked: (currentLabel ?? null) === null,
+          action: { type: "set-label" as const, label: null },
+        },
+      ],
+    };
+
     return this.showMenu<TaskAction>([
       this.item(isPinned ? "Unpin" : "Pin", { type: "pin" }),
       this.item("Rename", { type: "rename" }),
+      labelSubmenu,
       ...(canStop
         ? [this.separator(), this.item("Stop task", { type: "stop" as const })]
         : []),
@@ -367,6 +389,7 @@ export class ContextMenuService {
               submenu: def.items.map((sub) => ({
                 label: sub.label,
                 icon: sub.icon,
+                checked: sub.checked,
                 click: () => resolve({ action: sub.action }),
               })),
               click: () => {},

--- a/packages/core/src/context-menu/schemas.ts
+++ b/packages/core/src/context-menu/schemas.ts
@@ -1,3 +1,4 @@
+import { taskLabelSchema } from "@posthog/shared";
 import { z } from "zod";
 
 export const taskContextMenuInput = z.object({
@@ -9,6 +10,9 @@ export const taskContextMenuInput = z.object({
   canStop: z.boolean().optional(),
   isInCommandCenter: z.boolean().optional(),
   hasEmptyCommandCenterCell: z.boolean().optional(),
+  // The task's current label, so the Label submenu can check it. Omitted and
+  // null both read as unlabeled.
+  currentLabel: taskLabelSchema.nullable().optional(),
   // Top-level desktop_file_system channels available as "File to…" targets.
   // Omit (or pass empty) to hide the submenu entirely.
   channels: z.array(z.object({ id: z.string(), name: z.string() })).optional(),
@@ -53,6 +57,10 @@ const taskAction = z.discriminatedUnion("type", [
   z.object({ type: z.literal("add-to-command-center") }),
   z.object({ type: z.literal("external-app"), action: externalAppAction }),
   z.object({ type: z.literal("file-to-channel"), channelId: z.string() }),
+  z.object({
+    type: z.literal("set-label"),
+    label: taskLabelSchema.nullable(),
+  }),
 ]);
 
 const bulkTaskAction = z.discriminatedUnion("type", [

--- a/packages/core/src/context-menu/types.ts
+++ b/packages/core/src/context-menu/types.ts
@@ -21,6 +21,8 @@ export interface SubmenuItemDef<T> {
   items: Array<{
     label: string;
     icon?: string;
+    /** Checkmark for radio-style submenus (e.g. the current task label). */
+    checked?: boolean;
     action: T;
   }>;
 }

--- a/packages/core/src/sidebar/buildSidebarData.test.ts
+++ b/packages/core/src/sidebar/buildSidebarData.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { limitTasksPerGroup, sliceVisibleTasks } from "./buildSidebarData";
+import {
+  type DeriveTaskDataContext,
+  deriveTaskData,
+  limitTasksPerGroup,
+  partitionAndSortTasks,
+  type SidebarTask,
+  sliceVisibleTasks,
+} from "./buildSidebarData";
 import type { TaskData, TaskGroup } from "./sidebarData.types";
 
 function makeTask(id: string): TaskData {
@@ -18,6 +25,7 @@ function makeTask(id: string): TaskData {
     cloudPrUrl: null,
     branchName: null,
     linkedBranch: null,
+    label: null,
   };
 }
 
@@ -28,6 +36,78 @@ function makeGroup(id: string, taskCount: number): TaskGroup {
     tasks: Array.from({ length: taskCount }, (_, i) => makeTask(`${id}-${i}`)),
   };
 }
+
+describe("deriveTaskData", () => {
+  const baseTask: SidebarTask = {
+    id: "t1",
+    title: "Task",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-02T00:00:00.000Z",
+  };
+  const baseCtx: DeriveTaskDataContext = {
+    session: undefined,
+    workspace: undefined,
+    timestamp: undefined,
+    pinnedIds: new Set<string>(),
+    suspendedIds: new Set<string>(),
+    slackTaskIds: new Set<string>(),
+    slackThreadUrlByTaskId: new Map<string, string>(),
+  };
+
+  it("carries the label from the metadata record", () => {
+    const data = deriveTaskData(baseTask, {
+      ...baseCtx,
+      timestamp: { lastViewedAt: null, lastActivityAt: null, label: "done" },
+    });
+    expect(data.label).toBe("done");
+  });
+
+  it("defaults the label to null when the task has no metadata record", () => {
+    expect(deriveTaskData(baseTask, baseCtx).label).toBeNull();
+  });
+});
+
+describe("partitionAndSortTasks with priority sort", () => {
+  it("orders by label rank, unlabeled between active and deprioritized", () => {
+    const tasks: TaskData[] = [
+      { ...makeTask("done"), label: "done" },
+      { ...makeTask("none") },
+      { ...makeTask("high"), label: "high-priority" },
+      { ...makeTask("deprio"), label: "deprioritized" },
+      { ...makeTask("active"), label: "active" },
+    ];
+    const { sortedUnpinnedTasks } = partitionAndSortTasks(tasks, "priority");
+    expect(sortedUnpinnedTasks.map((t) => t.id)).toEqual([
+      "high",
+      "active",
+      "none",
+      "deprio",
+      "done",
+    ]);
+  });
+
+  it("breaks rank ties by most recent activity", () => {
+    const tasks: TaskData[] = [
+      { ...makeTask("older"), label: "active", lastActivityAt: 1 },
+      { ...makeTask("newer"), label: "active", lastActivityAt: 2 },
+    ];
+    const { sortedUnpinnedTasks } = partitionAndSortTasks(tasks, "priority");
+    expect(sortedUnpinnedTasks.map((t) => t.id)).toEqual(["newer", "older"]);
+  });
+
+  it("still partitions pinned tasks out first", () => {
+    const tasks: TaskData[] = [
+      { ...makeTask("pinned"), label: "done", isPinned: true },
+      { ...makeTask("high"), label: "high-priority" },
+    ];
+    const { pinnedTasks, sortedUnpinnedTasks } = partitionAndSortTasks(
+      tasks,
+      "priority",
+    );
+    expect(pinnedTasks.map((t) => t.id)).toEqual(["pinned"]);
+    expect(sortedUnpinnedTasks.map((t) => t.id)).toEqual(["high"]);
+  });
+});
 
 describe("sliceVisibleTasks", () => {
   it("caps the flat list to the visible count and reports hasMore", () => {

--- a/packages/core/src/sidebar/buildSidebarData.ts
+++ b/packages/core/src/sidebar/buildSidebarData.ts
@@ -1,9 +1,14 @@
-import { readPrUrls, type WorkspaceMode } from "@posthog/shared";
+import {
+  readPrUrls,
+  type TaskLabel,
+  taskLabelRank,
+  type WorkspaceMode,
+} from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
 import { getRepositoryInfo } from "./groupTasks";
 import type { TaskData, TaskGroup } from "./sidebarData.types";
 
-export type SortMode = "updated" | "created";
+export type SortMode = "updated" | "created" | "priority";
 export type OrganizeMode = "by-project" | "chronological";
 
 export interface FullTask {
@@ -123,6 +128,7 @@ export interface TaskWorkspace {
 export interface TaskTimestamp {
   lastViewedAt?: number | null;
   lastActivityAt?: number | null;
+  label?: TaskLabel | null;
 }
 
 export interface DeriveTaskDataContext {
@@ -188,6 +194,7 @@ export function deriveTaskData(
     cloudPrUrl,
     branchName: workspace?.branchName ?? null,
     linkedBranch: workspace?.linkedBranch ?? null,
+    label: timestamp?.label ?? null,
   };
 }
 
@@ -220,13 +227,19 @@ export function filterByWorkspaceMode(
 }
 
 function getSortValue(task: TaskData, sortMode: SortMode): number {
-  return sortMode === "updated" ? task.lastActivityAt : task.createdAt;
+  return sortMode === "created" ? task.createdAt : task.lastActivityAt;
 }
 
 function sortTasks(tasks: TaskData[], sortMode: SortMode): TaskData[] {
-  return [...tasks].sort(
-    (a, b) => getSortValue(b, sortMode) - getSortValue(a, sortMode),
-  );
+  return [...tasks].sort((a, b) => {
+    // Priority sorts by user-set label rank first, falling back to recency
+    // within a rank (getSortValue reads lastActivityAt for non-"created").
+    if (sortMode === "priority") {
+      const byRank = taskLabelRank(a.label) - taskLabelRank(b.label);
+      if (byRank !== 0) return byRank;
+    }
+    return getSortValue(b, sortMode) - getSortValue(a, sortMode);
+  });
 }
 
 export interface PartitionedTasks {

--- a/packages/core/src/sidebar/filterByWorkspaceMode.test.ts
+++ b/packages/core/src/sidebar/filterByWorkspaceMode.test.ts
@@ -18,6 +18,7 @@ const task = (overrides: Partial<TaskData>): TaskData => ({
   cloudPrUrl: null,
   branchName: null,
   linkedBranch: null,
+  label: null,
   ...overrides,
 });
 

--- a/packages/core/src/sidebar/runEnvironment.test.ts
+++ b/packages/core/src/sidebar/runEnvironment.test.ts
@@ -17,6 +17,7 @@ const task = (overrides: Partial<TaskData>): TaskData => ({
   cloudPrUrl: null,
   branchName: null,
   linkedBranch: null,
+  label: null,
   ...overrides,
 });
 

--- a/packages/core/src/sidebar/selection.test.ts
+++ b/packages/core/src/sidebar/selection.test.ts
@@ -26,6 +26,7 @@ function makeTaskData(id: string, overrides: Partial<TaskData> = {}): TaskData {
     cloudPrUrl: null,
     branchName: null,
     linkedBranch: null,
+    label: null,
     ...overrides,
   };
 }

--- a/packages/core/src/sidebar/sidebarData.types.ts
+++ b/packages/core/src/sidebar/sidebarData.types.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceMode } from "@posthog/shared";
+import type { TaskLabel, WorkspaceMode } from "@posthog/shared";
 import type { TaskRunStatus } from "@posthog/shared/domain-types";
 import type {
   TaskGroup as GenericTaskGroup,
@@ -26,6 +26,8 @@ export interface TaskData {
   cloudPrUrl: string | null;
   branchName: string | null;
   linkedBranch: string | null;
+  /** User-set label from device-local metadata; null = unlabeled. */
+  label: TaskLabel | null;
 }
 
 export type TaskGroup = GenericTaskGroup<TaskData>;

--- a/packages/core/src/sidebar/taskMeta.test.ts
+++ b/packages/core/src/sidebar/taskMeta.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseTimestamps } from "./taskMeta";
+
+describe("parseTimestamps", () => {
+  it("parses ISO strings to epoch ms and passes the label through", () => {
+    const result = parseTimestamps({
+      t1: {
+        pinnedAt: null,
+        lastViewedAt: "2026-01-01T00:00:00.000Z",
+        lastActivityAt: "2026-01-02T00:00:00.000Z",
+        label: "high-priority",
+      },
+    });
+
+    expect(result.t1).toEqual({
+      lastViewedAt: new Date("2026-01-01T00:00:00.000Z").getTime(),
+      lastActivityAt: new Date("2026-01-02T00:00:00.000Z").getTime(),
+      label: "high-priority",
+    });
+  });
+
+  it("keeps a null label for an unlabeled task", () => {
+    const result = parseTimestamps({
+      t1: {
+        pinnedAt: null,
+        lastViewedAt: null,
+        lastActivityAt: null,
+        label: null,
+      },
+    });
+
+    expect(result.t1).toEqual({
+      lastViewedAt: null,
+      lastActivityAt: null,
+      label: null,
+    });
+  });
+});

--- a/packages/core/src/sidebar/taskMeta.ts
+++ b/packages/core/src/sidebar/taskMeta.ts
@@ -1,12 +1,16 @@
+import type { TaskLabel } from "@posthog/shared";
+
 export interface RawTaskTimestamp {
   pinnedAt: string | null;
   lastViewedAt: string | null;
   lastActivityAt: string | null;
+  label: TaskLabel | null;
 }
 
 export interface TaskTimestamps {
   lastViewedAt: number | null;
   lastActivityAt: number | null;
+  label: TaskLabel | null;
 }
 
 export function parseTimestamps(
@@ -21,6 +25,7 @@ export function parseTimestamps(
       lastActivityAt: ts.lastActivityAt
         ? new Date(ts.lastActivityAt).getTime()
         : null,
+      label: ts.label ?? null,
     };
   }
   return result;

--- a/packages/core/src/sidebar/taskRunning.test.ts
+++ b/packages/core/src/sidebar/taskRunning.test.ts
@@ -18,6 +18,7 @@ const task = (overrides: Partial<TaskData>): TaskData => ({
   cloudPrUrl: null,
   branchName: null,
   linkedBranch: null,
+  label: null,
   ...overrides,
 });
 

--- a/packages/core/src/tasks/contextMenuActions.test.ts
+++ b/packages/core/src/tasks/contextMenuActions.test.ts
@@ -32,6 +32,15 @@ describe("resolveTaskContextMenuIntent", () => {
     );
   });
 
+  it("carries the set-label payload, including a null clear", () => {
+    expect(
+      resolveTaskContextMenuIntent({ type: "set-label", label: "done" }, {}),
+    ).toEqual({ type: "set-label", label: "done" });
+    expect(
+      resolveTaskContextMenuIntent({ type: "set-label", label: null }, {}),
+    ).toEqual({ type: "set-label", label: null });
+  });
+
   it("carries the external-app action payload", () => {
     expect(
       resolveTaskContextMenuIntent(

--- a/packages/core/src/tasks/contextMenuActions.ts
+++ b/packages/core/src/tasks/contextMenuActions.ts
@@ -2,6 +2,7 @@ import type {
   ExternalAppAction,
   TaskAction,
 } from "@posthog/core/context-menu/schemas";
+import type { TaskLabel } from "@posthog/shared";
 
 export type TaskContextMenuIntent =
   | { type: "rename" }
@@ -14,6 +15,7 @@ export type TaskContextMenuIntent =
   | { type: "delete" }
   | { type: "add-to-command-center" }
   | { type: "file-to-channel"; channelId: string }
+  | { type: "set-label"; label: TaskLabel | null }
   | { type: "external-app"; action: ExternalAppAction };
 
 export function resolveTaskContextMenuIntent(
@@ -39,6 +41,8 @@ export function resolveTaskContextMenuIntent(
       return { type: "add-to-command-center" };
     case "file-to-channel":
       return { type: "file-to-channel", channelId: action.channelId };
+    case "set-label":
+      return { type: "set-label", label: action.label };
     case "external-app":
       return { type: "external-app", action: action.action };
   }

--- a/packages/host-router/src/routers/workspace.router.ts
+++ b/packages/host-router/src/routers/workspace.router.ts
@@ -39,6 +39,8 @@ import {
   reconcileCloudWorkspacesInput,
   reconcileCloudWorkspacesOutput,
   setPrimaryPrUrlInput,
+  setTaskLabelInput,
+  setTaskLabelOutput,
   taskPrStatusInput,
   taskPrStatusOutput,
   togglePinInput,
@@ -197,6 +199,13 @@ export const workspaceRouter = router({
     .output(togglePinOutput)
     .mutation(({ ctx, input }) =>
       getMetadata(ctx.container).togglePin(input.taskId),
+    ),
+
+  setTaskLabel: publicProcedure
+    .input(setTaskLabelInput)
+    .output(setTaskLabelOutput)
+    .mutation(({ ctx, input }) =>
+      getMetadata(ctx.container).setTaskLabel(input.taskId, input.label),
     ),
 
   markViewed: publicProcedure

--- a/packages/platform/src/context-menu.ts
+++ b/packages/platform/src/context-menu.ts
@@ -3,6 +3,8 @@ export interface ContextMenuAction {
   icon?: string;
   enabled?: boolean;
   accelerator?: string;
+  /** Renders the item with a checkmark (radio-style selection in submenus). */
+  checked?: boolean;
   submenu?: ContextMenuItem[];
   click: () => void | Promise<void>;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -290,6 +290,14 @@ export type {
   TaskCreationOutput,
 } from "./task-creation-domain";
 export {
+  TASK_LABEL_META,
+  TASK_LABELS,
+  type TaskLabel,
+  type TaskLabelMeta,
+  taskLabelRank,
+  taskLabelSchema,
+} from "./task-label";
+export {
   formatClockTime,
   formatRelativeTimeLong,
   formatRelativeTimeShort,

--- a/packages/shared/src/task-label.test.ts
+++ b/packages/shared/src/task-label.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  TASK_LABEL_META,
+  TASK_LABELS,
+  type TaskLabel,
+  taskLabelRank,
+  taskLabelSchema,
+} from "./task-label";
+
+describe("taskLabelSchema", () => {
+  it.each(TASK_LABELS)("accepts %s", (label) => {
+    expect(taskLabelSchema.parse(label)).toBe(label);
+  });
+
+  it("rejects values outside the fixed set", () => {
+    expect(taskLabelSchema.safeParse("urgent").success).toBe(false);
+    expect(taskLabelSchema.safeParse("").success).toBe(false);
+  });
+});
+
+describe("TASK_LABEL_META", () => {
+  it("covers every label with a display name and accent", () => {
+    for (const label of TASK_LABELS) {
+      expect(TASK_LABEL_META[label].displayName).toBeTruthy();
+      expect(TASK_LABEL_META[label].accent).toMatch(/^var\(--/);
+    }
+  });
+});
+
+describe("taskLabelRank", () => {
+  it("orders high-priority and active above unlabeled, deprioritized and done below", () => {
+    const order: (TaskLabel | null)[] = [
+      "high-priority",
+      "active",
+      null,
+      "deprioritized",
+      "done",
+    ];
+    const ranks = order.map(taskLabelRank);
+    expect([...ranks].sort((a, b) => a - b)).toEqual(ranks);
+    expect(new Set(ranks).size).toBe(ranks.length);
+  });
+});

--- a/packages/shared/src/task-label.ts
+++ b/packages/shared/src/task-label.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+// User-set task labels: a small fixed triage vocabulary. Lives in shared so
+// workspace-server (persistence schema), core (sorting/derivation), ui
+// (rendering), and the web host all share one source of truth.
+export const TASK_LABELS = [
+  "high-priority",
+  "active",
+  "deprioritized",
+  "done",
+] as const;
+
+export const taskLabelSchema = z.enum(TASK_LABELS);
+export type TaskLabel = z.infer<typeof taskLabelSchema>;
+
+export interface TaskLabelMeta {
+  displayName: string;
+  /** Radix accent CSS variable, rendered as the row dot's background. */
+  accent: string;
+  /** Sort position for label-aware ordering; unlabeled tasks rank between
+   * "active" and "deprioritized" (see {@link taskLabelRank}). */
+  rank: number;
+}
+
+export const TASK_LABEL_META: Record<TaskLabel, TaskLabelMeta> = {
+  "high-priority": {
+    displayName: "High priority",
+    accent: "var(--orange-9)",
+    rank: 0,
+  },
+  active: { displayName: "Active", accent: "var(--blue-9)", rank: 1 },
+  deprioritized: {
+    displayName: "Deprioritized",
+    accent: "var(--gray-9)",
+    rank: 3,
+  },
+  done: { displayName: "Done", accent: "var(--grass-9)", rank: 4 },
+};
+
+const UNLABELED_RANK = 2;
+
+export function taskLabelRank(label: TaskLabel | null): number {
+  return label ? TASK_LABEL_META[label].rank : UNLABELED_RANK;
+}

--- a/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarMenu.tsx
@@ -324,6 +324,7 @@ function SidebarMenuComponent() {
         runId,
         isInCommandCenter,
         hasEmptyCommandCenterCell,
+        currentLabel: taskData?.label ?? null,
         onTogglePin: () => handleTaskTogglePin(taskId),
         onStop: (stopTaskId, taskTitle, stopRunId) =>
           setStopConfirm({

--- a/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -105,6 +105,7 @@ function TaskRow({
       depth={depth}
       taskId={task.id}
       label={task.title}
+      taskLabel={task.label}
       isActive={isActive}
       isSelected={isSelected}
       isArchiving={isArchiving}
@@ -191,8 +192,9 @@ export function TaskListView({
     useSidebarStore.getState().reorderFolders(sourceIndex, targetIndex);
   }, []);
 
+  // Priority sort tie-breaks by activity, so its rows show that timestamp too.
   const timestampKey: "lastActivityAt" | "createdAt" =
-    sortMode === "updated" ? "lastActivityAt" : "createdAt";
+    sortMode === "created" ? "createdAt" : "lastActivityAt";
 
   const dateGroupedTasks = useMemo(
     () => groupTasksByRelativeDate(flatTasks, timestampKey),

--- a/packages/ui/src/features/sidebar/components/TasksHeader.tsx
+++ b/packages/ui/src/features/sidebar/components/TasksHeader.tsx
@@ -147,6 +147,9 @@ function TaskFilterMenu() {
         >
           <DropdownMenuRadioItem value="created">Created</DropdownMenuRadioItem>
           <DropdownMenuRadioItem value="updated">Updated</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="priority">
+            Priority
+          </DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
 
         {import.meta.env.DEV && (

--- a/packages/ui/src/features/sidebar/components/items/TaskItem.test.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskItem.test.tsx
@@ -1,0 +1,44 @@
+import type { TaskLabel } from "@posthog/shared";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TaskItem } from "./TaskItem";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+function renderItem(taskLabel: TaskLabel | null) {
+  return render(
+    <Theme>
+      <TaskItem
+        taskId="t1"
+        label="My task"
+        isActive={false}
+        taskLabel={taskLabel}
+        onClick={() => {}}
+        onContextMenu={() => {}}
+      />
+    </Theme>,
+  );
+}
+
+describe("TaskItem label dot", () => {
+  it("shows a dot named after the label when the task is labeled", () => {
+    renderItem("high-priority");
+    expect(
+      screen.getByRole("img", { name: "Label: High priority" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing label-related when the task is unlabeled", () => {
+    renderItem(null);
+    expect(
+      screen.queryByRole("img", { name: /^Label:/ }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -1,6 +1,6 @@
 import { Archive, GitPullRequest, PushPin } from "@phosphor-icons/react";
 import { parseGithubUrl } from "@posthog/git/utils";
-import type { WorkspaceMode } from "@posthog/shared";
+import type { TaskLabel, WorkspaceMode } from "@posthog/shared";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import type { TaskRunStatus } from "@posthog/shared/domain-types";
 import { navigateToPullRequestView } from "@posthog/ui/router/navigationBridge";
@@ -11,6 +11,7 @@ import { Tooltip } from "../../../../primitives/Tooltip";
 import type { SidebarPrState } from "../../useTaskPrStatus";
 import { SidebarItem } from "../SidebarItem";
 import { ICON_SIZE, TaskIcon } from "./TaskIcon";
+import { TaskLabelDot } from "./TaskLabelDot";
 
 function PrBadge({ url, number }: { url: string; number: number }) {
   return (
@@ -33,6 +34,8 @@ interface TaskItemProps {
   depth?: number;
   taskId: string;
   label: string;
+  /** User-set task label (distinct from `label`, which is the row title). */
+  taskLabel?: TaskLabel | null;
   isActive: boolean;
   isSelected?: boolean;
   /** Archive request in flight: show a spinner and suppress hover actions. */
@@ -106,6 +109,7 @@ export function TaskItem({
   depth = 0,
   taskId,
   label,
+  taskLabel = null,
   isActive,
   isSelected = false,
   isArchiving = false,
@@ -173,9 +177,12 @@ export function TaskItem({
       />
     ) : null;
 
+  const labelDot = taskLabel ? <TaskLabelDot label={taskLabel} /> : null;
+
   const endContent =
-    prBadge || timestampNode || toolbar ? (
+    labelDot || prBadge || timestampNode || toolbar ? (
       <>
+        {labelDot}
         {prBadge}
         {timestampNode}
         {toolbar}

--- a/packages/ui/src/features/sidebar/components/items/TaskLabelDot.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskLabelDot.tsx
@@ -1,0 +1,22 @@
+import { TASK_LABEL_META, type TaskLabel } from "@posthog/shared";
+import { Tooltip } from "../../../../primitives/Tooltip";
+
+/**
+ * Subtle colored dot for a task's user-set label. Reused wherever a task row
+ * renders (sidebar today; channel feed cards can adopt it later). Renders
+ * nothing when the task is unlabeled.
+ */
+export function TaskLabelDot({ label }: { label: TaskLabel | null }) {
+  if (!label) return null;
+  const meta = TASK_LABEL_META[label];
+  return (
+    <Tooltip content={meta.displayName} side="top">
+      <span
+        role="img"
+        aria-label={`Label: ${meta.displayName}`}
+        className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+        style={{ backgroundColor: meta.accent }}
+      />
+    </Tooltip>
+  );
+}

--- a/packages/ui/src/features/sidebar/sidebarStore.ts
+++ b/packages/ui/src/features/sidebar/sidebarStore.ts
@@ -1,4 +1,7 @@
-import { ALL_WORKSPACE_MODES } from "@posthog/core/sidebar/buildSidebarData";
+import {
+  ALL_WORKSPACE_MODES,
+  type SortMode,
+} from "@posthog/core/sidebar/buildSidebarData";
 import type { WorkspaceMode } from "@posthog/shared";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
@@ -19,7 +22,7 @@ interface SidebarStoreState {
   folderOrder: string[];
   historyVisibleCount: number;
   organizeMode: "by-project" | "chronological";
-  sortMode: "updated" | "created";
+  sortMode: SortMode;
   showAllUsers: boolean;
   showInternal: boolean;
   taskTypeFilter: WorkspaceMode[];

--- a/packages/ui/src/features/sidebar/useTaskLabel.ts
+++ b/packages/ui/src/features/sidebar/useTaskLabel.ts
@@ -1,0 +1,64 @@
+import type { RawTaskTimestamp } from "@posthog/core/sidebar/taskMeta";
+import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
+import type { TaskLabel } from "@posthog/shared";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useRef } from "react";
+
+/**
+ * Sets a task's user-set label. Rides the shared getAllTaskTimestamps record
+ * (the same per-task metadata the sidebar already subscribes to), so the row
+ * updates optimistically and rolls back on failure.
+ */
+export function useTaskLabel() {
+  const trpc = useHostTRPC();
+  const hostClient = useHostTRPCClient();
+  const queryClient = useQueryClient();
+  const timestampsQueryKey = trpc.workspace.getAllTaskTimestamps.queryKey();
+
+  const setLabelMutation = useMutation({
+    mutationFn: ({
+      taskId,
+      label,
+    }: {
+      taskId: string;
+      label: TaskLabel | null;
+    }) => hostClient.workspace.setTaskLabel.mutate({ taskId, label }),
+    onMutate: async ({ taskId, label }) => {
+      await queryClient.cancelQueries({ queryKey: timestampsQueryKey });
+      const previous =
+        queryClient.getQueryData<Record<string, RawTaskTimestamp>>(
+          timestampsQueryKey,
+        );
+      queryClient.setQueryData<Record<string, RawTaskTimestamp>>(
+        timestampsQueryKey,
+        (old) => {
+          const base = old?.[taskId] ?? {
+            pinnedAt: null,
+            lastViewedAt: null,
+            lastActivityAt: null,
+            label: null,
+          };
+          return { ...old, [taskId]: { ...base, label } };
+        },
+      );
+      return { previous };
+    },
+    onError: (_, __, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(timestampsQueryKey, context.previous);
+      }
+    },
+  });
+
+  const setLabelMutationRef = useRef(setLabelMutation);
+  setLabelMutationRef.current = setLabelMutation;
+
+  const setLabel = useCallback(
+    async (taskId: string, label: TaskLabel | null) => {
+      await setLabelMutationRef.current.mutateAsync({ taskId, label });
+    },
+    [],
+  );
+
+  return { setLabel };
+}

--- a/packages/ui/src/features/sidebar/useTaskPrStatus.test.ts
+++ b/packages/ui/src/features/sidebar/useTaskPrStatus.test.ts
@@ -40,6 +40,7 @@ function makeTask(overrides: Partial<TaskData> = {}): TaskData {
     cloudPrUrl: null,
     branchName: "feat/test",
     linkedBranch: null,
+    label: null,
     ...overrides,
   };
 }

--- a/packages/ui/src/features/sidebar/useTaskViewed.ts
+++ b/packages/ui/src/features/sidebar/useTaskViewed.ts
@@ -42,6 +42,7 @@ export function useTaskViewed() {
                 pinnedAt: null,
                 lastViewedAt: now,
                 lastActivityAt: null,
+                label: null,
               },
             };
           return {
@@ -84,6 +85,7 @@ export function useTaskViewed() {
                 pinnedAt: null,
                 lastViewedAt: null,
                 lastActivityAt: activityIso,
+                label: null,
               },
             };
           return {

--- a/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -3,13 +3,14 @@ import {
   resolveTaskContextMenuIntent,
 } from "@posthog/core/tasks/contextMenuActions";
 import { useHostTRPCClient } from "@posthog/host-router/react";
-import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
+import { PROJECT_BLUEBIRD_FLAG, type TaskLabel } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useArchiveTask } from "@posthog/ui/features/archive/useArchiveTask";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelTaskMutations } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useExternalAppAction } from "@posthog/ui/features/external-apps/useExternalAppAction";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { useTaskLabel } from "@posthog/ui/features/sidebar/useTaskLabel";
 import { useRestoreTask } from "@posthog/ui/features/suspension/useRestoreTask";
 import { useSuspendTask } from "@posthog/ui/features/suspension/useSuspendTask";
 import { useDeleteTask } from "@posthog/ui/features/tasks/useTaskCrudMutations";
@@ -35,6 +36,7 @@ export function useTaskContextMenu() {
   );
   const { channels } = useChannels({ enabled: bluebirdEnabled });
   const { fileTask } = useChannelTaskMutations();
+  const { setLabel } = useTaskLabel();
 
   const showContextMenu = useCallback(
     async (
@@ -49,6 +51,7 @@ export function useTaskContextMenu() {
         runId?: string;
         isInCommandCenter?: boolean;
         hasEmptyCommandCenterCell?: boolean;
+        currentLabel?: TaskLabel | null;
         onTogglePin?: () => void;
         onStop?: (taskId: string, taskTitle: string, runId?: string) => void;
         onArchive?: (taskId: string) => void;
@@ -68,6 +71,7 @@ export function useTaskContextMenu() {
         runId,
         isInCommandCenter,
         hasEmptyCommandCenterCell,
+        currentLabel,
         onTogglePin,
         onStop,
         onArchive,
@@ -85,6 +89,7 @@ export function useTaskContextMenu() {
           canStop,
           isInCommandCenter,
           hasEmptyCommandCenterCell,
+          currentLabel,
           channels: channels.map(({ id, name }) => ({ id, name })),
         });
 
@@ -131,6 +136,16 @@ export function useTaskContextMenu() {
           case "add-to-command-center":
             onAddToCommandCenter?.();
             break;
+          case "set-label":
+            try {
+              await setLabel(task.id, intent.label);
+            } catch (error) {
+              toast.error("Couldn't set task label", {
+                description:
+                  error instanceof Error ? error.message : String(error),
+              });
+            }
+            break;
           case "file-to-channel":
             try {
               await fileTask(intent.channelId, task.id, task.title);
@@ -167,6 +182,7 @@ export function useTaskContextMenu() {
       deleteWithConfirm,
       fileTask,
       restoreTask,
+      setLabel,
       suspendTask,
       hostClient,
       openExternalApp,

--- a/packages/workspace-server/src/db/migrations/0023_task_labels.sql
+++ b/packages/workspace-server/src/db/migrations/0023_task_labels.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `workspaces` ADD `label` text;
+--> statement-breakpoint
+ALTER TABLE `task_metadata` ADD `label` text;

--- a/packages/workspace-server/src/db/migrations/meta/_journal.json
+++ b/packages/workspace-server/src/db/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1784804000000,
       "tag": "0022_archive_task_details",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1784950000000,
+      "tag": "0023_task_labels",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/workspace-server/src/db/repositories/task-label-persistence.test.ts
+++ b/packages/workspace-server/src/db/repositories/task-label-persistence.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { DatabaseService } from "../service";
+import { createTestDb, type TestDatabase } from "../test-helpers";
+import { TaskMetadataRepository } from "./task-metadata-repository";
+import { WorkspaceRepository } from "./workspace-repository";
+
+// Round-trips labels through real SQLite (createTestDb applies the full
+// migration chain), so a broken 0023_task_labels migration fails here rather
+// than on first launch.
+
+let testDb: TestDatabase;
+let workspaces: WorkspaceRepository;
+let taskMetadata: TaskMetadataRepository;
+
+beforeEach(() => {
+  testDb = createTestDb();
+  const databaseService = { db: testDb.db } as unknown as DatabaseService;
+  workspaces = new WorkspaceRepository(databaseService);
+  taskMetadata = new TaskMetadataRepository(databaseService);
+});
+
+afterEach(() => {
+  testDb.close();
+});
+
+describe("workspace label persistence", () => {
+  it("stores, reads back, and clears a label on the workspace row", () => {
+    workspaces.create({ taskId: "t1", repositoryId: null, mode: "cloud" });
+    expect(workspaces.findByTaskId("t1")?.label).toBeNull();
+
+    workspaces.updateLabel("t1", "high-priority");
+    expect(workspaces.findByTaskId("t1")?.label).toBe("high-priority");
+
+    workspaces.updateLabel("t1", null);
+    expect(workspaces.findByTaskId("t1")?.label).toBeNull();
+  });
+});
+
+describe("task_metadata label persistence (rowless tasks)", () => {
+  it("stores, reads back, and clears a label", () => {
+    taskMetadata.upsert("t1", { label: "done" });
+    expect(taskMetadata.findByTaskId("t1")?.label).toBe("done");
+
+    taskMetadata.upsert("t1", { label: null });
+    expect(taskMetadata.findByTaskId("t1")?.label).toBeNull();
+  });
+
+  it("keeps the label when other metadata fields are patched", () => {
+    taskMetadata.upsert("t1", { label: "active" });
+    taskMetadata.upsert("t1", { lastViewedAt: "2026-01-01T00:00:00.000Z" });
+    expect(taskMetadata.findByTaskId("t1")?.label).toBe("active");
+  });
+});

--- a/packages/workspace-server/src/db/repositories/task-metadata-repository.mock.ts
+++ b/packages/workspace-server/src/db/repositories/task-metadata-repository.mock.ts
@@ -29,6 +29,8 @@ export function createMockTaskMetadataRepository(): MockTaskMetadataRepository {
         "lastActivityAt" in patch
           ? (patch.lastActivityAt ?? null)
           : (existing?.lastActivityAt ?? null),
+      label:
+        "label" in patch ? (patch.label ?? null) : (existing?.label ?? null),
       archivedAt:
         "archivedAt" in patch
           ? (patch.archivedAt ?? null)

--- a/packages/workspace-server/src/db/repositories/task-metadata-repository.ts
+++ b/packages/workspace-server/src/db/repositories/task-metadata-repository.ts
@@ -1,3 +1,4 @@
+import type { TaskLabel } from "@posthog/shared";
 import { eq, isNotNull } from "drizzle-orm";
 import { inject, injectable } from "inversify";
 import { DATABASE_SERVICE } from "../identifiers";
@@ -13,6 +14,7 @@ export interface TaskMetadataPatch {
   pinnedAt?: string | null;
   lastViewedAt?: string | null;
   lastActivityAt?: string | null;
+  label?: TaskLabel | null;
   archivedAt?: string | null;
   archivedTitle?: string | null;
   archivedTaskCreatedAt?: string | null;

--- a/packages/workspace-server/src/db/repositories/workspace-repository.mock.ts
+++ b/packages/workspace-server/src/db/repositories/workspace-repository.mock.ts
@@ -63,6 +63,7 @@ export function createMockWorkspaceRepository(): MockWorkspaceRepository {
         pinnedAt: null,
         lastViewedAt: null,
         lastActivityAt: null,
+        label: null,
         linkedBranch: null,
         additionalDirectories: "[]",
         prUrl: null,
@@ -86,6 +87,7 @@ export function createMockWorkspaceRepository(): MockWorkspaceRepository {
           pinnedAt: null,
           lastViewedAt: null,
           lastActivityAt: null,
+          label: null,
           linkedBranch: null,
           additionalDirectories: "[]",
           prUrl: null,
@@ -124,6 +126,7 @@ export function createMockWorkspaceRepository(): MockWorkspaceRepository {
     updatePinnedAt: () => {},
     updateLastViewedAt: () => {},
     updateLastActivityAt: () => {},
+    updateLabel: () => {},
     updateMode: () => {},
     setModeAndRepository: (taskId, mode, repositoryId) => {
       const id = taskIndex.get(taskId);

--- a/packages/workspace-server/src/db/repositories/workspace-repository.ts
+++ b/packages/workspace-server/src/db/repositories/workspace-repository.ts
@@ -1,4 +1,9 @@
-import { mergePrUrls, promotePrUrl, type WorkspaceMode } from "@posthog/shared";
+import {
+  mergePrUrls,
+  promotePrUrl,
+  type TaskLabel,
+  type WorkspaceMode,
+} from "@posthog/shared";
 import { eq, isNotNull } from "drizzle-orm";
 import { inject, injectable } from "inversify";
 import { DATABASE_SERVICE } from "../identifiers";
@@ -36,6 +41,7 @@ export interface IWorkspaceRepository {
   updatePinnedAt(taskId: string, pinnedAt: string | null): void;
   updateLastViewedAt(taskId: string, lastViewedAt: string): void;
   updateLastActivityAt(taskId: string, lastActivityAt: string): void;
+  updateLabel(taskId: string, label: TaskLabel | null): void;
   updateLinkedBranch(taskId: string, linkedBranch: string | null): void;
   updateMode(taskId: string, mode: WorkspaceMode): void;
   setModeAndRepository(
@@ -168,6 +174,14 @@ export class WorkspaceRepository implements IWorkspaceRepository {
     this.db
       .update(workspaces)
       .set({ lastActivityAt, updatedAt: now() })
+      .where(byTaskId(taskId))
+      .run();
+  }
+
+  updateLabel(taskId: string, label: TaskLabel | null): void {
+    this.db
+      .update(workspaces)
+      .set({ label, updatedAt: now() })
       .where(byTaskId(taskId))
       .run();
   }

--- a/packages/workspace-server/src/db/schema.ts
+++ b/packages/workspace-server/src/db/schema.ts
@@ -31,6 +31,10 @@ export const workspaces = sqliteTable(
     pinnedAt: text(),
     lastViewedAt: text(),
     lastActivityAt: text(),
+    /** User-set task label (see TASK_LABELS in @posthog/shared); null = unlabeled. */
+    label: text({
+      enum: ["high-priority", "active", "deprioritized", "done"],
+    }),
     /** JSON-encoded array of absolute paths the agent can access for this task. */
     additionalDirectories: text().notNull().default("[]"),
     /** Cached PR URL for this task so task switches render without waiting on `gh`. */
@@ -54,6 +58,10 @@ export const taskMetadata = sqliteTable("task_metadata", {
   pinnedAt: text(),
   lastViewedAt: text(),
   lastActivityAt: text(),
+  /** User-set task label (see TASK_LABELS in @posthog/shared); null = unlabeled. */
+  label: text({
+    enum: ["high-priority", "active", "deprioritized", "done"],
+  }),
   // Archive state for rowless tasks. Tasks WITH a `workspaces` row record their
   // archived state in the `archives` table; rowless channel tasks have no such
   // row, so this timestamp is their only home — without it, archiving them is a

--- a/packages/workspace-server/src/services/workspace-metadata/workspace-metadata.test.ts
+++ b/packages/workspace-server/src/services/workspace-metadata/workspace-metadata.test.ts
@@ -15,6 +15,7 @@ function createService() {
     updatePinnedAt: vi.fn(),
     updateLastViewedAt: vi.fn(),
     updateLastActivityAt: vi.fn(),
+    updateLabel: vi.fn(),
   };
   const metadataRepo: MockTaskMetadataRepository =
     createMockTaskMetadataRepository();
@@ -137,6 +138,38 @@ describe("WorkspaceMetadataService.markActivity", () => {
   });
 });
 
+describe("WorkspaceMetadataService.setTaskLabel", () => {
+  it("writes the label to the workspace row when one exists", () => {
+    const { service, repo } = createService();
+    repo.findByTaskId.mockReturnValue({ taskId: "t1", label: null });
+
+    expect(service.setTaskLabel("t1", "high-priority")).toEqual({
+      label: "high-priority",
+    });
+    expect(repo.updateLabel).toHaveBeenCalledWith("t1", "high-priority");
+  });
+
+  it("clears the label with null", () => {
+    const { service, repo } = createService();
+    repo.findByTaskId.mockReturnValue({ taskId: "t1", label: "done" });
+
+    expect(service.setTaskLabel("t1", null)).toEqual({ label: null });
+    expect(repo.updateLabel).toHaveBeenCalledWith("t1", null);
+  });
+
+  it("stores the label in task_metadata for a rowless task", () => {
+    const { service, repo, metadataRepo } = createService();
+    repo.findByTaskId.mockReturnValue(undefined);
+
+    expect(service.setTaskLabel("t1", "active")).toEqual({ label: "active" });
+    expect(repo.updateLabel).not.toHaveBeenCalled();
+    expect(metadataRepo.findByTaskId("t1")?.label).toBe("active");
+
+    expect(service.setTaskLabel("t1", null)).toEqual({ label: null });
+    expect(metadataRepo.findByTaskId("t1")?.label).toBeNull();
+  });
+});
+
 describe("WorkspaceMetadataService projections", () => {
   it("unions pinned task ids from workspaces and task_metadata", () => {
     const { service, repo, metadataRepo } = createService();
@@ -153,24 +186,27 @@ describe("WorkspaceMetadataService projections", () => {
       pinnedAt: "2025-01-01T00:00:00.000Z",
       lastViewedAt: null,
       lastActivityAt: null,
+      label: "high-priority",
     });
 
     expect(service.getTaskTimestamps("t1")).toEqual({
       pinnedAt: "2025-01-01T00:00:00.000Z",
       lastViewedAt: null,
       lastActivityAt: null,
+      label: "high-priority",
     });
   });
 
   it("falls back to task_metadata for a rowless task", () => {
     const { service, repo, metadataRepo } = createService();
     repo.findByTaskId.mockReturnValue(undefined);
-    metadataRepo.upsert("t1", { lastViewedAt: NOW_ISO });
+    metadataRepo.upsert("t1", { lastViewedAt: NOW_ISO, label: "done" });
 
     expect(service.getTaskTimestamps("t1")).toEqual({
       pinnedAt: null,
       lastViewedAt: NOW_ISO,
       lastActivityAt: null,
+      label: "done",
     });
   });
 
@@ -182,19 +218,36 @@ describe("WorkspaceMetadataService projections", () => {
       pinnedAt: null,
       lastViewedAt: null,
       lastActivityAt: null,
+      label: null,
     });
   });
 
   it("merges all timestamps, with workspace rows winning on overlap", () => {
     const { service, repo, metadataRepo } = createService();
     repo.findAll.mockReturnValue([
-      { taskId: "a", pinnedAt: "p", lastViewedAt: "v", lastActivityAt: "x" },
+      {
+        taskId: "a",
+        pinnedAt: "p",
+        lastViewedAt: "v",
+        lastActivityAt: "x",
+        label: "active",
+      },
     ]);
-    metadataRepo.upsert("b", { lastViewedAt: "bv" });
+    metadataRepo.upsert("b", { lastViewedAt: "bv", label: "deprioritized" });
 
     expect(service.getAllTaskTimestamps()).toEqual({
-      a: { pinnedAt: "p", lastViewedAt: "v", lastActivityAt: "x" },
-      b: { pinnedAt: null, lastViewedAt: "bv", lastActivityAt: null },
+      a: {
+        pinnedAt: "p",
+        lastViewedAt: "v",
+        lastActivityAt: "x",
+        label: "active",
+      },
+      b: {
+        pinnedAt: null,
+        lastViewedAt: "bv",
+        lastActivityAt: null,
+        label: "deprioritized",
+      },
     });
   });
 });

--- a/packages/workspace-server/src/services/workspace-metadata/workspace-metadata.ts
+++ b/packages/workspace-server/src/services/workspace-metadata/workspace-metadata.ts
@@ -1,3 +1,4 @@
+import type { TaskLabel } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import {
   TASK_METADATA_REPOSITORY,
@@ -10,6 +11,7 @@ export interface TaskTimestamps {
   pinnedAt: string | null;
   lastViewedAt: string | null;
   lastActivityAt: string | null;
+  label: TaskLabel | null;
 }
 
 /**
@@ -73,6 +75,19 @@ export class WorkspaceMetadataService {
     this.taskMetadataRepo.upsert(taskId, { lastActivityAt });
   }
 
+  setTaskLabel(
+    taskId: string,
+    label: TaskLabel | null,
+  ): { label: TaskLabel | null } {
+    if (this.workspaceRepo.findByTaskId(taskId)) {
+      this.workspaceRepo.updateLabel(taskId, label);
+      return { label };
+    }
+    // Rowless task: fall back to the task_metadata table.
+    this.taskMetadataRepo.upsert(taskId, { label });
+    return { label };
+  }
+
   getPinnedTaskIds(): string[] {
     return [
       ...this.workspaceRepo.findAllPinned().map((w) => w.taskId),
@@ -88,6 +103,7 @@ export class WorkspaceMetadataService {
       pinnedAt: row?.pinnedAt ?? null,
       lastViewedAt: row?.lastViewedAt ?? null,
       lastActivityAt: row?.lastActivityAt ?? null,
+      label: row?.label ?? null,
     };
   }
 
@@ -100,6 +116,7 @@ export class WorkspaceMetadataService {
         pinnedAt: m.pinnedAt,
         lastViewedAt: m.lastViewedAt,
         lastActivityAt: m.lastActivityAt,
+        label: m.label,
       };
     }
     for (const w of this.workspaceRepo.findAll()) {
@@ -107,6 +124,7 @@ export class WorkspaceMetadataService {
         pinnedAt: w.pinnedAt,
         lastViewedAt: w.lastViewedAt,
         lastActivityAt: w.lastActivityAt,
+        label: w.label,
       };
     }
     return result;

--- a/packages/workspace-server/src/services/workspace/schemas.ts
+++ b/packages/workspace-server/src/services/workspace/schemas.ts
@@ -1,4 +1,5 @@
 import {
+  taskLabelSchema,
   workspaceInfoSchema,
   workspaceModeSchema,
   workspaceSchema,
@@ -270,6 +271,15 @@ export const markActivityInput = z.object({
 
 export const getPinnedTaskIdsOutput = z.array(z.string());
 
+export const setTaskLabelInput = z.object({
+  taskId: z.string(),
+  label: taskLabelSchema.nullable(),
+});
+
+export const setTaskLabelOutput = z.object({
+  label: taskLabelSchema.nullable(),
+});
+
 export const getTaskTimestampsInput = z.object({
   taskId: z.string(),
 });
@@ -278,6 +288,7 @@ export const getTaskTimestampsOutput = z.object({
   pinnedAt: z.string().nullable(),
   lastViewedAt: z.string().nullable(),
   lastActivityAt: z.string().nullable(),
+  label: taskLabelSchema.nullable(),
 });
 
 export const getAllTaskTimestampsOutput = z.record(
@@ -286,6 +297,7 @@ export const getAllTaskTimestampsOutput = z.record(
     pinnedAt: z.string().nullable(),
     lastViewedAt: z.string().nullable(),
     lastActivityAt: z.string().nullable(),
+    label: taskLabelSchema.nullable(),
   }),
 );
 


### PR DESCRIPTION
## Problem

There's no lightweight way to triage the sidebar task list — you can pin (moves the row to a dedicated section) or archive (removes it), but nothing in between to mark a task as high priority, actively worked, deprioritized, or done while keeping it in place.

## Changes

- **Label a task from its context menu**: right-click → new radio-style "Label" submenu (High priority / Active / Deprioritized / Done / None), with the current label checked. Labeled rows show a small colored dot (inbox priority-dot styling); unlabeled rows are unchanged.
- **New "Priority" option in the Sort by menu**: orders High priority → Active → unlabeled → Deprioritized → Done, tie-broken by last activity.
- **Persistence follows the pin pattern**: a nullable `label` column on `workspaces` and `task_metadata` (migration `0023_task_labels`), `WorkspaceMetadataService.setTaskLabel` with the dual-table rowless fallback, riding the existing `getAllTaskTimestamps` record into `TaskData` with optimistic updates. Per-device only, like pins.
- Label metadata (enum, display names, accents, sort ranks) lives in `@posthog/shared` (`task-label.ts`) so workspace-server, core, ui, and the web host share one source of truth. `apps/web` mirrors the field in its localStorage metadata store; setting labels is desktop-only for now (the web host has no task context menu).
- Labels are keyed by task id, so a labeled task keeps its label wherever it renders; channel feed cards don't render the dot yet (the `TaskLabelDot` component is reusable there later).

## How did you test this?

- TDD (red → green) at each layer with new/extended Vitest suites: shared label constants, `WorkspaceMetadataService.setTaskLabel` + timestamp projections, `parseTimestamps`/`deriveTaskData`, the context-menu Label submenu + intent resolution, `TaskItem` dot rendering, and priority sorting in `partitionAndSortTasks`.
- Integration test round-tripping labels through real SQLite via the full migration chain (`task-label-persistence.test.ts`), proving migration 0023 applies.
- `pnpm typecheck`, `pnpm lint`, `biome lint packages/core` (zero `noRestrictedImports`), and `node scripts/check-host-boundaries.mjs` all clean. Remaining test failures in the full suite are pre-existing sandbox git-environment failures (identical on a clean checkout).
- Could not drive the live Electron app in this environment (no display server / signed-in profile) — worth a quick manual pass: right-click a task → Label → High priority, confirm the orange dot, relaunch to confirm persistence, then Sort by → Priority.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
