### PR TITLE
feat(sidebar): Fade and ticker-scroll long titles

### DIFF
--- a/apps/code/snapshots.yml
+++ b/apps/code/snapshots.yml
@@ -567,7 +567,7 @@ snapshots:
     loops-loopslistview--long-mixed-list--dark:
         hash: v1.k4693efd2.654250bc74fff46c496747eb13031e0e7a7ef264be5bb7be41451d82a497a515.vvrxXbbABkVY3hcHS3oThQ339JFgwIzB8E4n1usVWf0
     loops-loopslistview--long-mixed-list--light:
-        hash: v1.k4693efd2.a8e53087efdaf58e351809775aaf410f53a781a97e10e973ee53fd0db2f94e73.7GcprWAYAgATLtNckNBd-44EyctqKNcb4FXiHA08QJs
+        hash: v1.k4693efd2.8dee426bab2a63843aefe9cf0765799ae9e3c5ece4adc522dc63faf3b362716b.K90qmg7hD8qD522iR-Y5lbr6ETEzRuYgQdYl0Z520do
     loops-loopslistview--with-builder-sessions--dark:
         hash: v1.k4693efd2.84cfc28bedc22a6728ba4ecf69274ab03537faeed5333775991716bf0b5f439e.fHsD0XKPnud-oDM4PLJ7edCbMnVcW6uVMdMHBYp3K08
     loops-loopslistview--with-builder-sessions--light:

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -372,7 +372,7 @@ function ChannelSection({
               <OverflowTickerText
                 reveal={isHovered || isKeyboardFocused}
                 className={cn(
-                  "text-[13px] group-hover/chan:mr-8",
+                  "text-[13px] group-hover/chan:mr-11",
                   // Bold is unread's alone; full contrast is shared with the
                   // channel you're in. Either way there's no hover brighten
                   // left to do, so those rows skip it.
@@ -380,7 +380,7 @@ function ChannelSection({
                   isUnread || isActive
                     ? "text-foreground"
                     : "text-muted-foreground group-hover/button:text-foreground",
-                  menuOpen && "mr-8",
+                  menuOpen && "mr-11",
                 )}
               >
                 {channel.name}

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -63,6 +63,7 @@ import {
 import { useIsChannelUnread } from "@posthog/ui/features/canvas/hooks/useUnreadChannels";
 import { copyChannelLink } from "@posthog/ui/features/canvas/utils/copyChannelLink";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
+import { OverflowTickerText } from "@posthog/ui/primitives/OverflowTickerText";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex } from "@radix-ui/themes";
@@ -310,6 +311,8 @@ function ChannelSection({
   // The "+" dropdown (New task / New canvas). Keeps the hover actions pinned
   // while open.
   const [newMenuOpen, setNewMenuOpen] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [isKeyboardFocused, setIsKeyboardFocused] = useState(false);
   const createAndOpenCanvas = useCreateAndOpenDashboard(channel.id);
   // Shared by the "..." dropdown and the right-click context menu so both offer
   // the same star / edit / rename / delete actions.
@@ -324,7 +327,11 @@ function ChannelSection({
   } = useChannelActions(channel);
 
   return (
-    <Box className="group/chan relative">
+    <Box
+      className="group/chan relative"
+      onPointerEnter={() => setIsHovered(true)}
+      onPointerLeave={() => setIsHovered(false)}
+    >
       {/* A single, non-expandable row: the "# name" navigates straight to the
           channel home. Right-clicking opens the same actions as the "..." menu. */}
       <ContextMenu>
@@ -346,6 +353,10 @@ function ChannelSection({
                   params: { channelId: channel.id },
                 });
               }}
+              onFocus={(e) =>
+                setIsKeyboardFocused(e.currentTarget.matches(":focus-visible"))
+              }
+              onBlur={() => setIsKeyboardFocused(false)}
               className="w-full min-w-0 justify-start gap-2 data-selected:bg-fill-selected data-selected:text-gray-12"
             >
               <HashIcon
@@ -358,9 +369,10 @@ function ChannelSection({
                     : "text-muted-foreground group-hover/button:text-foreground",
                 )}
               />
-              <span
+              <OverflowTickerText
+                reveal={isHovered || isKeyboardFocused}
                 className={cn(
-                  "truncate text-[13px] group-hover/chan:pr-8",
+                  "text-[13px] group-hover/chan:mr-8",
                   // Bold is unread's alone; full contrast is shared with the
                   // channel you're in. Either way there's no hover brighten
                   // left to do, so those rows skip it.
@@ -368,11 +380,11 @@ function ChannelSection({
                   isUnread || isActive
                     ? "text-foreground"
                     : "text-muted-foreground group-hover/button:text-foreground",
-                  menuOpen && "pr-8",
+                  menuOpen && "mr-8",
                 )}
               >
                 {channel.name}
-              </span>
+              </OverflowTickerText>
             </Button>
           }
         />

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -63,7 +63,10 @@ import {
 import { useIsChannelUnread } from "@posthog/ui/features/canvas/hooks/useUnreadChannels";
 import { copyChannelLink } from "@posthog/ui/features/canvas/utils/copyChannelLink";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
-import { OverflowTickerText } from "@posthog/ui/primitives/OverflowTickerText";
+import {
+  OverflowTickerText,
+  useOverflowTickerReveal,
+} from "@posthog/ui/primitives/OverflowTickerText";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex } from "@radix-ui/themes";
@@ -311,8 +314,7 @@ function ChannelSection({
   // The "+" dropdown (New task / New canvas). Keeps the hover actions pinned
   // while open.
   const [newMenuOpen, setNewMenuOpen] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isKeyboardFocused, setIsKeyboardFocused] = useState(false);
+  const { reveal, hoverProps, focusProps } = useOverflowTickerReveal();
   const createAndOpenCanvas = useCreateAndOpenDashboard(channel.id);
   // Shared by the "..." dropdown and the right-click context menu so both offer
   // the same star / edit / rename / delete actions.
@@ -327,11 +329,7 @@ function ChannelSection({
   } = useChannelActions(channel);
 
   return (
-    <Box
-      className="group/chan relative"
-      onPointerEnter={() => setIsHovered(true)}
-      onPointerLeave={() => setIsHovered(false)}
-    >
+    <Box className="group/chan relative" {...hoverProps}>
       {/* A single, non-expandable row: the "# name" navigates straight to the
           channel home. Right-clicking opens the same actions as the "..." menu. */}
       <ContextMenu>
@@ -353,10 +351,7 @@ function ChannelSection({
                   params: { channelId: channel.id },
                 });
               }}
-              onFocus={(e) =>
-                setIsKeyboardFocused(e.currentTarget.matches(":focus-visible"))
-              }
-              onBlur={() => setIsKeyboardFocused(false)}
+              {...focusProps}
               className="w-full min-w-0 justify-start gap-2 data-selected:bg-fill-selected data-selected:text-gray-12"
             >
               <HashIcon
@@ -370,8 +365,9 @@ function ChannelSection({
                 )}
               />
               <OverflowTickerText
-                reveal={isHovered || isKeyboardFocused}
+                reveal={reveal}
                 className={cn(
+                  // mr-11 clears the two icon-xs hover buttons pinned at right-1.
                   "text-[13px] group-hover/chan:mr-11",
                   // Bold is unread's alone; full contrast is shared with the
                   // channel you're in. Either way there's no hover brighten

--- a/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
@@ -157,7 +157,7 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
         <Flex
           direction="column"
           gap="2"
-          className="mx-auto w-full max-w-3xl px-8 pb-6"
+          className="mx-auto w-full max-w-3xl px-8 pt-3 pb-6"
         >
           <LoopBuilderComposer
             context={{ folderId: channelId, name: contextName }}

--- a/packages/ui/src/features/loops/components/LoopsListView.tsx
+++ b/packages/ui/src/features/loops/components/LoopsListView.tsx
@@ -266,7 +266,7 @@ export function LoopsListViewPresentation({
         <Flex
           direction="column"
           gap="2"
-          className="mx-auto w-full max-w-5xl px-8 pb-6"
+          className="mx-auto w-full max-w-5xl px-8 pt-3 pb-6"
         >
           {builderSessions.map((session) => (
             <BuilderSessionRow

--- a/packages/ui/src/features/sidebar/components/SidebarItem.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarItem.tsx
@@ -1,15 +1,11 @@
-import {
-  Button,
-  cn,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@posthog/quill";
+import { Button, cn } from "@posthog/quill";
 import type { SidebarItemAction } from "@posthog/ui/features/sidebar/types";
-import { useCallback } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export const INDENT_SIZE = 8;
+
+const TICKER_SPEED_PX_PER_SECOND = 50;
+const TICKER_FADE_PX = 24;
 
 export function getSidebarItemPaddingLeft(depth: number): string {
   return `${depth * INDENT_SIZE + 8 + (depth > 0 ? 4 : 0)}px`;
@@ -38,40 +34,67 @@ interface SidebarItemProps {
 function SidebarItemLabel({
   label,
   grow,
+  isRowHovered,
 }: {
   label: React.ReactNode;
   grow: boolean;
+  isRowHovered: boolean;
 }) {
-  const canTooltip = typeof label === "string" || typeof label === "number";
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const contentRef = useRef<HTMLSpanElement>(null);
+  const [overflowPx, setOverflowPx] = useState(0);
 
-  const measureRef = useCallback((el: HTMLSpanElement | null) => {
-    if (!el) return;
-    const update = () => {
-      el.style.pointerEvents = el.scrollWidth > el.clientWidth ? "" : "none";
+  useEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+    const measure = () => {
+      setOverflowPx(Math.max(0, container.scrollWidth - container.clientWidth));
     };
-    update();
-    const observer = new ResizeObserver(update);
-    observer.observe(el);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(container);
+    observer.observe(content);
     return () => observer.disconnect();
   }, []);
 
-  const span = (
-    <span ref={measureRef} className={cn("min-w-0 truncate", grow && "flex-1")}>
-      {label}
-    </span>
-  );
-
-  if (!canTooltip) return span;
+  const isTicking = isRowHovered && overflowPx > 0;
+  // Overshoot by the fade width so the title's end stops clear of the right fade.
+  const scrollDistance = overflowPx + TICKER_FADE_PX;
 
   return (
-    <TooltipProvider delay={600}>
-      <Tooltip>
-        <TooltipTrigger render={span} />
-        <TooltipContent side="top" className="max-w-[900px] break-words">
-          {label}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <span
+      ref={containerRef}
+      className={cn(
+        "min-w-0 overflow-hidden whitespace-nowrap",
+        grow && "flex-1",
+      )}
+      style={{
+        maskImage:
+          overflowPx === 0
+            ? undefined
+            : isTicking
+              ? `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px, black calc(100% - ${TICKER_FADE_PX}px), transparent)`
+              : `linear-gradient(to right, black calc(100% - ${TICKER_FADE_PX}px), transparent)`,
+      }}
+    >
+      <span
+        ref={contentRef}
+        className="inline-block"
+        style={
+          isTicking
+            ? {
+                transform: `translateX(-${scrollDistance}px)`,
+                transitionProperty: "transform",
+                transitionTimingFunction: "linear",
+                transitionDuration: `${scrollDistance / TICKER_SPEED_PX_PER_SECOND}s`,
+              }
+            : { transform: "translateX(0)", transitionProperty: "none" }
+        }
+      >
+        {label}
+      </span>
+    </span>
   );
 }
 
@@ -92,6 +115,8 @@ export function SidebarItem({
   endContent,
   disabled,
 }: SidebarItemProps) {
+  const [isHovered, setIsHovered] = useState(false);
+
   return (
     <Button
       type="button"
@@ -112,6 +137,8 @@ export function SidebarItem({
       onClick={onClick}
       onDoubleClick={onDoubleClick}
       onContextMenu={onContextMenu}
+      onPointerEnter={() => setIsHovered(true)}
+      onPointerLeave={() => setIsHovered(false)}
       disabled={disabled}
     >
       {icon ? (
@@ -121,7 +148,11 @@ export function SidebarItem({
       ) : null}
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="flex min-h-[18px] items-center gap-1">
-          <SidebarItemLabel label={label} grow={!badge} />
+          <SidebarItemLabel
+            label={label}
+            grow={!badge}
+            isRowHovered={isHovered}
+          />
           {badge ? (
             <span className="mr-auto ml-1 flex shrink-0 items-center">
               {badge}

--- a/packages/ui/src/features/sidebar/components/SidebarItem.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarItem.tsx
@@ -1,5 +1,6 @@
 import { Button, cn } from "@posthog/quill";
 import type { SidebarItemAction } from "@posthog/ui/features/sidebar/types";
+import { useReducedMotion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 
 export const INDENT_SIZE = 8;
@@ -63,7 +64,9 @@ function SidebarItemLabel({
     if (!revealOverflow) setReachedEnd(false);
   }, [revealOverflow]);
 
+  const prefersReducedMotion = useReducedMotion();
   const isTicking = revealOverflow && overflowPx > 0;
+  const showsEnd = reachedEnd || (isTicking && prefersReducedMotion);
 
   return (
     <span
@@ -77,7 +80,7 @@ function SidebarItemLabel({
           overflowPx === 0
             ? undefined
             : isTicking
-              ? reachedEnd
+              ? showsEnd
                 ? `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px)`
                 : `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px, black calc(100% - ${TICKER_FADE_PX}px), transparent)`
               : `linear-gradient(to right, black calc(100% - ${TICKER_FADE_PX}px), transparent)`,
@@ -93,7 +96,7 @@ function SidebarItemLabel({
           isTicking
             ? {
                 transform: `translateX(-${overflowPx}px)`,
-                transitionProperty: "transform",
+                transitionProperty: prefersReducedMotion ? "none" : "transform",
                 transitionTimingFunction: "linear",
                 transitionDuration: `${overflowPx / TICKER_SPEED_PX_PER_SECOND}s`,
               }

--- a/packages/ui/src/features/sidebar/components/SidebarItem.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarItem.tsx
@@ -1,12 +1,9 @@
 import { Button, cn } from "@posthog/quill";
 import type { SidebarItemAction } from "@posthog/ui/features/sidebar/types";
-import { useReducedMotion } from "framer-motion";
-import { useEffect, useRef, useState } from "react";
+import { OverflowTickerText } from "@posthog/ui/primitives/OverflowTickerText";
+import { useState } from "react";
 
 export const INDENT_SIZE = 8;
-
-const TICKER_SPEED_PX_PER_SECOND = 50;
-const TICKER_FADE_PX = 24;
 
 export function getSidebarItemPaddingLeft(depth: number): string {
   return `${depth * INDENT_SIZE + 8 + (depth > 0 ? 4 : 0)}px`;
@@ -30,83 +27,6 @@ interface SidebarItemProps {
   badge?: React.ReactNode;
   endContent?: React.ReactNode;
   disabled?: boolean;
-}
-
-function SidebarItemLabel({
-  label,
-  grow,
-  revealOverflow,
-}: {
-  label: React.ReactNode;
-  grow: boolean;
-  revealOverflow: boolean;
-}) {
-  const containerRef = useRef<HTMLSpanElement>(null);
-  const contentRef = useRef<HTMLSpanElement>(null);
-  const [overflowPx, setOverflowPx] = useState(0);
-  const [reachedEnd, setReachedEnd] = useState(false);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    const content = contentRef.current;
-    if (!container || !content) return;
-    const measure = () => {
-      setOverflowPx(Math.max(0, container.scrollWidth - container.clientWidth));
-    };
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(container);
-    observer.observe(content);
-    return () => observer.disconnect();
-  }, []);
-
-  useEffect(() => {
-    if (!revealOverflow) setReachedEnd(false);
-  }, [revealOverflow]);
-
-  const prefersReducedMotion = useReducedMotion();
-  const isTicking = revealOverflow && overflowPx > 0;
-  const showsEnd = reachedEnd || (isTicking && prefersReducedMotion);
-
-  return (
-    <span
-      ref={containerRef}
-      className={cn(
-        "min-w-0 overflow-hidden whitespace-nowrap",
-        grow && "flex-1",
-      )}
-      style={{
-        maskImage:
-          overflowPx === 0
-            ? undefined
-            : isTicking
-              ? showsEnd
-                ? `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px)`
-                : `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px, black calc(100% - ${TICKER_FADE_PX}px), transparent)`
-              : `linear-gradient(to right, black calc(100% - ${TICKER_FADE_PX}px), transparent)`,
-      }}
-    >
-      <span
-        ref={contentRef}
-        className="inline-block"
-        onTransitionEnd={(e) => {
-          if (e.propertyName === "transform") setReachedEnd(true);
-        }}
-        style={
-          isTicking
-            ? {
-                transform: `translateX(-${overflowPx}px)`,
-                transitionProperty: prefersReducedMotion ? "none" : "transform",
-                transitionTimingFunction: "linear",
-                transitionDuration: `${overflowPx / TICKER_SPEED_PX_PER_SECOND}s`,
-              }
-            : { transform: "translateX(0)", transitionProperty: "none" }
-        }
-      >
-        {label}
-      </span>
-    </span>
-  );
 }
 
 export function SidebarItem({
@@ -164,11 +84,12 @@ export function SidebarItem({
       ) : null}
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="flex min-h-[18px] items-center gap-1">
-          <SidebarItemLabel
-            label={label}
-            grow={!badge}
-            revealOverflow={isHovered || isKeyboardFocused}
-          />
+          <OverflowTickerText
+            reveal={isHovered || isKeyboardFocused}
+            className={cn(!badge && "flex-1")}
+          >
+            {label}
+          </OverflowTickerText>
           {badge ? (
             <span className="mr-auto ml-1 flex shrink-0 items-center">
               {badge}

--- a/packages/ui/src/features/sidebar/components/SidebarItem.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarItem.tsx
@@ -34,11 +34,11 @@ interface SidebarItemProps {
 function SidebarItemLabel({
   label,
   grow,
-  isRowHovered,
+  revealOverflow,
 }: {
   label: React.ReactNode;
   grow: boolean;
-  isRowHovered: boolean;
+  revealOverflow: boolean;
 }) {
   const containerRef = useRef<HTMLSpanElement>(null);
   const contentRef = useRef<HTMLSpanElement>(null);
@@ -60,10 +60,10 @@ function SidebarItemLabel({
   }, []);
 
   useEffect(() => {
-    if (!isRowHovered) setReachedEnd(false);
-  }, [isRowHovered]);
+    if (!revealOverflow) setReachedEnd(false);
+  }, [revealOverflow]);
 
-  const isTicking = isRowHovered && overflowPx > 0;
+  const isTicking = revealOverflow && overflowPx > 0;
 
   return (
     <span
@@ -124,6 +124,7 @@ export function SidebarItem({
   disabled,
 }: SidebarItemProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const [isKeyboardFocused, setIsKeyboardFocused] = useState(false);
 
   return (
     <Button
@@ -147,6 +148,10 @@ export function SidebarItem({
       onContextMenu={onContextMenu}
       onPointerEnter={() => setIsHovered(true)}
       onPointerLeave={() => setIsHovered(false)}
+      onFocus={(e) =>
+        setIsKeyboardFocused(e.currentTarget.matches(":focus-visible"))
+      }
+      onBlur={() => setIsKeyboardFocused(false)}
       disabled={disabled}
     >
       {icon ? (
@@ -159,7 +164,7 @@ export function SidebarItem({
           <SidebarItemLabel
             label={label}
             grow={!badge}
-            isRowHovered={isHovered}
+            revealOverflow={isHovered || isKeyboardFocused}
           />
           {badge ? (
             <span className="mr-auto ml-1 flex shrink-0 items-center">

--- a/packages/ui/src/features/sidebar/components/SidebarItem.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarItem.tsx
@@ -43,6 +43,7 @@ function SidebarItemLabel({
   const containerRef = useRef<HTMLSpanElement>(null);
   const contentRef = useRef<HTMLSpanElement>(null);
   const [overflowPx, setOverflowPx] = useState(0);
+  const [reachedEnd, setReachedEnd] = useState(false);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -58,9 +59,11 @@ function SidebarItemLabel({
     return () => observer.disconnect();
   }, []);
 
+  useEffect(() => {
+    if (!isRowHovered) setReachedEnd(false);
+  }, [isRowHovered]);
+
   const isTicking = isRowHovered && overflowPx > 0;
-  // Overshoot by the fade width so the title's end stops clear of the right fade.
-  const scrollDistance = overflowPx + TICKER_FADE_PX;
 
   return (
     <span
@@ -74,20 +77,25 @@ function SidebarItemLabel({
           overflowPx === 0
             ? undefined
             : isTicking
-              ? `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px, black calc(100% - ${TICKER_FADE_PX}px), transparent)`
+              ? reachedEnd
+                ? `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px)`
+                : `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px, black calc(100% - ${TICKER_FADE_PX}px), transparent)`
               : `linear-gradient(to right, black calc(100% - ${TICKER_FADE_PX}px), transparent)`,
       }}
     >
       <span
         ref={contentRef}
         className="inline-block"
+        onTransitionEnd={(e) => {
+          if (e.propertyName === "transform") setReachedEnd(true);
+        }}
         style={
           isTicking
             ? {
-                transform: `translateX(-${scrollDistance}px)`,
+                transform: `translateX(-${overflowPx}px)`,
                 transitionProperty: "transform",
                 transitionTimingFunction: "linear",
-                transitionDuration: `${scrollDistance / TICKER_SPEED_PX_PER_SECOND}s`,
+                transitionDuration: `${overflowPx / TICKER_SPEED_PX_PER_SECOND}s`,
               }
             : { transform: "translateX(0)", transitionProperty: "none" }
         }

--- a/packages/ui/src/features/sidebar/components/SidebarItem.tsx
+++ b/packages/ui/src/features/sidebar/components/SidebarItem.tsx
@@ -1,7 +1,9 @@
 import { Button, cn } from "@posthog/quill";
 import type { SidebarItemAction } from "@posthog/ui/features/sidebar/types";
-import { OverflowTickerText } from "@posthog/ui/primitives/OverflowTickerText";
-import { useState } from "react";
+import {
+  OverflowTickerText,
+  useOverflowTickerReveal,
+} from "@posthog/ui/primitives/OverflowTickerText";
 
 export const INDENT_SIZE = 8;
 
@@ -46,8 +48,7 @@ export function SidebarItem({
   endContent,
   disabled,
 }: SidebarItemProps) {
-  const [isHovered, setIsHovered] = useState(false);
-  const [isKeyboardFocused, setIsKeyboardFocused] = useState(false);
+  const { reveal, hoverProps, focusProps } = useOverflowTickerReveal();
 
   return (
     <Button
@@ -69,12 +70,8 @@ export function SidebarItem({
       onClick={onClick}
       onDoubleClick={onDoubleClick}
       onContextMenu={onContextMenu}
-      onPointerEnter={() => setIsHovered(true)}
-      onPointerLeave={() => setIsHovered(false)}
-      onFocus={(e) =>
-        setIsKeyboardFocused(e.currentTarget.matches(":focus-visible"))
-      }
-      onBlur={() => setIsKeyboardFocused(false)}
+      {...hoverProps}
+      {...focusProps}
       disabled={disabled}
     >
       {icon ? (
@@ -85,7 +82,7 @@ export function SidebarItem({
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="flex min-h-[18px] items-center gap-1">
           <OverflowTickerText
-            reveal={isHovered || isKeyboardFocused}
+            reveal={reveal}
             className={cn(!badge && "flex-1")}
           >
             {label}

--- a/packages/ui/src/primitives/OverflowTickerText.test.tsx
+++ b/packages/ui/src/primitives/OverflowTickerText.test.tsx
@@ -1,0 +1,173 @@
+import { act, render, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  OverflowTickerText,
+  useOverflowTickerReveal,
+} from "./OverflowTickerText";
+
+let reducedMotion = false;
+vi.mock("framer-motion", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("framer-motion")>()),
+  useReducedMotion: () => reducedMotion,
+}));
+
+afterEach(() => {
+  reducedMotion = false;
+  vi.restoreAllMocks();
+});
+
+// jsdom does no layout; report widths only for the ticker's overflow-hidden
+// container so the mount-time measure sees the requested overflow.
+function mockOverflow(overflowPx: number) {
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockImplementation(
+    function (this: HTMLElement) {
+      return this.classList.contains("overflow-hidden") ? 200 : 0;
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockImplementation(
+    function (this: HTMLElement) {
+      return this.classList.contains("overflow-hidden") ? 200 + overflowPx : 0;
+    },
+  );
+}
+
+function renderTicker(reveal: boolean, overflowPx: number) {
+  mockOverflow(overflowPx);
+  const view = render(
+    <OverflowTickerText reveal={reveal}>long title</OverflowTickerText>,
+  );
+  const tickerContainer = view.container.firstElementChild as HTMLElement;
+  const content = tickerContainer.firstElementChild as HTMLElement;
+  return { ...view, tickerContainer, content };
+}
+
+function endTransition(el: HTMLElement, propertyName: string) {
+  const event = new Event("transitionend", { bubbles: true });
+  Object.assign(event, { propertyName });
+  act(() => {
+    el.dispatchEvent(event);
+  });
+}
+
+const FADE_IN = "transparent, black 24px";
+const FADE_OUT = "black calc(100% - 24px), transparent";
+
+describe("OverflowTickerText", () => {
+  it.each([
+    { name: "fitting text", overflowPx: 0, reveal: true, fades: [] },
+    { name: "narrow text", overflowPx: -50, reveal: true, fades: [] },
+    {
+      name: "resting overflow",
+      overflowPx: 40,
+      reveal: false,
+      fades: [FADE_OUT],
+    },
+    {
+      name: "ticking overflow",
+      overflowPx: 40,
+      reveal: true,
+      fades: [FADE_IN, FADE_OUT],
+    },
+  ])("masks $name", ({ overflowPx, reveal, fades }) => {
+    const { tickerContainer } = renderTicker(reveal, overflowPx);
+    const mask = tickerContainer.style.maskImage ?? "";
+    expect(mask.includes(FADE_IN)).toBe(fades.includes(FADE_IN));
+    expect(mask.includes(FADE_OUT)).toBe(fades.includes(FADE_OUT));
+  });
+
+  it("scrolls exactly the overflow at constant speed", () => {
+    const { content } = renderTicker(true, 40);
+    expect(content.style.transform).toBe("translateX(-40px)");
+    expect(content.style.transitionProperty).toBe("transform");
+    expect(content.style.transitionTimingFunction).toBe("linear");
+    expect(content.style.transitionDuration).toBe("0.8s");
+  });
+
+  it("snaps back without a transition when reveal ends", () => {
+    const { rerender, content } = renderTicker(true, 40);
+    rerender(
+      <OverflowTickerText reveal={false}>long title</OverflowTickerText>,
+    );
+    expect(content.style.transform).toBe("translateX(0)");
+    expect(content.style.transitionProperty).toBe("none");
+  });
+
+  it("drops the end fade once the scroll finishes", () => {
+    const { tickerContainer, content } = renderTicker(true, 40);
+    endTransition(content, "transform");
+    const mask = tickerContainer.style.maskImage ?? "";
+    expect(mask).toContain(FADE_IN);
+    expect(mask).not.toContain(FADE_OUT);
+  });
+
+  it("ignores transition ends for other properties", () => {
+    const { tickerContainer, content } = renderTicker(true, 40);
+    endTransition(content, "opacity");
+    expect(tickerContainer.style.maskImage ?? "").toContain(FADE_OUT);
+  });
+
+  it("ignores transition ends bubbled from children", () => {
+    mockOverflow(40);
+    const view = render(
+      <OverflowTickerText reveal>
+        <i data-testid="inner">long title</i>
+      </OverflowTickerText>,
+    );
+    const tickerContainer = view.container.firstElementChild as HTMLElement;
+    endTransition(view.getByTestId("inner"), "transform");
+    expect(tickerContainer.style.maskImage ?? "").toContain(FADE_OUT);
+  });
+
+  it("restores both fades on the next reveal", () => {
+    const { rerender, tickerContainer, content } = renderTicker(true, 40);
+    endTransition(content, "transform");
+    rerender(
+      <OverflowTickerText reveal={false}>long title</OverflowTickerText>,
+    );
+    rerender(<OverflowTickerText reveal>long title</OverflowTickerText>);
+    const mask = tickerContainer.style.maskImage ?? "";
+    expect(mask).toContain(FADE_IN);
+    expect(mask).toContain(FADE_OUT);
+  });
+
+  it("jumps straight to the end under reduced motion", () => {
+    reducedMotion = true;
+    const { tickerContainer, content } = renderTicker(true, 40);
+    expect(content.style.transform).toBe("translateX(-40px)");
+    expect(content.style.transitionProperty).toBe("none");
+    const mask = tickerContainer.style.maskImage ?? "";
+    expect(mask).toContain(FADE_IN);
+    expect(mask).not.toContain(FADE_OUT);
+  });
+});
+
+describe("useOverflowTickerReveal", () => {
+  function focusEvent(matchesFocusVisible: boolean) {
+    return {
+      currentTarget: { matches: () => matchesFocusVisible },
+    } as unknown as React.FocusEvent<HTMLElement>;
+  }
+
+  it("reveals while hovered", () => {
+    const { result } = renderHook(() => useOverflowTickerReveal());
+    expect(result.current.reveal).toBe(false);
+    act(() => result.current.hoverProps.onPointerEnter());
+    expect(result.current.reveal).toBe(true);
+    act(() => result.current.hoverProps.onPointerLeave());
+    expect(result.current.reveal).toBe(false);
+  });
+
+  it("reveals on keyboard focus until blur", () => {
+    const { result } = renderHook(() => useOverflowTickerReveal());
+    act(() => result.current.focusProps.onFocus(focusEvent(true)));
+    expect(result.current.reveal).toBe(true);
+    act(() => result.current.focusProps.onBlur());
+    expect(result.current.reveal).toBe(false);
+  });
+
+  it("does not reveal on pointer-driven focus", () => {
+    const { result } = renderHook(() => useOverflowTickerReveal());
+    act(() => result.current.focusProps.onFocus(focusEvent(false)));
+    expect(result.current.reveal).toBe(false);
+  });
+});

--- a/packages/ui/src/primitives/OverflowTickerText.tsx
+++ b/packages/ui/src/primitives/OverflowTickerText.tsx
@@ -1,0 +1,80 @@
+import { cn } from "@posthog/quill";
+import { useReducedMotion } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+const TICKER_SPEED_PX_PER_SECOND = 50;
+const TICKER_FADE_PX = 24;
+
+export function OverflowTickerText({
+  reveal,
+  className,
+  children,
+}: {
+  reveal: boolean;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const contentRef = useRef<HTMLSpanElement>(null);
+  const [overflowPx, setOverflowPx] = useState(0);
+  const [reachedEnd, setReachedEnd] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+    const measure = () => {
+      setOverflowPx(Math.max(0, container.scrollWidth - container.clientWidth));
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(container);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!reveal) setReachedEnd(false);
+  }, [reveal]);
+
+  const prefersReducedMotion = useReducedMotion();
+  const isTicking = reveal && overflowPx > 0;
+  const showsEnd = reachedEnd || (isTicking && prefersReducedMotion);
+
+  return (
+    <span
+      ref={containerRef}
+      className={cn("min-w-0 overflow-hidden whitespace-nowrap", className)}
+      style={{
+        maskImage:
+          overflowPx === 0
+            ? undefined
+            : isTicking
+              ? showsEnd
+                ? `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px)`
+                : `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px, black calc(100% - ${TICKER_FADE_PX}px), transparent)`
+              : `linear-gradient(to right, black calc(100% - ${TICKER_FADE_PX}px), transparent)`,
+      }}
+    >
+      <span
+        ref={contentRef}
+        className="inline-block"
+        onTransitionEnd={(e) => {
+          if (e.propertyName === "transform") setReachedEnd(true);
+        }}
+        style={
+          isTicking
+            ? {
+                transform: `translateX(-${overflowPx}px)`,
+                transitionProperty: prefersReducedMotion ? "none" : "transform",
+                transitionTimingFunction: "linear",
+                transitionDuration: `${overflowPx / TICKER_SPEED_PX_PER_SECOND}s`,
+              }
+            : { transform: "translateX(0)", transitionProperty: "none" }
+        }
+      >
+        {children}
+      </span>
+    </span>
+  );
+}

--- a/packages/ui/src/primitives/OverflowTickerText.tsx
+++ b/packages/ui/src/primitives/OverflowTickerText.tsx
@@ -5,6 +5,32 @@ import { useEffect, useRef, useState } from "react";
 const TICKER_SPEED_PX_PER_SECOND = 50;
 const TICKER_FADE_PX = 24;
 
+function tickerMask(overflowPx: number, isTicking: boolean, showsEnd: boolean) {
+  if (overflowPx === 0) return undefined;
+  const fadeIn = `transparent, black ${TICKER_FADE_PX}px`;
+  const fadeOut = `black calc(100% - ${TICKER_FADE_PX}px), transparent`;
+  if (!isTicking) return `linear-gradient(to right, ${fadeOut})`;
+  if (showsEnd) return `linear-gradient(to right, ${fadeIn})`;
+  return `linear-gradient(to right, ${fadeIn}, ${fadeOut})`;
+}
+
+export function useOverflowTickerReveal() {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isKeyboardFocused, setIsKeyboardFocused] = useState(false);
+  return {
+    reveal: isHovered || isKeyboardFocused,
+    hoverProps: {
+      onPointerEnter: () => setIsHovered(true),
+      onPointerLeave: () => setIsHovered(false),
+    },
+    focusProps: {
+      onFocus: (e: React.FocusEvent<HTMLElement>) =>
+        setIsKeyboardFocused(e.currentTarget.matches(":focus-visible")),
+      onBlur: () => setIsKeyboardFocused(false),
+    },
+  };
+}
+
 export function OverflowTickerText({
   reveal,
   className,
@@ -23,6 +49,11 @@ export function OverflowTickerText({
     setPrevReveal(reveal);
     if (!reveal) setReachedEnd(false);
   }
+  const [prevOverflowPx, setPrevOverflowPx] = useState(overflowPx);
+  if (overflowPx !== prevOverflowPx) {
+    setPrevOverflowPx(overflowPx);
+    setReachedEnd(false);
+  }
 
   useEffect(() => {
     const container = containerRef.current;
@@ -40,28 +71,22 @@ export function OverflowTickerText({
 
   const prefersReducedMotion = useReducedMotion();
   const isTicking = reveal && overflowPx > 0;
-  const showsEnd = reachedEnd || (isTicking && prefersReducedMotion);
+  const showsEnd = reachedEnd || (isTicking && prefersReducedMotion === true);
+  const maskImage = tickerMask(overflowPx, isTicking, showsEnd);
 
   return (
     <span
       ref={containerRef}
       className={cn("min-w-0 overflow-hidden whitespace-nowrap", className)}
-      style={{
-        maskImage:
-          overflowPx === 0
-            ? undefined
-            : isTicking
-              ? showsEnd
-                ? `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px)`
-                : `linear-gradient(to right, transparent, black ${TICKER_FADE_PX}px, black calc(100% - ${TICKER_FADE_PX}px), transparent)`
-              : `linear-gradient(to right, black calc(100% - ${TICKER_FADE_PX}px), transparent)`,
-      }}
+      style={{ maskImage, WebkitMaskImage: maskImage }}
     >
       <span
         ref={contentRef}
         className="inline-block"
         onTransitionEnd={(e) => {
-          if (e.propertyName === "transform") setReachedEnd(true);
+          if (e.target === e.currentTarget && e.propertyName === "transform") {
+            setReachedEnd(true);
+          }
         }}
         style={
           isTicking

--- a/packages/ui/src/primitives/OverflowTickerText.tsx
+++ b/packages/ui/src/primitives/OverflowTickerText.tsx
@@ -18,6 +18,11 @@ export function OverflowTickerText({
   const contentRef = useRef<HTMLSpanElement>(null);
   const [overflowPx, setOverflowPx] = useState(0);
   const [reachedEnd, setReachedEnd] = useState(false);
+  const [prevReveal, setPrevReveal] = useState(reveal);
+  if (reveal !== prevReveal) {
+    setPrevReveal(reveal);
+    if (!reveal) setReachedEnd(false);
+  }
 
   useEffect(() => {
     const container = containerRef.current;
@@ -32,10 +37,6 @@ export function OverflowTickerText({
     observer.observe(content);
     return () => observer.disconnect();
   }, []);
-
-  useEffect(() => {
-    if (!reveal) setReachedEnd(false);
-  }, [reveal]);
 
   const prefersReducedMotion = useReducedMotion();
   const isTicking = reveal && overflowPx > 0;


### PR DESCRIPTION
## Problem

Long task titles in the sidebar truncate with an ellipsis, so the end of the title is unreadable.

## Changes

Overflowing sidebar titles now fade out at the right edge instead of showing "...". Hovering the row scrolls the title left at a constant speed like a stock ticker until the end is visible, with the fade flipping to the left edge, and it snaps back to the start on mouse leave. Titles that fit are unchanged. The truncation tooltip is removed since the ticker now reveals the full title.

## How did you test this?

Biome, `pnpm --filter @posthog/ui typecheck` and the sidebar Vitest suite (109 tests pass).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?