### PR TITLE
feat(channels): add the structured Activity view (4/4)

### DIFF
--- a/packages/core/src/canvas/runArtifactSchemas.test.ts
+++ b/packages/core/src/canvas/runArtifactSchemas.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseRunPlans } from "./runArtifactSchemas";
+
+describe("parseRunPlans", () => {
+  it.each([
+    { name: "undefined", raw: undefined },
+    { name: "null", raw: null },
+    { name: "an object", raw: { artifacts: [] } },
+    { name: "a string", raw: "plan" },
+  ])("reads $name as no artifacts", ({ raw }) => {
+    expect(parseRunPlans(raw)).toEqual([]);
+  });
+
+  it("keeps only plan artifacts", () => {
+    const plans = parseRunPlans([
+      { id: "a", type: "plan", name: "Plan A" },
+      { id: "b", type: "upload", name: "internal blob" },
+    ]);
+    expect(plans).toEqual([{ id: "a", type: "plan", name: "Plan A" }]);
+  });
+
+  // One bad entry shouldn't take the Artifacts tab down with it.
+  it("drops entries that don't match the shape", () => {
+    const plans = parseRunPlans([
+      { id: 42, type: "plan" },
+      null,
+      "not an object",
+      { type: "plan", storage_path: "runs/1/plan.md" },
+    ]);
+    expect(plans).toEqual([{ type: "plan", storage_path: "runs/1/plan.md" }]);
+  });
+
+  it("ignores an artifact with no type", () => {
+    expect(parseRunPlans([{ id: "a", name: "mystery" }])).toEqual([]);
+  });
+});

--- a/packages/core/src/canvas/runArtifactSchemas.test.ts
+++ b/packages/core/src/canvas/runArtifactSchemas.test.ts
@@ -1,36 +1,68 @@
 import { describe, expect, it } from "vitest";
-import { parseRunPlans } from "./runArtifactSchemas";
+import { OUTPUT_ARTIFACT_TYPES, parseRunArtifacts } from "./runArtifactSchemas";
 
-describe("parseRunPlans", () => {
+describe("parseRunArtifacts", () => {
   it.each([
     { name: "undefined", raw: undefined },
     { name: "null", raw: null },
     { name: "an object", raw: { artifacts: [] } },
-    { name: "a string", raw: "plan" },
+    { name: "a string", raw: "output" },
   ])("reads $name as no artifacts", ({ raw }) => {
-    expect(parseRunPlans(raw)).toEqual([]);
+    expect(parseRunArtifacts(raw, OUTPUT_ARTIFACT_TYPES)).toEqual([]);
   });
 
-  it("keeps only plan artifacts", () => {
-    const plans = parseRunPlans([
-      { id: "a", type: "plan", name: "Plan A" },
-      { id: "b", type: "upload", name: "internal blob" },
+  // A run's manifest mixes deliverables with plumbing nobody asked to see.
+  it("keeps only the requested types", () => {
+    const outputs = parseRunArtifacts(
+      [
+        { id: "a", type: "output", name: "report.md" },
+        { id: "b", type: "user_attachment", name: "clipboard.png" },
+        { id: "c", type: "skill_bundle", name: "skills.zip" },
+      ],
+      OUTPUT_ARTIFACT_TYPES,
+    );
+    expect(outputs).toEqual([{ id: "a", type: "output", name: "report.md" }]);
+  });
+
+  it("reads the size and upload time the row renders", () => {
+    const artifact = {
+      id: "a",
+      type: "output",
+      name: "report.md",
+      size: 16861,
+      content_type: "text/markdown",
+      uploaded_at: "2026-07-27T08:27:26.896719+00:00",
+    };
+    expect(parseRunArtifacts([artifact], OUTPUT_ARTIFACT_TYPES)).toEqual([
+      artifact,
     ]);
-    expect(plans).toEqual([{ id: "a", type: "plan", name: "Plan A" }]);
+  });
+
+  it("keeps an artifact that omits the optional fields", () => {
+    expect(
+      parseRunArtifacts([{ type: "output" }], OUTPUT_ARTIFACT_TYPES),
+    ).toEqual([{ type: "output" }]);
   });
 
   // One bad entry shouldn't take the Artifacts tab down with it.
   it("drops entries that don't match the shape", () => {
-    const plans = parseRunPlans([
-      { id: 42, type: "plan" },
-      null,
-      "not an object",
-      { type: "plan", storage_path: "runs/1/plan.md" },
+    const outputs = parseRunArtifacts(
+      [
+        { id: 42, type: "output" },
+        null,
+        "not an object",
+        { type: "output", storage_path: "runs/1/report.md" },
+      ],
+      OUTPUT_ARTIFACT_TYPES,
+    );
+    expect(outputs).toEqual([
+      { type: "output", storage_path: "runs/1/report.md" },
     ]);
-    expect(plans).toEqual([{ type: "plan", storage_path: "runs/1/plan.md" }]);
   });
 
   it("ignores an artifact with no type", () => {
-    expect(parseRunPlans([{ id: "a", name: "mystery" }])).toEqual([]);
+    expect(
+      parseRunArtifacts([{ id: "a", name: "mystery" }], OUTPUT_ARTIFACT_TYPES),
+    ).toEqual([]);
   });
 });

--- a/packages/core/src/canvas/runArtifactSchemas.ts
+++ b/packages/core/src/canvas/runArtifactSchemas.ts
@@ -4,14 +4,30 @@ export const runArtifactSchema = z.object({
   id: z.string().optional(),
   name: z.string().optional(),
   type: z.string().optional(),
+  size: z.number().optional(),
+  content_type: z.string().optional(),
   storage_path: z.string().optional(),
+  uploaded_at: z.string().optional(),
 });
 export type RunArtifact = z.infer<typeof runArtifactSchema>;
 
-export function parseRunPlans(raw: unknown): RunArtifact[] {
+/** Artifacts the agent hands back as deliverables, via the `upload_artifact` tool. */
+export const OUTPUT_ARTIFACT_TYPES = ["output"] as const;
+
+/**
+ * The run's artifacts of the given types, in manifest order. A run's manifest
+ * also carries plumbing the user never asked for — skill bundles, their own
+ * attachments — so callers name the types they want.
+ */
+export function parseRunArtifacts(
+  raw: unknown,
+  types: readonly string[],
+): RunArtifact[] {
   if (!Array.isArray(raw)) return [];
   return raw.flatMap((entry) => {
     const parsed = runArtifactSchema.safeParse(entry);
-    return parsed.success && parsed.data.type === "plan" ? [parsed.data] : [];
+    if (!parsed.success) return [];
+    const { type } = parsed.data;
+    return type && types.includes(type) ? [parsed.data] : [];
   });
 }

--- a/packages/core/src/canvas/runArtifactSchemas.ts
+++ b/packages/core/src/canvas/runArtifactSchemas.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const runArtifactSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().optional(),
+  type: z.string().optional(),
+  storage_path: z.string().optional(),
+});
+export type RunArtifact = z.infer<typeof runArtifactSchema>;
+
+export function parseRunPlans(raw: unknown): RunArtifact[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    const parsed = runArtifactSchema.safeParse(entry);
+    return parsed.success && parsed.data.type === "plan" ? [parsed.data] : [];
+  });
+}

--- a/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -1,4 +1,8 @@
-import { CaretRightIcon } from "@phosphor-icons/react";
+import {
+  ArrowSquareOutIcon,
+  CaretRightIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import { Button, cn, Tabs, TabsList, TabsTrigger } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
@@ -8,7 +12,6 @@ import { TaskArtifactsList } from "@posthog/ui/features/canvas/components/TaskAr
 import {
   AgentStatusLine,
   ThreadLoadingState,
-  ThreadPanelHeader,
   ThreadReplyComposer,
   ThreadTimeline,
 } from "@posthog/ui/features/canvas/components/ThreadPanel";
@@ -35,27 +38,76 @@ const TABS_WITH_COMPOSER: ReadonlySet<ActivityTab> = new Set([
 const TIMESTAMP_END_CLASS =
   "[&_[data-slot=thread-item-timestamp]]:ml-auto [&_[data-slot=thread-item-timestamp]]:shrink-0 [&_[data-slot=thread-item-timestamp]]:pl-2";
 
-function ActivityTabsRow({
+/** The 32px row this panel leads with: the tabs are the header, so the strip
+ *  lines up with the tab bar of the pane on its left (TabbedPanel) and the
+ *  review toolbar, which are the same fixed height and border. */
+function ActivityHeader({
   tab,
   onTabChange,
+  onClose,
+  onToggleCollapsed,
+  onOpenFull,
 }: {
   tab: ActivityTab;
   onTabChange: (tab: ActivityTab) => void;
+  onClose?: () => void;
+  onToggleCollapsed?: () => void;
+  onOpenFull?: () => void;
 }) {
   return (
-    <div className="shrink-0 border-border border-b px-2 py-1.5">
+    <div className="flex h-[32px] shrink-0 items-center gap-1 border-b border-b-(--gray-6) pr-1 pl-2">
       <Tabs
         value={tab}
         onValueChange={(value: string) => onTabChange(value as ActivityTab)}
       >
-        <TabsList variant="line" className="h-auto gap-0.5">
+        {/* Nothing spells out "Activity" any more, so the strip carries the name.
+            The list fills the row's 32px and drops quill's 3px inset so the
+            line-variant indicator (bottom: 0 of the list) lands on the row's
+            bottom border, the way the left pane's tabs underline does. */}
+        <TabsList
+          variant="line"
+          aria-label="Activity"
+          className="h-[31px] gap-0.5 p-0"
+        >
           {ACTIVITY_TABS.map((t) => (
-            <TabsTrigger key={t.key} value={t.key} className="px-2.5 py-1">
+            <TabsTrigger key={t.key} value={t.key} className="px-2.5">
               <span className="font-medium text-[13px]">{t.label}</span>
             </TabsTrigger>
           ))}
         </TabsList>
       </Tabs>
+      <div className="ml-auto flex shrink-0 items-center gap-1">
+        {onOpenFull && (
+          <Button
+            variant="default"
+            size="icon-sm"
+            aria-label="Open full task"
+            onClick={onOpenFull}
+          >
+            <ArrowSquareOutIcon size={14} />
+          </Button>
+        )}
+        {onToggleCollapsed && (
+          <Button
+            variant="default"
+            size="icon-sm"
+            aria-label="Collapse activity"
+            onClick={onToggleCollapsed}
+          >
+            <CaretRightIcon size={14} />
+          </Button>
+        )}
+        {onClose && (
+          <Button
+            variant="default"
+            size="icon-sm"
+            aria-label="Close activity"
+            onClick={onClose}
+          >
+            <XIcon size={14} />
+          </Button>
+        )}
+      </div>
     </div>
   );
 }
@@ -170,13 +222,13 @@ function ActivityConversation({
         TIMESTAMP_END_CLASS,
       )}
     >
-      <ThreadPanelHeader
-        title="Activity"
+      <ActivityHeader
+        tab={tab}
+        onTabChange={handleTabChange}
         onOpenFull={onOpenFull}
         onToggleCollapsed={onToggleCollapsed}
         onClose={onClose}
       />
-      <ActivityTabsRow tab={tab} onTabChange={handleTabChange} />
 
       {showTaskSummary && (
         <div className="z-10 px-2">
@@ -235,15 +287,18 @@ export function ActivityPanel({
 
   if (collapsed) {
     return (
-      <div className="flex h-full w-9 flex-col items-center border-border border-l bg-gray-1 py-2">
-        <Button
-          variant="default"
-          size="icon-sm"
-          aria-label="Expand activity"
-          onClick={onToggleCollapsed}
-        >
-          <CaretRightIcon size={14} className="rotate-180" />
-        </Button>
+      <div className="flex h-full w-9 flex-col items-center border-border border-l bg-gray-1">
+        {/* Same 32px band as the expanded header, so the button doesn't jump. */}
+        <div className="flex h-[32px] shrink-0 items-center">
+          <Button
+            variant="default"
+            size="icon-sm"
+            aria-label="Expand activity"
+            onClick={onToggleCollapsed}
+          >
+            <CaretRightIcon size={14} className="rotate-180" />
+          </Button>
+        </div>
       </div>
     );
   }

--- a/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -1,0 +1,265 @@
+import { CaretRightIcon } from "@phosphor-icons/react";
+import { Button, cn, Tabs, TabsList, TabsTrigger } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import type { Task } from "@posthog/shared/domain-types";
+import { ActivityTimeline } from "@posthog/ui/features/canvas/components/ActivityTimeline";
+import { TaskCard } from "@posthog/ui/features/canvas/components/ChannelFeedView";
+import { TaskArtifactsList } from "@posthog/ui/features/canvas/components/TaskArtifactsList";
+import {
+  AgentStatusLine,
+  ThreadLoadingState,
+  ThreadPanelHeader,
+  ThreadReplyComposer,
+  ThreadTimeline,
+} from "@posthog/ui/features/canvas/components/ThreadPanel";
+import { useThreadConversation } from "@posthog/ui/features/canvas/hooks/useThreadConversation";
+import { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
+import { track } from "@posthog/ui/shell/analytics";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+type ActivityTab = "timeline" | "artifacts" | "comments";
+
+const ACTIVITY_TABS: readonly { key: ActivityTab; label: string }[] = [
+  { key: "timeline", label: "Timeline" },
+  { key: "artifacts", label: "Artifacts" },
+  { key: "comments", label: "Comments" },
+] as const;
+
+const TABS_WITH_COMPOSER: ReadonlySet<ActivityTab> = new Set([
+  "timeline",
+  "comments",
+]);
+
+const TIMESTAMP_END_CLASS =
+  "[&_[data-slot=thread-item-timestamp]]:ml-auto [&_[data-slot=thread-item-timestamp]]:shrink-0 [&_[data-slot=thread-item-timestamp]]:pl-2";
+
+function ActivityTabsRow({
+  tab,
+  onTabChange,
+}: {
+  tab: ActivityTab;
+  onTabChange: (tab: ActivityTab) => void;
+}) {
+  return (
+    <div className="shrink-0 border-border border-b px-2 py-1.5">
+      <Tabs
+        value={tab}
+        onValueChange={(value: string) => onTabChange(value as ActivityTab)}
+      >
+        <TabsList variant="line" className="h-auto gap-0.5">
+          {ACTIVITY_TABS.map((t) => (
+            <TabsTrigger key={t.key} value={t.key} className="px-2.5 py-1">
+              <span className="font-medium text-[13px]">{t.label}</span>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+    </div>
+  );
+}
+
+function ActivityConversation({
+  task,
+  channelId,
+  onClose,
+  onToggleCollapsed,
+  onOpenFull,
+  showTaskSummary,
+}: {
+  task: Task;
+  channelId: string;
+  onClose?: () => void;
+  onToggleCollapsed?: () => void;
+  onOpenFull?: () => void;
+  showTaskSummary: boolean;
+}) {
+  const taskId = task.id;
+  const {
+    timeline,
+    agentStatus,
+    events,
+    isPromptPending,
+    isReady,
+    members,
+    currentUser,
+    isTaskAuthor,
+    canForward,
+    draft,
+    setDraft,
+    isSubmitDisabled,
+    submit,
+    sendMessageToAgent,
+    deleteMessage,
+    onMentionInsert,
+  } = useThreadConversation(task, { surface: "activity_panel" });
+
+  const [tab, setTab] = useState<ActivityTab>("timeline");
+  const handleTabChange = useCallback(
+    (next: ActivityTab) => {
+      setTab(next);
+      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        action_type: "activity_tab_change",
+        surface: "activity_panel",
+        task_id: taskId,
+        tab: next,
+      });
+    },
+    [taskId],
+  );
+
+  const commentRows = useMemo(
+    () => timeline.filter((row) => row.kind === "human"),
+    [timeline],
+  );
+  const conversationItems = useMemo(
+    () =>
+      tab === "timeline"
+        ? buildConversationItems(events, isPromptPending).items
+        : [],
+    [tab, events, isPromptPending],
+  );
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll when rendered thread content changes
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [timeline, events.length, agentStatus?.phase, tab]);
+
+  const showComposer = TABS_WITH_COMPOSER.has(tab);
+
+  const body = () => {
+    if (tab === "artifacts") {
+      return <TaskArtifactsList task={task} timeline={timeline} />;
+    }
+    if (tab === "comments") {
+      return (
+        <ThreadTimeline
+          timeline={commentRows}
+          isReady={isReady}
+          currentUserUuid={currentUser?.uuid}
+          currentUserEmail={currentUser?.email}
+          isTaskAuthor={isTaskAuthor}
+          canForward={canForward}
+          onSendToAgent={sendMessageToAgent}
+          onDelete={deleteMessage}
+        />
+      );
+    }
+    if (!isReady) return <ThreadLoadingState />;
+    return (
+      <ActivityTimeline
+        task={task}
+        timeline={timeline}
+        conversationItems={conversationItems}
+        currentUserUuid={currentUser?.uuid}
+        currentUserEmail={currentUser?.email}
+        isTaskAuthor={isTaskAuthor}
+        canForward={canForward}
+        onSendToAgent={sendMessageToAgent}
+        onDelete={deleteMessage}
+      />
+    );
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex h-full min-w-0 flex-col bg-gray-1",
+        TIMESTAMP_END_CLASS,
+      )}
+    >
+      <ThreadPanelHeader
+        title="Activity"
+        onOpenFull={onOpenFull}
+        onToggleCollapsed={onToggleCollapsed}
+        onClose={onClose}
+      />
+      <ActivityTabsRow tab={tab} onTabChange={handleTabChange} />
+
+      {showTaskSummary && (
+        <div className="z-10 px-2">
+          <TaskCard task={task} channelId={channelId} inThread />
+        </div>
+      )}
+      <div
+        ref={scrollRef}
+        aria-busy={!isReady}
+        className="flex-1 overflow-y-auto"
+      >
+        {body()}
+      </div>
+
+      {showComposer && agentStatus && <AgentStatusLine status={agentStatus} />}
+
+      {showComposer && (
+        <ThreadReplyComposer
+          draft={draft}
+          onDraftChange={setDraft}
+          onSubmit={submit}
+          members={members}
+          allowAgentMention={isTaskAuthor && canForward}
+          onMentionInsert={onMentionInsert}
+          disabled={isSubmitDisabled}
+        />
+      )}
+    </div>
+  );
+}
+
+export function ActivityPanel({
+  taskId,
+  channelId,
+  task: taskProp,
+  onClose,
+  collapsed,
+  onToggleCollapsed,
+  onOpenFull,
+  showTaskSummary = true,
+}: {
+  taskId: string;
+  channelId: string;
+  task?: Task;
+  onClose?: () => void;
+  collapsed?: boolean;
+  onToggleCollapsed?: () => void;
+  onOpenFull?: () => void;
+  showTaskSummary?: boolean;
+}) {
+  const { data: fetchedTask } = useQuery({
+    ...taskDetailQuery(taskId),
+    enabled: !taskProp && !collapsed,
+  });
+  const task = taskProp ?? fetchedTask;
+
+  if (collapsed) {
+    return (
+      <div className="flex h-full w-9 flex-col items-center border-border border-l bg-gray-1 py-2">
+        <Button
+          variant="default"
+          size="icon-sm"
+          aria-label="Expand activity"
+          onClick={onToggleCollapsed}
+        >
+          <CaretRightIcon size={14} className="rotate-180" />
+        </Button>
+      </div>
+    );
+  }
+
+  if (!task) {
+    return <ThreadLoadingState />;
+  }
+
+  return (
+    <ActivityConversation
+      task={task}
+      channelId={channelId}
+      onClose={onClose}
+      onToggleCollapsed={onToggleCollapsed}
+      onOpenFull={onOpenFull}
+      showTaskSummary={showTaskSummary}
+    />
+  );
+}

--- a/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -1,0 +1,262 @@
+import { CheckCircleIcon, XCircleIcon } from "@phosphor-icons/react";
+import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
+import {
+  ThreadItem,
+  ThreadItemAuthor,
+  ThreadItemBody,
+  ThreadItemContent,
+  ThreadItemGroup,
+  ThreadItemGutter,
+  ThreadItemHeader,
+} from "@posthog/quill";
+import type {
+  Task,
+  TaskThreadMessage,
+  UserBasic,
+} from "@posthog/shared/domain-types";
+import { isTerminalStatus } from "@posthog/shared/domain-types";
+import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
+import {
+  ThreadArtifactRow,
+  ThreadMessageRow,
+} from "@posthog/ui/features/canvas/components/ThreadPanel";
+import { ThreadTimestamp } from "@posthog/ui/features/canvas/components/ThreadTimestamp";
+import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import type { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { Fragment, type ReactNode, useMemo } from "react";
+
+type ConversationItem = ReturnType<
+  typeof buildConversationItems
+>["items"][number];
+
+function ActivityEventRow({
+  node,
+  title,
+  action,
+  timestamp,
+}: {
+  node: ReactNode;
+  title: string;
+  action?: string;
+  timestamp: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 py-1.5 pr-2 pl-2">
+      <div className="flex w-10 shrink-0 justify-end">
+        <div className="flex w-[2.35rem] justify-center">{node}</div>
+      </div>
+      <span className="min-w-0 truncate text-[13px]">
+        <span className="font-medium text-gray-12">{title}</span>
+        {action && <span className="text-muted-foreground"> {action}</span>}
+      </span>
+      <ThreadTimestamp dateTime={timestamp} />
+    </div>
+  );
+}
+
+function EventNode({ icon }: { icon: ReactNode }) {
+  return (
+    <span className="relative z-10 flex size-6 items-center justify-center rounded-full bg-gray-3">
+      {icon}
+    </span>
+  );
+}
+
+function UserMessageRow({
+  author,
+  content,
+  timestamp,
+}: {
+  author?: UserBasic | null;
+  content: string;
+  timestamp: string;
+}) {
+  return (
+    <ThreadItem>
+      <ThreadItemGutter>
+        <UserAvatar user={author} size="lg" className="sticky top-2" />
+      </ThreadItemGutter>
+      <ThreadItemContent>
+        <ThreadItemHeader>
+          <ThreadItemAuthor>
+            {author ? userDisplayName(author) : "You"}
+          </ThreadItemAuthor>
+          <ThreadTimestamp dateTime={timestamp} />
+        </ThreadItemHeader>
+        <ThreadItemBody>
+          <span className="line-clamp-4 whitespace-pre-wrap break-words text-[13px]">
+            {content}
+          </span>
+        </ThreadItemBody>
+      </ThreadItemContent>
+    </ThreadItem>
+  );
+}
+
+export function ActivityTimeline({
+  task,
+  timeline,
+  conversationItems,
+  currentUserUuid,
+  currentUserEmail,
+  isTaskAuthor,
+  canForward,
+  onSendToAgent,
+  onDelete,
+}: {
+  task: Task;
+  timeline: ThreadTimelineRow<TaskThreadMessage>[];
+  conversationItems: ConversationItem[];
+  currentUserUuid?: string;
+  currentUserEmail?: string | null;
+  isTaskAuthor: boolean;
+  canForward: boolean;
+  onSendToAgent: (messageId: string) => void;
+  onDelete: (messageId: string) => void;
+}) {
+  const nodes = useMemo(() => {
+    const entries: { key: string; ts: number; node: ReactNode }[] = [];
+    const createdTs = Date.parse(task.created_at) || 0;
+    entries.push({
+      key: "task-created",
+      ts: createdTs,
+      node: (
+        <ActivityEventRow
+          node={
+            <UserAvatar
+              user={task.created_by}
+              size="sm"
+              className="relative z-10"
+            />
+          }
+          title={task.created_by ? userDisplayName(task.created_by) : "Someone"}
+          action="created this task"
+          timestamp={task.created_at}
+        />
+      ),
+    });
+
+    for (const item of conversationItems) {
+      if (item.type !== "user_message") continue;
+      entries.push({
+        key: `user-message-${item.id}`,
+        ts: item.timestamp,
+        node: (
+          <UserMessageRow
+            author={task.created_by}
+            content={item.content}
+            timestamp={new Date(item.timestamp).toISOString()}
+          />
+        ),
+      });
+    }
+
+    let hasPrArtifact = false;
+    for (const row of timeline) {
+      if (row.kind === "artifact" && row.artifact.kind === "pr") {
+        hasPrArtifact = true;
+      }
+      entries.push({
+        key: `thread-${row.message.id}`,
+        ts: row.timestamp,
+        node:
+          row.kind === "human" ? (
+            <ThreadMessageRow
+              message={row.message}
+              isTaskAuthor={isTaskAuthor}
+              isOwnMessage={
+                !!currentUserUuid &&
+                currentUserUuid === row.message.author?.uuid
+              }
+              currentUserEmail={currentUserEmail}
+              canForward={canForward}
+              onSendToAgent={() => onSendToAgent(row.message.id)}
+              onDelete={() => onDelete(row.message.id)}
+            />
+          ) : (
+            <ThreadArtifactRow
+              artifact={row.artifact}
+              createdAt={row.message.created_at}
+            />
+          ),
+      });
+    }
+
+    const updatedTs = Date.parse(task.updated_at) || createdTs;
+    const outputPr = task.latest_run?.output?.pr_url;
+    if (typeof outputPr === "string" && outputPr && !hasPrArtifact) {
+      entries.push({
+        key: "output-pr",
+        ts: updatedTs,
+        node: (
+          <ThreadArtifactRow
+            artifact={{ kind: "pr", url: outputPr }}
+            createdAt={task.updated_at}
+          />
+        ),
+      });
+    }
+
+    const runStatus = task.latest_run?.status;
+    if (runStatus && isTerminalStatus(runStatus)) {
+      const succeeded = runStatus === "completed";
+      entries.push({
+        key: "run-status",
+        ts: updatedTs + 1,
+        node: (
+          <ActivityEventRow
+            node={
+              <EventNode
+                icon={
+                  succeeded ? (
+                    <CheckCircleIcon
+                      size={14}
+                      weight="fill"
+                      className="text-green-9"
+                    />
+                  ) : (
+                    <XCircleIcon
+                      size={14}
+                      weight="fill"
+                      className="text-red-9"
+                    />
+                  )
+                }
+              />
+            }
+            title={`Task ${runStatus.replace(/_/g, " ")}`}
+            timestamp={task.updated_at}
+          />
+        ),
+      });
+    }
+
+    return entries.sort((a, b) => a.ts - b.ts);
+  }, [
+    conversationItems,
+    timeline,
+    task,
+    isTaskAuthor,
+    canForward,
+    currentUserUuid,
+    currentUserEmail,
+    onSendToAgent,
+    onDelete,
+  ]);
+
+  return (
+    <div className="relative">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute top-4 bottom-4 left-[1.825rem] w-px bg-border"
+      />
+      <div className="relative z-10">
+        <ThreadItemGroup>
+          {nodes.map((entry) => (
+            <Fragment key={entry.key}>{entry.node}</Fragment>
+          ))}
+        </ThreadItemGroup>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/features/canvas/components/ChannelHeader.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHeader.tsx
@@ -1,54 +1,20 @@
-import { StarIcon } from "@phosphor-icons/react";
 import { Button, cn } from "@posthog/quill";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { ChannelTabs } from "@posthog/ui/features/canvas/components/ChannelTabs";
 import { channelGlyph } from "@posthog/ui/features/canvas/components/channelGlyph";
-import { useChannelStarToggle } from "@posthog/ui/features/canvas/hooks/useChannelStars";
-import {
-  type Channel,
-  useChannels,
-} from "@posthog/ui/features/canvas/hooks/useChannels";
+import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useMarkChannelSeen } from "@posthog/ui/features/canvas/hooks/useMarkChannelSeen";
-import { PERSONAL_CHANNEL_NAME } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
-import { track } from "@posthog/ui/shell/analytics";
 import { Text } from "@radix-ui/themes";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 
-// The feed-side counterpart to the sidebar back row's hover star.
-function ChannelStarButton({ channel }: { channel: Channel }) {
-  const { isStarred, toggleStar } = useChannelStarToggle(channel);
-  return (
-    <Button
-      type="button"
-      size="icon-sm"
-      aria-label={isStarred ? "Unstar space" : "Star space"}
-      onClick={() => {
-        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
-          action_type: isStarred ? "unstar" : "star",
-          surface: "channel_home",
-          channel_id: channel.id,
-        });
-        toggleStar();
-      }}
-    >
-      <StarIcon
-        size={14}
-        weight={isStarred ? "fill" : "regular"}
-        className={isStarred ? undefined : "text-muted-foreground/80"}
-      />
-    </Button>
-  );
-}
-
 // The shared channel header. The new layout drops the section tab strip — the
-// channel sidebar carries those entries — while flag off keeps it.
+// channel sidebar carries those entries — while flag off keeps it. Starring
+// lives on the sidebar back row and the channel list, not here.
 export function ChannelHeader({ channelId }: { channelId: string }) {
   const navigate = useNavigate();
   const channelsLayout = useChannelsLayout();
   const { channels } = useChannels();
-  const channel = channels.find((c) => c.id === channelId);
-  const channelName = channel?.name;
+  const channelName = channels.find((c) => c.id === channelId)?.name;
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const isHome = pathname === `/website/${channelId}`;
   // Every channel surface renders this header, so mark the channel read here.
@@ -73,9 +39,6 @@ export function ChannelHeader({ channelId }: { channelId: string }) {
           {channelName ?? (channelsLayout ? "Space" : "Channel")}
         </Text>
       </Button>
-      {channelsLayout && channel && channel.name !== PERSONAL_CHANNEL_NAME && (
-        <ChannelStarButton channel={channel} />
-      )}
       {!channelsLayout && <ChannelTabs channelId={channelId} />}
     </div>
   );

--- a/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
+++ b/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
@@ -4,16 +4,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   runs: [] as TaskRun[],
-  presignTaskRunArtifact: vi.fn(),
+  openArtifactTab: vi.fn(),
 }));
 
 vi.mock("@posthog/ui/features/canvas/hooks/useTaskRuns", () => ({
   useTaskRuns: () => ({ runs: mocks.runs, isLoading: false }),
 }));
-vi.mock("@posthog/ui/features/auth/authClient", () => ({
-  useOptionalAuthenticatedClient: () => ({
-    presignTaskRunArtifact: mocks.presignTaskRunArtifact,
-  }),
+vi.mock("@posthog/ui/features/panels/panelLayoutStore", () => ({
+  usePanelLayoutStore: () => mocks.openArtifactTab,
 }));
 vi.mock("@posthog/ui/features/git-interaction/usePrArtifact", () => ({
   usePrArtifact: (url: string) => ({
@@ -66,8 +64,7 @@ function outputFile(
 describe("TaskArtifactsList", () => {
   beforeEach(() => {
     mocks.runs = [run("run-1", { prNumber: 1 }), run("run-2", { prNumber: 2 })];
-    mocks.presignTaskRunArtifact.mockReset();
-    mocks.presignTaskRunArtifact.mockResolvedValue("https://signed.example/x");
+    mocks.openArtifactTab.mockReset();
     useReviewNavigationStore.setState({
       reviewModes: {},
       selectedPrUrls: {},
@@ -97,7 +94,22 @@ describe("TaskArtifactsList", () => {
     expect(screen.getByText("File · 17 KB")).toBeTruthy();
   });
 
-  it("presigns the artifact of the run that produced it", () => {
+  // The row should read like the chat's file list: markdown looks like
+  // markdown, HTML looks like HTML.
+  it.each([
+    { name: "notes.md", icon: "markdown" },
+    { name: "demo.html", icon: "html" },
+  ])("gives $name an icon for its file type", ({ name, icon }) => {
+    mocks.runs = [run("run-1", { artifacts: [outputFile({ id: "a", name })] })];
+
+    const { container } = render(
+      <TaskArtifactsList task={task} timeline={[]} />,
+    );
+
+    expect(container.querySelector("img")?.getAttribute("src")).toContain(icon);
+  });
+
+  it("opens the artifact of the run that produced it beside the chat", () => {
     mocks.runs = [
       run("run-1", { artifacts: [outputFile({ id: "a", name: "old.md" })] }),
       run("run-2", {
@@ -114,11 +126,11 @@ describe("TaskArtifactsList", () => {
     render(<TaskArtifactsList task={task} timeline={[]} />);
     fireEvent.click(screen.getByText("new.md"));
 
-    expect(mocks.presignTaskRunArtifact).toHaveBeenCalledWith(
-      "task-1",
-      "run-2",
-      "runs/2/new.md",
-    );
+    expect(mocks.openArtifactTab).toHaveBeenCalledWith("task-1", {
+      runId: "run-2",
+      artifactId: "b",
+      name: "new.md",
+    });
   });
 
   // Agents revise a deliverable and upload it again under the same name.

--- a/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
+++ b/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
@@ -1,0 +1,63 @@
+import type { Task, TaskRun } from "@posthog/shared/domain-types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  runs: [] as TaskRun[],
+}));
+
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskRuns", () => ({
+  useTaskRuns: () => ({ runs: mocks.runs, isLoading: false }),
+}));
+vi.mock("@posthog/ui/features/git-interaction/usePrArtifact", () => ({
+  usePrArtifact: (url: string) => ({
+    safeUrl: url,
+    title: `Pull request #${url.split("/").at(-1)}`,
+    stateLabel: "Open",
+    Icon: () => <span />,
+    iconColor: "currentColor",
+  }),
+}));
+vi.mock("@posthog/ui/features/pr-review/usePrComments", () => ({
+  usePrComments: () => ({ data: undefined }),
+}));
+vi.mock("@posthog/ui/features/pr-review/usePrReviewThreads", () => ({
+  usePrReviewThreads: () => ({ data: undefined }),
+}));
+
+import { useReviewNavigationStore } from "@posthog/ui/features/code-review/reviewNavigationStore";
+import { TaskArtifactsList } from "./TaskArtifactsList";
+
+const task = {
+  id: "task-1",
+  latest_run: null,
+} as unknown as Task;
+
+function run(id: string, prNumber: number): TaskRun {
+  return {
+    id,
+    output: { pr_url: `https://github.com/acme/repo/pull/${prNumber}` },
+  } as unknown as TaskRun;
+}
+
+describe("TaskArtifactsList", () => {
+  beforeEach(() => {
+    mocks.runs = [run("run-1", 1), run("run-2", 2)];
+    useReviewNavigationStore.setState({
+      reviewModes: {},
+      selectedPrUrls: {},
+    });
+  });
+
+  it("opens the PR represented by the selected historical row", () => {
+    render(<TaskArtifactsList task={task} timeline={[]} />);
+
+    fireEvent.click(screen.getByText("Pull request #2"));
+
+    const state = useReviewNavigationStore.getState();
+    expect(state.selectedPrUrls[task.id]).toBe(
+      "https://github.com/acme/repo/pull/2",
+    );
+    expect(state.reviewModes[task.id]).toBe("split");
+  });
+});

--- a/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
+++ b/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
@@ -1,13 +1,19 @@
-import type { Task, TaskRun } from "@posthog/shared/domain-types";
+import type { Task, TaskRun, TaskRunArtifact } from "@posthog/shared";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   runs: [] as TaskRun[],
+  presignTaskRunArtifact: vi.fn(),
 }));
 
 vi.mock("@posthog/ui/features/canvas/hooks/useTaskRuns", () => ({
   useTaskRuns: () => ({ runs: mocks.runs, isLoading: false }),
+}));
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => ({
+    presignTaskRunArtifact: mocks.presignTaskRunArtifact,
+  }),
 }));
 vi.mock("@posthog/ui/features/git-interaction/usePrArtifact", () => ({
   usePrArtifact: (url: string) => ({
@@ -33,16 +39,35 @@ const task = {
   latest_run: null,
 } as unknown as Task;
 
-function run(id: string, prNumber: number): TaskRun {
+function run(
+  id: string,
+  options: { prNumber?: number; artifacts?: Partial<TaskRunArtifact>[] } = {},
+): TaskRun {
   return {
     id,
-    output: { pr_url: `https://github.com/acme/repo/pull/${prNumber}` },
+    output: options.prNumber
+      ? { pr_url: `https://github.com/acme/repo/pull/${options.prNumber}` }
+      : null,
+    artifacts: options.artifacts,
   } as unknown as TaskRun;
+}
+
+function outputFile(
+  overrides: Partial<TaskRunArtifact>,
+): Partial<TaskRunArtifact> {
+  return {
+    type: "output",
+    name: "report.md",
+    storage_path: "runs/1/report.md",
+    ...overrides,
+  };
 }
 
 describe("TaskArtifactsList", () => {
   beforeEach(() => {
-    mocks.runs = [run("run-1", 1), run("run-2", 2)];
+    mocks.runs = [run("run-1", { prNumber: 1 }), run("run-2", { prNumber: 2 })];
+    mocks.presignTaskRunArtifact.mockReset();
+    mocks.presignTaskRunArtifact.mockResolvedValue("https://signed.example/x");
     useReviewNavigationStore.setState({
       reviewModes: {},
       selectedPrUrls: {},
@@ -59,5 +84,78 @@ describe("TaskArtifactsList", () => {
       "https://github.com/acme/repo/pull/2",
     );
     expect(state.reviewModes[task.id]).toBe("split");
+  });
+
+  it("lists the files the agent uploaded, with their size", () => {
+    mocks.runs = [
+      run("run-1", { artifacts: [outputFile({ id: "a", size: 16861 })] }),
+    ];
+
+    render(<TaskArtifactsList task={task} timeline={[]} />);
+
+    expect(screen.getByText("report.md")).toBeTruthy();
+    expect(screen.getByText("File · 17 KB")).toBeTruthy();
+  });
+
+  it("presigns the artifact of the run that produced it", () => {
+    mocks.runs = [
+      run("run-1", { artifacts: [outputFile({ id: "a", name: "old.md" })] }),
+      run("run-2", {
+        artifacts: [
+          outputFile({
+            id: "b",
+            name: "new.md",
+            storage_path: "runs/2/new.md",
+          }),
+        ],
+      }),
+    ];
+
+    render(<TaskArtifactsList task={task} timeline={[]} />);
+    fireEvent.click(screen.getByText("new.md"));
+
+    expect(mocks.presignTaskRunArtifact).toHaveBeenCalledWith(
+      "task-1",
+      "run-2",
+      "runs/2/new.md",
+    );
+  });
+
+  // Agents revise a deliverable and upload it again under the same name.
+  it("keeps only the newest upload of a repeatedly revised file", () => {
+    mocks.runs = [
+      run("run-1", {
+        artifacts: [
+          outputFile({
+            id: "a",
+            size: 1000,
+            uploaded_at: "2026-07-27T08:00:00+00:00",
+          }),
+          outputFile({
+            id: "b",
+            size: 2000,
+            storage_path: "runs/1/report-v2.md",
+            uploaded_at: "2026-07-27T09:00:00+00:00",
+          }),
+        ],
+      }),
+    ];
+
+    render(<TaskArtifactsList task={task} timeline={[]} />);
+
+    expect(screen.getAllByText("report.md")).toHaveLength(1);
+    expect(screen.getByText("File · 2 KB")).toBeTruthy();
+  });
+
+  it.each([
+    { name: "a plan", type: "plan" as const },
+    { name: "a user attachment", type: "user_attachment" as const },
+    { name: "a skill bundle", type: "skill_bundle" as const },
+  ])("shows the empty state for a run with only $name", ({ type }) => {
+    mocks.runs = [run("run-1", { artifacts: [outputFile({ id: "a", type })] })];
+
+    render(<TaskArtifactsList task={task} timeline={[]} />);
+
+    expect(screen.getByText("No artifacts yet")).toBeTruthy();
   });
 });

--- a/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
+++ b/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
@@ -1,11 +1,11 @@
 import {
   ArrowSquareOutIcon,
-  ClipboardTextIcon,
   PackageIcon,
   SlackLogoIcon,
 } from "@phosphor-icons/react";
 import {
-  parseRunPlans,
+  OUTPUT_ARTIFACT_TYPES,
+  parseRunArtifacts,
   type RunArtifact,
 } from "@posthog/core/canvas/runArtifactSchemas";
 import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
@@ -28,8 +28,10 @@ import { useReviewNavigationStore } from "@posthog/ui/features/code-review/revie
 import { usePrArtifact } from "@posthog/ui/features/git-interaction/usePrArtifact";
 import { usePrComments } from "@posthog/ui/features/pr-review/usePrComments";
 import { usePrReviewThreads } from "@posthog/ui/features/pr-review/usePrReviewThreads";
+import { FileIcon } from "@posthog/ui/primitives/FileIcon";
 import { toast } from "@posthog/ui/primitives/toast";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { formatFileSize } from "@posthog/ui/utils/formatFileSize";
 import { parseHttpsUrl, parseShareLink } from "@posthog/ui/utils/posthogLinks";
 import { navigateToShareTarget } from "@posthog/ui/utils/shareLinks";
 import { getPostHogUrl } from "@posthog/ui/utils/urls";
@@ -39,23 +41,20 @@ type ArtifactRow =
   | { kind: "pr"; key: string; url: string }
   | { kind: "canvas"; key: string; name: string; url: string | null }
   | {
-      kind: "plan";
+      kind: "file";
       key: string;
       name: string;
       storagePath: string | null;
       runId: string | null;
+      size: number | undefined;
     }
   | { kind: "slack"; key: string; url: string };
 
-function readRunPlans(run: TaskRun): RunArtifact[] {
-  return parseRunPlans((run as { artifacts?: unknown }).artifacts);
-}
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
-function planTitle(name: string | undefined): string {
-  if (!name || UUID_RE.test(name)) return "Plan";
-  return name;
+function readRunOutputs(run: TaskRun): RunArtifact[] {
+  return parseRunArtifacts(
+    (run as { artifacts?: unknown }).artifacts,
+    OUTPUT_ARTIFACT_TYPES,
+  );
 }
 
 function buildRows(
@@ -65,7 +64,6 @@ function buildRows(
 ): ArtifactRow[] {
   const rows: ArtifactRow[] = [];
   const seenPrUrls = new Set<string>();
-  const seenPlanKeys = new Set<string>();
 
   const addPr = (url: string, key: string) => {
     if (seenPrUrls.has(url)) return;
@@ -89,23 +87,34 @@ function buildRows(
 
   const allRuns =
     runs.length > 0 ? runs : task.latest_run ? [task.latest_run] : [];
+
+  // Re-uploading a file replaces it rather than adding a second one: agents
+  // revise a deliverable and upload it again under the same name, so keeping
+  // every copy would bury the current one under its own drafts.
+  const newestByName = new Map<string, { file: RunArtifact; runId: string }>();
   for (const run of allRuns) {
     const outputPr = run.output?.pr_url;
     if (typeof outputPr === "string" && outputPr) {
       addPr(outputPr, `output-pr:${outputPr}`);
     }
-    for (const plan of readRunPlans(run)) {
-      const key = `plan:${plan.id ?? plan.storage_path ?? plan.name}`;
-      if (seenPlanKeys.has(key)) continue;
-      seenPlanKeys.add(key);
-      rows.push({
-        kind: "plan",
-        key,
-        name: planTitle(plan.name),
-        storagePath: plan.storage_path ?? null,
-        runId: run.id,
-      });
+    for (const file of readRunOutputs(run)) {
+      if (!file.name) continue;
+      const previous = newestByName.get(file.name);
+      const isNewer =
+        !previous ||
+        (file.uploaded_at ?? "") >= (previous.file.uploaded_at ?? "");
+      if (isNewer) newestByName.set(file.name, { file, runId: run.id });
     }
+  }
+  for (const [name, { file, runId }] of newestByName) {
+    rows.push({
+      kind: "file",
+      key: `file:${file.id ?? file.storage_path ?? name}`,
+      name,
+      storagePath: file.storage_path ?? null,
+      runId,
+      size: file.size,
+    });
   }
 
   const slackUrl = task.latest_run?.state?.slack_thread_url;
@@ -226,16 +235,18 @@ function CanvasRow({ name, url }: { name: string; url: string | null }) {
   );
 }
 
-function PlanRow({
+function FileRow({
   taskId,
   runId,
   name,
   storagePath,
+  size,
 }: {
   taskId: string;
   runId: string | null;
   name: string;
   storagePath: string | null;
+  size: number | undefined;
 }) {
   const client = useOptionalAuthenticatedClient();
   const canOpen = !!client && !!runId && !!storagePath;
@@ -249,7 +260,7 @@ function PlanRow({
           )
           .then((url) => openExternalUrl(url))
           .catch((error: unknown) => {
-            toast.error("Couldn't open plan", {
+            toast.error("Couldn't open file", {
               description:
                 error instanceof Error ? error.message : String(error),
             });
@@ -258,9 +269,9 @@ function PlanRow({
     : undefined;
   return (
     <ArtifactListRow
-      icon={<ClipboardTextIcon size={14} className="shrink-0 text-amber-9" />}
+      icon={<FileIcon filename={name} size={14} />}
       title={name}
-      detail="Plan"
+      detail={["File", formatFileSize(size)].filter(Boolean).join(" · ")}
       external={canOpen}
       onOpen={onOpen}
     />
@@ -289,8 +300,8 @@ export function TaskArtifactsList({
           </EmptyMedia>
           <EmptyTitle>No artifacts yet</EmptyTitle>
           <EmptyDescription>
-            Pull requests and canvases produced while working on this task show
-            up here.
+            Pull requests, canvases, and files produced while working on this
+            task show up here.
           </EmptyDescription>
         </EmptyHeader>
       </Empty>
@@ -304,13 +315,14 @@ export function TaskArtifactsList({
           <PrRow key={row.key} url={row.url} taskId={task.id} />
         ) : row.kind === "canvas" ? (
           <CanvasRow key={row.key} name={row.name} url={row.url} />
-        ) : row.kind === "plan" ? (
-          <PlanRow
+        ) : row.kind === "file" ? (
+          <FileRow
             key={row.key}
             taskId={task.id}
             runId={row.runId}
             name={row.name}
             storagePath={row.storagePath}
+            size={row.size}
           />
         ) : (
           <ArtifactListRow

--- a/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
+++ b/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
@@ -1,0 +1,328 @@
+import {
+  ArrowSquareOutIcon,
+  ClipboardTextIcon,
+  PackageIcon,
+  SlackLogoIcon,
+} from "@phosphor-icons/react";
+import {
+  parseRunPlans,
+  type RunArtifact,
+} from "@posthog/core/canvas/runArtifactSchemas";
+import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@posthog/quill";
+import type {
+  Task,
+  TaskRun,
+  TaskThreadMessage,
+} from "@posthog/shared/domain-types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
+import { useTaskRuns } from "@posthog/ui/features/canvas/hooks/useTaskRuns";
+import { useReviewNavigationStore } from "@posthog/ui/features/code-review/reviewNavigationStore";
+import { usePrArtifact } from "@posthog/ui/features/git-interaction/usePrArtifact";
+import { usePrComments } from "@posthog/ui/features/pr-review/usePrComments";
+import { usePrReviewThreads } from "@posthog/ui/features/pr-review/usePrReviewThreads";
+import { toast } from "@posthog/ui/primitives/toast";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { parseHttpsUrl, parseShareLink } from "@posthog/ui/utils/posthogLinks";
+import { navigateToShareTarget } from "@posthog/ui/utils/shareLinks";
+import { getPostHogUrl } from "@posthog/ui/utils/urls";
+import { type ReactNode, useMemo, useState } from "react";
+
+type ArtifactRow =
+  | { kind: "pr"; key: string; url: string }
+  | { kind: "canvas"; key: string; name: string; url: string | null }
+  | {
+      kind: "plan";
+      key: string;
+      name: string;
+      storagePath: string | null;
+      runId: string | null;
+    }
+  | { kind: "slack"; key: string; url: string };
+
+function readRunPlans(run: TaskRun): RunArtifact[] {
+  return parseRunPlans((run as { artifacts?: unknown }).artifacts);
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+function planTitle(name: string | undefined): string {
+  if (!name || UUID_RE.test(name)) return "Plan";
+  return name;
+}
+
+function buildRows(
+  task: Task,
+  timeline: ThreadTimelineRow<TaskThreadMessage>[],
+  runs: TaskRun[],
+): ArtifactRow[] {
+  const rows: ArtifactRow[] = [];
+  const seenPrUrls = new Set<string>();
+  const seenPlanKeys = new Set<string>();
+
+  const addPr = (url: string, key: string) => {
+    if (seenPrUrls.has(url)) return;
+    seenPrUrls.add(url);
+    rows.push({ kind: "pr", key, url });
+  };
+
+  for (const row of timeline) {
+    if (row.kind !== "artifact") continue;
+    if (row.artifact.kind === "pr") {
+      addPr(row.artifact.url, row.message.id);
+    } else {
+      rows.push({
+        kind: "canvas",
+        key: row.message.id,
+        name: row.artifact.name,
+        url: row.artifact.url,
+      });
+    }
+  }
+
+  const allRuns =
+    runs.length > 0 ? runs : task.latest_run ? [task.latest_run] : [];
+  for (const run of allRuns) {
+    const outputPr = run.output?.pr_url;
+    if (typeof outputPr === "string" && outputPr) {
+      addPr(outputPr, `output-pr:${outputPr}`);
+    }
+    for (const plan of readRunPlans(run)) {
+      const key = `plan:${plan.id ?? plan.storage_path ?? plan.name}`;
+      if (seenPlanKeys.has(key)) continue;
+      seenPlanKeys.add(key);
+      rows.push({
+        kind: "plan",
+        key,
+        name: planTitle(plan.name),
+        storagePath: plan.storage_path ?? null,
+        runId: run.id,
+      });
+    }
+  }
+
+  const slackUrl = task.latest_run?.state?.slack_thread_url;
+  if (typeof slackUrl === "string" && slackUrl) {
+    rows.push({ kind: "slack", key: "slack-thread", url: slackUrl });
+  }
+
+  return rows;
+}
+
+function ArtifactListRow({
+  icon,
+  title,
+  detail,
+  external,
+  onOpen,
+  onHoverStart,
+}: {
+  icon: ReactNode;
+  title: string;
+  detail?: string | null;
+  external?: boolean;
+  onOpen?: () => void;
+  onHoverStart?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      disabled={!onOpen}
+      onPointerEnter={onHoverStart}
+      onFocus={onHoverStart}
+      className="flex w-full items-center gap-2 rounded-md border border-border bg-muted px-2.5 py-2 text-left text-[13px] transition-colors enabled:hover:bg-gray-3"
+    >
+      {icon}
+      <span className="min-w-0 flex-1 truncate font-medium">{title}</span>
+      {detail && (
+        <span className="shrink-0 text-muted-foreground text-xs">{detail}</span>
+      )}
+      {external && (
+        <ArrowSquareOutIcon size={12} className="shrink-0 text-gray-9" />
+      )}
+    </button>
+  );
+}
+
+function PrRow({ url, taskId }: { url: string; taskId: string }) {
+  const { safeUrl, title, stateLabel, Icon, iconColor } = usePrArtifact(url);
+  const setReviewMode = useReviewNavigationStore((s) => s.setReviewMode);
+  const setSelectedPrUrl = useReviewNavigationStore((s) => s.setSelectedPrUrl);
+
+  const [countsWanted, setCountsWanted] = useState(false);
+  const comments = usePrComments(countsWanted ? safeUrl : null);
+  const threads = usePrReviewThreads(countsWanted ? safeUrl : null);
+
+  const commentCount =
+    (comments.data?.length ?? 0) +
+    (threads.data ?? []).reduce(
+      (sum, thread) => sum + thread.comments.length,
+      0,
+    );
+  const detailParts = [
+    stateLabel,
+    comments.data || threads.data
+      ? `${commentCount} ${commentCount === 1 ? "comment" : "comments"}`
+      : null,
+  ].filter(Boolean);
+
+  return (
+    <ArtifactListRow
+      icon={
+        <Icon
+          size={14}
+          weight="bold"
+          className="shrink-0"
+          style={{ color: iconColor }}
+        />
+      }
+      title={title}
+      detail={detailParts.join(" · ") || null}
+      onHoverStart={() => setCountsWanted(true)}
+      onOpen={
+        safeUrl
+          ? () => {
+              setSelectedPrUrl(taskId, safeUrl);
+              setReviewMode(taskId, "split");
+            }
+          : undefined
+      }
+    />
+  );
+}
+
+function CanvasRow({ name, url }: { name: string; url: string | null }) {
+  const parsed = url ? parseHttpsUrl(url) : null;
+  const target = parsed ? parseShareLink(parsed.href) : null;
+  const open =
+    parsed && target
+      ? () => {
+          const currentPostHogUrl = getPostHogUrl("/");
+          const currentPostHogOrigin = currentPostHogUrl
+            ? parseHttpsUrl(currentPostHogUrl)?.origin
+            : null;
+          if (parsed.origin === currentPostHogOrigin) {
+            navigateToShareTarget(target);
+          } else {
+            openExternalUrl(parsed.href);
+          }
+        }
+      : undefined;
+  return (
+    <ArtifactListRow
+      icon={iconForTemplate("", { size: 14, className: "text-violet-9" })}
+      title={name}
+      detail="Canvas"
+      onOpen={open}
+    />
+  );
+}
+
+function PlanRow({
+  taskId,
+  runId,
+  name,
+  storagePath,
+}: {
+  taskId: string;
+  runId: string | null;
+  name: string;
+  storagePath: string | null;
+}) {
+  const client = useOptionalAuthenticatedClient();
+  const canOpen = !!client && !!runId && !!storagePath;
+  const onOpen = canOpen
+    ? () => {
+        client
+          .presignTaskRunArtifact(
+            taskId,
+            runId as string,
+            storagePath as string,
+          )
+          .then((url) => openExternalUrl(url))
+          .catch((error: unknown) => {
+            toast.error("Couldn't open plan", {
+              description:
+                error instanceof Error ? error.message : String(error),
+            });
+          });
+      }
+    : undefined;
+  return (
+    <ArtifactListRow
+      icon={<ClipboardTextIcon size={14} className="shrink-0 text-amber-9" />}
+      title={name}
+      detail="Plan"
+      external={canOpen}
+      onOpen={onOpen}
+    />
+  );
+}
+
+export function TaskArtifactsList({
+  task,
+  timeline,
+}: {
+  task: Task;
+  timeline: ThreadTimelineRow<TaskThreadMessage>[];
+}) {
+  const { runs } = useTaskRuns(task.id);
+  const rows = useMemo(
+    () => buildRows(task, timeline, runs),
+    [task, timeline, runs],
+  );
+
+  if (rows.length === 0) {
+    return (
+      <Empty className="h-full border-0">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <PackageIcon size={18} />
+          </EmptyMedia>
+          <EmptyTitle>No artifacts yet</EmptyTitle>
+          <EmptyDescription>
+            Pull requests and canvases produced while working on this task show
+            up here.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 p-2">
+      {rows.map((row) =>
+        row.kind === "pr" ? (
+          <PrRow key={row.key} url={row.url} taskId={task.id} />
+        ) : row.kind === "canvas" ? (
+          <CanvasRow key={row.key} name={row.name} url={row.url} />
+        ) : row.kind === "plan" ? (
+          <PlanRow
+            key={row.key}
+            taskId={task.id}
+            runId={row.runId}
+            name={row.name}
+            storagePath={row.storagePath}
+          />
+        ) : (
+          <ArtifactListRow
+            key={row.key}
+            icon={<SlackLogoIcon size={14} className="shrink-0 text-gray-11" />}
+            title="Slack thread"
+            detail="External"
+            external
+            onOpen={() => openExternalUrl(row.url)}
+          />
+        ),
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
+++ b/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
@@ -21,15 +21,14 @@ import type {
   TaskRun,
   TaskThreadMessage,
 } from "@posthog/shared/domain-types";
-import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
 import { useTaskRuns } from "@posthog/ui/features/canvas/hooks/useTaskRuns";
 import { useReviewNavigationStore } from "@posthog/ui/features/code-review/reviewNavigationStore";
 import { usePrArtifact } from "@posthog/ui/features/git-interaction/usePrArtifact";
+import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStore";
 import { usePrComments } from "@posthog/ui/features/pr-review/usePrComments";
 import { usePrReviewThreads } from "@posthog/ui/features/pr-review/usePrReviewThreads";
 import { FileIcon } from "@posthog/ui/primitives/FileIcon";
-import { toast } from "@posthog/ui/primitives/toast";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { formatFileSize } from "@posthog/ui/utils/formatFileSize";
 import { parseHttpsUrl, parseShareLink } from "@posthog/ui/utils/posthogLinks";
@@ -43,8 +42,8 @@ type ArtifactRow =
   | {
       kind: "file";
       key: string;
+      artifactId: string | null;
       name: string;
-      storagePath: string | null;
       runId: string | null;
       size: number | undefined;
     }
@@ -110,8 +109,8 @@ function buildRows(
     rows.push({
       kind: "file",
       key: `file:${file.id ?? file.storage_path ?? name}`,
+      artifactId: file.id ?? null,
       name,
-      storagePath: file.storage_path ?? null,
       runId,
       size: file.size,
     });
@@ -238,33 +237,25 @@ function CanvasRow({ name, url }: { name: string; url: string | null }) {
 function FileRow({
   taskId,
   runId,
+  artifactId,
   name,
-  storagePath,
   size,
 }: {
   taskId: string;
   runId: string | null;
+  artifactId: string | null;
   name: string;
-  storagePath: string | null;
   size: number | undefined;
 }) {
-  const client = useOptionalAuthenticatedClient();
-  const canOpen = !!client && !!runId && !!storagePath;
+  const openArtifactTab = usePanelLayoutStore((state) => state.openArtifactTab);
+  const canOpen = !!runId && !!artifactId;
   const onOpen = canOpen
     ? () => {
-        client
-          .presignTaskRunArtifact(
-            taskId,
-            runId as string,
-            storagePath as string,
-          )
-          .then((url) => openExternalUrl(url))
-          .catch((error: unknown) => {
-            toast.error("Couldn't open file", {
-              description:
-                error instanceof Error ? error.message : String(error),
-            });
-          });
+        openArtifactTab(taskId, {
+          runId: runId as string,
+          artifactId: artifactId as string,
+          name,
+        });
       }
     : undefined;
   return (
@@ -272,7 +263,6 @@ function FileRow({
       icon={<FileIcon filename={name} size={14} />}
       title={name}
       detail={["File", formatFileSize(size)].filter(Boolean).join(" · ")}
-      external={canOpen}
       onOpen={onOpen}
     />
   );
@@ -320,8 +310,8 @@ export function TaskArtifactsList({
             key={row.key}
             taskId={task.id}
             runId={row.runId}
+            artifactId={row.artifactId}
             name={row.name}
-            storagePath={row.storagePath}
             size={row.size}
           />
         ) : (

--- a/packages/ui/src/features/canvas/components/ThreadPanel.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadPanel.tsx
@@ -289,9 +289,9 @@ export function ThreadLoadingState() {
   );
 }
 
-/** The panel's title row and window controls. Shared with ActivityPanel, which
- *  is the same chrome under a different title. */
-export function ThreadPanelHeader({
+/** The panel's title row and window controls. ActivityPanel has its own header
+ *  (the tabs are its title row), so this is the legacy panel's alone. */
+function ThreadPanelHeader({
   title,
   onClose,
   onToggleCollapsed,

--- a/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
@@ -1,15 +1,15 @@
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
+import { ActivityPanel } from "@posthog/ui/features/canvas/components/ActivityPanel";
 import { ThreadPanel } from "@posthog/ui/features/canvas/components/ThreadPanel";
+import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import { track } from "@posthog/ui/shell/analytics";
 import { useState } from "react";
 
-// The right-hand dock hosting a task's ThreadPanel: a thin rail when
-// collapsed, a resizable sidebar otherwise. Shared by the channel feed and the
-// task detail route; owns the panel-store size/collapse reads so parents don't
-// re-render on every resize tick.
+// The right-hand dock for a task's thread (collapsible, resizable). Flag on
+// swaps the legacy ThreadPanel for the tabbed ActivityPanel.
 export function ThreadSidebar({
   taskId,
   channelId,
@@ -31,19 +31,21 @@ export function ThreadSidebar({
   const setWidth = useThreadPanelStore((s) => s.setWidth);
   const setCollapsed = useThreadPanelStore((s) => s.setCollapsed);
   const [isResizing, setIsResizing] = useState(false);
+  const channelsLayout = useChannelsLayout();
+  const Panel = channelsLayout ? ActivityPanel : ThreadPanel;
 
   const toggleCollapsed = (next: boolean) => {
     setCollapsed(next);
     track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
       action_type: next ? "collapse_thread" : "expand_thread",
-      surface: "thread_panel",
+      surface: channelsLayout ? "activity_panel" : "thread_panel",
       task_id: taskId,
     });
   };
 
   if (collapsed) {
     return (
-      <ThreadPanel
+      <Panel
         taskId={taskId}
         channelId={channelId}
         task={task}
@@ -62,7 +64,7 @@ export function ThreadSidebar({
       setIsResizing={setIsResizing}
       side="right"
     >
-      <ThreadPanel
+      <Panel
         taskId={taskId}
         channelId={channelId}
         task={task}

--- a/packages/ui/src/features/canvas/hooks/useTaskRuns.ts
+++ b/packages/ui/src/features/canvas/hooks/useTaskRuns.ts
@@ -1,0 +1,20 @@
+import type { TaskRun } from "@posthog/shared/domain-types";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
+
+const TASK_RUNS_POLL_INTERVAL_MS = 30_000;
+
+/** Every run of a task — for gathering artifacts across all runs, not just the latest. */
+export function useTaskRuns(taskId: string | undefined): {
+  runs: TaskRun[];
+  isLoading: boolean;
+} {
+  const query = useAuthenticatedQuery<TaskRun[]>(
+    ["task-runs", taskId ?? "none"],
+    (client) => client.listTaskRuns(taskId as string),
+    {
+      enabled: !!taskId,
+      refetchInterval: TASK_RUNS_POLL_INTERVAL_MS,
+    },
+  );
+  return { runs: query.data ?? [], isLoading: query.isLoading };
+}

--- a/packages/ui/src/features/code-review/components/CloudReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/CloudReviewPage.tsx
@@ -25,6 +25,9 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
   const isReviewOpen = useReviewNavigationStore(
     (s) => (s.reviewModes[taskId] ?? "closed") !== "closed",
   );
+  const selectedPrUrl = useReviewNavigationStore(
+    (s) => s.selectedPrUrls[taskId],
+  );
   const showReviewComments = useDiffViewerStore((s) => s.showReviewComments);
   const {
     effectiveBranch,
@@ -34,7 +37,7 @@ export function CloudReviewPage({ task }: CloudReviewPageProps) {
     reviewFiles,
     toolCalls,
     isLoading,
-  } = useCloudChangedFiles(taskId, task, isReviewOpen);
+  } = useCloudChangedFiles(taskId, task, isReviewOpen, selectedPrUrl);
   const { commentThreads, commentsLoading } = usePrDetails(prUrl, {
     includeComments: isReviewOpen && showReviewComments,
   });

--- a/packages/ui/src/features/code-review/components/ReviewPage.tsx
+++ b/packages/ui/src/features/code-review/components/ReviewPage.tsx
@@ -97,6 +97,9 @@ export function ReviewPage({ task }: ReviewPageProps) {
   const isReviewOpen = useReviewNavigationStore(
     (s) => (s.reviewModes[taskId] ?? "closed") !== "closed",
   );
+  const selectedPrUrl = useReviewNavigationStore(
+    (s) => s.selectedPrUrls[taskId],
+  );
 
   const {
     effectiveSource,
@@ -105,7 +108,7 @@ export function ReviewPage({ task }: ReviewPageProps) {
     defaultBranch,
     branchSourceAvailable,
     prSourceAvailable,
-  } = useEffectiveDiffSource(taskId);
+  } = useEffectiveDiffSource(taskId, selectedPrUrl);
 
   const showReviewComments = useDiffViewerStore((s) => s.showReviewComments);
   const { commentThreads, commentsLoading } = usePrDetails(prUrl, {

--- a/packages/ui/src/features/code-review/hooks/useEffectiveDiffSource.ts
+++ b/packages/ui/src/features/code-review/hooks/useEffectiveDiffSource.ts
@@ -23,7 +23,10 @@ export interface EffectiveDiffSource {
   diffStats: DiffStats;
 }
 
-export function useEffectiveDiffSource(taskId: string): EffectiveDiffSource {
+export function useEffectiveDiffSource(
+  taskId: string,
+  prUrlOverride?: string,
+): EffectiveDiffSource {
   const trpc = useHostTRPC();
   const repoPath = useCwd(taskId);
   const workspace = useWorkspace(taskId);
@@ -54,7 +57,8 @@ export function useEffectiveDiffSource(taskId: string): EffectiveDiffSource {
   const hasLocalChanges = diffStats.filesChanged > 0;
   const branchSourceAvailable = !!linkedBranch && aheadOfDefault > 0;
 
-  const prUrl = useTaskPrUrl(taskId, workspace?.mode === "cloud");
+  const taskPrUrl = useTaskPrUrl(taskId, workspace?.mode === "cloud");
+  const prUrl = prUrlOverride ?? taskPrUrl;
   const prSourceAvailable = !!prUrl;
 
   const repoSlug = repoInfo
@@ -62,7 +66,7 @@ export function useEffectiveDiffSource(taskId: string): EffectiveDiffSource {
     : null;
 
   const effectiveSource = resolveDiffSource({
-    configured,
+    configured: prUrlOverride ? "pr" : configured,
     hasLocalChanges,
     linkedBranch,
     aheadOfDefault,

--- a/packages/ui/src/features/code-review/reviewNavigationStore.test.ts
+++ b/packages/ui/src/features/code-review/reviewNavigationStore.test.ts
@@ -7,8 +7,25 @@ describe("reviewNavigationStore", () => {
       activeFilePaths: {},
       scrollRequests: {},
       reviewModes: {},
+      selectedPrUrls: {},
       commentFileFilters: {},
     });
+  });
+
+  it("keeps a selected PR until the review closes", () => {
+    const store = useReviewNavigationStore.getState();
+    store.setSelectedPrUrl("task-1", "https://github.com/acme/repo/pull/2");
+    store.setReviewMode("task-1", "split");
+
+    expect(useReviewNavigationStore.getState().selectedPrUrls["task-1"]).toBe(
+      "https://github.com/acme/repo/pull/2",
+    );
+
+    store.setReviewMode("task-1", "closed");
+
+    expect(
+      useReviewNavigationStore.getState().selectedPrUrls["task-1"],
+    ).toBeUndefined();
   });
 
   it("clears the comment filter when navigating to a file", () => {

--- a/packages/ui/src/features/code-review/reviewNavigationStore.ts
+++ b/packages/ui/src/features/code-review/reviewNavigationStore.ts
@@ -7,6 +7,7 @@ interface ReviewNavigationStoreState {
   activeFilePaths: Record<string, string | null>;
   scrollRequests: Record<string, string | null>;
   reviewModes: Record<string, ReviewMode>;
+  selectedPrUrls: Record<string, string | undefined>;
   commentFileFilters: Record<string, CommentFileFilter>;
 }
 
@@ -16,6 +17,7 @@ interface ReviewNavigationStoreActions {
   clearScrollRequest: (taskId: string) => void;
   clearTask: (taskId: string) => void;
   setReviewMode: (taskId: string, mode: ReviewMode) => void;
+  setSelectedPrUrl: (taskId: string, url: string) => void;
   setCommentFileFilter: (taskId: string, filter: CommentFileFilter) => void;
   getReviewMode: (taskId: string) => ReviewMode;
 }
@@ -28,6 +30,7 @@ export const useReviewNavigationStore = create<ReviewNavigationStore>()(
     activeFilePaths: {},
     scrollRequests: {},
     reviewModes: {},
+    selectedPrUrls: {},
     commentFileFilters: {},
 
     setActiveFilePath: (taskId, path) =>
@@ -57,11 +60,23 @@ export const useReviewNavigationStore = create<ReviewNavigationStore>()(
           ...state.commentFileFilters,
           [taskId]: "none",
         },
+        selectedPrUrls: { ...state.selectedPrUrls, [taskId]: undefined },
       })),
 
     setReviewMode: (taskId, mode) =>
       set((state) => ({
         reviewModes: { ...state.reviewModes, [taskId]: mode },
+        // A row-selected historical PR only applies to this review visit.
+        // Closing restores the task's normal primary-PR resolution.
+        selectedPrUrls:
+          mode === "closed"
+            ? { ...state.selectedPrUrls, [taskId]: undefined }
+            : state.selectedPrUrls,
+      })),
+
+    setSelectedPrUrl: (taskId, url) =>
+      set((state) => ({
+        selectedPrUrls: { ...state.selectedPrUrls, [taskId]: url },
       })),
 
     setCommentFileFilter: (taskId, filter) =>

--- a/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
+++ b/packages/ui/src/features/sessions/components/CloudArtifactDownloads.tsx
@@ -15,16 +15,10 @@ import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStor
 import { useSessionSelector } from "@posthog/ui/features/sessions/sessionStore";
 import { FileIcon } from "@posthog/ui/primitives/FileIcon";
 import { toast } from "@posthog/ui/primitives/toast";
+import { formatFileSize } from "@posthog/ui/utils/formatFileSize";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
-
-function formatFileSize(size: number | undefined): string | null {
-  if (size === undefined) return null;
-  if (size < 1_000) return `${size} B`;
-  if (size < 1_000_000) return `${Math.round(size / 1_000)} KB`;
-  return `${(size / 1_000_000).toFixed(1)} MB`;
-}
 
 export function CloudArtifactDownloads({
   taskId,

--- a/packages/ui/src/features/task-detail/hooks/useCloudChangedFiles.ts
+++ b/packages/ui/src/features/task-detail/hooks/useCloudChangedFiles.ts
@@ -12,9 +12,11 @@ export function useCloudChangedFiles(
   taskId: string,
   task: Task,
   isActive = true,
+  prUrlOverride?: string,
 ) {
   const cloudRunState = useCloudRunState(taskId, task);
-  const { prUrl, effectiveBranch, repo, isRunActive } = cloudRunState;
+  const prUrl = prUrlOverride ?? cloudRunState.prUrl;
+  const { effectiveBranch, repo, isRunActive } = cloudRunState;
 
   const {
     data: prFiles,
@@ -45,6 +47,7 @@ export function useCloudChangedFiles(
 
   return {
     ...cloudRunState,
+    prUrl,
     changedFiles,
     remoteFiles,
     reviewFiles: changedFiles,

--- a/packages/ui/src/utils/formatFileSize.ts
+++ b/packages/ui/src/utils/formatFileSize.ts
@@ -1,0 +1,7 @@
+/** Byte count as a short label for artifact and attachment rows. */
+export function formatFileSize(size: number | undefined): string | null {
+  if (size === undefined) return null;
+  if (size < 1_000) return `${size} B`;
+  if (size < 1_000_000) return `${Math.round(size / 1_000)} KB`;
+  return `${(size / 1_000_000).toFixed(1)} MB`;
+}


### PR DESCRIPTION
## Problem

The task thread has no structured place for lifecycle history, durable artifacts, and human comments.

## Changes

- Add Timeline, Artifacts, and Comments tabs to the flag-gated task panel.
- Collect pull requests, canvases, plans, and Slack context across task runs.
- Preserve selected historical pull requests when opening review.
- Leave the flag-off Thread experience unchanged.

This is PR 4 of the stack, based on [#3814](https://github.com/PostHog/code/pull/3814). It completes the flag-on Spaces + Activity experience.

## How did you test this?

- `pnpm --filter @posthog/core test -- src/canvas/runArtifactSchemas.test.ts`
- Three focused UI suites covering artifacts, selected PR navigation, and the shared Thread panel (13 tests)
- `pnpm typecheck` in `packages/ui`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
