### PR TITLE
perf: reduce task-time CPU and process leaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,8 @@ See [docs/conventions.md](./docs/conventions.md).
 
 ## Testing
 
+Measure the live process tree before fixing sustained resource-use reports.
+
 - Unit tests: Vitest.
 - E2E tests: Playwright.
 - Test core/UI services and stores with faked injected dependencies and explicit props.

--- a/packages/core/src/pi-runtime/piSessionController.test.ts
+++ b/packages/core/src/pi-runtime/piSessionController.test.ts
@@ -1332,6 +1332,43 @@ describe("PiSessionController", () => {
     ]);
   });
 
+  it("does not append a chunk twice when it arrives during initial load", async () => {
+    vi.useFakeTimers();
+    let resolveConversation: (events: AgentConversationEvent[]) => void =
+      () => {};
+    const conversation = new Promise<AgentConversationEvent[]>((resolve) => {
+      resolveConversation = resolve;
+    });
+    const chunk: AgentConversationEvent = {
+      type: "assistant_message_chunk",
+      timestamp: 1,
+      content: { type: "text", text: "hello" },
+    };
+    let onEvent: (event: AgentConversationEvent) => void = () => {};
+    const client = createClient();
+    vi.mocked(client.conversation).mockReturnValue(conversation);
+    vi.mocked(client.status).mockResolvedValue({
+      ...(await client.status("task-1")),
+      isStreaming: true,
+    });
+    vi.mocked(client.subscribe).mockImplementation((_taskId, handler) => {
+      onEvent = handler;
+      return () => {};
+    });
+    const controller = createController(client);
+
+    const connection = controller.connect("task-1");
+    onEvent(chunk);
+    resolveConversation([]);
+    await connection;
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(controller.store.getState().sessions["task-1"].events).toEqual([
+      chunk,
+    ]);
+    vi.useRealTimers();
+  });
+
   it("loads session state and appends normalized runtime events", async () => {
     const initialEvent: AgentConversationEvent = {
       type: "assistant_message_chunk",

--- a/packages/core/src/pi-runtime/piSessionController.test.ts
+++ b/packages/core/src/pi-runtime/piSessionController.test.ts
@@ -1345,19 +1345,22 @@ describe("PiSessionController", () => {
       content: { type: "text", text: "hello" },
     };
     let onEvent: (event: AgentConversationEvent) => void = () => {};
-    const client = createClient();
-    vi.mocked(client.conversation).mockReturnValue(conversation);
-    vi.mocked(client.status).mockResolvedValue({
-      ...(await client.status("task-1")),
+    const session = createSession();
+    vi.mocked(session.getConversation).mockReturnValue(conversation);
+    vi.mocked(session.client.getState).mockResolvedValue({
+      ...(await session.client.getState()),
       isStreaming: true,
     });
-    vi.mocked(client.subscribe).mockImplementation((_taskId, handler) => {
+    vi.mocked(session.onConversationEvent).mockImplementation((handler) => {
       onEvent = handler;
       return () => {};
     });
-    const controller = createController(client);
+    const controller = createController(session);
 
     const connection = controller.connect("task-1");
+    await vi.waitFor(() =>
+      expect(session.onConversationEvent).toHaveBeenCalledOnce(),
+    );
     onEvent(chunk);
     resolveConversation([]);
     await connection;
@@ -1411,12 +1414,12 @@ describe("PiSessionController", () => {
       content: { type: "text", text: " world" },
     };
     let onEvent: (event: AgentConversationEvent) => void = () => {};
-    const client = createClient();
-    vi.mocked(client.subscribe).mockImplementation((_taskId, handler) => {
+    const session = createSession();
+    vi.mocked(session.onConversationEvent).mockImplementation((handler) => {
       onEvent = handler;
       return () => {};
     });
-    const controller = createController(client);
+    const controller = createController(session);
     await controller.connect("task-1");
     const listener = vi.fn();
     controller.store.subscribe(listener);
@@ -1445,12 +1448,12 @@ describe("PiSessionController", () => {
       timestamp: 2,
     };
     let onEvent: (event: AgentConversationEvent) => void = () => {};
-    const client = createClient();
-    vi.mocked(client.subscribe).mockImplementation((_taskId, handler) => {
+    const session = createSession();
+    vi.mocked(session.onConversationEvent).mockImplementation((handler) => {
       onEvent = handler;
       return () => {};
     });
-    const controller = createController(client);
+    const controller = createController(session);
     await controller.connect("task-1");
 
     onEvent(chunk);
@@ -1460,79 +1463,5 @@ describe("PiSessionController", () => {
       chunk,
       completed,
     ]);
-  });
-
-  it("does not append a chunk twice when it arrives during conversation refresh", async () => {
-    vi.useFakeTimers();
-    let resolveConversation: (events: AgentConversationEvent[]) => void =
-      () => {};
-    const refreshedConversation = new Promise<AgentConversationEvent[]>(
-      (resolve) => {
-        resolveConversation = resolve;
-      },
-    );
-    const completed: AgentConversationEvent = {
-      type: "turn_completed",
-      timestamp: 1,
-    };
-    const nextChunk: AgentConversationEvent = {
-      type: "assistant_message_chunk",
-      timestamp: 2,
-      content: { type: "text", text: "next" },
-    };
-    let onEvent: (event: AgentConversationEvent) => void = () => {};
-    const client = createClient();
-    vi.mocked(client.subscribe).mockImplementation((_taskId, handler) => {
-      onEvent = handler;
-      return () => {};
-    });
-    const controller = createController(client);
-    await controller.connect("task-1");
-    vi.mocked(client.conversation).mockReturnValue(refreshedConversation);
-
-    onEvent(completed);
-    onEvent(nextChunk);
-    resolveConversation([completed]);
-    await vi.waitFor(() => {
-      expect(controller.store.getState().sessions["task-1"].events).toEqual([
-        completed,
-        nextChunk,
-      ]);
-    });
-    await vi.advanceTimersByTimeAsync(50);
-
-    expect(controller.store.getState().sessions["task-1"].events).toEqual([
-      completed,
-      nextChunk,
-    ]);
-    vi.useRealTimers();
-  });
-
-  it("drops pending chunks when an uncaptured refresh replaces the transcript", async () => {
-    vi.useFakeTimers();
-    const chunk: AgentConversationEvent = {
-      type: "assistant_message_chunk",
-      timestamp: 1,
-      content: { type: "text", text: "hello" },
-    };
-    let onEvent: (event: AgentConversationEvent) => void = () => {};
-    const client = createClient();
-    vi.mocked(client.subscribe).mockImplementation((_taskId, handler) => {
-      onEvent = handler;
-      return () => {};
-    });
-    const controller = createController(client);
-    await controller.connect("task-1");
-
-    onEvent(chunk);
-    vi.mocked(client.conversation).mockResolvedValue([chunk]);
-    const bash = controller.bash("task-1", "ls");
-    await vi.advanceTimersByTimeAsync(50);
-    await bash;
-
-    expect(controller.store.getState().sessions["task-1"].events).toEqual([
-      chunk,
-    ]);
-    vi.useRealTimers();
   });
 });

--- a/packages/core/src/pi-runtime/piSessionController.test.ts
+++ b/packages/core/src/pi-runtime/piSessionController.test.ts
@@ -1424,4 +1424,50 @@ describe("PiSessionController", () => {
       completed,
     ]);
   });
+
+  it("does not append a chunk twice when it arrives during conversation refresh", async () => {
+    vi.useFakeTimers();
+    let resolveConversation: (events: AgentConversationEvent[]) => void =
+      () => {};
+    const refreshedConversation = new Promise<AgentConversationEvent[]>(
+      (resolve) => {
+        resolveConversation = resolve;
+      },
+    );
+    const completed: AgentConversationEvent = {
+      type: "turn_completed",
+      timestamp: 1,
+    };
+    const nextChunk: AgentConversationEvent = {
+      type: "assistant_message_chunk",
+      timestamp: 2,
+      content: { type: "text", text: "next" },
+    };
+    let onEvent: (event: AgentConversationEvent) => void = () => {};
+    const client = createClient();
+    vi.mocked(client.subscribe).mockImplementation((_taskId, handler) => {
+      onEvent = handler;
+      return () => {};
+    });
+    const controller = createController(client);
+    await controller.connect("task-1");
+    vi.mocked(client.conversation).mockReturnValue(refreshedConversation);
+
+    onEvent(completed);
+    onEvent(nextChunk);
+    resolveConversation([completed]);
+    await vi.waitFor(() => {
+      expect(controller.store.getState().sessions["task-1"].events).toEqual([
+        completed,
+        nextChunk,
+      ]);
+    });
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(controller.store.getState().sessions["task-1"].events).toEqual([
+      completed,
+      nextChunk,
+    ]);
+    vi.useRealTimers();
+  });
 });

--- a/packages/core/src/pi-runtime/piSessionController.test.ts
+++ b/packages/core/src/pi-runtime/piSessionController.test.ts
@@ -1360,4 +1360,68 @@ describe("PiSessionController", () => {
       status: { isCompacting: true },
     });
   });
+
+  it("batches streamed chunks into one store update", async () => {
+    vi.useFakeTimers();
+    const first: AgentConversationEvent = {
+      type: "assistant_message_chunk",
+      timestamp: 1,
+      content: { type: "text", text: "hello" },
+    };
+    const second: AgentConversationEvent = {
+      type: "assistant_message_chunk",
+      timestamp: 2,
+      content: { type: "text", text: " world" },
+    };
+    let onEvent: (event: AgentConversationEvent) => void = () => {};
+    const client = createClient();
+    vi.mocked(client.subscribe).mockImplementation((_taskId, handler) => {
+      onEvent = handler;
+      return () => {};
+    });
+    const controller = createController(client);
+    await controller.connect("task-1");
+    const listener = vi.fn();
+    controller.store.subscribe(listener);
+
+    onEvent(first);
+    onEvent(second);
+
+    expect(listener).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(controller.store.getState().sessions["task-1"].events).toEqual([
+      first,
+      second,
+    ]);
+    vi.useRealTimers();
+  });
+
+  it("flushes streamed chunks before a turn completes", async () => {
+    const chunk: AgentConversationEvent = {
+      type: "assistant_message_chunk",
+      timestamp: 1,
+      content: { type: "text", text: "done" },
+    };
+    const completed: AgentConversationEvent = {
+      type: "turn_completed",
+      timestamp: 2,
+    };
+    let onEvent: (event: AgentConversationEvent) => void = () => {};
+    const client = createClient();
+    vi.mocked(client.subscribe).mockImplementation((_taskId, handler) => {
+      onEvent = handler;
+      return () => {};
+    });
+    const controller = createController(client);
+    await controller.connect("task-1");
+
+    onEvent(chunk);
+    onEvent(completed);
+
+    expect(controller.store.getState().sessions["task-1"].events).toEqual([
+      chunk,
+      completed,
+    ]);
+  });
 });

--- a/packages/core/src/pi-runtime/piSessionController.test.ts
+++ b/packages/core/src/pi-runtime/piSessionController.test.ts
@@ -1470,4 +1470,32 @@ describe("PiSessionController", () => {
     ]);
     vi.useRealTimers();
   });
+
+  it("drops pending chunks when an uncaptured refresh replaces the transcript", async () => {
+    vi.useFakeTimers();
+    const chunk: AgentConversationEvent = {
+      type: "assistant_message_chunk",
+      timestamp: 1,
+      content: { type: "text", text: "hello" },
+    };
+    let onEvent: (event: AgentConversationEvent) => void = () => {};
+    const client = createClient();
+    vi.mocked(client.subscribe).mockImplementation((_taskId, handler) => {
+      onEvent = handler;
+      return () => {};
+    });
+    const controller = createController(client);
+    await controller.connect("task-1");
+
+    onEvent(chunk);
+    vi.mocked(client.conversation).mockResolvedValue([chunk]);
+    const bash = controller.bash("task-1", "ls");
+    await vi.advanceTimersByTimeAsync(50);
+    await bash;
+
+    expect(controller.store.getState().sessions["task-1"].events).toEqual([
+      chunk,
+    ]);
+    vi.useRealTimers();
+  });
 });

--- a/packages/core/src/pi-runtime/piSessionController.ts
+++ b/packages/core/src/pi-runtime/piSessionController.ts
@@ -80,6 +80,8 @@ export type PiSessionProvider = PiSessionFactory;
 
 export type PiSubmitResult = "prompt" | "steer" | "followUp" | "compact";
 
+const STREAM_UPDATE_INTERVAL_MS = 50;
+
 type PiOperation =
   | "prompt"
   | "compact"
@@ -122,6 +124,11 @@ export class PiSessionController {
   private readonly sessions = new Map<string, Promise<PiSession>>();
   private readonly subscriptions = new Map<string, () => void>();
   private readonly liveEvents = new Map<string, AgentConversationEvent[]>();
+  private readonly pendingEvents = new Map<string, AgentConversationEvent[]>();
+  private readonly pendingEventTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
   private readonly connections = new Map<string, Promise<void>>();
   private readonly readiness = new Map<string, Promise<void>>();
   private readonly sessionVersions = new Map<string, number>();
@@ -201,6 +208,7 @@ export class PiSessionController {
 
   disconnect(taskId: string): void {
     this.cancelAuthRestoration.get(taskId)?.();
+    this.flushPendingEvents(taskId);
     this.resetTransport(taskId);
     this.taskRunIds.delete(taskId);
     this.liveEvents.delete(taskId);
@@ -600,11 +608,15 @@ export class PiSessionController {
       const conversationEvents = events.filter(
         (event) => event.type !== "queue_update",
       );
-      const liveEvents = this.liveEvents.get(taskId) ?? [];
+      const liveEvents = [
+        ...(this.liveEvents.get(taskId) ?? []),
+        ...(this.pendingEvents.get(taskId) ?? []),
+      ];
       const newLiveEvents = this.reconcileLiveEvents(
         conversationEvents,
         liveEvents,
       );
+      this.discardPendingEvents(taskId);
       this.liveEvents.set(taskId, newLiveEvents);
       const historyUserMessageIds = new Set(
         conversationEvents.flatMap((event) =>
@@ -701,6 +713,16 @@ export class PiSessionController {
   }
 
   private handleEvent(taskId: string, event: AgentConversationEvent): void {
+    if (
+      event.type === "assistant_message_chunk" ||
+      event.type === "assistant_thought_chunk" ||
+      event.type === "tool_call_updated"
+    ) {
+      this.queueEvent(taskId, event);
+      return;
+    }
+
+    this.flushPendingEvents(taskId);
     if (event.type === "queue_update") {
       const queue = {
         steering: event.steering,
@@ -742,16 +764,9 @@ export class PiSessionController {
         );
       }
     }
-    const isDirectBashEvent =
-      (event.type === "tool_call_started" ||
-        event.type === "tool_call_updated") &&
-      event.toolCall.origin === "user_shell";
     const hasTurnActivity =
-      !isDirectBashEvent &&
-      (event.type === "assistant_message_chunk" ||
-        event.type === "assistant_thought_chunk" ||
-        event.type === "tool_call_started" ||
-        event.type === "tool_call_updated");
+      event.type === "tool_call_started" &&
+      event.toolCall.origin !== "user_shell";
     if (status && hasTurnActivity) {
       status = { ...status, isStreaming: true };
     }
@@ -794,6 +809,78 @@ export class PiSessionController {
     if (event.type === "turn_completed") {
       void this.refreshStats(taskId);
     }
+  }
+
+  private queueEvent(taskId: string, event: AgentConversationEvent): void {
+    const pending = this.pendingEvents.get(taskId) ?? [];
+    pending.push(event);
+    this.pendingEvents.set(taskId, pending);
+
+    if (this.pendingEventTimers.has(taskId)) return;
+    this.pendingEventTimers.set(
+      taskId,
+      setTimeout(() => {
+        this.pendingEventTimers.delete(taskId);
+        this.flushPendingEvents(taskId);
+      }, STREAM_UPDATE_INTERVAL_MS),
+    );
+  }
+
+  private flushPendingEvents(taskId: string): void {
+    const timer = this.pendingEventTimers.get(taskId);
+    if (timer) {
+      clearTimeout(timer);
+      this.pendingEventTimers.delete(taskId);
+    }
+
+    const pending = this.pendingEvents.get(taskId);
+    if (!pending?.length) return;
+    this.pendingEvents.delete(taskId);
+
+    const session = this.getSession(taskId);
+    const seenSourceIds = new Set(
+      session.events.flatMap((event) =>
+        event.sourceId ? [event.sourceId] : [],
+      ),
+    );
+    const events = pending.filter((event) => {
+      if (!event.sourceId || !seenSourceIds.has(event.sourceId)) {
+        if (event.sourceId) seenSourceIds.add(event.sourceId);
+        return true;
+      }
+      return false;
+    });
+    if (events.length === 0) return;
+
+    this.liveEvents.set(taskId, [
+      ...(this.liveEvents.get(taskId) ?? []),
+      ...events,
+    ]);
+    const hasTurnActivity = events.some(
+      (event) =>
+        event.type !== "tool_call_updated" ||
+        event.toolCall.origin !== "user_shell",
+    );
+    const latestSession = this.getSession(taskId);
+    this.updateSession(taskId, {
+      connectionState: "connected",
+      events: [...latestSession.events, ...events],
+      status:
+        latestSession.status && hasTurnActivity
+          ? { ...latestSession.status, isStreaming: true }
+          : latestSession.status,
+      error:
+        latestSession.error?.scope === "operation"
+          ? latestSession.error
+          : undefined,
+    });
+  }
+
+  private discardPendingEvents(taskId: string): void {
+    const timer = this.pendingEventTimers.get(taskId);
+    if (timer) clearTimeout(timer);
+    this.pendingEventTimers.delete(taskId);
+    this.pendingEvents.delete(taskId);
   }
 
   private async refreshStats(taskId: string): Promise<void> {
@@ -1188,6 +1275,7 @@ export class PiSessionController {
   }
 
   private resetTransport(taskId: string): void {
+    this.discardPendingEvents(taskId);
     this.advanceSessionVersion(taskId);
     this.subscriptions.get(taskId)?.();
     this.subscriptions.delete(taskId);

--- a/packages/core/src/sessions/sessionEventBatching.test.ts
+++ b/packages/core/src/sessions/sessionEventBatching.test.ts
@@ -4,7 +4,7 @@ import { SessionService, type SessionServiceDeps } from "./sessionService";
 
 const TASK_ID = "task-1";
 const RUN_ID = "run-1";
-const FLUSH_MS = 16;
+const FLUSH_MS = 50;
 
 /** A plain streamed agent-message chunk — the common per-token event that just
  * gets appended to the transcript. */
@@ -175,6 +175,7 @@ describe("streamed event batching", () => {
     // A single flush tick drains the whole burst, in arrival order.
     vi.advanceTimersByTime(FLUSH_MS);
     expect(h.events().map(chunkText)).toEqual(["a", "b", "c"]);
+    expect(h.appendEvents).toHaveBeenCalledOnce();
   });
 
   it("flushes buffered events synchronously on teardown", () => {

--- a/packages/core/src/sessions/sessionEventBatching.test.ts
+++ b/packages/core/src/sessions/sessionEventBatching.test.ts
@@ -51,6 +51,32 @@ function toolCall(id: string): AcpMessage {
   } as unknown as AcpMessage;
 }
 
+function configOptionUpdate(): AcpMessage {
+  return {
+    ts: 3,
+    message: {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: RUN_ID,
+        update: {
+          sessionUpdate: "config_option_update",
+          configOptions: [
+            {
+              id: "mode",
+              name: "Mode",
+              category: "mode",
+              type: "select",
+              currentValue: "default",
+              options: [],
+            },
+          ],
+        },
+      },
+    },
+  } as unknown as AcpMessage;
+}
+
 function createHarness() {
   const sessions: Record<string, AgentSession> = {
     [RUN_ID]: {
@@ -143,6 +169,7 @@ function createHarness() {
     service,
     appendEvents,
     notifyPromptComplete,
+    setPersistedConfigOptions: deps.setPersistedConfigOptions,
     updateSession: store.updateSession,
     emit: (event: AcpMessage) => onEvent?.(event),
     events: () => sessions[RUN_ID].events,
@@ -225,6 +252,18 @@ describe("streamed event batching", () => {
     vi.advanceTimersByTime(FLUSH_MS);
     expect(h.events()).toEqual([streamed, active]);
     expect(h.appendEvents).toHaveBeenCalledOnce();
+  });
+
+  it("applies and persists config option updates immediately", () => {
+    const h = createHarness();
+    const streamed = chunk("a");
+    const configUpdate = configOptionUpdate();
+
+    h.emit(streamed);
+    h.emit(configUpdate);
+
+    expect(h.events()).toEqual([streamed, configUpdate]);
+    expect(h.setPersistedConfigOptions).toHaveBeenCalledOnce();
   });
 
   it("keeps the turn duration when the prompt mutation clears state before the response flushes", () => {

--- a/packages/core/src/sessions/sessionEventBatching.test.ts
+++ b/packages/core/src/sessions/sessionEventBatching.test.ts
@@ -213,7 +213,7 @@ describe("streamed event batching", () => {
     expect(h.events()).toHaveLength(2);
   });
 
-  it("flushes passive events in order before an active event", () => {
+  it("batches interleaved text and tool updates in order", () => {
     const h = createHarness();
     const streamed = chunk("a");
     const active = toolCall("tool-1");
@@ -221,10 +221,10 @@ describe("streamed event batching", () => {
     h.emit(streamed);
     h.emit(active);
 
-    expect(h.events()).toEqual([streamed, active]);
-    expect(h.appendEvents).toHaveBeenCalledTimes(2);
+    expect(h.events()).toEqual([]);
     vi.advanceTimersByTime(FLUSH_MS);
     expect(h.events()).toEqual([streamed, active]);
+    expect(h.appendEvents).toHaveBeenCalledOnce();
   });
 
   it("keeps the turn duration when the prompt mutation clears state before the response flushes", () => {

--- a/packages/core/src/sessions/sessionEventBatching.test.ts
+++ b/packages/core/src/sessions/sessionEventBatching.test.ts
@@ -32,6 +32,25 @@ function chunkText(event: AcpMessage): string {
   return params.update.content.text;
 }
 
+function toolCall(id: string): AcpMessage {
+  return {
+    ts: 2,
+    message: {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: RUN_ID,
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: id,
+          title: "Read file",
+          status: "in_progress",
+        },
+      },
+    },
+  } as unknown as AcpMessage;
+}
+
 function createHarness() {
   const sessions: Record<string, AgentSession> = {
     [RUN_ID]: {
@@ -192,6 +211,20 @@ describe("streamed event batching", () => {
     // The flush timer was cleared, so advancing does not re-apply anything.
     vi.advanceTimersByTime(FLUSH_MS);
     expect(h.events()).toHaveLength(2);
+  });
+
+  it("flushes passive events in order before an active event", () => {
+    const h = createHarness();
+    const streamed = chunk("a");
+    const active = toolCall("tool-1");
+
+    h.emit(streamed);
+    h.emit(active);
+
+    expect(h.events()).toEqual([streamed, active]);
+    expect(h.appendEvents).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(FLUSH_MS);
+    expect(h.events()).toEqual([streamed, active]);
   });
 
   it("keeps the turn duration when the prompt mutation clears state before the response flushes", () => {

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -124,10 +124,10 @@ const MAX_RESPONDED_PERMISSION_REQUEST_IDS = 500;
  * Streamed events are buffered and flushed on this cadence so a burst of tokens
  * coalesces into one processing pass (and roughly one render) instead of one
  * per event. Electron IPC delivers each event as its own task, so a microtask
- * flush wouldn't batch across them — a short timer does. One frame is
- * imperceptible for streamed text.
+ * flush wouldn't batch across them — a short timer does. A 50ms presentation
+ * delay is imperceptible for streamed text and cuts update churn substantially.
  */
-const SESSION_EVENT_FLUSH_MS = 16;
+const SESSION_EVENT_FLUSH_MS = 50;
 /**
  * A backgrounded session's transcript is freed this long after it stops being
  * viewed, and reloaded from disk on return. Only disconnected (idle, no live
@@ -1537,6 +1537,18 @@ function classifyTurnEventKind(
   return "other";
 }
 
+function isPassiveStreamEvent(acpMsg: AcpMessage): boolean {
+  const msg = acpMsg.message;
+  if (!("method" in msg) || msg.method !== "session/update") return false;
+  const sessionUpdate = (
+    msg as { params?: { update?: { sessionUpdate?: string } } }
+  ).params?.update?.sessionUpdate;
+  return (
+    sessionUpdate === "agent_message_chunk" ||
+    sessionUpdate === "agent_thought_chunk"
+  );
+}
+
 export class SessionService {
   private connectingTasks = new Map<string, Promise<void>>();
   private reconcilingTasks = new Set<string>();
@@ -2593,9 +2605,7 @@ export class SessionService {
     const batches = this.pendingSessionEvents;
     this.pendingSessionEvents = new Map();
     for (const [taskRunId, events] of batches) {
-      for (const acpMsg of events) {
-        this.handleSessionEvent(taskRunId, acpMsg);
-      }
+      this.handleSessionEventBatch(taskRunId, events);
     }
   }
 
@@ -2605,9 +2615,36 @@ export class SessionService {
     const events = this.pendingSessionEvents.get(taskRunId);
     if (!events) return;
     this.pendingSessionEvents.delete(taskRunId);
-    for (const acpMsg of events) {
-      this.handleSessionEvent(taskRunId, acpMsg);
+    this.handleSessionEventBatch(taskRunId, events);
+  }
+
+  private handleSessionEventBatch(
+    taskRunId: string,
+    events: AcpMessage[],
+  ): void {
+    let passive: AcpMessage[] = [];
+    const flushPassive = () => {
+      if (passive.length === 0) return;
+      const session = this.d.store.getSessions()[taskRunId];
+      if (session) {
+        if (session.initialPrompt?.length) {
+          this.d.store.updateSession(taskRunId, { initialPrompt: undefined });
+        }
+        this.d.store.appendEvents(taskRunId, passive);
+        this.updatePromptStateFromEvents(taskRunId, passive, { isLive: true });
+      }
+      passive = [];
+    };
+
+    for (const event of events) {
+      if (isPassiveStreamEvent(event)) {
+        passive.push(event);
+      } else {
+        flushPassive();
+        this.handleSessionEvent(taskRunId, event);
+      }
     }
+    flushPassive();
   }
 
   // --- Transcript residency (memory eviction) ---
@@ -2713,7 +2750,13 @@ export class SessionService {
       { taskRunId },
       {
         onData: (payload: unknown) => {
-          this.enqueueSessionEvent(taskRunId, payload as AcpMessage);
+          const event = payload as AcpMessage;
+          if (isPassiveStreamEvent(event)) {
+            this.enqueueSessionEvent(taskRunId, event);
+          } else {
+            this.flushSessionEventsForTask(taskRunId);
+            this.handleSessionEvent(taskRunId, event);
+          }
         },
         onError: (err) => {
           this.d.log.error("Session subscription error", {

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1539,7 +1539,10 @@ function classifyTurnEventKind(
 
 function isStreamUpdateEvent(acpMsg: AcpMessage): boolean {
   const msg = acpMsg.message;
-  return "method" in msg && msg.method === "session/update";
+  if (!("method" in msg) || msg.method !== "session/update") return false;
+  const update = (msg as { params?: { update?: { sessionUpdate?: string } } })
+    .params?.update;
+  return update?.sessionUpdate !== "config_option_update";
 }
 
 export class SessionService {

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -1537,16 +1537,9 @@ function classifyTurnEventKind(
   return "other";
 }
 
-function isPassiveStreamEvent(acpMsg: AcpMessage): boolean {
+function isStreamUpdateEvent(acpMsg: AcpMessage): boolean {
   const msg = acpMsg.message;
-  if (!("method" in msg) || msg.method !== "session/update") return false;
-  const sessionUpdate = (
-    msg as { params?: { update?: { sessionUpdate?: string } } }
-  ).params?.update?.sessionUpdate;
-  return (
-    sessionUpdate === "agent_message_chunk" ||
-    sessionUpdate === "agent_thought_chunk"
-  );
+  return "method" in msg && msg.method === "session/update";
 }
 
 export class SessionService {
@@ -2637,7 +2630,7 @@ export class SessionService {
     };
 
     for (const event of events) {
-      if (isPassiveStreamEvent(event)) {
+      if (isStreamUpdateEvent(event)) {
         passive.push(event);
       } else {
         flushPassive();
@@ -2751,7 +2744,7 @@ export class SessionService {
       {
         onData: (payload: unknown) => {
           const event = payload as AcpMessage;
-          if (isPassiveStreamEvent(event)) {
+          if (isStreamUpdateEvent(event)) {
             this.enqueueSessionEvent(taskRunId, event);
           } else {
             this.flushSessionEventsForTask(taskRunId);

--- a/packages/core/src/sidebar/buildSidebarData.ts
+++ b/packages/core/src/sidebar/buildSidebarData.ts
@@ -1,4 +1,8 @@
-import { readPrUrls, type WorkspaceMode } from "@posthog/shared";
+import {
+  readPrUrls,
+  type SessionStatus,
+  type WorkspaceMode,
+} from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
 import { getRepositoryInfo } from "./groupTasks";
 import type { TaskData, TaskGroup } from "./sidebarData.types";
@@ -83,7 +87,7 @@ export function filterVisibleTasks(
 }
 
 export interface TaskSession {
-  status?: string;
+  status?: SessionStatus;
   isPromptPending?: boolean;
   pendingPermissions?: { size: number };
   cloudStatus?: TaskRunStatus;

--- a/packages/core/src/sidebar/buildSidebarData.ts
+++ b/packages/core/src/sidebar/buildSidebarData.ts
@@ -83,6 +83,7 @@ export function filterVisibleTasks(
 }
 
 export interface TaskSession {
+  status?: string;
   isPromptPending?: boolean;
   pendingPermissions?: { size: number };
   cloudStatus?: TaskRunStatus;
@@ -105,7 +106,7 @@ export function computeSidebarSessionSignature(
       typeof session.cloudOutput?.pr_url === "string"
         ? session.cloudOutput.pr_url
         : "";
-    signature += `${session.taskId}:${session.isPromptPending ? 1 : 0}:${
+    signature += `${session.taskId}:${session.status ?? ""}:${session.isPromptPending ? 1 : 0}:${
       session.pendingPermissions?.size ?? 0
     }:${session.cloudStatus ?? ""}:${prUrl};`;
   }

--- a/packages/core/src/task-detail/cloudToolChanges.test.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.test.ts
@@ -69,6 +69,24 @@ describe("createCloudEventSummaryTracker", () => {
 
     expect(tracker.update([started, textEvent("hello")])).toBe(first);
   });
+
+  it("retains the changed-files revision for irrelevant streamed content", () => {
+    const tracker = createCloudEventSummaryTracker();
+    const started = toolEvent("tool-1", {
+      title: "Edit file",
+      locations: [{ path: "src/file.ts", line: null }],
+    });
+    const first = tracker.update([started]);
+    const input = toolEvent("tool-1", {
+      content: [
+        { type: "content", content: { type: "text", text: "partial" } },
+      ],
+    });
+
+    const second = tracker.update([started, input]);
+
+    expect(second.changedFilesRevision).toBe(first.changedFilesRevision);
+  });
 });
 
 function diffObj(

--- a/packages/core/src/task-detail/cloudToolChanges.test.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.test.ts
@@ -26,6 +26,23 @@ function toolEvent(
   } as AcpMessage;
 }
 
+function textEvent(text: string): AcpMessage {
+  return {
+    ts: 1,
+    message: {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "run-1",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text },
+        },
+      },
+    },
+  } as AcpMessage;
+}
+
 describe("createCloudEventSummaryTracker", () => {
   it("merges appended tool updates and resets when the transcript is replaced", () => {
     const tracker = createCloudEventSummaryTracker();
@@ -43,6 +60,14 @@ describe("createCloudEventSummaryTracker", () => {
       toolEvent("tool-2", { title: "Write file" }),
     ]);
     expect([...replacement.toolCalls.keys()]).toEqual(["tool-2"]);
+  });
+
+  it("reuses the projected summary when appended events do not change tools", () => {
+    const tracker = createCloudEventSummaryTracker();
+    const started = toolEvent("tool-1", { title: "Edit file" });
+    const first = tracker.update([started]);
+
+    expect(tracker.update([started, textEvent("hello")])).toBe(first);
   });
 });
 

--- a/packages/core/src/task-detail/cloudToolChanges.test.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.test.ts
@@ -1,11 +1,50 @@
+import type { AcpMessage } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
 
 import {
   cachedDiffStats,
+  createCloudEventSummaryTracker,
   extractCloudFileContent,
   extractCloudToolChangedFiles,
   type ParsedToolCall,
 } from "./cloudToolChanges";
+
+function toolEvent(
+  toolCallId: string,
+  update: Record<string, unknown>,
+): AcpMessage {
+  return {
+    ts: 1,
+    message: {
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "run-1",
+        update: { sessionUpdate: "tool_call_update", toolCallId, ...update },
+      },
+    },
+  } as AcpMessage;
+}
+
+describe("createCloudEventSummaryTracker", () => {
+  it("merges appended tool updates and resets when the transcript is replaced", () => {
+    const tracker = createCloudEventSummaryTracker();
+    const started = toolEvent("tool-1", { title: "Edit file" });
+    const completed = toolEvent("tool-1", { status: "completed" });
+
+    tracker.update([started]);
+    const appended = tracker.update([started, completed]);
+    expect(appended.toolCalls.get("tool-1")).toMatchObject({
+      title: "Edit file",
+      status: "completed",
+    });
+
+    const replacement = tracker.update([
+      toolEvent("tool-2", { title: "Write file" }),
+    ]);
+    expect([...replacement.toolCalls.keys()]).toEqual(["tool-2"]);
+  });
+});
 
 function diffObj(
   newText: string,

--- a/packages/core/src/task-detail/cloudToolChanges.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.ts
@@ -8,6 +8,7 @@ import {
   isJsonRpcNotification,
 } from "@posthog/shared";
 import type { ChangedFile } from "@posthog/shared/domain-types";
+import { createAppendOnlyTracker } from "../sessions/appendOnlyTracker";
 
 function getContentText(
   content: ToolCallContent[] | undefined,
@@ -180,6 +181,46 @@ export interface CloudEventSummary {
   toolCalls: Map<string, ParsedToolCall>;
 }
 
+function applyCloudEvent(
+  toolCalls: Map<string, ParsedToolCall>,
+  event: AcpMessage,
+): void {
+  const message = event.message;
+  if (!isJsonRpcNotification(message) || message.method !== "session/update") {
+    return;
+  }
+  const params = message.params as
+    | { update?: Record<string, unknown> }
+    | undefined;
+  const update = params?.update;
+  if (!update || typeof update !== "object") return;
+
+  const sessionUpdate = update.sessionUpdate;
+  if (sessionUpdate !== "tool_call" && sessionUpdate !== "tool_call_update") {
+    return;
+  }
+
+  const toolCallId =
+    typeof update.toolCallId === "string" ? update.toolCallId : undefined;
+  if (!toolCallId) return;
+
+  const patch: Partial<ParsedToolCall> = {
+    toolCallId,
+    kind: typeof update.kind === "string" ? update.kind : null,
+    title: typeof update.title === "string" ? update.title : undefined,
+    status: typeof update.status === "string" ? update.status : null,
+    locations: Array.isArray(update.locations)
+      ? (update.locations as ToolCallLocation[])
+      : undefined,
+    content: Array.isArray(update.content)
+      ? (update.content as ToolCallContent[])
+      : undefined,
+    rawOutput: update.rawOutput,
+  };
+
+  toolCalls.set(toolCallId, mergeToolCall(toolCalls.get(toolCallId), patch));
+}
+
 /**
  * Single-pass extraction of tool calls from events.
  */
@@ -189,48 +230,23 @@ export function buildCloudEventSummary(
   const toolCalls = new Map<string, ParsedToolCall>();
 
   for (const event of events) {
-    const message = event.message;
-    if (!isJsonRpcNotification(message)) continue;
-
-    if (message.method === "session/update") {
-      const params = message.params as
-        | { update?: Record<string, unknown> }
-        | undefined;
-      const update = params?.update;
-      if (!update || typeof update !== "object") continue;
-
-      const sessionUpdate = update.sessionUpdate;
-      if (
-        sessionUpdate !== "tool_call" &&
-        sessionUpdate !== "tool_call_update"
-      ) {
-        continue;
-      }
-
-      const toolCallId =
-        typeof update.toolCallId === "string" ? update.toolCallId : undefined;
-      if (!toolCallId) continue;
-
-      const patch: Partial<ParsedToolCall> = {
-        toolCallId,
-        kind: typeof update.kind === "string" ? update.kind : null,
-        title: typeof update.title === "string" ? update.title : undefined,
-        status: typeof update.status === "string" ? update.status : null,
-        locations: Array.isArray(update.locations)
-          ? (update.locations as ToolCallLocation[])
-          : undefined,
-        content: Array.isArray(update.content)
-          ? (update.content as ToolCallContent[])
-          : undefined,
-        rawOutput: update.rawOutput,
-      };
-
-      const merged = mergeToolCall(toolCalls.get(toolCallId), patch);
-      toolCalls.set(toolCallId, merged);
-    }
+    applyCloudEvent(toolCalls, event);
   }
 
   return { toolCalls };
+}
+
+export function createCloudEventSummaryTracker(): {
+  update(events: AcpMessage[]): CloudEventSummary;
+} {
+  return createAppendOnlyTracker<
+    Map<string, ParsedToolCall>,
+    CloudEventSummary
+  >({
+    init: () => new Map(),
+    processEvent: applyCloudEvent,
+    getResult: (toolCalls) => ({ toolCalls: new Map(toolCalls) }),
+  });
 }
 
 export function extractCloudFileDiff(

--- a/packages/core/src/task-detail/cloudToolChanges.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.ts
@@ -184,25 +184,25 @@ export interface CloudEventSummary {
 function applyCloudEvent(
   toolCalls: Map<string, ParsedToolCall>,
   event: AcpMessage,
-): void {
+): boolean {
   const message = event.message;
   if (!isJsonRpcNotification(message) || message.method !== "session/update") {
-    return;
+    return false;
   }
   const params = message.params as
     | { update?: Record<string, unknown> }
     | undefined;
   const update = params?.update;
-  if (!update || typeof update !== "object") return;
+  if (!update || typeof update !== "object") return false;
 
   const sessionUpdate = update.sessionUpdate;
   if (sessionUpdate !== "tool_call" && sessionUpdate !== "tool_call_update") {
-    return;
+    return false;
   }
 
   const toolCallId =
     typeof update.toolCallId === "string" ? update.toolCallId : undefined;
-  if (!toolCallId) return;
+  if (!toolCallId) return false;
 
   const patch: Partial<ParsedToolCall> = {
     toolCallId,
@@ -219,6 +219,7 @@ function applyCloudEvent(
   };
 
   toolCalls.set(toolCallId, mergeToolCall(toolCalls.get(toolCallId), patch));
+  return true;
 }
 
 /**
@@ -239,13 +240,28 @@ export function buildCloudEventSummary(
 export function createCloudEventSummaryTracker(): {
   update(events: AcpMessage[]): CloudEventSummary;
 } {
-  return createAppendOnlyTracker<
-    Map<string, ParsedToolCall>,
-    CloudEventSummary
-  >({
-    init: () => new Map(),
-    processEvent: applyCloudEvent,
-    getResult: (toolCalls) => ({ toolCalls: new Map(toolCalls) }),
+  interface TrackerState {
+    toolCalls: Map<string, ParsedToolCall>;
+    revision: number;
+  }
+
+  let projectedState: TrackerState | undefined;
+  let projectedRevision = -1;
+  let projectedResult: CloudEventSummary = { toolCalls: new Map() };
+
+  return createAppendOnlyTracker<TrackerState, CloudEventSummary>({
+    init: () => ({ toolCalls: new Map(), revision: 0 }),
+    processEvent: (state, event) => {
+      if (applyCloudEvent(state.toolCalls, event)) state.revision++;
+    },
+    getResult: (state) => {
+      if (state !== projectedState || state.revision !== projectedRevision) {
+        projectedState = state;
+        projectedRevision = state.revision;
+        projectedResult = { toolCalls: new Map(state.toolCalls) };
+      }
+      return projectedResult;
+    },
   });
 }
 

--- a/packages/core/src/task-detail/cloudToolChanges.ts
+++ b/packages/core/src/task-detail/cloudToolChanges.ts
@@ -179,30 +179,50 @@ export function cachedDiffStats(
 
 export interface CloudEventSummary {
   toolCalls: Map<string, ParsedToolCall>;
+  revision: number;
+  changedFilesRevision: number;
+}
+
+function changedFilesKey(toolCall: ParsedToolCall): string {
+  const diff = getDiffContent(toolCall.content);
+  return JSON.stringify({
+    kind: inferKind(toolCall.kind, toolCall.title),
+    failed: toolCall.status === "failed",
+    locations: toolCall.locations?.map((location) => location.path),
+    diff: diff
+      ? {
+          path: diff.path,
+          oldText: diff.oldText,
+          newText: diff.newText,
+        }
+      : undefined,
+  });
 }
 
 function applyCloudEvent(
   toolCalls: Map<string, ParsedToolCall>,
   event: AcpMessage,
-): boolean {
+): { toolChanged: boolean; changedFilesChanged: boolean } {
   const message = event.message;
   if (!isJsonRpcNotification(message) || message.method !== "session/update") {
-    return false;
+    return { toolChanged: false, changedFilesChanged: false };
   }
   const params = message.params as
     | { update?: Record<string, unknown> }
     | undefined;
   const update = params?.update;
-  if (!update || typeof update !== "object") return false;
+  if (!update || typeof update !== "object") {
+    return { toolChanged: false, changedFilesChanged: false };
+  }
 
   const sessionUpdate = update.sessionUpdate;
   if (sessionUpdate !== "tool_call" && sessionUpdate !== "tool_call_update") {
-    return false;
+    return { toolChanged: false, changedFilesChanged: false };
   }
 
   const toolCallId =
     typeof update.toolCallId === "string" ? update.toolCallId : undefined;
-  if (!toolCallId) return false;
+  if (!toolCallId) return { toolChanged: false, changedFilesChanged: false };
 
   const patch: Partial<ParsedToolCall> = {
     toolCallId,
@@ -218,8 +238,14 @@ function applyCloudEvent(
     rawOutput: update.rawOutput,
   };
 
-  toolCalls.set(toolCallId, mergeToolCall(toolCalls.get(toolCallId), patch));
-  return true;
+  const existing = toolCalls.get(toolCallId);
+  const merged = mergeToolCall(existing, patch);
+  toolCalls.set(toolCallId, merged);
+  return {
+    toolChanged: true,
+    changedFilesChanged:
+      !existing || changedFilesKey(existing) !== changedFilesKey(merged),
+  };
 }
 
 /**
@@ -234,7 +260,7 @@ export function buildCloudEventSummary(
     applyCloudEvent(toolCalls, event);
   }
 
-  return { toolCalls };
+  return { toolCalls, revision: 0, changedFilesRevision: 0 };
 }
 
 export function createCloudEventSummaryTracker(): {
@@ -243,22 +269,37 @@ export function createCloudEventSummaryTracker(): {
   interface TrackerState {
     toolCalls: Map<string, ParsedToolCall>;
     revision: number;
+    changedFilesRevision: number;
   }
 
   let projectedState: TrackerState | undefined;
   let projectedRevision = -1;
-  let projectedResult: CloudEventSummary = { toolCalls: new Map() };
+  let projectedResult: CloudEventSummary = {
+    toolCalls: new Map(),
+    revision: 0,
+    changedFilesRevision: 0,
+  };
 
   return createAppendOnlyTracker<TrackerState, CloudEventSummary>({
-    init: () => ({ toolCalls: new Map(), revision: 0 }),
+    init: () => ({
+      toolCalls: new Map(),
+      revision: 0,
+      changedFilesRevision: 0,
+    }),
     processEvent: (state, event) => {
-      if (applyCloudEvent(state.toolCalls, event)) state.revision++;
+      const change = applyCloudEvent(state.toolCalls, event);
+      if (change.toolChanged) state.revision++;
+      if (change.changedFilesChanged) state.changedFilesRevision++;
     },
     getResult: (state) => {
       if (state !== projectedState || state.revision !== projectedRevision) {
         projectedState = state;
         projectedRevision = state.revision;
-        projectedResult = { toolCalls: new Map(state.toolCalls) };
+        projectedResult = {
+          toolCalls: state.toolCalls,
+          revision: state.revision,
+          changedFilesRevision: state.changedFilesRevision,
+        };
       }
       return projectedResult;
     },

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -29,7 +29,7 @@ import {
   useFreeformThread,
 } from "@posthog/ui/features/canvas/stores/freeformChatStore";
 import type { EditorHandle } from "@posthog/ui/features/message-editor/types";
-import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
+import { useSessionSelector } from "@posthog/ui/features/sessions/useSession";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import {
@@ -44,6 +44,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useMemo, useRef, useState } from "react";
+import { shallow } from "zustand/shallow";
 import { CanvasFramePlaceholder } from "./CanvasFramePlaceholder";
 import { CanvasGenerateHero } from "./CanvasGenerateHero";
 import { CanvasPermissionDialog } from "./CanvasPermissionDialog";
@@ -139,7 +140,18 @@ export function FreeformCanvasView({
     enabled: !!effectiveTaskId,
     refetchInterval: effectiveTaskId ? 5000 : false,
   });
-  const genSession = useSessionForTask(effectiveTaskId ?? undefined);
+  const genSession = useSessionSelector(
+    effectiveTaskId ?? undefined,
+    (session) =>
+      session
+        ? {
+            status: session.status,
+            cloudStatus: session.cloudStatus,
+            isPromptPending: session.isPromptPending,
+          }
+        : undefined,
+    shallow,
+  );
   // Whether the run's session is still alive. Drives record polling so a freshly
   // published canvas gets picked up. A local ACP session stays "connected" after
   // its generation prompt finishes, so this keeps syncing until it disconnects.

--- a/packages/ui/src/features/canvas/freeform/useCanvasGenerationToasts.ts
+++ b/packages/ui/src/features/canvas/freeform/useCanvasGenerationToasts.ts
@@ -80,15 +80,23 @@ export function useCanvasGenerationToasts(): void {
     })),
   });
 
-  // The live ACP sessions — for local runs this, not the run record, is what
-  // tells us generation has actually finished.
-  const sessions = useSessionStore((s) => s.sessions);
-  const taskIdIndex = useSessionStore((s) => s.taskIdIndex);
+  // Subscribe only to fields that affect generation state. Transcript appends
+  // must not rerender this persistent root-mounted watcher.
+  const sessionSignature = useSessionStore((state) =>
+    taskIds
+      .map((id) => {
+        const runId = state.taskIdIndex[id];
+        const session = runId ? state.sessions[runId] : undefined;
+        return `${id}:${session?.status ?? ""}:${session?.cloudStatus ?? ""}:${session?.isPromptPending ? 1 : 0}`;
+      })
+      .join("|"),
+  );
+  const sessionState = useSessionStore.getState();
 
   // Compute the "still generating?" signal per tracked task each render.
   const states = taskIds.map((id, i) => {
-    const runId = taskIdIndex[id];
-    const session = runId ? sessions[runId] : undefined;
+    const runId = sessionState.taskIdIndex[id];
+    const session = runId ? sessionState.sessions[runId] : undefined;
     const latestRun = details[i]?.data?.latest_run;
     const generating = isCanvasGenerating({
       genTaskId: id,
@@ -100,12 +108,12 @@ export function useCanvasGenerationToasts(): void {
   });
 
   // A stable signature so the transition effect only runs on real changes.
-  const sig = states
+  const sig = `${sessionSignature}|${states
     .map(
       (s) =>
         `${s.id}:${s.generating ? 1 : 0}:${s.latestRun?.status ?? ""}:${s.session?.status ?? ""}:${s.session?.cloudStatus ?? ""}:${s.session?.isPromptPending ? 1 : 0}`,
     )
-    .join("|");
+    .join("|")}`;
 
   const statesRef = useRef(states);
   statesRef.current = states;

--- a/packages/ui/src/features/canvas/hooks/useChannelTaskData.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelTaskData.ts
@@ -5,12 +5,13 @@ import {
 } from "@posthog/core/sidebar/buildSidebarData";
 import type { TaskData } from "@posthog/core/sidebar/sidebarData.types";
 import type { Task } from "@posthog/shared/domain-types";
-import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
+import { useSessionSelector } from "@posthog/ui/features/sessions/useSession";
 import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import { useSuspendedTaskIds } from "@posthog/ui/features/suspension/useSuspendedTaskIds";
 import { useWorkspace } from "@posthog/ui/features/workspace/useWorkspace";
 import { useMemo } from "react";
+import { shallow } from "zustand/shallow";
 
 const EMPTY_SET: ReadonlySet<string> = new Set();
 const EMPTY_MAP: ReadonlyMap<string, string> = new Map();
@@ -21,7 +22,19 @@ const EMPTY_MAP: ReadonlyMap<string, string> = new Map();
 export function useChannelTaskData(
   task: Task | undefined,
 ): TaskData | undefined {
-  const session = useSessionForTask(task?.id);
+  const session = useSessionSelector(
+    task?.id,
+    (current): TaskSession | undefined =>
+      current
+        ? {
+            isPromptPending: current.isPromptPending,
+            pendingPermissions: current.pendingPermissions,
+            cloudStatus: current.cloudStatus,
+            cloudOutput: current.cloudOutput,
+          }
+        : undefined,
+    shallow,
+  );
   const workspace = useWorkspace(task?.id);
   const { pinnedTaskIds } = usePinnedTasks();
   const suspendedTaskIds = useSuspendedTaskIds();
@@ -31,7 +44,7 @@ export function useChannelTaskData(
     if (!task) return undefined;
     const sidebarTask = narrowFullTask(task);
     return deriveTaskData(sidebarTask, {
-      session: session as TaskSession | undefined,
+      session,
       workspace: workspace ?? undefined,
       timestamp: timestamps[task.id],
       pinnedIds: pinnedTaskIds,

--- a/packages/ui/src/features/command-center/hooks/useCommandCenterData.ts
+++ b/packages/ui/src/features/command-center/hooks/useCommandCenterData.ts
@@ -9,8 +9,7 @@ import {
 } from "@posthog/core/command-center/status";
 import type { Task } from "@posthog/shared/domain-types";
 import { useMemo } from "react";
-import type { AgentSession } from "../../sessions/sessionStore";
-import { useSessions } from "../../sessions/useSession";
+import { useSidebarSessionMap } from "../../sidebar/useSidebarSessionMap";
 import { useTasks } from "../../tasks/useTasks";
 import { useWorkspaces } from "../../workspace/useWorkspace";
 import { useCommandCenterStore } from "../commandCenterStore";
@@ -24,7 +23,7 @@ export function useCommandCenterData(): {
 } {
   const storeCells = useCommandCenterStore((s) => s.cells);
   const { data: tasks = [] } = useTasks();
-  const sessions = useSessions();
+  const sessionByTaskId = useSidebarSessionMap();
   const { data: workspaces } = useWorkspaces();
 
   const taskById = useMemo(() => {
@@ -34,16 +33,6 @@ export function useCommandCenterData(): {
     }
     return map;
   }, [tasks]);
-
-  const sessionByTaskId = useMemo(() => {
-    const map = new Map<string, AgentSession>();
-    for (const session of Object.values(sessions)) {
-      if (session.taskId) {
-        map.set(session.taskId, session);
-      }
-    }
-    return map;
-  }, [sessions]);
 
   const cells = useMemo(
     () =>

--- a/packages/ui/src/features/editor/components/useSmoothedText.test.ts
+++ b/packages/ui/src/features/editor/components/useSmoothedText.test.ts
@@ -115,6 +115,21 @@ describe("useSmoothedText", () => {
     expect(result.current.length).toBe(11);
   });
 
+  it("caps streaming renders at 20 frames per second", () => {
+    const { result, rerender } = renderHook(
+      ({ t }) => useSmoothedText(t, 100),
+      { initialProps: { t: "" } },
+    );
+    rerender({ t: "x".repeat(50) });
+
+    flushFrame(0);
+    expect(result.current.length).toBe(1);
+    flushFrame(16);
+    expect(result.current.length).toBe(1);
+    flushFrame(34);
+    expect(result.current.length).toBe(6);
+  });
+
   it("cancels the pending frame on unmount", () => {
     const { rerender, unmount } = renderHook(
       ({ t }) => useSmoothedText(t, 100),

--- a/packages/ui/src/features/editor/components/useSmoothedText.ts
+++ b/packages/ui/src/features/editor/components/useSmoothedText.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 // one, so the cadence reads as even typing instead of speeding up to clear a
 // backlog. Matches the feel of #2685. See https://upstash.com/blog/smooth-streaming.
 const DEFAULT_CHARS_PER_SECOND = 120;
+const FRAME_INTERVAL_MS = 50;
 // Past this backlog we stop easing and snap, so a large buffered chunk (e.g. a
 // reconnect replaying a long message) never crawls.
 const MAX_LAG_CHARS = 600;
@@ -75,6 +76,13 @@ export function useSmoothedText(
       lastTsRef.current = null;
       const tick = (ts: number) => {
         const last = lastTsRef.current ?? ts;
+        if (
+          lastTsRef.current !== null &&
+          ts - lastTsRef.current < FRAME_INTERVAL_MS
+        ) {
+          rafRef.current = requestAnimationFrame(tick);
+          return;
+        }
         lastTsRef.current = ts;
         shownLenRef.current = nextRevealLength(
           shownLenRef.current,

--- a/packages/ui/src/features/git-interaction/cloudPrUrl.ts
+++ b/packages/ui/src/features/git-interaction/cloudPrUrl.ts
@@ -1,10 +1,11 @@
 import { mergePrUrls, readPrSummaries, readPrUrls } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
-import type { AgentSession } from "@posthog/ui/features/sessions/sessionStore";
+
+type CloudPrSession = { cloudOutput?: Record<string, unknown> | null };
 
 export function resolveCloudPrUrls(
   task: Task | undefined,
-  session: AgentSession | undefined,
+  session: CloudPrSession | undefined,
 ): string[] {
   return mergePrUrls(
     readPrUrls(task?.latest_run?.output),
@@ -14,7 +15,7 @@ export function resolveCloudPrUrls(
 
 export function resolveCloudPrSummaries(
   task: Task | undefined,
-  session: AgentSession | undefined,
+  session: CloudPrSession | undefined,
 ): Record<string, string> {
   return {
     ...readPrSummaries(session?.cloudOutput),
@@ -24,7 +25,7 @@ export function resolveCloudPrSummaries(
 
 export function resolveCloudPrUrl(
   task: Task | undefined,
-  session: AgentSession | undefined,
+  session: CloudPrSession | undefined,
 ): string | null {
   return resolveCloudPrUrls(task, session)[0] ?? null;
 }

--- a/packages/ui/src/features/git-interaction/components/CloudGitInteractionHeader.tsx
+++ b/packages/ui/src/features/git-interaction/components/CloudGitInteractionHeader.tsx
@@ -14,7 +14,7 @@ import { useFeatureFlag } from "../../feature-flags/useFeatureFlag";
 import { DirtyTreeDialog } from "../../sessions/components/DirtyTreeDialog";
 import { HandoffConfirmDialog } from "../../sessions/components/HandoffConfirmDialog";
 import { useHandoffDialogStore } from "../../sessions/handoffDialogStore";
-import { useSessionForTask } from "../../sessions/useSession";
+import { useSessionSelector } from "../../sessions/useSession";
 import {
   GIT_CACHE_KEY_PROVIDER,
   type GitCacheKeyProvider,
@@ -35,7 +35,14 @@ export function CloudGitInteractionHeader({
   taskId,
   task,
 }: CloudGitInteractionHeaderProps) {
-  const session = useSessionForTask(taskId);
+  const inProgress = useSessionSelector(
+    taskId,
+    (session) => session?.handoffInProgress ?? false,
+  );
+  const cloudBranch = useSessionSelector(
+    taskId,
+    (session) => session?.cloudBranch ?? null,
+  );
   const queryClient = useQueryClient();
   const cacheKeyProvider = useService<GitCacheKeyProvider>(
     GIT_CACHE_KEY_PROVIDER,
@@ -112,8 +119,6 @@ export function CloudGitInteractionHeader({
   if (!cloudHandoffEnabled || !localWorkspaces) return null;
   if (task.origin_product === "image_builder") return null;
 
-  const inProgress = session?.handoffInProgress ?? false;
-
   return (
     <>
       <div className="no-drag flex items-center">
@@ -121,9 +126,7 @@ export function CloudGitInteractionHeader({
           variant="outline"
           size="sm"
           disabled={inProgress}
-          onClick={() =>
-            localHandoff.openConfirm(taskId, session?.cloudBranch ?? null)
-          }
+          onClick={() => localHandoff.openConfirm(taskId, cloudBranch)}
         >
           {inProgress ? (
             <Spinner size={14} className="shrink-0 animate-spin" />

--- a/packages/ui/src/features/git-interaction/components/CloudGitInteractionHeader.tsx
+++ b/packages/ui/src/features/git-interaction/components/CloudGitInteractionHeader.tsx
@@ -14,7 +14,10 @@ import { useFeatureFlag } from "../../feature-flags/useFeatureFlag";
 import { DirtyTreeDialog } from "../../sessions/components/DirtyTreeDialog";
 import { HandoffConfirmDialog } from "../../sessions/components/HandoffConfirmDialog";
 import { useHandoffDialogStore } from "../../sessions/handoffDialogStore";
-import { useSessionSelector } from "../../sessions/useSession";
+import {
+  useSessionHandoffInProgress,
+  useSessionSelector,
+} from "../../sessions/useSession";
 import {
   GIT_CACHE_KEY_PROVIDER,
   type GitCacheKeyProvider,
@@ -35,10 +38,7 @@ export function CloudGitInteractionHeader({
   taskId,
   task,
 }: CloudGitInteractionHeaderProps) {
-  const inProgress = useSessionSelector(
-    taskId,
-    (session) => session?.handoffInProgress ?? false,
-  );
+  const inProgress = useSessionHandoffInProgress(taskId);
   const cloudBranch = useSessionSelector(
     taskId,
     (session) => session?.cloudBranch ?? null,

--- a/packages/ui/src/features/git-interaction/useCloudPrUrl.ts
+++ b/packages/ui/src/features/git-interaction/useCloudPrUrl.ts
@@ -1,4 +1,4 @@
-import { useSessionForTask } from "../sessions/useSession";
+import { useSessionSelector } from "../sessions/useSession";
 import { useTasks } from "../tasks/useTasks";
 import {
   resolveCloudPrSummaries,
@@ -16,13 +16,21 @@ export function useCloudPrUrl(taskId: string): string | null {
 export function useCloudPrUrls(taskId: string): string[] {
   const { data: tasks = [] } = useTasks();
   const task = tasks.find((t) => t.id === taskId);
-  const session = useSessionForTask(taskId);
+  const cloudOutput = useSessionSelector(
+    taskId,
+    (session) => session?.cloudOutput,
+  );
+  const session = cloudOutput ? { cloudOutput } : undefined;
   return resolveCloudPrUrls(task, session);
 }
 
 export function useCloudPrSummaries(taskId: string): Record<string, string> {
   const { data: tasks = [] } = useTasks();
   const task = tasks.find((t) => t.id === taskId);
-  const session = useSessionForTask(taskId);
+  const cloudOutput = useSessionSelector(
+    taskId,
+    (session) => session?.cloudOutput,
+  );
+  const session = cloudOutput ? { cloudOutput } : undefined;
   return resolveCloudPrSummaries(task, session);
 }

--- a/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -156,8 +156,8 @@ export function ConversationView({
   // Streaming appends one event per token. The parse is incremental — each
   // event is handled once and completed turns are reused by reference — so per
   // token the work tracks the active turn, not the whole thread. We feed
-  // `events` directly (no frame-throttle) so a sent message's optimistic->real
-  // swap is never delayed past the frame the store commits it.
+  // `events` directly; the controller batches streaming-only updates while
+  // terminal and status events still flush immediately.
   const {
     items: conversationItems,
     lastTurnInfo,

--- a/packages/ui/src/features/sessions/components/EmbeddedSessionView.tsx
+++ b/packages/ui/src/features/sessions/components/EmbeddedSessionView.tsx
@@ -47,7 +47,7 @@ export function EmbeddedSessionView({
     handleRetry,
     handleNewSession,
     handleBashCommand,
-  } = useSessionCallbacks({ taskId, task, session, repoPath });
+  } = useSessionCallbacks({ taskId, task, repoPath });
 
   useEffect(() => {
     requestFocus(taskId);

--- a/packages/ui/src/features/sessions/components/GeneratingIndicator.test.ts
+++ b/packages/ui/src/features/sessions/components/GeneratingIndicator.test.ts
@@ -1,5 +1,10 @@
-import { formatDuration } from "@posthog/ui/features/sessions/components/GeneratingIndicator";
-import { describe, expect, it } from "vitest";
+import {
+  formatDuration,
+  GeneratingIndicator,
+} from "@posthog/ui/features/sessions/components/GeneratingIndicator";
+import { render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { describe, expect, it, vi } from "vitest";
 
 describe("formatDuration", () => {
   it("formats sub-minute durations with configurable precision", () => {
@@ -10,5 +15,19 @@ describe("formatDuration", () => {
   it("preserves minute formatting", () => {
     expect(formatDuration(62_340)).toBe("1m 02s");
     expect(formatDuration(62_340, 1)).toBe("1m 02s");
+  });
+});
+
+describe("GeneratingIndicator", () => {
+  it("shows elapsed time immediately when remounted", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T12:00:30Z"));
+
+    render(
+      createElement(GeneratingIndicator, { startedAt: Date.now() - 30_000 }),
+    );
+
+    expect(screen.getByText(/30s\)/)).toBeInTheDocument();
+    vi.useRealTimers();
   });
 });

--- a/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
+++ b/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
@@ -59,9 +59,11 @@ export function GeneratingIndicator({
 
   useEffect(() => {
     const startTime = startedAt ?? Date.now();
-    const interval = setInterval(() => {
+    const tick = () => {
       setElapsed(Math.max(0, Date.now() - startTime - pausedRef.current));
-    }, 1000);
+    };
+    tick();
+    const interval = setInterval(tick, 1000);
 
     return () => clearInterval(interval);
   }, [startedAt]);

--- a/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
+++ b/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
@@ -61,7 +61,7 @@ export function GeneratingIndicator({
     const startTime = startedAt ?? Date.now();
     const interval = setInterval(() => {
       setElapsed(Math.max(0, Date.now() - startTime - pausedRef.current));
-    }, 100);
+    }, 1000);
 
     return () => clearInterval(interval);
   }, [startedAt]);
@@ -94,7 +94,7 @@ export function GeneratingIndicator({
           className="mx-1 inline-block align-middle text-gray-9"
         />
         <span style={{ fontVariantNumeric: "tabular-nums" }}>
-          {formatDuration(elapsed, 1)})
+          {formatDuration(elapsed, 0)})
         </span>
       </Text>
     </Flex>

--- a/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -133,7 +133,6 @@ export interface ItemBuilder {
    *  reads it after to detect a card being mutated inside an already frozen
    *  (completed) turn, which would otherwise go unseen. */
   lowestTouchedProgressIndex: number;
-  lowestCompletedTurnIndex: number;
   /** Count of tool calls that have reached a terminal status (completed /
    *  failed / cancelled). Increments once per tool call when it first settles.
    *  Drives the generating indicator's status word so it advances on real work
@@ -156,7 +155,6 @@ export function createItemBuilder(): ItemBuilder {
     nextId: () => idCounter++,
     progressCards: new Map(),
     lowestTouchedProgressIndex: Number.POSITIVE_INFINITY,
-    lowestCompletedTurnIndex: Number.POSITIVE_INFINITY,
     completedToolCallCount: 0,
     runStartedRunIds: new Set(),
   };
@@ -610,10 +608,7 @@ function completePromptTurn(
 
 function replaceTurnContextRows(b: ItemBuilder, context: TurnContext): void {
   const visited = new Set<ConversationItem[]>();
-  const replaceRows = (
-    items: ConversationItem[],
-    trackIndex: boolean,
-  ): void => {
+  const replaceRows = (items: ConversationItem[]): void => {
     if (visited.has(items)) return;
     visited.add(items);
     for (let index = 0; index < items.length; index++) {
@@ -621,19 +616,13 @@ function replaceTurnContextRows(b: ItemBuilder, context: TurnContext): void {
       if (item.type !== "session_update") continue;
       if (item.turnContext === context) {
         items[index] = { ...item };
-        if (trackIndex) {
-          b.lowestCompletedTurnIndex = Math.min(
-            b.lowestCompletedTurnIndex,
-            index,
-          );
-        }
       }
       for (const children of item.turnContext.childItems.values()) {
-        replaceRows(children, false);
+        replaceRows(children);
       }
     }
   };
-  replaceRows(b.items, true);
+  replaceRows(b.items);
 }
 
 function handleNotification(
@@ -994,6 +983,7 @@ function pushChildItem(b: ItemBuilder, parentId: string, update: RenderItem) {
     update,
     turnContext: turn.context,
   });
+  reissueToolCallRow(b, parentId);
 }
 
 function appendTextChunkToChildren(
@@ -1032,6 +1022,7 @@ function appendTextChunkToChildren(
         },
       },
     };
+    reissueToolCallRow(b, parentId);
   } else {
     turn.itemCount++;
     children.push({
@@ -1040,7 +1031,44 @@ function appendTextChunkToChildren(
       update: { ...update, content: { ...update.content } },
       turnContext: turn.context,
     });
+    reissueToolCallRow(b, parentId);
   }
+}
+
+function reissueToolCallRow(
+  b: ItemBuilder,
+  toolCallId: string,
+  nextUpdate?: ToolCall,
+): void {
+  const turn = b.currentTurn;
+  if (!turn) return;
+  const current = turn.toolCalls.get(toolCallId);
+  const update = nextUpdate ?? (current ? { ...current } : undefined);
+  if (!update) return;
+  turn.toolCalls.set(toolCallId, update);
+
+  const visited = new Set<ConversationItem[]>();
+  const replace = (items: ConversationItem[]): void => {
+    if (visited.has(items)) return;
+    visited.add(items);
+    for (let index = 0; index < items.length; index++) {
+      const item = items[index];
+      if (item.type !== "session_update") continue;
+      if (
+        item.update.sessionUpdate === "tool_call" &&
+        item.update.toolCallId === toolCallId
+      ) {
+        items[index] = {
+          ...item,
+          update: { ...update, sessionUpdate: "tool_call" },
+        };
+      }
+      for (const children of item.turnContext.childItems.values()) {
+        replace(children);
+      }
+    }
+  };
+  replace(b.items);
 }
 
 function processSessionUpdate(
@@ -1072,8 +1100,9 @@ function processSessionUpdate(
       const existing = turn.toolCalls.get(update.toolCallId);
       if (existing) {
         const wasTerminal = isTerminalToolStatus(existing.status);
-        Object.assign(existing, update);
-        if (!wasTerminal && isTerminalToolStatus(existing.status)) {
+        const merged = { ...existing, ...update };
+        reissueToolCallRow(b, update.toolCallId, merged);
+        if (!wasTerminal && isTerminalToolStatus(merged.status)) {
           b.completedToolCallCount++;
         }
       } else {
@@ -1099,8 +1128,25 @@ function processSessionUpdate(
       if (existing) {
         const wasTerminal = isTerminalToolStatus(existing.status);
         const { sessionUpdate: _, ...rest } = update;
-        Object.assign(existing, rest);
-        if (!wasTerminal && isTerminalToolStatus(existing.status)) {
+        const merged: ToolCall = {
+          ...existing,
+          ...rest,
+          toolCallId: existing.toolCallId,
+          title: rest.title ?? existing.title,
+          content:
+            rest.content === null
+              ? undefined
+              : (rest.content ?? existing.content),
+          kind: rest.kind === null ? undefined : (rest.kind ?? existing.kind),
+          locations:
+            rest.locations === null
+              ? undefined
+              : (rest.locations ?? existing.locations),
+          status:
+            rest.status === null ? undefined : (rest.status ?? existing.status),
+        };
+        reissueToolCallRow(b, update.toolCallId, merged);
+        if (!wasTerminal && isTerminalToolStatus(merged.status)) {
           b.completedToolCallCount++;
         }
       }

--- a/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -133,6 +133,7 @@ export interface ItemBuilder {
    *  reads it after to detect a card being mutated inside an already frozen
    *  (completed) turn, which would otherwise go unseen. */
   lowestTouchedProgressIndex: number;
+  lowestCompletedTurnIndex: number;
   /** Count of tool calls that have reached a terminal status (completed /
    *  failed / cancelled). Increments once per tool call when it first settles.
    *  Drives the generating indicator's status word so it advances on real work
@@ -155,6 +156,7 @@ export function createItemBuilder(): ItemBuilder {
     nextId: () => idCounter++,
     progressCards: new Map(),
     lowestTouchedProgressIndex: Number.POSITIVE_INFINITY,
+    lowestCompletedTurnIndex: Number.POSITIVE_INFINITY,
     completedToolCallCount: 0,
     runStartedRunIds: new Set(),
   };
@@ -582,6 +584,7 @@ function completePromptTurn(
 
   const wasCancelled = turn.stopReason === "cancelled";
   turn.context.turnCancelled = wasCancelled;
+  replaceTurnContextRows(b, turn.context);
 
   if (turn.gitAction.isGitAction && turn.gitAction.actionType) {
     b.items.push({
@@ -603,6 +606,34 @@ function completePromptTurn(
   if (turn.promptId !== -1) {
     b.pendingPrompts.delete(turn.promptId);
   }
+}
+
+function replaceTurnContextRows(b: ItemBuilder, context: TurnContext): void {
+  const visited = new Set<ConversationItem[]>();
+  const replaceRows = (
+    items: ConversationItem[],
+    trackIndex: boolean,
+  ): void => {
+    if (visited.has(items)) return;
+    visited.add(items);
+    for (let index = 0; index < items.length; index++) {
+      const item = items[index];
+      if (item.type !== "session_update") continue;
+      if (item.turnContext === context) {
+        items[index] = { ...item };
+        if (trackIndex) {
+          b.lowestCompletedTurnIndex = Math.min(
+            b.lowestCompletedTurnIndex,
+            index,
+          );
+        }
+      }
+      for (const children of item.turnContext.childItems.values()) {
+        replaceRows(children, false);
+      }
+    }
+  };
+  replaceRows(b.items, true);
 }
 
 function handleNotification(

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThreadGrouping.test.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThreadGrouping.test.ts
@@ -53,4 +53,23 @@ describe("createIncrementalChatRowGrouper", () => {
       { type: "agent_turn", items: [{ id: "x2" }] },
     ]);
   });
+
+  it("replaces an optimistic boundary whose confirmed item has a new id", () => {
+    const grouper = createIncrementalChatRowGrouper();
+    const prefix = [userMessage("u1"), agentMessage("a1")];
+    grouper.update([...prefix, userMessage("optimistic-u2")]);
+
+    expect(
+      grouper.update([
+        ...prefix,
+        userMessage("confirmed-u2"),
+        agentMessage("a2"),
+      ]),
+    ).toMatchObject([
+      { id: "u1" },
+      { type: "agent_turn", items: [{ id: "a1" }] },
+      { id: "confirmed-u2" },
+      { type: "agent_turn", items: [{ id: "a2" }] },
+    ]);
+  });
 });

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThreadGrouping.test.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThreadGrouping.test.ts
@@ -54,6 +54,24 @@ describe("createIncrementalChatRowGrouper", () => {
     ]);
   });
 
+  it("rebuilds when a row inside the retained prefix is replaced in place", () => {
+    // The conversation builder swaps row objects at arbitrary indices (a status
+    // completing, a shell result arriving) — including inside turns the grouper
+    // already cached. The cached rows must not survive such a replacement.
+    const grouper = createIncrementalChatRowGrouper();
+    const u1 = userMessage("u1");
+    const status = agentMessage("s1");
+    const u2 = userMessage("u2");
+    grouper.update([u1, status, u2]);
+
+    const replaced = { ...status };
+    const rows = grouper.update([u1, replaced, u2, agentMessage("a2")]);
+
+    const turn = rows[1];
+    if (turn.type !== "agent_turn") throw new Error("expected an agent turn");
+    expect(turn.items[0]).toBe(replaced);
+  });
+
   it("replaces an optimistic boundary whose confirmed item has a new id", () => {
     const grouper = createIncrementalChatRowGrouper();
     const prefix = [userMessage("u1"), agentMessage("a1")];

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThreadGrouping.test.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThreadGrouping.test.ts
@@ -1,0 +1,56 @@
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { createIncrementalChatRowGrouper } from "@posthog/ui/features/sessions/components/chat-thread/chatRowGrouping";
+import { describe, expect, it } from "vitest";
+
+function userMessage(id: string): ConversationItem {
+  return { type: "user_message", id, content: id, timestamp: 1 };
+}
+
+function agentMessage(id: string): ConversationItem {
+  return {
+    type: "session_update",
+    id,
+    turnContext: {
+      toolCalls: new Map(),
+      childItems: new Map(),
+      turnCancelled: false,
+      turnComplete: false,
+    },
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: id },
+    },
+  };
+}
+
+describe("createIncrementalChatRowGrouper", () => {
+  it("reuses completed turns while rebuilding the active turn", () => {
+    const grouper = createIncrementalChatRowGrouper();
+    const firstItems = [userMessage("u1"), agentMessage("a1")];
+    const first = grouper.update(firstItems);
+    const secondItems = [...firstItems, userMessage("u2"), agentMessage("a2")];
+    const second = grouper.update(secondItems);
+    const third = grouper.update([...secondItems, agentMessage("a3")]);
+
+    expect(second[0]).toBe(first[0]);
+    expect(second[1]).toBe(first[1]);
+    expect(third[0]).toBe(second[0]);
+    expect(third[1]).toBe(second[1]);
+    expect(third.at(-1)).toMatchObject({
+      type: "agent_turn",
+      items: [{ id: "a2" }, { id: "a3" }],
+    });
+  });
+
+  it("fully rebuilds after a non-append replacement", () => {
+    const grouper = createIncrementalChatRowGrouper();
+    grouper.update([userMessage("u1"), agentMessage("a1")]);
+
+    expect(
+      grouper.update([userMessage("x1"), agentMessage("x2")]),
+    ).toMatchObject([
+      { id: "x1" },
+      { type: "agent_turn", items: [{ id: "x2" }] },
+    ]);
+  });
+});

--- a/packages/ui/src/features/sessions/components/chat-thread/chatRowGrouping.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/chatRowGrouping.ts
@@ -1,10 +1,9 @@
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
-import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
-
-export type ThreadItem = ConversationItem | ToolGroupItem;
-export type AgentTurn = { type: "agent_turn"; id: string; items: ThreadItem[] };
-
-export type TurnRow = ThreadItem | AgentTurn;
+import type {
+  ThreadItem,
+  TurnRow,
+} from "@posthog/ui/features/sessions/components/chat-thread/threadVirtualization";
+import { isUserInitiatedConversationItem } from "@posthog/ui/features/sessions/components/isUserInitiatedConversationItem";
 
 type SessionUpdateItem = Extract<ConversationItem, { type: "session_update" }>;
 
@@ -76,11 +75,7 @@ function groupIntoTurns(rows: ThreadItem[]): TurnRow[] {
     }
   };
   for (const row of rows) {
-    if (
-      row.type === "user_message" ||
-      row.type === "git_action" ||
-      row.type === "skill_button_action"
-    ) {
+    if (isUserInitiatedConversationItem(row)) {
       flush();
       out.push(row);
     } else {
@@ -101,12 +96,7 @@ export function createIncrementalChatRowGrouper() {
 
       let rebuildStart = 0;
       for (let index = items.length - 1; index >= 0; index--) {
-        const item = items[index];
-        if (
-          item.type === "user_message" ||
-          item.type === "git_action" ||
-          item.type === "skill_button_action"
-        ) {
+        if (isUserInitiatedConversationItem(items[index])) {
           rebuildStart = index;
           break;
         }

--- a/packages/ui/src/features/sessions/components/chat-thread/chatRowGrouping.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/chatRowGrouping.ts
@@ -112,10 +112,15 @@ export function createIncrementalChatRowGrouper() {
         }
       }
 
-      const prefixUnchanged =
-        rebuildStart === 0 ||
-        cachedItems[rebuildStart - 1] === items[rebuildStart - 1];
-      if (!prefixUnchanged) rebuildStart = 0;
+      // The builder replaces rows in place anywhere in the list (a status
+      // completing, a shell result arriving, a thought settling), so every
+      // retained item must be identity-checked — pointer compares, cheap.
+      for (let i = 0; i < rebuildStart; i++) {
+        if (cachedItems[i] !== items[i]) {
+          rebuildStart = 0;
+          break;
+        }
+      }
 
       let boundaryId = items[rebuildStart]?.id;
       let cachedBoundaryIndex = boundaryId

--- a/packages/ui/src/features/sessions/components/chat-thread/chatRowGrouping.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/chatRowGrouping.ts
@@ -1,0 +1,138 @@
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
+
+export type ThreadItem = ConversationItem | ToolGroupItem;
+export type AgentTurn = { type: "agent_turn"; id: string; items: ThreadItem[] };
+
+export type TurnRow = ThreadItem | AgentTurn;
+
+type SessionUpdateItem = Extract<ConversationItem, { type: "session_update" }>;
+
+function isToolCallItem(item: ConversationItem): item is SessionUpdateItem {
+  return (
+    item.type === "session_update" && item.update.sessionUpdate === "tool_call"
+  );
+}
+
+const INVISIBLE_UPDATES = new Set([
+  "user_message_chunk",
+  "tool_call_update",
+  "plan",
+  "available_commands_update",
+  "config_option_update",
+]);
+
+function isInvisibleItem(item: ConversationItem): boolean {
+  if (item.type !== "session_update") return false;
+  const update = item.update;
+  if (INVISIBLE_UPDATES.has(update.sessionUpdate)) return true;
+  if (
+    update.sessionUpdate === "agent_message_chunk" ||
+    update.sessionUpdate === "agent_thought_chunk"
+  ) {
+    return update.content.type !== "text" || update.content.text.trim() === "";
+  }
+  return false;
+}
+
+function groupToolRuns(items: ConversationItem[]): ThreadItem[] {
+  const out: ThreadItem[] = [];
+  let buffer: ConversationItem[] = [];
+  let toolCount = 0;
+
+  const flush = () => {
+    if (toolCount >= 2) {
+      const tools = buffer.filter(isToolCallItem);
+      out.push({ type: "tool_group", id: tools[0].id, tools });
+    } else {
+      out.push(...buffer);
+    }
+    buffer = [];
+    toolCount = 0;
+  };
+
+  for (const item of items) {
+    if (isToolCallItem(item)) {
+      buffer.push(item);
+      toolCount++;
+    } else if (isInvisibleItem(item)) {
+      buffer.push(item);
+    } else {
+      flush();
+      out.push(item);
+    }
+  }
+  flush();
+  return out;
+}
+
+function groupIntoTurns(rows: ThreadItem[]): TurnRow[] {
+  const out: TurnRow[] = [];
+  let buffer: ThreadItem[] = [];
+  const flush = () => {
+    if (buffer.length > 0) {
+      out.push({ type: "agent_turn", id: buffer[0].id, items: buffer });
+      buffer = [];
+    }
+  };
+  for (const row of rows) {
+    if (
+      row.type === "user_message" ||
+      row.type === "git_action" ||
+      row.type === "skill_button_action"
+    ) {
+      flush();
+      out.push(row);
+    } else {
+      buffer.push(row);
+    }
+  }
+  flush();
+  return out;
+}
+
+export function createIncrementalChatRowGrouper() {
+  let cachedItems: ConversationItem[] = [];
+  let cachedRows: TurnRow[] = [];
+
+  return {
+    update(items: ConversationItem[]): TurnRow[] {
+      if (items === cachedItems) return cachedRows;
+
+      let rebuildStart = 0;
+      for (let index = items.length - 1; index >= 0; index--) {
+        const item = items[index];
+        if (
+          item.type === "user_message" ||
+          item.type === "git_action" ||
+          item.type === "skill_button_action"
+        ) {
+          rebuildStart = index;
+          break;
+        }
+      }
+
+      const prefixUnchanged =
+        rebuildStart === 0 ||
+        cachedItems[rebuildStart - 1] === items[rebuildStart - 1];
+      if (!prefixUnchanged) rebuildStart = 0;
+
+      const boundaryId = items[rebuildStart]?.id;
+      const cachedBoundaryIndex = boundaryId
+        ? cachedRows.findIndex((row) => row.id === boundaryId)
+        : -1;
+      const prefixRowCount =
+        rebuildStart === 0
+          ? 0
+          : cachedBoundaryIndex >= 0
+            ? cachedBoundaryIndex
+            : cachedRows.length;
+      const suffixRows = groupIntoTurns(
+        groupToolRuns(items.slice(rebuildStart)),
+      );
+      cachedItems = items;
+      cachedRows = [...cachedRows.slice(0, prefixRowCount), ...suffixRows];
+      return cachedRows;
+    },
+  };
+}

--- a/packages/ui/src/features/sessions/components/chat-thread/chatRowGrouping.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/chatRowGrouping.ts
@@ -117,10 +117,21 @@ export function createIncrementalChatRowGrouper() {
         cachedItems[rebuildStart - 1] === items[rebuildStart - 1];
       if (!prefixUnchanged) rebuildStart = 0;
 
-      const boundaryId = items[rebuildStart]?.id;
-      const cachedBoundaryIndex = boundaryId
+      let boundaryId = items[rebuildStart]?.id;
+      let cachedBoundaryIndex = boundaryId
         ? cachedRows.findIndex((row) => row.id === boundaryId)
         : -1;
+      if (
+        rebuildStart > 0 &&
+        rebuildStart < cachedItems.length &&
+        cachedBoundaryIndex < 0
+      ) {
+        rebuildStart = 0;
+        boundaryId = items[0]?.id;
+        cachedBoundaryIndex = boundaryId
+          ? cachedRows.findIndex((row) => row.id === boundaryId)
+          : -1;
+      }
       const prefixRowCount =
         rebuildStart === 0
           ? 0

--- a/packages/ui/src/features/sessions/components/incrementalConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/incrementalConversationItems.test.ts
@@ -569,6 +569,32 @@ describe("createIncrementalConversationBuilder", () => {
     expect(thought2).not.toBe(thought1);
   });
 
+  it("settles an older turn's thought after a newer turn starts", () => {
+    const inc = createIncrementalConversationBuilder();
+    const beforeCompletion = [
+      userPromptMsg(1, 1, "first"),
+      thoughtChunk(2, "hmm"),
+      userPromptMsg(3, 2, "second"),
+      agentChunk(4, "working"),
+    ];
+    inc.update(beforeCompletion, true);
+
+    const result = inc.update(
+      [...beforeCompletion, promptResponseMsg(5, 1, "cancelled")],
+      true,
+    );
+    const thought = result.items.find(
+      (item) =>
+        item.type === "session_update" &&
+        item.update.sessionUpdate === "agent_thought_chunk",
+    );
+
+    if (thought?.type !== "session_update") {
+      throw new Error("expected thought row");
+    }
+    expect(thought.thoughtComplete).toBe(true);
+  });
+
   it("groups canonical PostHog child metadata under its subagent", () => {
     const inc = createIncrementalConversationBuilder();
     const messages = [

--- a/packages/ui/src/features/sessions/components/incrementalConversationItems.test.ts
+++ b/packages/ui/src/features/sessions/components/incrementalConversationItems.test.ts
@@ -492,31 +492,32 @@ describe("createIncrementalConversationBuilder", () => {
     }
   });
 
-  it("gives the active turn a fresh toolCalls Map identity each call so an in-place tool update re-renders", () => {
-    // SessionUpdateView is memoized on `turnContext.toolCalls`, and tool_call_update
-    // mutates the tool entry in place. If the Map reference is reused across calls
-    // the memo bails and the completed status (and streamed output) stay hidden
-    // until the turn ends. Guard that the Map identity changes every event.
+  it("replaces the tool row's update object when a tool_call_update lands so its memoized view re-renders", () => {
+    // Memoized rows compare the row's `update` object; a tool_call_update must
+    // surface as a fresh object carrying the merged state, or the completed
+    // status (and streamed output) stay hidden until the turn ends.
     const inc = createIncrementalConversationBuilder();
     const base = [userPromptMsg(1, 1, "go"), toolCallMsg(2, "t1")];
     const r1 = inc.update(base, true);
     const next = [...base, toolUpdateMsg(3, "t1", { status: "completed" })];
     const r2 = inc.update(next, true);
 
-    const ctx1 = r1.items.find((i) => i.type === "session_update");
-    const ctx2 = r2.items.find((i) => i.type === "session_update");
-    if (ctx1?.type !== "session_update" || ctx2?.type !== "session_update") {
+    const row1 = r1.items.find((i) => i.type === "session_update");
+    const row2 = r2.items.find((i) => i.type === "session_update");
+    if (row1?.type !== "session_update" || row2?.type !== "session_update") {
       throw new Error("expected tool-call session_update rows");
     }
-    expect(ctx2.turnContext.toolCalls).not.toBe(ctx1.turnContext.toolCalls);
-    expect(ctx2.turnContext.childItems).not.toBe(ctx1.turnContext.childItems);
+    expect(row2.update).not.toBe(row1.update);
+    expect((row2.update as { status?: string }).status).toBe("completed");
+    // The shared toolCalls Map holds the merged entry the view resolves.
+    expect(row2.turnContext.toolCalls.get("t1")?.status).toBe("completed");
   });
 
   it("surfaces a running agent's child tool calls live, before the turn completes", () => {
     // A subagent appends child tool calls (parentToolCallId) while it runs. The
-    // parent row is memoized on `turnContext.childItems`; without a fresh Map ref
-    // the new children stay invisible until turn end. Guard that a child appended
-    // mid-turn changes the childItems Map identity and is present.
+    // parent row renders them, so the parent's update object must be re-issued
+    // when a child arrives — otherwise its memoized view bails and the new
+    // children stay invisible until turn end.
     const inc = createIncrementalConversationBuilder();
     const base = [
       userPromptMsg(1, 1, "go"),
@@ -533,9 +534,39 @@ describe("createIncrementalConversationBuilder", () => {
     if (row1?.type !== "session_update" || row2?.type !== "session_update") {
       throw new Error("expected agent session_update rows");
     }
-    // New child arrived mid-turn: fresh Map identity so the memoized parent re-renders.
-    expect(row2.turnContext.childItems).not.toBe(row1.turnContext.childItems);
+    // New child arrived mid-turn: fresh parent update so the memoized row re-renders.
+    expect(row2).not.toBe(row1);
+    expect(row2.update).not.toBe(row1.update);
     expect(row2.turnContext.childItems.get("agent1")?.length).toBe(1);
+  });
+
+  it("re-issues a thought row's identity when its turn completes in the same batch a new turn starts", () => {
+    // The settled thought then sits before the next turn's boundary, where
+    // row caches retain by identity — only a fresh object surfaces the flip.
+    const inc = createIncrementalConversationBuilder();
+    const base = [userPromptMsg(1, 1, "go"), thoughtChunk(2, "hmm")];
+    const r1 = inc.update(base, true);
+    const next = [
+      ...base,
+      promptResponseMsg(3, 1),
+      userPromptMsg(4, 2, "next"),
+    ];
+    const r2 = inc.update(next, true);
+
+    const isThought = (i: ConversationItem) =>
+      i.type === "session_update" &&
+      i.update.sessionUpdate === "agent_thought_chunk";
+    const thought1 = r1.items.find(isThought);
+    const thought2 = r2.items.find(isThought);
+    if (
+      thought1?.type !== "session_update" ||
+      thought2?.type !== "session_update"
+    ) {
+      throw new Error("expected thought rows");
+    }
+    expect(thought1.thoughtComplete).toBe(false);
+    expect(thought2.thoughtComplete).toBe(true);
+    expect(thought2).not.toBe(thought1);
   });
 
   it("groups canonical PostHog child metadata under its subagent", () => {

--- a/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
@@ -110,6 +110,7 @@ export function createIncrementalConversationBuilder() {
 
     const builder = b as ItemBuilder;
     builder.lowestTouchedProgressIndex = Number.POSITIVE_INFINITY;
+    builder.lowestCompletedTurnIndex = Number.POSITIVE_INFINITY;
     // Thought completion can only change from the turn that was active when
     // this batch started (a turn completed by the batch settles its thoughts
     // on this call, before the index moves to a newer turn).
@@ -145,7 +146,11 @@ export function createIncrementalConversationBuilder() {
 
     markThoughtCompletion(
       builder.items,
-      Math.min(thoughtScanStart, builder.currentTurnStartIndex),
+      Math.min(
+        thoughtScanStart,
+        builder.currentTurnStartIndex,
+        builder.lowestCompletedTurnIndex,
+      ),
     );
 
     // Rows keep their identity across calls — the builder replaces a row

--- a/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
@@ -3,14 +3,12 @@ import {
   type BuildConversationOptions,
   type BuildResult,
   buildConversationItems,
-  type ConversationItem,
   createItemBuilder,
   finalizeBuilder,
   type ItemBuilder,
   markThoughtCompletion,
   processEvent,
   readLastTurnInfo,
-  type TurnContext,
 } from "./buildConversationItems";
 
 /**
@@ -112,6 +110,10 @@ export function createIncrementalConversationBuilder() {
 
     const builder = b as ItemBuilder;
     builder.lowestTouchedProgressIndex = Number.POSITIVE_INFINITY;
+    // Thought completion can only change from the turn that was active when
+    // this batch started (a turn completed by the batch settles its thoughts
+    // on this call, before the index moves to a newer turn).
+    const thoughtScanStart = builder.currentTurnStartIndex;
     for (let i = processedCount; i < events.length; i++) {
       processEvent(builder, events[i], options);
     }
@@ -141,10 +143,18 @@ export function createIncrementalConversationBuilder() {
       turn.context.turnComplete = true;
     }
 
-    markThoughtCompletion(builder.items);
+    markThoughtCompletion(
+      builder.items,
+      Math.min(thoughtScanStart, builder.currentTurnStartIndex),
+    );
 
+    // Rows keep their identity across calls — the builder replaces a row
+    // object whenever its content changes (tool merges, child streams,
+    // progress cards), so memoized views re-render exactly the changed rows.
+    // Turn flags and `thoughtComplete` are surfaced as value props by the
+    // renderers, not via row identity.
     return {
-      items: assembleItems(builder, activeStart),
+      items: builder.items.slice(),
       lastTurnInfo: readLastTurnInfoForOutput(builder),
       isCompacting: builder.isCompacting,
       completedToolCallCount: builder.completedToolCallCount,
@@ -152,50 +162,6 @@ export function createIncrementalConversationBuilder() {
   }
 
   return { update, reset };
-}
-
-function assembleItems(
-  b: ItemBuilder,
-  activeStart: number,
-): ConversationItem[] {
-  // Completed turns: reuse the builder's own objects. They aren't rebuilt
-  // across calls, so their identity is stable and memoized rows skip work.
-  const out = b.items.slice(0, activeStart);
-  if (activeStart >= b.items.length) return out;
-
-  const turn = b.currentTurn;
-  // The active turn streams: clone its rows onto a fresh shared context each
-  // call so their memoized views re-render and read the latest tool/child
-  // state — matching the all-new-objects behavior a full rebuild gives the
-  // live turn. Non-update rows (the user message, git actions) never change,
-  // so pass them through by reference.
-  const activeContext: TurnContext | null = turn
-    ? {
-        toolCalls: new Map(turn.context.toolCalls),
-        childItems: new Map(turn.context.childItems),
-        turnCancelled: turn.context.turnCancelled,
-        turnComplete: turn.context.turnComplete,
-      }
-    : null;
-
-  for (let i = activeStart; i < b.items.length; i++) {
-    const item = b.items[i];
-    // Only rows of the active turn get the fresh context. A prompt can open
-    // its turn *before* a trailing progress card from the previous turn (see
-    // `handlePromptRequest`), so the active range may hold older-turn rows —
-    // those keep their own (frozen) context, matching a full rebuild.
-    if (
-      item.type === "session_update" &&
-      activeContext &&
-      turn &&
-      item.turnContext === turn.context
-    ) {
-      out.push({ ...item, turnContext: activeContext });
-    } else {
-      out.push(item);
-    }
-  }
-  return out;
 }
 
 function readLastTurnInfoForOutput(b: ItemBuilder) {

--- a/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
+++ b/packages/ui/src/features/sessions/components/incrementalConversationItems.ts
@@ -110,11 +110,6 @@ export function createIncrementalConversationBuilder() {
 
     const builder = b as ItemBuilder;
     builder.lowestTouchedProgressIndex = Number.POSITIVE_INFINITY;
-    builder.lowestCompletedTurnIndex = Number.POSITIVE_INFINITY;
-    // Thought completion can only change from the turn that was active when
-    // this batch started (a turn completed by the batch settles its thoughts
-    // on this call, before the index moves to a newer turn).
-    const thoughtScanStart = builder.currentTurnStartIndex;
     for (let i = processedCount; i < events.length; i++) {
       processEvent(builder, events[i], options);
     }
@@ -144,14 +139,7 @@ export function createIncrementalConversationBuilder() {
       turn.context.turnComplete = true;
     }
 
-    markThoughtCompletion(
-      builder.items,
-      Math.min(
-        thoughtScanStart,
-        builder.currentTurnStartIndex,
-        builder.lowestCompletedTurnIndex,
-      ),
-    );
+    markThoughtCompletion(builder.items);
 
     // Rows keep their identity across calls — the builder replaces a row
     // object whenever its content changes (tool merges, child streams,

--- a/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
@@ -198,7 +198,7 @@ function RetryingStatusView({
       setRemainingMs(Math.max(0, delayMs - (Date.now() - start)));
     };
     tick();
-    const interval = setInterval(tick, 100);
+    const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
   }, [delayMs, startedAt]);
 
@@ -240,7 +240,7 @@ function CompactingStatusView({ startedAt }: { startedAt?: number }) {
     const start = startedAt ?? Date.now();
     const tick = () => setElapsed(Date.now() - start);
     tick();
-    const interval = setInterval(tick, 100);
+    const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
   }, [startedAt]);
 
@@ -252,7 +252,7 @@ function CompactingStatusView({ startedAt }: { startedAt?: number }) {
           Compacting conversation history...
         </Text>
         <Text className="text-[13px] text-gray-10 tabular-nums">
-          {formatDuration(elapsed, 1)}
+          {formatDuration(elapsed, 0)}
         </Text>
       </Flex>
       {/* Decorative: the spinner and the text above carry the accessible status. */}

--- a/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/SubagentToolView.tsx
@@ -54,6 +54,7 @@ export function SubagentToolView({
             childItems={turnContext.childItems}
             turnCancelled={turnContext.turnCancelled}
             turnComplete={turnContext.turnComplete}
+            thoughtComplete={child.thoughtComplete}
           />
         ) : null,
       )

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
@@ -1,4 +1,5 @@
 import type { Schemas } from "@posthog/api-client";
+import { createAppendOnlyTracker } from "@posthog/core/sessions/appendOnlyTracker";
 import {
   canApplyTitleFromPrompts,
   decideTitleGeneration,
@@ -28,9 +29,19 @@ import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { logger } from "@posthog/ui/shell/logger";
 import { titleAttachmentStoreApi } from "@posthog/ui/shell/titleAttachmentStore";
 import { type QueryClient, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 const log = logger.scope("chat-title-generator");
+
+function createPromptCountTracker() {
+  return createAppendOnlyTracker<{ count: number }, number>({
+    init: () => ({ count: 0 }),
+    processEvent: (state, event) => {
+      state.count += extractUserPromptsFromEvents([event]).length;
+    },
+    getResult: (state) => state.count,
+  });
+}
 
 function getCachedTask(
   queryClient: QueryClient,
@@ -55,13 +66,19 @@ export function useChatTitleGenerator(task: Task): void {
     (state) => state.status === "authenticated" && !!state.cloudRegion,
   );
 
-  const promptCount = useSessionStore((state) => {
+  const events = useSessionStore((state) => {
     const taskRunId = state.taskIdIndex[taskId];
-    if (!taskRunId) return 0;
-    const session = state.sessions[taskRunId];
-    if (!session?.events) return 0;
-    return extractUserPromptsFromEvents(session.events).length;
+    return taskRunId ? state.sessions[taskRunId]?.events : undefined;
   });
+  const promptCountTrackerRef = useRef<ReturnType<
+    typeof createPromptCountTracker
+  > | null>(null);
+  promptCountTrackerRef.current ??= createPromptCountTracker();
+  const promptCountTracker = promptCountTrackerRef.current;
+  const promptCount = useMemo(
+    () => (events ? promptCountTracker.update(events) : 0),
+    [events, promptCountTracker],
+  );
 
   useEffect(() => {
     if (!isAuthenticated || (task.created_by && !currentUser)) return;

--- a/packages/ui/src/features/sessions/hooks/useSessionCallbacks.test.tsx
+++ b/packages/ui/src/features/sessions/hooks/useSessionCallbacks.test.tsx
@@ -87,7 +87,6 @@ function renderCallbacks() {
     useSessionCallbacks({
       taskId: TASK,
       task,
-      session: undefined,
       repoPath: "/repo",
     }),
   );

--- a/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
+++ b/packages/ui/src/features/sessions/hooks/useSessionCallbacks.ts
@@ -21,10 +21,7 @@ import {
 } from "@posthog/ui/features/message-editor/commands";
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
 import { useMessagingMode } from "@posthog/ui/features/sessions/hooks/useMessagingMode";
-import {
-  type AgentSession,
-  sessionStoreSetters,
-} from "@posthog/ui/features/sessions/sessionStore";
+import { sessionStoreSetters } from "@posthog/ui/features/sessions/sessionStore";
 import { useTaskViewed } from "@posthog/ui/features/sidebar/useTaskViewed";
 import {
   SHELL_CLIENT,
@@ -33,21 +30,19 @@ import {
 import { toast } from "@posthog/ui/primitives/toast";
 import { getAppViewSnapshot } from "@posthog/ui/router/useAppView";
 import { logger } from "@posthog/ui/shell/logger";
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 
 const log = logger.scope("session-callbacks");
 
 interface UseSessionCallbacksOptions {
   taskId: string;
   task: Task;
-  session: AgentSession | undefined;
   repoPath: string | null;
 }
 
 export function useSessionCallbacks({
   taskId,
   task,
-  session,
   repoPath,
 }: UseSessionCallbacksOptions) {
   const sessionService = useService<SessionService>(SESSION_SERVICE);
@@ -56,14 +51,11 @@ export function useSessionCallbacks({
   const { markActivity, markAsViewed } = useTaskViewed();
   const { requestFocus, setPendingContent } = useDraftStore((s) => s.actions);
 
-  const sessionRef = useRef(session);
-  sessionRef.current = session;
-
   const messagingMode = useMessagingMode(taskId);
 
   const handleSendPrompt = useCallback(
     async (text: string): Promise<boolean> => {
-      const currentSession = sessionRef.current;
+      const currentSession = sessionStoreSetters.getSessionByTaskId(taskId);
       const currentEvents = currentSession?.events ?? [];
       const handled = await tryExecuteCodeCommand(text, {
         taskId,
@@ -173,6 +165,7 @@ export function useSessionCallbacks({
     // composer would clobber the in-progress edit. The edit hold keeps the
     // queue from auto-sending until the edit is saved or cancelled.
     const currentSession = sessionStoreSetters.getSessionByTaskId(taskId);
+    const isCloud = currentSession?.isCloud ?? false;
     const editingId = currentSession?.editingQueuedId;
     if (
       editingId &&
@@ -188,12 +181,12 @@ export function useSessionCallbacks({
     const result = await sessionService.cancelPrompt(taskId);
     log.info("Prompt cancelled", { success: result });
 
-    const queuedPrompt = sessionRef.current?.isCloud
+    const queuedPrompt = isCloud
       ? combineQueuedCloudPrompts(queuedMessages)
       : queuedMessages.map((message) => message.content).join("\n\n");
 
     if (queuedPrompt) {
-      const pendingContent = sessionRef.current?.isCloud
+      const pendingContent = isCloud
         ? promptToQueuedEditorContent(queuedPrompt)
         : textToContent(typeof queuedPrompt === "string" ? queuedPrompt : "");
 
@@ -204,7 +197,7 @@ export function useSessionCallbacks({
 
   const handleRetry = useCallback(async () => {
     try {
-      if (sessionRef.current?.isCloud) {
+      if (sessionStoreSetters.getSessionByTaskId(taskId)?.isCloud) {
         await sessionService.retryCloudTaskWatch(taskId);
         return;
       }

--- a/packages/ui/src/features/task-detail/components/TaskHeaderActions.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskHeaderActions.tsx
@@ -17,7 +17,8 @@ import { HandoffConfirmDialog } from "@posthog/ui/features/sessions/components/H
 import { StopCloudRunButton } from "@posthog/ui/features/sessions/components/StopCloudRunButton";
 import { useHandoffDialogStore } from "@posthog/ui/features/sessions/handoffDialogStore";
 import { useSessionCallbacks } from "@posthog/ui/features/sessions/hooks/useSessionCallbacks";
-import { useSessionForTask } from "@posthog/ui/features/sessions/useSession";
+import { useSessionHandoffInProgress } from "@posthog/ui/features/sessions/useSession";
+import { SkillButtonsMenu } from "@posthog/ui/features/skill-buttons/components/SkillButtonsMenu";
 import {
   useWorkspace,
   useWorkspaceLoaded,
@@ -29,7 +30,7 @@ import { useState } from "react";
 const CLOUD_HANDOFF_FLAG = "phc-cloud-handoff";
 
 function LocalHandoffButton({ taskId, task }: { taskId: string; task: Task }) {
-  const session = useSessionForTask(taskId);
+  const inProgress = useSessionHandoffInProgress(taskId);
   const workspace = useWorkspace(taskId);
   const repoPath = workspace?.folderPath ?? null;
   const authStatus = useAuthStateValue((s) => s.status);
@@ -38,7 +39,6 @@ function LocalHandoffButton({ taskId, task }: { taskId: string; task: Task }) {
   const { initiateHandoffToCloud } = useSessionCallbacks({
     taskId,
     task,
-    session: session ?? undefined,
     repoPath,
   });
 
@@ -65,8 +65,6 @@ function LocalHandoffButton({ taskId, task }: { taskId: string; task: Task }) {
       setIsSubmitting(false);
     }
   };
-
-  const inProgress = session?.handoffInProgress ?? false;
 
   return (
     <>

--- a/packages/ui/src/features/task-detail/components/TaskLogsPanel.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskLogsPanel.tsx
@@ -85,7 +85,7 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
     handleRetry,
     handleNewSession,
     handleBashCommand,
-  } = useSessionCallbacks({ taskId, task, session, repoPath });
+  } = useSessionCallbacks({ taskId, task, repoPath });
 
   const { handleBeforeSubmit, dialogProps } = useBranchMismatchDialog({
     taskId,

--- a/packages/ui/src/features/task-detail/hooks/useCloudEventSummary.ts
+++ b/packages/ui/src/features/task-detail/hooks/useCloudEventSummary.ts
@@ -7,6 +7,8 @@ import { useSessionSelector } from "../../sessions/useSession";
 
 const EMPTY_SUMMARY: CloudEventSummary = {
   toolCalls: new Map(),
+  revision: 0,
+  changedFilesRevision: 0,
 };
 
 export function useCloudEventSummary(

--- a/packages/ui/src/features/task-detail/hooks/useCloudEventSummary.ts
+++ b/packages/ui/src/features/task-detail/hooks/useCloudEventSummary.ts
@@ -1,9 +1,9 @@
 import {
-  buildCloudEventSummary,
   type CloudEventSummary,
+  createCloudEventSummaryTracker,
 } from "@posthog/core/task-detail/cloudToolChanges";
-import { useMemo } from "react";
-import { useSessionForTask } from "../../sessions/useSession";
+import { useMemo, useRef } from "react";
+import { useSessionSelector } from "../../sessions/useSession";
 
 const EMPTY_SUMMARY: CloudEventSummary = {
   toolCalls: new Map(),
@@ -13,10 +13,17 @@ export function useCloudEventSummary(
   taskId: string,
   enabled = true,
 ): CloudEventSummary {
-  const session = useSessionForTask(enabled ? taskId : undefined);
-  const events = session?.events;
+  const events = useSessionSelector(
+    enabled ? taskId : undefined,
+    (session) => session?.events,
+  );
+  const trackerRef = useRef<ReturnType<
+    typeof createCloudEventSummaryTracker
+  > | null>(null);
+  trackerRef.current ??= createCloudEventSummaryTracker();
+  const tracker = trackerRef.current;
   return useMemo(
-    () => (events ? buildCloudEventSummary(events) : EMPTY_SUMMARY),
-    [events],
+    () => (events ? tracker.update(events) : EMPTY_SUMMARY),
+    [events, tracker],
   );
 }

--- a/packages/ui/src/features/task-detail/hooks/useCloudRunState.ts
+++ b/packages/ui/src/features/task-detail/hooks/useCloudRunState.ts
@@ -2,8 +2,9 @@ import { deriveCloudRunState } from "@posthog/core/task-detail/cloudRunState";
 import { extractCloudToolChangedFiles } from "@posthog/core/task-detail/cloudToolChanges";
 import type { Task } from "@posthog/shared/domain-types";
 import { useMemo } from "react";
+import { shallow } from "zustand/shallow";
 import { resolveCloudPrUrl } from "../../git-interaction/cloudPrUrl";
-import { useSessionForTask } from "../../sessions/useSession";
+import { useSessionSelector } from "../../sessions/useSession";
 import { pickFreshestTask } from "../../tasks/taskFreshness";
 import { useTasks } from "../../tasks/useTasks";
 import { useCloudEventSummary } from "./useCloudEventSummary";
@@ -19,7 +20,19 @@ export function useCloudRunState(taskId: string, task: Task) {
     [task, taskId, tasks],
   );
 
-  const session = useSessionForTask(taskId);
+  const session = useSessionSelector(
+    taskId,
+    (current) =>
+      current
+        ? {
+            taskRunId: current.taskRunId,
+            cloudBranch: current.cloudBranch,
+            cloudStatus: current.cloudStatus,
+            cloudOutput: current.cloudOutput,
+          }
+        : undefined,
+    shallow,
+  );
 
   const prUrl = resolveCloudPrUrl(freshTask, session);
   const { effectiveBranch, repo, cloudStatus, isRunActive } =

--- a/packages/ui/src/features/task-detail/hooks/useCloudRunState.ts
+++ b/packages/ui/src/features/task-detail/hooks/useCloudRunState.ts
@@ -1,7 +1,7 @@
 import { deriveCloudRunState } from "@posthog/core/task-detail/cloudRunState";
 import { extractCloudToolChangedFiles } from "@posthog/core/task-detail/cloudToolChanges";
 import type { Task } from "@posthog/shared/domain-types";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { shallow } from "zustand/shallow";
 import { resolveCloudPrUrl } from "../../git-interaction/cloudPrUrl";
 import { useSessionSelector } from "../../sessions/useSession";
@@ -39,10 +39,25 @@ export function useCloudRunState(taskId: string, task: Task) {
     deriveCloudRunState(freshTask, session, prUrl);
 
   const summary = useCloudEventSummary(taskId);
-  const fallbackFiles = useMemo(
-    () => extractCloudToolChangedFiles(summary.toolCalls),
-    [summary],
-  );
+  const fallbackFilesRef = useRef<
+    | {
+        taskId: string;
+        revision: number;
+        files: ReturnType<typeof extractCloudToolChangedFiles>;
+      }
+    | undefined
+  >(undefined);
+  if (
+    fallbackFilesRef.current?.taskId !== taskId ||
+    fallbackFilesRef.current.revision !== summary.changedFilesRevision
+  ) {
+    fallbackFilesRef.current = {
+      taskId,
+      revision: summary.changedFilesRevision,
+      files: extractCloudToolChangedFiles(summary.toolCalls),
+    };
+  }
+  const fallbackFiles = fallbackFilesRef.current.files;
 
   return {
     freshTask,

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -454,16 +454,15 @@ body:has(.rt-DialogOverlay[data-state="open"]) [data-quill-portal] {
   0%,
   100% {
     opacity: 1;
-    color: var(--accent-9);
   }
   50% {
     opacity: 0.5;
-    color: var(--accent-11);
   }
 }
 
 .ph-pulse {
-  animation: ph-pulse 1s ease-in-out infinite;
+  color: var(--accent-9);
+  animation: ph-pulse 1s step-end infinite;
 }
 
 /* Shimmer for an item whose run is still in flight. A highlight band sweeps
@@ -508,8 +507,7 @@ body:has(.rt-DialogOverlay[data-state="open"]) [data-quill-portal] {
 
 /* Freeze CSS keyframe animations while the app window is unfocused or hidden.
    Perpetual indicators (spinners, pulses, floats) otherwise keep the compositor
-   and GPU busy in the background for animations nobody is looking at — and some,
-   like ph-pulse's color shift, force main-thread repaints every frame. The class
+   and GPU busy in the background for animations nobody is looking at. The class
    is toggled from the renderer focus store (see GlobalEventHandlers). Transitions
    are unaffected, and animations resume where they left off on refocus. */
 body.ph-window-blurred *,

--- a/packages/workspace-server/src/services/process-tracking/process-tracking.test.ts
+++ b/packages/workspace-server/src/services/process-tracking/process-tracking.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockPlatform = vi.hoisted(() => vi.fn(() => "darwin"));
 const mockIsProcessAlive = vi.hoisted(() => vi.fn((_pid: number) => true));
 const mockKillProcessTree = vi.hoisted(() => vi.fn());
+const mockKillProcessTrees = vi.hoisted(() => vi.fn());
 const mockExecAsync = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
@@ -23,6 +24,7 @@ vi.mock("node:os", () => ({
 vi.mock("./process-utils", () => ({
   isProcessAlive: mockIsProcessAlive,
   killProcessTree: mockKillProcessTree,
+  killProcessTrees: mockKillProcessTrees,
 }));
 
 import { ProcessTrackingService } from "./process-tracking";
@@ -314,9 +316,7 @@ describe("ProcessTrackingService", () => {
 
       service.killByCategory("shell");
 
-      expect(mockKillProcessTree).toHaveBeenCalledWith(1);
-      expect(mockKillProcessTree).toHaveBeenCalledWith(2);
-      expect(mockKillProcessTree).not.toHaveBeenCalledWith(3);
+      expect(mockKillProcessTrees).toHaveBeenCalledWith([1, 2]);
       expect(service.getByCategory("shell")).toHaveLength(0);
       expect(service.getByCategory("agent")).toHaveLength(1);
     });
@@ -327,6 +327,7 @@ describe("ProcessTrackingService", () => {
       service.killByCategory("shell");
 
       expect(mockKillProcessTree).not.toHaveBeenCalled();
+      expect(mockKillProcessTrees).toHaveBeenCalledWith([]);
       expect(service.getAll()).toHaveLength(1);
     });
   });
@@ -363,9 +364,7 @@ describe("ProcessTrackingService", () => {
 
       service.killByTaskId("task-1");
 
-      expect(mockKillProcessTree).toHaveBeenCalledWith(1);
-      expect(mockKillProcessTree).toHaveBeenCalledWith(2);
-      expect(mockKillProcessTree).not.toHaveBeenCalledWith(3);
+      expect(mockKillProcessTrees).toHaveBeenCalledWith([1, 2]);
       expect(service.getByTaskId("task-1")).toEqual([]);
       expect(service.getByTaskId("task-2")).toHaveLength(1);
     });
@@ -376,6 +375,7 @@ describe("ProcessTrackingService", () => {
       service.killByTaskId("task-999");
 
       expect(mockKillProcessTree).not.toHaveBeenCalled();
+      expect(mockKillProcessTrees).toHaveBeenCalledWith([]);
       expect(service.getAll()).toHaveLength(1);
     });
   });
@@ -426,9 +426,7 @@ describe("ProcessTrackingService", () => {
 
       service.killAll();
 
-      expect(mockKillProcessTree).toHaveBeenCalledWith(1);
-      expect(mockKillProcessTree).toHaveBeenCalledWith(2);
-      expect(mockKillProcessTree).toHaveBeenCalledWith(3);
+      expect(mockKillProcessTrees).toHaveBeenCalledWith([1, 2, 3]);
       expect(service.getAll()).toHaveLength(0);
     });
 
@@ -436,6 +434,7 @@ describe("ProcessTrackingService", () => {
       service.killAll();
 
       expect(mockKillProcessTree).not.toHaveBeenCalled();
+      expect(mockKillProcessTrees).toHaveBeenCalledWith([]);
     });
   });
 });

--- a/packages/workspace-server/src/services/process-tracking/process-tracking.ts
+++ b/packages/workspace-server/src/services/process-tracking/process-tracking.ts
@@ -2,7 +2,11 @@ import { exec } from "node:child_process";
 import { platform } from "node:os";
 import { promisify } from "node:util";
 import { injectable, preDestroy } from "inversify";
-import { isProcessAlive, killProcessTree } from "./process-utils";
+import {
+  isProcessAlive,
+  killProcessTree,
+  killProcessTrees,
+} from "./process-utils";
 import type {
   DiscoveredProcess,
   ProcessCategory,
@@ -195,25 +199,24 @@ export class ProcessTrackingService {
 
   killByCategory(category: ProcessCategory): void {
     const procs = this.getByCategory(category);
-    for (const proc of procs) {
-      this.kill(proc.pid);
-    }
+    this.killProcesses(procs);
   }
 
   killByTaskId(taskId: string): void {
     const procs = this.getByTaskId(taskId);
-    for (const proc of procs) {
-      this.kill(proc.pid);
-    }
+    this.killProcesses(procs);
+  }
+
+  private killProcesses(procs: readonly TrackedProcess[]): void {
+    killProcessTrees(procs.map((proc) => proc.pid));
+    for (const proc of procs) this.unregister(proc.pid, "killed");
   }
 
   @preDestroy()
   killAll(): void {
     this._isShuttingDown = true;
 
-    for (const proc of this.processes.values()) {
-      killProcessTree(proc.pid);
-    }
+    killProcessTrees(Array.from(this.processes.keys()));
     this.processes.clear();
     this.taskProcesses.clear();
   }

--- a/packages/workspace-server/src/services/process-tracking/process-utils.test.ts
+++ b/packages/workspace-server/src/services/process-tracking/process-utils.test.ts
@@ -1,26 +1,107 @@
-import { describe, expect, it } from "vitest";
-import { findProcessTree } from "./process-utils";
+import { describe, expect, it, vi } from "vitest";
+import {
+  findMatchingProcessTargets,
+  findProcessTree,
+  killUnixProcessTrees,
+} from "./process-utils";
+
+const startedAt = "Sat Jul 25 00:00:00 2026";
 
 describe("findProcessTree", () => {
   it("returns descendants deepest-first across nested process groups", () => {
     const result = findProcessTree(10, [
-      { pid: 1, ppid: 0, pgid: 1 },
-      { pid: 10, ppid: 1, pgid: 10 },
-      { pid: 11, ppid: 10, pgid: 10 },
-      { pid: 12, ppid: 11, pgid: 12 },
-      { pid: 13, ppid: 12, pgid: 12 },
-      { pid: 20, ppid: 1, pgid: 20 },
+      { pid: 1, ppid: 0, pgid: 1, startedAt },
+      { pid: 10, ppid: 1, pgid: 10, startedAt },
+      { pid: 11, ppid: 10, pgid: 10, startedAt },
+      { pid: 12, ppid: 11, pgid: 12, startedAt },
+      { pid: 13, ppid: 12, pgid: 12, startedAt },
+      { pid: 20, ppid: 1, pgid: 20, startedAt },
     ]);
 
     expect(result).toEqual([
-      { pid: 13, ppid: 12, pgid: 12 },
-      { pid: 12, ppid: 11, pgid: 12 },
-      { pid: 11, ppid: 10, pgid: 10 },
-      { pid: 10, ppid: 1, pgid: 10 },
+      { pid: 13, ppid: 12, pgid: 12, startedAt },
+      { pid: 12, ppid: 11, pgid: 12, startedAt },
+      { pid: 11, ppid: 10, pgid: 10, startedAt },
+      { pid: 10, ppid: 1, pgid: 10, startedAt },
     ]);
   });
 
   it("returns no unrelated processes when the root has exited", () => {
-    expect(findProcessTree(10, [{ pid: 20, ppid: 1, pgid: 20 }])).toEqual([]);
+    expect(
+      findProcessTree(10, [{ pid: 20, ppid: 1, pgid: 20, startedAt }]),
+    ).toEqual([]);
+  });
+});
+
+describe("findMatchingProcessTargets", () => {
+  it("excludes reused process and group ids", () => {
+    const original = [
+      { pid: 10, ppid: 1, pgid: 10, startedAt },
+      { pid: 11, ppid: 10, pgid: 11, startedAt },
+    ];
+    const current = [
+      { pid: 10, ppid: 1, pgid: 10, startedAt: "later" },
+      { pid: 11, ppid: 1, pgid: 11, startedAt: "later" },
+    ];
+
+    expect(findMatchingProcessTargets(original, current, undefined)).toEqual(
+      [],
+    );
+  });
+
+  it("targets surviving descendants after they are reparented", () => {
+    const original = [
+      { pid: 11, ppid: 10, pgid: 11, startedAt },
+      { pid: 10, ppid: 1, pgid: 10, startedAt },
+    ];
+    const current = [{ pid: 11, ppid: 1, pgid: 11, startedAt }];
+
+    expect(findMatchingProcessTargets(original, current, undefined)).toEqual([
+      -11, 11,
+    ]);
+  });
+});
+
+describe("killUnixProcessTrees", () => {
+  it("revalidates identities before the delayed kill", () => {
+    const original = [
+      { pid: 1, ppid: 0, pgid: 1, startedAt },
+      { pid: 10, ppid: 1, pgid: 10, startedAt },
+      { pid: 11, ppid: 10, pgid: 11, startedAt },
+    ];
+    const current = [
+      { pid: 10, ppid: 1, pgid: 10, startedAt: "reused" },
+      { pid: 11, ppid: 1, pgid: 11, startedAt },
+    ];
+    const signal = vi.fn();
+    let delayed: (() => void) | undefined;
+
+    killUnixProcessTrees([10], original, 1, {
+      currentProcesses: () => current,
+      signal,
+      schedule: (callback) => {
+        delayed = callback;
+      },
+    });
+    delayed?.();
+
+    expect(signal.mock.calls).toEqual([
+      [[-10, -11, 10, 11], "SIGTERM"],
+      [[-11, 11], "SIGKILL"],
+    ]);
+  });
+
+  it("does not signal raw ids when the root identity is unavailable", () => {
+    const signal = vi.fn();
+    const schedule = vi.fn();
+
+    killUnixProcessTrees([10], [{ pid: 20, ppid: 1, pgid: 20, startedAt }], 1, {
+      currentProcesses: () => [],
+      signal,
+      schedule,
+    });
+
+    expect(signal).not.toHaveBeenCalled();
+    expect(schedule).not.toHaveBeenCalled();
   });
 });

--- a/packages/workspace-server/src/services/process-tracking/process-utils.test.ts
+++ b/packages/workspace-server/src/services/process-tracking/process-utils.test.ts
@@ -91,7 +91,7 @@ describe("killUnixProcessTrees", () => {
     ]);
   });
 
-  it("does not signal raw ids when the root identity is unavailable", () => {
+  it("falls back to the raw group when the root identity is unavailable", () => {
     const signal = vi.fn();
     const schedule = vi.fn();
 
@@ -101,7 +101,7 @@ describe("killUnixProcessTrees", () => {
       schedule,
     });
 
-    expect(signal).not.toHaveBeenCalled();
+    expect(signal).toHaveBeenCalledWith([-10, 10], "SIGTERM");
     expect(schedule).not.toHaveBeenCalled();
   });
 });

--- a/packages/workspace-server/src/services/process-tracking/process-utils.test.ts
+++ b/packages/workspace-server/src/services/process-tracking/process-utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { findProcessTree } from "./process-utils";
+
+describe("findProcessTree", () => {
+  it("returns descendants deepest-first across nested process groups", () => {
+    const result = findProcessTree(10, [
+      { pid: 1, ppid: 0, pgid: 1 },
+      { pid: 10, ppid: 1, pgid: 10 },
+      { pid: 11, ppid: 10, pgid: 10 },
+      { pid: 12, ppid: 11, pgid: 12 },
+      { pid: 13, ppid: 12, pgid: 12 },
+      { pid: 20, ppid: 1, pgid: 20 },
+    ]);
+
+    expect(result).toEqual([
+      { pid: 13, ppid: 12, pgid: 12 },
+      { pid: 12, ppid: 11, pgid: 12 },
+      { pid: 11, ppid: 10, pgid: 10 },
+      { pid: 10, ppid: 1, pgid: 10 },
+    ]);
+  });
+
+  it("returns no unrelated processes when the root has exited", () => {
+    expect(findProcessTree(10, [{ pid: 20, ppid: 1, pgid: 20 }])).toEqual([]);
+  });
+});

--- a/packages/workspace-server/src/services/process-tracking/process-utils.test.ts
+++ b/packages/workspace-server/src/services/process-tracking/process-utils.test.ts
@@ -104,4 +104,21 @@ describe("killUnixProcessTrees", () => {
     expect(signal).toHaveBeenCalledWith([-10, 10], "SIGTERM");
     expect(schedule).not.toHaveBeenCalled();
   });
+
+  it("falls back for missing roots in a mixed batch", () => {
+    const signal = vi.fn();
+
+    killUnixProcessTrees(
+      [10, 20],
+      [{ pid: 10, ppid: 1, pgid: 10, startedAt }],
+      1,
+      {
+        currentProcesses: () => [],
+        signal,
+        schedule: vi.fn(),
+      },
+    );
+
+    expect(signal).toHaveBeenCalledWith([-20, 20, -10, 10], "SIGTERM");
+  });
 });

--- a/packages/workspace-server/src/services/process-tracking/process-utils.ts
+++ b/packages/workspace-server/src/services/process-tracking/process-utils.ts
@@ -3,10 +3,11 @@ import { platform } from "node:os";
 
 const SIGKILL_GRACE_MS = 5_000;
 
-interface ProcessEntry {
+export interface ProcessEntry {
   pid: number;
   ppid: number;
   pgid: number;
+  startedAt: string;
 }
 
 export function findProcessTree(
@@ -34,24 +35,91 @@ export function findProcessTree(
   return tree;
 }
 
-function snapshotUnixProcessTree(rootPid: number): ProcessEntry[] {
+function snapshotUnixProcesses(): ProcessEntry[] {
   try {
-    const output = execFileSync("ps", ["-axo", "pid=,ppid=,pgid="], {
+    const output = execFileSync("ps", ["-axo", "pid=,ppid=,pgid=,lstart="], {
       encoding: "utf8",
     });
-    const entries = output
+    return output
       .trim()
       .split("\n")
-      .map((line) => line.trim().split(/\s+/).map(Number))
-      .filter(
-        (parts) =>
-          parts.length === 3 && parts.every((part) => Number.isInteger(part)),
-      )
-      .map(([pid, ppid, pgid]) => ({ pid, ppid, pgid }));
-    return findProcessTree(rootPid, entries);
+      .map((line): ProcessEntry | null => {
+        const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.+)$/);
+        if (!match) return null;
+        return {
+          pid: Number(match[1]),
+          ppid: Number(match[2]),
+          pgid: Number(match[3]),
+          startedAt: match[4],
+        };
+      })
+      .filter((entry): entry is ProcessEntry => entry !== null);
   } catch {
     return [];
   }
+}
+
+export function findMatchingProcessTargets(
+  originalTree: readonly ProcessEntry[],
+  currentProcesses: readonly ProcessEntry[],
+  excludedPgid: number | undefined,
+): number[] {
+  const originalByPid = new Map(
+    originalTree.map((entry) => [entry.pid, entry]),
+  );
+  const matching = currentProcesses.filter((entry) => {
+    const original = originalByPid.get(entry.pid);
+    return (
+      original?.pgid === entry.pgid && original.startedAt === entry.startedAt
+    );
+  });
+  const groups = new Set(
+    matching
+      .map((entry) => entry.pgid)
+      .filter((pgid) => pgid > 0 && pgid !== excludedPgid),
+  );
+  return [
+    ...Array.from(groups, (pgid) => -pgid),
+    ...matching.map((entry) => entry.pid),
+  ];
+}
+
+export interface UnixProcessKillerDeps {
+  currentProcesses: () => ProcessEntry[];
+  signal: (targets: readonly number[], signal: NodeJS.Signals) => void;
+  schedule: (callback: () => void, delayMs: number) => void;
+}
+
+export function killUnixProcessTrees(
+  rootPids: readonly number[],
+  initialProcesses: readonly ProcessEntry[],
+  ownPgid: number | undefined,
+  deps: UnixProcessKillerDeps,
+): void {
+  const trees = rootPids
+    .map((pid) => findProcessTree(pid, initialProcesses))
+    .filter((tree) => tree.length > 0);
+  const originalTree = Array.from(
+    new Map(trees.flat().map((entry) => [entry.pid, entry])).values(),
+  );
+  if (originalTree.length === 0) return;
+
+  const targets = findMatchingProcessTargets(
+    originalTree,
+    initialProcesses,
+    ownPgid,
+  );
+  deps.signal(targets, "SIGTERM");
+  deps.schedule(() => {
+    deps.signal(
+      findMatchingProcessTargets(
+        originalTree,
+        deps.currentProcesses(),
+        ownPgid,
+      ),
+      "SIGKILL",
+    );
+  }, SIGKILL_GRACE_MS);
 }
 
 function signalTargets(
@@ -70,33 +138,32 @@ function signalTargets(
  * their own process groups.
  * On Windows, we use taskkill with /T flag to kill the process tree.
  */
-export function killProcessTree(pid: number): void {
+export function killProcessTrees(pids: readonly number[]): void {
+  if (pids.length === 0) return;
   try {
     if (platform() === "win32") {
       // Windows: use taskkill with /T to kill process tree
-      execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore" });
+      for (const pid of pids) {
+        execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore" });
+      }
     } else {
-      const tree = snapshotUnixProcessTree(pid);
-      const ownProcess = snapshotUnixProcessTree(process.pid).at(-1);
-      const groups = new Set(
-        tree
-          .map((entry) => entry.pgid)
-          .filter((pgid) => pgid > 0 && pgid !== ownProcess?.pgid),
-      );
-      const targets = [
-        ...Array.from(groups, (pgid) => -pgid),
-        ...tree.map((entry) => entry.pid),
-      ];
-      if (targets.length === 0) targets.push(-pid, pid);
-
-      signalTargets(targets, "SIGTERM");
-
-      // Force kill after a grace period — unref so the timer doesn't delay app exit.
-      setTimeout(() => {
-        signalTargets(targets, "SIGKILL");
-      }, SIGKILL_GRACE_MS).unref();
+      const processes = snapshotUnixProcesses();
+      const ownPgid = processes.find(
+        (entry) => entry.pid === process.pid,
+      )?.pgid;
+      killUnixProcessTrees(pids, processes, ownPgid, {
+        currentProcesses: snapshotUnixProcesses,
+        signal: signalTargets,
+        schedule: (callback, delayMs) => {
+          setTimeout(callback, delayMs).unref();
+        },
+      });
     }
   } catch {}
+}
+
+export function killProcessTree(pid: number): void {
+  killProcessTrees([pid]);
 }
 
 /**

--- a/packages/workspace-server/src/services/process-tracking/process-utils.ts
+++ b/packages/workspace-server/src/services/process-tracking/process-utils.ts
@@ -114,20 +114,16 @@ export function killUnixProcessTrees(
   deps: UnixProcessKillerDeps,
 ): void {
   const children = indexProcesses(initialProcesses);
-  const trees = rootPids
-    .map((pid) => findProcessTreeFromIndex(pid, initialProcesses, children))
-    .filter((tree) => tree.length > 0);
+  const missingRootPids: number[] = [];
+  const trees = rootPids.flatMap((pid) => {
+    const tree = findProcessTreeFromIndex(pid, initialProcesses, children);
+    if (tree.length === 0) missingRootPids.push(pid);
+    return tree;
+  });
   const originalTree = Array.from(
     new Map(trees.flat().map((entry) => [entry.pid, entry])).values(),
   );
-  if (originalTree.length === 0) {
-    deps.signal(
-      rootPids.flatMap((pid) => [-pid, pid]),
-      "SIGTERM",
-    );
-    return;
-  }
-  if (ownPgid === undefined) {
+  if (originalTree.length === 0 || ownPgid === undefined) {
     deps.signal(
       rootPids.flatMap((pid) => [-pid, pid]),
       "SIGTERM",
@@ -135,11 +131,10 @@ export function killUnixProcessTrees(
     return;
   }
 
-  const targets = findMatchingProcessTargets(
-    originalTree,
-    initialProcesses,
-    ownPgid,
-  );
+  const targets = [
+    ...missingRootPids.flatMap((pid) => [-pid, pid]),
+    ...findMatchingProcessTargets(originalTree, initialProcesses, ownPgid),
+  ];
   deps.signal(targets, "SIGTERM");
   deps.schedule(() => {
     deps.signal(

--- a/packages/workspace-server/src/services/process-tracking/process-utils.ts
+++ b/packages/workspace-server/src/services/process-tracking/process-utils.ts
@@ -1,11 +1,73 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { platform } from "node:os";
 
 const SIGKILL_GRACE_MS = 5_000;
 
+interface ProcessEntry {
+  pid: number;
+  ppid: number;
+  pgid: number;
+}
+
+export function findProcessTree(
+  rootPid: number,
+  processTable: readonly ProcessEntry[],
+): ProcessEntry[] {
+  const children = new Map<number, ProcessEntry[]>();
+  for (const entry of processTable) {
+    const siblings = children.get(entry.ppid) ?? [];
+    siblings.push(entry);
+    children.set(entry.ppid, siblings);
+  }
+
+  const tree: ProcessEntry[] = [];
+  const visit = (pid: number): void => {
+    for (const child of children.get(pid) ?? []) {
+      visit(child.pid);
+      tree.push(child);
+    }
+  };
+  visit(rootPid);
+
+  const root = processTable.find((entry) => entry.pid === rootPid);
+  if (root) tree.push(root);
+  return tree;
+}
+
+function snapshotUnixProcessTree(rootPid: number): ProcessEntry[] {
+  try {
+    const output = execFileSync("ps", ["-axo", "pid=,ppid=,pgid="], {
+      encoding: "utf8",
+    });
+    const entries = output
+      .trim()
+      .split("\n")
+      .map((line) => line.trim().split(/\s+/).map(Number))
+      .filter(
+        (parts) =>
+          parts.length === 3 && parts.every((part) => Number.isInteger(part)),
+      )
+      .map(([pid, ppid, pgid]) => ({ pid, ppid, pgid }));
+    return findProcessTree(rootPid, entries);
+  } catch {
+    return [];
+  }
+}
+
+function signalTargets(
+  targets: readonly number[],
+  signal: NodeJS.Signals,
+): void {
+  for (const target of targets) {
+    try {
+      process.kill(target, signal);
+    } catch {}
+  }
+}
+
 /**
- * Kill a process and all its children by killing the process group.
- * On Unix, we use process.kill(-pid) to kill the entire process group.
+ * Kill a process and all its descendants, including children that created
+ * their own process groups.
  * On Windows, we use taskkill with /T flag to kill the process tree.
  */
 export function killProcessTree(pid: number): void {
@@ -14,28 +76,24 @@ export function killProcessTree(pid: number): void {
       // Windows: use taskkill with /T to kill process tree
       execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore" });
     } else {
-      // SIGTERM the process group first, fall back to individual process
-      let sent = false;
-      for (const target of [-pid, pid]) {
-        try {
-          process.kill(target, "SIGTERM");
-          sent = true;
-          break;
-        } catch {}
-      }
+      const tree = snapshotUnixProcessTree(pid);
+      const ownProcess = snapshotUnixProcessTree(process.pid).at(-1);
+      const groups = new Set(
+        tree
+          .map((entry) => entry.pgid)
+          .filter((pgid) => pgid > 0 && pgid !== ownProcess?.pgid),
+      );
+      const targets = [
+        ...Array.from(groups, (pgid) => -pgid),
+        ...tree.map((entry) => entry.pid),
+      ];
+      if (targets.length === 0) targets.push(-pid, pid);
 
-      if (!sent) return;
+      signalTargets(targets, "SIGTERM");
 
       // Force kill after a grace period — unref so the timer doesn't delay app exit.
-      // We skip the liveness check since isProcessAlive only tests the group leader;
-      // orphaned children in the same group would be missed. The catch blocks
-      // handle ESRCH if everything already exited.
       setTimeout(() => {
-        for (const target of [-pid, pid]) {
-          try {
-            process.kill(target, "SIGKILL");
-          } catch {}
-        }
+        signalTargets(targets, "SIGKILL");
       }, SIGKILL_GRACE_MS).unref();
     }
   } catch {}

--- a/packages/workspace-server/src/services/process-tracking/process-utils.ts
+++ b/packages/workspace-server/src/services/process-tracking/process-utils.ts
@@ -14,13 +14,30 @@ export function findProcessTree(
   rootPid: number,
   processTable: readonly ProcessEntry[],
 ): ProcessEntry[] {
+  return findProcessTreeFromIndex(
+    rootPid,
+    processTable,
+    indexProcesses(processTable),
+  );
+}
+
+function indexProcesses(
+  processTable: readonly ProcessEntry[],
+): Map<number, ProcessEntry[]> {
   const children = new Map<number, ProcessEntry[]>();
   for (const entry of processTable) {
     const siblings = children.get(entry.ppid) ?? [];
     siblings.push(entry);
     children.set(entry.ppid, siblings);
   }
+  return children;
+}
 
+function findProcessTreeFromIndex(
+  rootPid: number,
+  processTable: readonly ProcessEntry[],
+  children: ReadonlyMap<number, readonly ProcessEntry[]>,
+): ProcessEntry[] {
   const tree: ProcessEntry[] = [];
   const visit = (pid: number): void => {
     for (const child of children.get(pid) ?? []) {
@@ -96,13 +113,27 @@ export function killUnixProcessTrees(
   ownPgid: number | undefined,
   deps: UnixProcessKillerDeps,
 ): void {
+  const children = indexProcesses(initialProcesses);
   const trees = rootPids
-    .map((pid) => findProcessTree(pid, initialProcesses))
+    .map((pid) => findProcessTreeFromIndex(pid, initialProcesses, children))
     .filter((tree) => tree.length > 0);
   const originalTree = Array.from(
     new Map(trees.flat().map((entry) => [entry.pid, entry])).values(),
   );
-  if (originalTree.length === 0) return;
+  if (originalTree.length === 0) {
+    deps.signal(
+      rootPids.flatMap((pid) => [-pid, pid]),
+      "SIGTERM",
+    );
+    return;
+  }
+  if (ownPgid === undefined) {
+    deps.signal(
+      rootPids.flatMap((pid) => [-pid, pid]),
+      "SIGTERM",
+    );
+    return;
+  }
 
   const targets = findMatchingProcessTargets(
     originalTree,
@@ -140,13 +171,15 @@ function signalTargets(
  */
 export function killProcessTrees(pids: readonly number[]): void {
   if (pids.length === 0) return;
-  try {
-    if (platform() === "win32") {
-      // Windows: use taskkill with /T to kill process tree
-      for (const pid of pids) {
+  if (platform() === "win32") {
+    // Windows: use taskkill with /T to kill process tree
+    for (const pid of pids) {
+      try {
         execSync(`taskkill /PID ${pid} /T /F`, { stdio: "ignore" });
-      }
-    } else {
+      } catch {}
+    }
+  } else {
+    try {
       const processes = snapshotUnixProcesses();
       const ownPgid = processes.find(
         (entry) => entry.pid === process.pid,
@@ -158,8 +191,8 @@ export function killProcessTrees(pids: readonly number[]): void {
           setTimeout(callback, delayMs).unref();
         },
       });
-    }
-  } catch {}
+    } catch {}
+  }
 }
 
 export function killProcessTree(pid: number): void {

--- a/packages/workspace-server/src/services/watcher/service.test.ts
+++ b/packages/workspace-server/src/services/watcher/service.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FileWatcherEvent, WatcherEvent } from "./schemas";
-import { DEBOUNCE_MS, MAX_WAIT_MS, WatcherService } from "./service";
+import {
+  accumulateFsEvents,
+  DEBOUNCE_MS,
+  drainPending,
+  MAX_WAIT_MS,
+  WatcherService,
+} from "./service";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -207,5 +213,28 @@ describe("WatcherService.watchRepo debounce", () => {
 
     wt.end();
     await done;
+  });
+});
+
+describe("WatcherService bulk changes", () => {
+  it("stops retaining paths after crossing the bulk threshold", () => {
+    const pending: Parameters<typeof accumulateFsEvents>[0] = {
+      dirs: new Set(),
+      files: new Set(),
+      deletes: new Set(),
+      bulkChanged: false,
+    };
+    const events = Array.from({ length: 1000 }, (_, index) => ({
+      type: "update" as const,
+      path: `/repo/dist/${index}.js`,
+    }));
+
+    accumulateFsEvents(pending, events);
+
+    expect(pending.files.size).toBe(0);
+    expect(drainPending("/repo", pending)).toEqual([
+      { kind: "working-tree-changed", repoPath: "/repo" },
+    ]);
+    expect(pending.bulkChanged).toBe(false);
   });
 });

--- a/packages/workspace-server/src/services/watcher/service.ts
+++ b/packages/workspace-server/src/services/watcher/service.ts
@@ -29,7 +29,7 @@ export const DEBOUNCE_MS = 500;
 // wise never trip it until it paused, freezing the diff panel/stats mid-run.
 // The max-wait forces a flush at least this often during sustained activity so
 // the UI keeps advancing while the agent works.
-export const MAX_WAIT_MS = 1000;
+export const MAX_WAIT_MS = 3000;
 const BULK_THRESHOLD = 100;
 
 const dirname = (p: string): string => {
@@ -51,12 +51,14 @@ interface Pending {
   dirs: Set<string>;
   files: Set<string>;
   deletes: Set<string>;
+  bulkChanged: boolean;
 }
 
 const createPending = (): Pending => ({
   dirs: new Set(),
   files: new Set(),
   deletes: new Set(),
+  bulkChanged: false,
 });
 
 export const accumulateFsEvents = (
@@ -64,9 +66,16 @@ export const accumulateFsEvents = (
   events: WatcherEvent[],
 ): void => {
   for (const event of events) {
+    if (pending.bulkChanged) continue;
     pending.dirs.add(dirname(event.path));
     if (event.type === "delete") pending.deletes.add(event.path);
     else pending.files.add(event.path);
+    if (pending.files.size + pending.deletes.size > BULK_THRESHOLD) {
+      pending.dirs.clear();
+      pending.files.clear();
+      pending.deletes.clear();
+      pending.bulkChanged = true;
+    }
   }
 };
 
@@ -76,12 +85,14 @@ export const drainPending = (
 ): FileWatcherEvent[] => {
   const totalChanges = pending.files.size + pending.deletes.size;
   const out: FileWatcherEvent[] = [];
-  if (totalChanges === 0 && pending.dirs.size === 0) return out;
+  if (!pending.bulkChanged && totalChanges === 0 && pending.dirs.size === 0) {
+    return out;
+  }
 
-  if (totalChanges > 0) {
+  if (pending.bulkChanged || totalChanges > 0) {
     out.push({ kind: "working-tree-changed", repoPath });
   }
-  if (totalChanges <= BULK_THRESHOLD) {
+  if (!pending.bulkChanged) {
     for (const dirPath of pending.dirs)
       out.push({ kind: "directory-changed", repoPath, dirPath });
     for (const filePath of pending.files)
@@ -92,6 +103,7 @@ export const drainPending = (
   pending.dirs.clear();
   pending.files.clear();
   pending.deletes.clear();
+  pending.bulkChanged = false;
   return out;
 };
 


### PR DESCRIPTION
## Problem

Running tasks can keep the renderer, GPU, filesystem watcher, and orphaned child processes busy enough to heat the laptop. Live sampling found per-event transcript work and two task servers that survived for over a day at roughly 100% CPU each.

## Changes

I batch streamed `session/update` notifications at 50ms while keeping completion, permission, and runtime state events immediate. Long transcripts derive incrementally: each event is parsed once, and a content change (tool merge, streamed subagent output, progress step, thought settling, or turn completion) re-issues just that row object. Memoized rows re-render exactly where something happened instead of cloning the whole active turn per frame. The chat-thread row grouper reuses cached rows across frames and identity-checks its retained prefix, including late completion of an older turn.

Diff workers are capped at two, persistent timers and watcher invalidations run less often, and narrower subscriptions cut re-renders. Changed-file derivation has its own revision, so partial tool input does not clone and rescan the full tool map. Process cleanup indexes each process snapshot once, terminates nested descendant groups in batches, isolates Windows failures per PID, and revalidates pid, pgid, and start time before delayed signals. It falls back to the tracked process group when a snapshot cannot recover an orphaned tree. Conversation refreshes drop pending batches atomically so events cannot be appended twice during initial load or later refreshes.

## How did you test this?

- Ran the full core (2,512), UI (2,193), and workspace-server (794) suites plus package typechecks and Biome checks after rebasing onto main's chat-thread virtualization.
- Re-ran 99 focused core, UI, and workspace-server tests after review fixes, plus all three package typechecks, the full workspace typecheck commit hook, Biome, and the host-boundary checker.
- Added regressions for chunks arriving during initial load, interleaved text and tool batching, late completion of an older turn, immediate elapsed-time rendering, changed-file revision stability, orphaned process-group fallback, and delayed process identity validation.
- Benchmarks measured against `bf27356b8` (main at the time of measurement; none of the measured code paths changed on main since). A deterministic synthetic 10,000-event transcript uses 9,000 history events and streams 1,000 events through each side's real derivation and grouping pipeline, one frame per event. The 50ms batching is excluded, so these streaming numbers are the PR's worst case. Times are medians of three runs. Process rows spawn a real six-PID tree across three process groups and poll liveness.

| Benchmark | Base | This PR | Change |
| --- | --- | --- | --- |
| Streaming derivation + row grouping (1,000 frames) | 138.5 ms | 19.6 ms | 7.1× faster |
| Initial 9,000-event history build | 1.8 ms | 2.6 ms | comparable |
| Row identities changed per frame | 334 | 1 | 334× fewer |
| React re-render time across the streamed window | 4.25 s | 1.06 s | 4.0× faster |
| Nested process-tree kill | 5 of 6 processes leak | all 6 dead in 32 ms | leak fixed |

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*