### PR TITLE
fix(loops): Stop flaky ownership tab test

### DIFF
--- a/packages/ui/src/features/loops/components/LoopsListView.test.tsx
+++ b/packages/ui/src/features/loops/components/LoopsListView.test.tsx
@@ -1,6 +1,6 @@
 import type { LoopSchemas } from "@posthog/api-client/loops";
 import { Theme } from "@radix-ui/themes";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { LoopsListViewPresentation } from "./LoopsListView";
@@ -58,6 +58,9 @@ describe("LoopsListViewPresentation", () => {
     expect(
       within(controlledPanel(teamTab)).getByText("team loop"),
     ).toBeVisible();
-    expect(controlledPanel(personalTab)).toHaveAttribute("inert");
+    // The deselected panel is inert, then unmounts when its transition ends.
+    await waitFor(() =>
+      expect(screen.queryByText("personal loop")).not.toBeInTheDocument(),
+    );
   });
 });


### PR DESCRIPTION
## Problem

`LoopsListViewPresentation > shows only the selected ownership tab` fails intermittently in CI with `Error: Tab does not control a panel`, blocking unrelated PRs.

## Changes

Base UI's `Tabs.Panel` defaults to `keepMounted: false` and renders while `keepMounted || mounted`, so the deselected panel is inert and then unmounts when its transition ends. The test asserted the old panel was still present and `inert`, which only holds if the assertion lands inside that window. It now waits for the deselected loop to be gone, which is true whichever way the timing falls.

## How did you test this?

Ran the test five times locally; passes consistently. It previously passed locally and failed only on slower CI runners.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
