### PR TITLE
fix(code): restore zoom after task navigation

### DIFF
--- a/apps/code/src/main/zoom.test.ts
+++ b/apps/code/src/main/zoom.test.ts
@@ -28,10 +28,6 @@ class FakeWebContents extends EventEmitter {
     return this.destroyed;
   }
 
-  public getZoomLevel(): number {
-    return this.zoomLevel;
-  }
-
   public setZoomLevel(level: number): void {
     this.setZoomLevelCalls.push(level);
     this.zoomLevel = level;
@@ -92,6 +88,16 @@ describe("window zoom", () => {
     window.webContents.zoomLevel = 0;
 
     window.webContents.emit("did-finish-load");
+
+    expect(window.webContents.zoomLevel).toBe(0.5);
+  });
+
+  it("restores the persisted level after in-page task navigation", () => {
+    const window = createWindow();
+    setupWindowZoom(window);
+    window.webContents.zoomLevel = 0;
+
+    window.webContents.emit("did-navigate-in-page");
 
     expect(window.webContents.zoomLevel).toBe(0.5);
   });
@@ -169,29 +175,27 @@ describe("window zoom", () => {
     },
   );
 
-  it("skips redundant restoration during a resize storm", () => {
+  it("reapplies zoom when Chromium reports the expected level after a visible reset", () => {
     const window = createWindow();
     setupWindowZoom(window);
     window.webContents.zoomLevel = 0.5;
 
     window.emit("resize");
     vi.runAllTimers();
-    vi.advanceTimersByTime(16);
-    window.emit("resize");
-    vi.runAllTimers();
-    const callsBeforeReset = [...window.webContents.setZoomLevelCalls];
 
-    window.webContents.zoomLevel = 0;
+    expect(window.webContents.setZoomLevelCalls).toEqual([0.5]);
+  });
+
+  it("debounces restoration during a resize storm", () => {
+    const window = createWindow();
+    setupWindowZoom(window);
+
     window.emit("resize");
+    window.emit("resize");
+    window.emit("resized");
     vi.runAllTimers();
 
-    expect({
-      callsBeforeReset,
-      callsAfterReset: window.webContents.setZoomLevelCalls,
-    }).toEqual({
-      callsBeforeReset: [],
-      callsAfterReset: [0.5],
-    });
+    expect(window.webContents.setZoomLevelCalls).toEqual([0.5]);
   });
 
   it("ignores queued zoom work after the window is destroyed", () => {

--- a/apps/code/src/main/zoom.ts
+++ b/apps/code/src/main/zoom.ts
@@ -6,9 +6,11 @@ const ZOOM_MIN = -3;
 const ZOOM_MAX = 3;
 
 interface ZoomWebContents {
-  getZoomLevel(): number;
   isDestroyed(): boolean;
-  on(event: "did-finish-load", listener: () => void): void;
+  on(
+    event: "did-finish-load" | "did-navigate-in-page",
+    listener: () => void,
+  ): void;
   on(
     event: "zoom-changed",
     listener: (
@@ -88,9 +90,7 @@ export function restoreWindowZoom(window: ZoomWindow): void {
   runAfterWheelZoom(window, () => {
     if (window.webContents.isDestroyed()) return;
     const zoomLevel = getCurrentZoomLevel(window);
-    if (window.webContents.getZoomLevel() !== zoomLevel) {
-      window.webContents.setZoomLevel(zoomLevel);
-    }
+    window.webContents.setZoomLevel(zoomLevel);
   });
 }
 
@@ -113,6 +113,9 @@ export function setupWindowZoom(window: ZoomWindow): void {
   };
 
   window.webContents.on("did-finish-load", () => restoreWindowZoom(window));
+  window.webContents.on("did-navigate-in-page", () =>
+    restoreWindowZoom(window),
+  );
   window.webContents.on("zoom-changed", (event, zoomDirection) => {
     event.preventDefault();
     state.wheelZoomDelta += zoomDirection === "in" ? ZOOM_STEP : -ZOOM_STEP;


### PR DESCRIPTION
## Problem

Chromium keeps zoom levels for individual hash routes. Switching tasks can render a cached base zoom while Electron still reports the expected global level, so the existing restoration skips the update.

## Changes

I restore the in-memory zoom after in-page navigation and always reapply it when restoration runs. There are no UI layout changes.

## How did you test this?

- Added regression coverage for task navigation and stale reported zoom state (`16` focused tests pass).
- Ran the full workspace typecheck and Biome checks.
- Reproduced the failure in a packaged app with conflicting Chromium Preferences, then verified the fix across 10 native resize and task-switch cycles.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*