### PR TITLE
fix(agent): honor a cancel that lands while a turn is being set up

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -151,7 +151,7 @@
     "clean": "node ../../scripts/rimraf.mjs dist .turbo"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.19.0"
   },
   "devDependencies": {
     "@posthog/shared": "workspace:*",

--- a/packages/agent/src/adapters/base-acp-agent.ts
+++ b/packages/agent/src/adapters/base-acp-agent.ts
@@ -47,6 +47,13 @@ export interface BaseSettingsManager {
 export interface BaseSession {
   notificationHistory: SessionNotification[];
   cancelled: boolean;
+  /**
+   * Bumped on every cancel. An adapter whose `prompt()` awaits before registering
+   * the turn must snapshot this on entry and re-check it before handing the prompt
+   * to the backend: a cancel landing in that window reaches no turn, and `cancelled`
+   * alone cannot distinguish it from a stale flag left by an earlier cancel.
+   */
+  cancelSeq: number;
   interruptReason?: string;
   abortController: AbortController;
   settingsManager: BaseSettingsManager;
@@ -78,10 +85,12 @@ export abstract class BaseAcpAgent implements Agent {
       throw new Error("Session ID mismatch");
     }
     this.session.cancelled = true;
+    this.session.cancelSeq += 1;
     const meta = params._meta as { interruptReason?: string } | undefined;
-    if (meta?.interruptReason) {
-      this.session.interruptReason = meta.interruptReason;
-    }
+    // Assign even when absent, so the reason always describes the current cancel.
+    // A turn cancelled during setup keeps this value through activation, so a
+    // leftover reason would otherwise be reported for a cancel that supplied none.
+    this.session.interruptReason = meta?.interruptReason;
     await this.interrupt();
   }
 

--- a/packages/agent/src/adapters/claude/claude-agent.cancel-during-setup.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.cancel-during-setup.test.ts
@@ -1,0 +1,230 @@
+import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockQuery,
+  createSuccessResult,
+  type MockQuery,
+} from "../../test/mocks/claude-sdk";
+import { Pushable } from "../../utils/streams";
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: vi.fn(),
+}));
+
+vi.mock("./mcp/tool-metadata", () => ({
+  fetchMcpToolMetadata: vi.fn().mockResolvedValue(undefined),
+  getConnectedMcpServerNames: vi.fn().mockReturnValue([]),
+  getCachedMcpTools: vi.fn().mockReturnValue([]),
+  clearMcpToolMetadataCache: vi.fn(),
+  setMcpToolApprovalStates: vi.fn(),
+  isMcpToolReadOnly: vi.fn().mockReturnValue(false),
+  getMcpToolMetadata: vi.fn().mockReturnValue(undefined),
+  getMcpToolApprovalState: vi.fn().mockReturnValue(undefined),
+}));
+
+const { ClaudeAcpAgent } = await import("./claude-agent");
+type Agent = InstanceType<typeof ClaudeAcpAgent>;
+
+const SESSION_ID = "s-cancel";
+
+/** Lets the consumer loop re-park in `query.next()` between messages. */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+interface Harness {
+  agent: Agent;
+  session: { cancelled: boolean; cancelSeq: number };
+  /** Resolves once prompt() has entered the pre-prompt MCP status await. */
+  inSetup: Promise<void>;
+  /** Lets the stalled status check return, so setup continues. */
+  finishSetup: () => void;
+  /** Drives the queued turn to a normal completion. */
+  completeTurn: () => Promise<void>;
+  /** Whether anything was handed to the SDK. */
+  sdkReceivedMessage: () => boolean;
+  prompt: () => Promise<{ stopReason: string; _meta?: unknown }>;
+}
+
+/**
+ * A session whose pre-prompt `ensureLocalToolsConnected` can be held open, which
+ * is the window a Ctrl-C lands in before the prompt reaches the SDK.
+ *
+ * `query.interrupt` is a deferred no-op on purpose. In production it asks the
+ * Claude subprocess to stop and the message stream keeps running until the
+ * subprocess acknowledges; the default mock ends the stream synchronously, so the
+ * consumer takes the stream-`done` branch and rejects the still-queued turn as
+ * session-ended, never reaching `activateTurn`.
+ */
+function makeHarness(): Harness {
+  const client = {
+    sessionUpdate: vi.fn().mockResolvedValue(undefined),
+    extNotification: vi.fn().mockResolvedValue(undefined),
+  };
+  const agent = new ClaudeAcpAgent(client as unknown as AgentSideConnection);
+
+  const query = createMockQuery();
+  query.interrupt = vi.fn(async () => {});
+  const input = new Pushable<SDKUserMessage>();
+  const pushToSdk = vi.spyOn(input, "push");
+  const abortController = new AbortController();
+
+  const session = {
+    query,
+    queryOptions: { sessionId: SESSION_ID, cwd: "/tmp/repo", abortController },
+    // Non-empty, so ensureLocalToolsConnected does not short-circuit.
+    localToolsServerNames: ["posthog-code-tools"],
+    buildInProcessMcpServers: () => ({
+      "posthog-code-tools": {
+        type: "sdk",
+        name: "posthog-code-tools",
+        instance: {},
+      },
+    }),
+    input,
+    cancelled: false,
+    cancelSeq: 0,
+    interruptReason: undefined as string | undefined,
+    settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
+    permissionMode: "auto" as const,
+    abortController,
+    accumulatedUsage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+    },
+    sessionResources: new Set(),
+    configOptions: [],
+    turnQueue: [],
+    activeTurn: null,
+    pendingOrphanResults: 0,
+    queryGeneration: 0,
+    cwd: "/tmp/repo",
+    notificationHistory: [] as unknown[],
+    taskRunId: "run-1",
+    lastContextWindowSize: 200_000,
+    modelId: "claude-sonnet-4-6",
+    taskState: new Map(),
+  };
+  (agent as unknown as { session: typeof session }).session = session;
+  (agent as unknown as { sessionId: string }).sessionId = SESSION_ID;
+
+  const { promise: inSetup, resolve: signalInSetup } =
+    Promise.withResolvers<void>();
+  const { promise: held, resolve: releaseSetup } = Promise.withResolvers<[]>();
+  query.mcpServerStatus = vi.fn(() => {
+    signalInSetup();
+    return held;
+  }) as unknown as MockQuery["mcpServerStatus"];
+
+  return {
+    agent,
+    session,
+    inSetup,
+    finishSetup: () => releaseSetup([]),
+    prompt: () =>
+      agent.prompt({
+        sessionId: SESSION_ID,
+        prompt: [{ type: "text", text: "do the thing" }],
+      }) as Promise<{ stopReason: string; _meta?: unknown }>,
+    // Echo the turn's own user message back, then send the terminal result, the
+    // way the SDK would for a turn that ran to completion.
+    completeTurn: async () => {
+      const { value: pushed } = await input[Symbol.asyncIterator]().next();
+      query._mockHelpers.sendMessage(pushed as never);
+      await tick();
+      query._mockHelpers.complete(createSuccessResult());
+    },
+    sdkReceivedMessage: () => pushToSdk.mock.calls.length > 0,
+  };
+}
+
+/**
+ * `cancelSeq` lets `prompt()` tell a cancel aimed at the prompt it is setting up
+ * from a stale one that already stopped an earlier turn. The first drops the
+ * prompt before it reaches the SDK; the second leaves it alone.
+ */
+describe("cancel arriving while a prompt is being set up", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("drops the prompt instead of handing it to the SDK", async () => {
+    const h = makeHarness();
+
+    const pending = h.prompt();
+    await h.inSetup;
+    // Ctrl-C lands here: nothing is queued yet, so cancel() finds no turn to stop
+    // and arms no backstop. Only the early return in prompt() can honor it.
+    await h.agent.cancel({ sessionId: SESSION_ID });
+    h.finishSetup();
+
+    await expect(pending).resolves.toMatchObject({ stopReason: "cancelled" });
+    expect(h.sdkReceivedMessage()).toBe(false);
+    expect(h.session.cancelled).toBe(true);
+  });
+
+  it("carries the interrupt reason the cancel supplied", async () => {
+    const h = makeHarness();
+
+    const pending = h.prompt();
+    await h.inSetup;
+    await h.agent.cancel({
+      sessionId: SESSION_ID,
+      _meta: { interruptReason: "user_stopped" },
+    });
+    h.finishSetup();
+
+    await expect(pending).resolves.toMatchObject({
+      stopReason: "cancelled",
+      _meta: { interruptReason: "user_stopped" },
+    });
+  });
+
+  it("runs the next prompt on the same session normally", async () => {
+    const h = makeHarness();
+
+    const cancelled = h.prompt();
+    await h.inSetup;
+    await h.agent.cancel({ sessionId: SESSION_ID });
+    h.finishSetup();
+    await expect(cancelled).resolves.toMatchObject({ stopReason: "cancelled" });
+    // The flag is left standing so a still-settling earlier turn can read it.
+    expect(h.session.cancelled).toBe(true);
+
+    const pending = h.prompt();
+    await h.completeTurn();
+
+    await expect(pending).resolves.toMatchObject({ stopReason: "end_turn" });
+    expect(h.session.cancelled).toBe(false);
+  });
+
+  it("runs a prompt normally when the cancel predates it", async () => {
+    const h = makeHarness();
+
+    // Cancel with nothing in flight, which is how a cancel for an
+    // already-finished turn looks by the time the next prompt arrives.
+    await h.agent.cancel({ sessionId: SESSION_ID });
+    expect(h.session.cancelled).toBe(true);
+
+    const pending = h.prompt();
+    await h.inSetup;
+    h.finishSetup();
+    await h.completeTurn();
+
+    await expect(pending).resolves.toMatchObject({ stopReason: "end_turn" });
+    expect(h.session.cancelled).toBe(false);
+  });
+
+  it("leaves a mismatched cancel uncounted", async () => {
+    const h = makeHarness();
+
+    await expect(h.agent.cancel({ sessionId: "other" })).rejects.toThrow(
+      /Session ID mismatch/,
+    );
+    expect(h.session.cancelSeq).toBe(0);
+    expect(h.session.cancelled).toBe(false);
+  });
+});

--- a/packages/agent/src/adapters/claude/claude-agent.cancel-during-setup.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.cancel-during-setup.test.ts
@@ -1,5 +1,8 @@
 import type { AgentSideConnection } from "@agentclientprotocol/sdk";
-import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMockQuery,
@@ -42,9 +45,15 @@ interface Harness {
   finishSetup: () => void;
   /** Drives the queued turn to a normal completion. */
   completeTurn: () => Promise<void>;
+  /** Promotes the queued turn the way a local-only command's output does. */
+  activateQueuedTurn: () => Promise<void>;
+  /** Ends the active turn with the SDK's terminal result. */
+  finishTurn: () => void;
   /** Whether anything was handed to the SDK. */
   sdkReceivedMessage: () => boolean;
-  prompt: () => Promise<{ stopReason: string; _meta?: unknown }>;
+  /** The text of every message handed to the SDK, in order. */
+  sdkPromptTexts: () => string[];
+  prompt: (text?: string) => Promise<{ stopReason: string; _meta?: unknown }>;
 }
 
 /**
@@ -124,11 +133,22 @@ function makeHarness(): Harness {
     session,
     inSetup,
     finishSetup: () => releaseSetup([]),
-    prompt: () =>
+    prompt: (text = "do the thing") =>
       agent.prompt({
         sessionId: SESSION_ID,
-        prompt: [{ type: "text", text: "do the thing" }],
+        prompt: [{ type: "text", text }],
       }) as Promise<{ stopReason: string; _meta?: unknown }>,
+    activateQueuedTurn: async () => {
+      query._mockHelpers.sendMessage({
+        type: "system",
+        subtype: "local_command_output",
+        content: "context report",
+        uuid: crypto.randomUUID(),
+        session_id: SESSION_ID,
+      } as SDKMessage);
+      await tick();
+    },
+    finishTurn: () => query._mockHelpers.complete(createSuccessResult()),
     // Echo the turn's own user message back, then send the terminal result, the
     // way the SDK would for a turn that ran to completion.
     completeTurn: async () => {
@@ -138,6 +158,16 @@ function makeHarness(): Harness {
       query._mockHelpers.complete(createSuccessResult());
     },
     sdkReceivedMessage: () => pushToSdk.mock.calls.length > 0,
+    sdkPromptTexts: () =>
+      pushToSdk.mock.calls.map(([message]) => {
+        const content = message.message.content;
+        if (typeof content === "string") {
+          return content;
+        }
+        return content
+          .map((block) => (block.type === "text" ? block.text : ""))
+          .join("");
+      }),
   };
 }
 
@@ -216,6 +246,30 @@ describe("cancel arriving while a prompt is being set up", () => {
 
     await expect(pending).resolves.toMatchObject({ stopReason: "end_turn" });
     expect(h.session.cancelled).toBe(false);
+  });
+
+  it("drops the prompt even when a later turn activates during setup", async () => {
+    const h = makeHarness();
+
+    const cancelled = h.prompt();
+    await h.inSetup;
+    await h.agent.cancel({ sessionId: SESSION_ID });
+
+    // A local-only command skips the pre-prompt status check the first prompt is
+    // parked in, so it queues and activates while that prompt is still stalled.
+    // Activation clears `session.cancelled`, leaving the count as the only record
+    // that a cancel landed.
+    const local = h.prompt("/context");
+    await h.activateQueuedTurn();
+    expect(h.session.cancelled).toBe(false);
+
+    h.finishSetup();
+
+    await expect(cancelled).resolves.toMatchObject({ stopReason: "cancelled" });
+    expect(h.sdkPromptTexts()).toEqual(["/context"]);
+
+    h.finishTurn();
+    await expect(local).resolves.toMatchObject({ stopReason: "end_turn" });
   });
 
   it("leaves a mismatched cancel uncounted", async () => {

--- a/packages/agent/src/adapters/claude/claude-agent.permission-mode.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.permission-mode.test.ts
@@ -54,6 +54,7 @@ function installFakeSession(
     localToolsServerNames: [] as string[],
     input,
     cancelled: false,
+    cancelSeq: 0,
     interruptReason: undefined,
     settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
     permissionMode,

--- a/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.refresh.test.ts
@@ -117,6 +117,7 @@ function installFakeSession(
     localToolsServerNames: ["posthog-code-tools"],
     input,
     cancelled: false,
+    cancelSeq: 0,
     settingsManager: { dispose: vi.fn() },
     permissionMode: "default",
     abortController,

--- a/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.slash-command.test.ts
@@ -50,6 +50,7 @@ function installFakeSession(
     localToolsServerNames: [] as string[],
     input,
     cancelled: false,
+    cancelSeq: 0,
     interruptReason: undefined,
     settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
     permissionMode: "default" as const,

--- a/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
@@ -54,6 +54,7 @@ function installFakeSession(
     localToolsServerNames: [] as string[],
     input,
     cancelled: false,
+    cancelSeq: 0,
     interruptReason: undefined,
     settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
     permissionMode: "default" as const,

--- a/packages/agent/src/adapters/claude/claude-agent.task-notification.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.task-notification.test.ts
@@ -54,6 +54,7 @@ function installFakeSession(
     localToolsServerNames: [] as string[],
     input,
     cancelled: false,
+    cancelSeq: 0,
     interruptReason: undefined,
     settingsManager: { dispose: vi.fn(), getRepoRoot: () => "/tmp/repo" },
     permissionMode: "default" as const,

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -455,6 +455,9 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   }
 
   async prompt(params: PromptRequest): Promise<PromptResponse> {
+    // Read before any await: setup below can take seconds (the pre-prompt MCP
+    // reconnect), and a cancel landing in that window belongs to this prompt.
+    const cancelSeqAtEntry = this.session.cancelSeq;
     const userMessage = promptToClaude(params);
     const promptUuid = randomUUID();
     userMessage.uuid = promptUuid;
@@ -518,6 +521,15 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         modelId: this.session.modelId,
         contextWindowSize: this.session.lastContextWindowSize,
       });
+    }
+
+    // A cancel counted during setup targets this prompt. It is not queued yet, so
+    // `interrupt()` had nothing to stop and armed no backstop; returning here,
+    // before the message reaches the SDK, is what actually cancels it. Leave
+    // `cancelled` standing: an earlier turn may still be settling against it, and
+    // `activateTurn` clears it for the next turn that runs.
+    if (this.session.cancelSeq > cancelSeqAtEntry && this.session.cancelled) {
+      return this.cancelledResponse();
     }
 
     const turn: Turn = {
@@ -696,6 +708,9 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
 
     const activateTurn = async (turn: Turn) => {
       session.activeTurn = turn;
+      // Any cancel aimed at this turn already settled it: during setup `prompt()`
+      // returns early, and once queued `interrupt()` sweeps it. Reaching here means
+      // the flag is left over from an earlier turn.
       session.cancelled = false;
       session.interruptReason = undefined;
       session.pendingOrphanResults = 0;
@@ -2111,6 +2126,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       localToolsServerNames,
       input,
       cancelled: false,
+      cancelSeq: 0,
       settingsManager,
       permissionMode,
       cloudMode: cloudRun,

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -525,10 +525,13 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
 
     // A cancel counted during setup targets this prompt. It is not queued yet, so
     // `interrupt()` had nothing to stop and armed no backstop; returning here,
-    // before the message reaches the SDK, is what actually cancels it. Leave
-    // `cancelled` standing: an earlier turn may still be settling against it, and
-    // `activateTurn` clears it for the next turn that runs.
-    if (this.session.cancelSeq > cancelSeqAtEntry && this.session.cancelled) {
+    // before the message reaches the SDK, is what actually cancels it. The counter
+    // alone decides: `session.cancelled` belongs to the session, and `activateTurn`
+    // clears it for whichever turn runs next, so a prompt that raced past this one
+    // into the queue would otherwise erase the cancel this check exists to catch.
+    // The flag is left standing here, because an earlier turn may still be settling
+    // against it.
+    if (this.session.cancelSeq > cancelSeqAtEntry) {
       return this.cancelledResponse();
     }
 

--- a/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -342,6 +342,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       ),
       notificationHistory: [],
       cancelled: false,
+      cancelSeq: 0,
     };
   }
 


### PR DESCRIPTION
## Problem

A cancel arriving while `prompt()` was still setting up got silently dropped. That setup can run for seconds: `ensureLocalToolsConnected` awaits an MCP status RPC bounded at 5s, and an unknown slash command reloads skills before that. Incoming messages are dispatched concurrently, so a cancel landing in that window found an empty turn queue and no active turn. `interrupt()` had nothing to settle and armed no force-cancel backstop, so setup went on to hand the message to the SDK. The turn then ran to completion and reported `end_turn`, with tools still executing after the user pressed stop.

## Changes

`session.cancelSeq` counts cancels on the session. `prompt()` snapshots it on entry before any await, then re-checks it once setup finishes. A higher count means the cancel targets this prompt, so it returns `cancelled` without pushing to the SDK. That is the last point where the turn can still be stopped, and no await separates the check from the push.

The count is the whole test. `session.cancelled` belongs to the session, and `activateTurn` clears it for whichever turn runs next, so a prompt that raced past the stalled one into the queue erases it — a local-only command such as `/context` skips the pre-prompt status check entirely and can get there first. The count survives that. The flag itself is deliberately left standing on this path, because an earlier turn may still be settling against it.

Cancels landing outside that window behave as before. Once a turn is queued `interrupt()` sweeps it, and once it is active the existing backstop applies.

`cancel()` now assigns `interruptReason` on every call, including when the client supplies none, so a turn no longer reports a stale reason left by an earlier cancel.

The Codex adapter takes `cancelSeq: 0` as an inert field. It resets `cancelled` synchronously at prompt entry and refuses concurrent prompts, so it has no equivalent window.

The package's `engines.node` moves to `>=22.19.0` to match the root, which the new test's `Promise.withResolvers` requires.

One downstream effect worth knowing about: focusing a worktree broadcasts a `moving_to_worktree` cancel to local sessions, and that cancel now registers in the setup window where it used to slip through. Autoresearch treats any `cancelled` as a user stop and pauses the run. This already happens on main whenever the cancel lands on an active turn, so the change makes it consistent rather than introducing it. Whether that case should be an `interrupted` with auto-recovery instead of a `paused` is a separate question in `autoresearch.ts`.

## How did you test this?

New test file covering the race, 6 cases. Neutralizing the early return fails 4 of them, so they guard the behavior rather than just describing it. The sixth case drives the concurrent interleaving: one prompt stalled in setup, a cancel, then a `/context` that queues and activates in that window. Putting the `session.cancelled` term back into the check fails that case alone.

Full `@posthog/agent` suite: 1648 tests across 98 files, all passing. `pnpm typecheck` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
