### PR TITLE
feat(canvas): deterministic local build adapter and preview artifacts (phase 2)

### DIFF
--- a/packages/core/src/canvas/freeformWhitelist.contract.test.ts
+++ b/packages/core/src/canvas/freeformWhitelist.contract.test.ts
@@ -1,0 +1,41 @@
+import { CANVAS_PLATFORM_DEPENDENCIES } from "@posthog/shared";
+import { describe, expect, it } from "vitest";
+import { FREEFORM_WHITELIST } from "./freeformWhitelist";
+
+function isSubpathSpecifier(name: string): boolean {
+  const segments = name.split("/");
+  return name.startsWith("@") ? segments.length > 2 : segments.length > 1;
+}
+
+describe("freeform whitelist ↔ platform dependency registry", () => {
+  // The legacy runtime's import whitelist and the build pipeline's platform
+  // dependency registry describe the same pinned package set. If one moves
+  // without the other, a canvas that previews in one tier fails in the other.
+  it("pins the same packages at the same versions", () => {
+    const whitelist = Object.fromEntries(
+      FREEFORM_WHITELIST.filter((entry) => !isSubpathSpecifier(entry.name)).map(
+        (entry) => [entry.name, entry.version],
+      ),
+    );
+    const registry = Object.fromEntries(
+      Object.entries(CANVAS_PLATFORM_DEPENDENCIES).map(([name, admission]) => [
+        name,
+        admission.version,
+      ]),
+    );
+    expect(whitelist).toEqual(registry);
+  });
+
+  it("covers every whitelisted subpath specifier with a runtime import", () => {
+    for (const entry of FREEFORM_WHITELIST.filter((e) =>
+      isSubpathSpecifier(e.name),
+    )) {
+      const segments = entry.name.split("/");
+      const packageName = entry.name.startsWith("@")
+        ? segments.slice(0, 2).join("/")
+        : segments[0];
+      const admission = CANVAS_PLATFORM_DEPENDENCIES[packageName];
+      expect(admission?.runtimeImports?.[entry.name], entry.name).toBeTruthy();
+    }
+  });
+});

--- a/packages/shared/src/canvas-build-contract.ts
+++ b/packages/shared/src/canvas-build-contract.ts
@@ -1,0 +1,207 @@
+import { z } from "zod";
+import {
+  CANVAS_ENTRY_HTML,
+  type CanvasSourceProject,
+  canvasArtifactManifestSchema,
+  canvasDiagnosticSchema,
+  canvasSourceProjectSchema,
+} from "./canvas-contracts";
+
+// The shared canvas build contract (no I/O). Local (workspace-server) and
+// cloud build adapters implement the same request/result shapes and run the
+// same contract fixtures, so a publish never produces different diagnostics
+// than the preview that preceded it.
+
+export const CANVAS_BUILD_CONTRACT_VERSION = 1;
+
+/** One platform-supported dependency: pinned, pre-admitted, and resolvable. */
+export interface CanvasDependencyAdmission {
+  /** The exact version every canvas gets — canvases cannot pick their own. */
+  version: string;
+  /**
+   * Browser module URL the preview import map resolves the bare specifier to.
+   * Cloud builds may substitute self-hosted copies; the specifier and version
+   * stay identical so source is portable across tiers.
+   */
+  importUrl: string;
+  /** Extra import-map entries the package needs at runtime (subpath modules). */
+  runtimeImports?: Record<string, string>;
+}
+
+const ESM_HOST = "https://esm.sh";
+const QUILL_VERSION = "0.3.0-beta.18";
+
+/**
+ * Platform-supported dependencies with pinned versions and pre-admitted
+ * status. Mirrors the legacy runtime's import whitelist (a drift test in
+ * @posthog/core asserts the two stay aligned). npm packages outside this
+ * registry go through guarded admission once the build service ships.
+ */
+export const CANVAS_PLATFORM_DEPENDENCIES: Record<
+  string,
+  CanvasDependencyAdmission
+> = {
+  react: {
+    version: "19.0.0",
+    importUrl: `${ESM_HOST}/react@19.0.0`,
+    runtimeImports: {
+      "react/jsx-runtime": `${ESM_HOST}/react@19.0.0/jsx-runtime`,
+    },
+  },
+  "react-dom": {
+    version: "19.0.0",
+    importUrl: `${ESM_HOST}/react-dom@19.0.0?external=react`,
+    runtimeImports: {
+      "react-dom/client": `${ESM_HOST}/react-dom@19.0.0/client?external=react`,
+    },
+  },
+  "@posthog/quill": {
+    version: QUILL_VERSION,
+    importUrl: `${ESM_HOST}/@posthog/quill@${QUILL_VERSION}?external=react,react-dom`,
+  },
+  recharts: {
+    version: "2.15.0",
+    importUrl: `${ESM_HOST}/recharts@2.15.0?external=react,react-dom`,
+  },
+  "lucide-react": {
+    version: "1.21.0",
+    importUrl: `${ESM_HOST}/lucide-react@1.21.0?external=react`,
+  },
+  dayjs: {
+    version: "1.11.13",
+    importUrl: `${ESM_HOST}/dayjs@1.11.13`,
+  },
+};
+
+/** Import specifiers resolvable at runtime (package roots + subpath modules). */
+export function canvasRuntimeImportMap(
+  dependencies: Record<string, string>,
+): Record<string, string> {
+  const imports: Record<string, string> = {};
+  for (const name of Object.keys(dependencies)) {
+    const admission = CANVAS_PLATFORM_DEPENDENCIES[name];
+    if (!admission) continue;
+    imports[name] = admission.importUrl;
+    Object.assign(imports, admission.runtimeImports);
+  }
+  return imports;
+}
+
+// Emitted-artifact budgets, enforced by every adapter's output scan. The
+// per-file budget is deliberately below the source-project total so a bundle
+// that concatenates many modules into one chunk still has a ceiling.
+export const MAX_CANVAS_ARTIFACT_FILE_BYTES = 1024 * 1024;
+export const MAX_CANVAS_ARTIFACT_TOTAL_BYTES = 8 * 1024 * 1024;
+export const CANVAS_BUILD_TIMEOUT_MS = 30_000;
+
+export const canvasBuildModeSchema = z.enum(["validate", "publish"]);
+export type CanvasBuildMode = z.infer<typeof canvasBuildModeSchema>;
+
+export const canvasBuildRequestSchema = z.object({
+  /** Target canvas, when known (previews for an unsaved draft may omit it). */
+  canvasId: z.string().optional(),
+  /** Source version the project was read at, for attribution/conflicts. */
+  sourceVersionId: z.string().optional(),
+  project: canvasSourceProjectSchema,
+  /**
+   * "validate" returns diagnostics and a short-lived preview artifact;
+   * "publish" additionally makes the artifact eligible for upload. Local
+   * adapters only ever validate — cloud builds are authoritative for
+   * publication.
+   */
+  mode: canvasBuildModeSchema,
+});
+export type CanvasBuildRequest = z.infer<typeof canvasBuildRequestSchema>;
+
+/** One emitted artifact file. Text content (HTML/JS/CSS) in phase 2. */
+export const canvasArtifactFileSchema = z.object({
+  path: z.string(),
+  content: z.string(),
+  /** Hex SHA-256 of the UTF-8 content. */
+  contentHash: z.string(),
+  sizeBytes: z.number().int().nonnegative(),
+});
+export type CanvasArtifactFile = z.infer<typeof canvasArtifactFileSchema>;
+
+export const canvasBuildResultSchema = z.object({
+  contractVersion: z.literal(CANVAS_BUILD_CONTRACT_VERSION),
+  status: z.enum(["ready", "failed"]),
+  diagnostics: z.array(canvasDiagnosticSchema),
+  /** Present when status is "ready". */
+  manifest: canvasArtifactManifestSchema.optional(),
+  /** Emitted files, entry first. Present when status is "ready". */
+  files: z.array(canvasArtifactFileSchema).optional(),
+});
+export type CanvasBuildResult = z.infer<typeof canvasBuildResultSchema>;
+
+/** The one build boundary: source in, artifact + diagnostics out — never shell commands. */
+export interface CanvasBuildAdapter {
+  buildCanvas(request: CanvasBuildRequest): Promise<CanvasBuildResult>;
+}
+
+// ── Neutral web-project starter ─────────────────────────────────────────────
+// New canvases start from one intentionally small project. The entry stays
+// vanilla TypeScript; importing React (or anything else platform-supported)
+// is an edit, not a different canvas kind.
+
+export const CANVAS_STARTER_INDEX_HTML = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>
+`;
+
+export const CANVAS_STARTER_MAIN_TS = `const root = document.getElementById("root");
+
+if (root) {
+  const heading = document.createElement("h1");
+  heading.textContent = "New canvas";
+  const hint = document.createElement("p");
+  hint.textContent = "Edit src/main.ts to build this canvas.";
+  root.append(heading, hint);
+}
+
+export {};
+`;
+
+export const CANVAS_STARTER_STYLE_CSS = `:root {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--foreground, #0d0d0d);
+  background: var(--background, #ffffff);
+}
+
+#root {
+  padding: 24px;
+}
+`;
+
+export function createCanvasStarterProject(): CanvasSourceProject {
+  return {
+    schemaVersion: 1,
+    files: {
+      [CANVAS_ENTRY_HTML]: CANVAS_STARTER_INDEX_HTML,
+      "src/main.ts": CANVAS_STARTER_MAIN_TS,
+      "src/style.css": CANVAS_STARTER_STYLE_CSS,
+    },
+    entryHtml: CANVAS_ENTRY_HTML,
+    dependencies: Object.fromEntries(
+      Object.entries(CANVAS_PLATFORM_DEPENDENCIES).map(([name, admission]) => [
+        name,
+        admission.version,
+      ]),
+    ),
+    canvasSdkVersion: "0.1.0",
+  };
+}

--- a/packages/shared/src/canvas-build-fixtures.ts
+++ b/packages/shared/src/canvas-build-fixtures.ts
@@ -1,0 +1,202 @@
+import {
+  canvasRuntimeImportMap,
+  createCanvasStarterProject,
+  MAX_CANVAS_ARTIFACT_FILE_BYTES,
+} from "./canvas-build-contract";
+import {
+  CANVAS_ENTRY_HTML,
+  type CanvasSourceProject,
+} from "./canvas-contracts";
+
+// Contract fixtures every canvas build adapter (workspace-server local build,
+// cloud build) must produce the same outcome for. Running the identical
+// fixtures through each adapter catches toolchain drift before a publish
+// produces different diagnostics than the preview that preceded it.
+
+export interface CanvasBuildContractFixture {
+  name: string;
+  project: CanvasSourceProject;
+  expected: {
+    status: "ready" | "failed";
+    /** Diagnostic codes that must be present (subset match). */
+    diagnosticCodes?: string[];
+  };
+}
+
+function project(
+  files: Record<string, string>,
+  dependencies: Record<string, string> = {},
+): CanvasSourceProject {
+  return {
+    schemaVersion: 1,
+    files,
+    entryHtml: CANVAS_ENTRY_HTML,
+    dependencies,
+    canvasSdkVersion: "0.1.0",
+  };
+}
+
+const HTML_SHELL = (body: string, head = "") => `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+${head}
+  </head>
+  <body>
+${body}
+  </body>
+</html>
+`;
+
+const REACT_DEPS = {
+  react: "19.0.0",
+  "react-dom": "19.0.0",
+  "@posthog/quill": "0.3.0-beta.18",
+};
+
+export const CANVAS_BUILD_CONTRACT_FIXTURES: CanvasBuildContractFixture[] = [
+  {
+    name: "neutral starter project",
+    project: createCanvasStarterProject(),
+    expected: { status: "ready" },
+  },
+  {
+    name: "react + quill application",
+    project: project(
+      {
+        [CANVAS_ENTRY_HTML]: HTML_SHELL(
+          '    <div id="root"></div>\n    <script type="module" src="/src/main.tsx"></script>',
+        ),
+        "src/main.tsx": [
+          'import { createRoot } from "react-dom/client";',
+          'import { App } from "./App";',
+          'createRoot(document.getElementById("root")!).render(<App />);',
+        ].join("\n"),
+        "src/App.tsx": [
+          'import { useState } from "react";',
+          "export function App() {",
+          "  const [count, setCount] = useState(0);",
+          "  return <button onClick={() => setCount((c) => c + 1)}>clicked {count}</button>;",
+          "}",
+        ].join("\n"),
+      },
+      REACT_DEPS,
+    ),
+    expected: { status: "ready" },
+  },
+  {
+    name: "semantic html document",
+    project: project({
+      [CANVAS_ENTRY_HTML]: HTML_SHELL(
+        [
+          "    <article>",
+          "      <h1>Quarterly notes</h1>",
+          "      <p>A document canvas needs no framework.</p>",
+          "    </article>",
+          '    <script type="module" src="/src/main.ts"></script>',
+        ].join("\n"),
+        '    <link rel="stylesheet" href="/src/style.css" />',
+      ),
+      "src/main.ts":
+        'document.querySelector("article")?.classList.add("ready");\nexport {};',
+      "src/style.css": "article { max-width: 60ch; margin: 0 auto; }",
+    }),
+    expected: { status: "ready" },
+  },
+  {
+    name: "webgl experience on raw browser APIs",
+    project: project({
+      [CANVAS_ENTRY_HTML]: HTML_SHELL(
+        '    <canvas id="scene"></canvas>\n    <script type="module" src="/src/main.ts"></script>',
+      ),
+      "src/main.ts": [
+        'const canvas = document.getElementById("scene") as HTMLCanvasElement;',
+        'const gl = canvas.getContext("webgl2");',
+        "function frame(t: number) {",
+        "  if (gl) {",
+        "    gl.clearColor(Math.sin(t / 1000) ** 2, 0.2, 0.4, 1);",
+        "    gl.clear(gl.COLOR_BUFFER_BIT);",
+        "  }",
+        "  requestAnimationFrame(frame);",
+        "}",
+        "requestAnimationFrame(frame);",
+        "export {};",
+      ].join("\n"),
+    }),
+    expected: { status: "ready" },
+  },
+  {
+    name: "import of a non-admitted package",
+    project: project(
+      {
+        [CANVAS_ENTRY_HTML]: HTML_SHELL(
+          '    <script type="module" src="/src/main.ts"></script>',
+        ),
+        "src/main.ts":
+          'import _ from "lodash";\nconsole.log(_.chunk([1, 2, 3], 2));\nexport {};',
+      },
+      { lodash: "4.17.21" },
+    ),
+    expected: {
+      status: "failed",
+      diagnosticCodes: ["dependency_not_admitted"],
+    },
+  },
+  {
+    name: "undeclared bare import",
+    project: project({
+      [CANVAS_ENTRY_HTML]: HTML_SHELL(
+        '    <script type="module" src="/src/main.ts"></script>',
+      ),
+      "src/main.ts": 'import _ from "lodash";\nconsole.log(_);\nexport {};',
+    }),
+    expected: { status: "failed", diagnosticCodes: ["import_not_declared"] },
+  },
+  {
+    name: "typescript syntax error",
+    project: project({
+      [CANVAS_ENTRY_HTML]: HTML_SHELL(
+        '    <script type="module" src="/src/main.ts"></script>',
+      ),
+      "src/main.ts": "const broken = {;\nexport {};",
+    }),
+    expected: { status: "failed", diagnosticCodes: ["bundle_error"] },
+  },
+  {
+    name: "missing module entry in html",
+    project: project({
+      [CANVAS_ENTRY_HTML]: HTML_SHELL(
+        '    <script type="module" src="/src/missing.ts"></script>',
+      ),
+      "src/main.ts": "export {};",
+    }),
+    expected: { status: "failed", diagnosticCodes: ["entry_not_found"] },
+  },
+  {
+    name: "oversized emitted output",
+    project: project({
+      [CANVAS_ENTRY_HTML]: HTML_SHELL(
+        '    <script type="module" src="/src/main.ts"></script>',
+      ),
+      // Three modules, each under the per-source-file limit, bundle into one
+      // chunk beyond the per-artifact-file budget — the output scan must trip
+      // even though every input passed stage-1 validation.
+      "src/main.ts": [
+        'import { a } from "./a";',
+        'import { b } from "./b";',
+        'import { c } from "./c";',
+        "console.log(a.length + b.length + c.length);",
+        "export {};",
+      ].join("\n"),
+      "src/a.ts": `export const a = "${"a".repeat(Math.floor(MAX_CANVAS_ARTIFACT_FILE_BYTES * 0.45))}";`,
+      "src/b.ts": `export const b = "${"b".repeat(Math.floor(MAX_CANVAS_ARTIFACT_FILE_BYTES * 0.45))}";`,
+      "src/c.ts": `export const c = "${"c".repeat(Math.floor(MAX_CANVAS_ARTIFACT_FILE_BYTES * 0.45))}";`,
+    }),
+    expected: { status: "failed", diagnosticCodes: ["artifact_too_large"] },
+  },
+];
+
+/** Runtime import-map entries a ready react-fixture artifact must resolve. */
+export const CANVAS_FIXTURE_REACT_IMPORTS = Object.keys(
+  canvasRuntimeImportMap(REACT_DEPS),
+);

--- a/packages/shared/src/canvas-preview.test.ts
+++ b/packages/shared/src/canvas-preview.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { CanvasArtifactFile } from "./canvas-build-contract";
+import { renderCanvasPreviewDocument } from "./canvas-preview";
+
+function file(path: string, content: string): CanvasArtifactFile {
+  return {
+    path,
+    content,
+    contentHash: "0".repeat(64),
+    sizeBytes: content.length,
+  };
+}
+
+const ARTIFACT: CanvasArtifactFile[] = [
+  file(
+    "index.html",
+    [
+      "<!doctype html>",
+      "<html>",
+      "  <head>",
+      '    <link rel="stylesheet" href="./assets/style-abc.css" />',
+      "  </head>",
+      "  <body>",
+      '    <div id="root"></div>',
+      '    <script type="module" src="./assets/main-abc.js"></script>',
+      "  </body>",
+      "</html>",
+    ].join("\n"),
+  ),
+  file(
+    "assets/main-abc.js",
+    'console.log("built \\u003c/script\\u003e safe");',
+  ),
+  file("assets/style-abc.css", "#root { padding: 1px; }"),
+];
+
+describe("renderCanvasPreviewDocument", () => {
+  it("inlines emitted assets into one self-contained document with a CSP", () => {
+    const doc = renderCanvasPreviewDocument(ARTIFACT);
+
+    // Everything the iframe needs is in the one document — no asset fetches,
+    // no runtime compiler.
+    expect(doc).toContain('<script type="module">console.log');
+    expect(doc).toContain("<style>#root { padding: 1px; }</style>");
+    expect(doc).not.toContain("./assets/main-abc.js");
+    expect(doc).not.toContain("./assets/style-abc.css");
+    expect(doc).toContain('http-equiv="Content-Security-Policy"');
+    expect(doc).toContain("default-src 'none'");
+  });
+
+  it("escapes closing tags so inlined code cannot break out of its element", () => {
+    const doc = renderCanvasPreviewDocument([
+      ARTIFACT[0],
+      file("assets/main-abc.js", 'const s = "</script><script>alert(1)";'),
+      ARTIFACT[2],
+    ]);
+
+    expect(doc).toContain("<\\/script>");
+    expect(doc).not.toContain('"</script><script>alert(1)');
+  });
+
+  it("returns null when the artifact has no entry html", () => {
+    expect(renderCanvasPreviewDocument([ARTIFACT[1]])).toBeNull();
+  });
+});

--- a/packages/shared/src/canvas-preview.ts
+++ b/packages/shared/src/canvas-preview.ts
@@ -1,0 +1,67 @@
+import type { CanvasArtifactFile } from "./canvas-build-contract";
+
+// Folds a built canvas artifact into one self-contained HTML document the
+// existing null-origin iframe host can load (srcdoc), replacing the legacy
+// preview path's in-browser Babel + Tailwind JIT with ahead-of-time build
+// output. Only the pinned platform-dependency host remains reachable — the
+// emitted application code itself is inlined.
+
+const PREVIEW_DEPENDENCY_HOST = "https://esm.sh";
+
+// srcdoc previews have no response headers, so the policy rides in a meta tag.
+// frame-ancestors/report-uri are ignored in meta CSP; everything else applies.
+const PREVIEW_CSP = [
+  "default-src 'none'",
+  `script-src 'unsafe-inline' ${PREVIEW_DEPENDENCY_HOST}`,
+  `style-src 'unsafe-inline' ${PREVIEW_DEPENDENCY_HOST}`,
+  `font-src ${PREVIEW_DEPENDENCY_HOST} data:`,
+  "img-src data: blob:",
+  `connect-src ${PREVIEW_DEPENDENCY_HOST}`,
+].join("; ");
+
+function escapeClosingTags(content: string, tag: string): string {
+  return content.replaceAll(`</${tag}`, `<\\/${tag}`);
+}
+
+/**
+ * Inline every emitted asset the entry HTML references, producing a single
+ * document with a strict CSP. Returns null when the artifact has no entry
+ * HTML (a failed or empty build has nothing to preview).
+ */
+export function renderCanvasPreviewDocument(
+  files: CanvasArtifactFile[],
+  entryHtml = "index.html",
+): string | null {
+  const entry = files.find((file) => file.path === entryHtml);
+  if (!entry) return null;
+
+  let html = entry.content;
+  for (const file of files) {
+    if (file.path === entryHtml) continue;
+    const ref = `./${file.path}`;
+    if (file.path.endsWith(".js")) {
+      const scriptTag = new RegExp(
+        `<script\\s[^>]*src\\s*=\\s*["']${ref.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["'][^>]*>\\s*</script>`,
+        "i",
+      );
+      html = html.replace(
+        scriptTag,
+        `<script type="module">${escapeClosingTags(file.content, "script")}</script>`,
+      );
+    } else if (file.path.endsWith(".css")) {
+      const linkTag = new RegExp(
+        `<link\\s[^>]*href\\s*=\\s*["']${ref.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["'][^>]*/?>`,
+        "i",
+      );
+      html = html.replace(
+        linkTag,
+        `<style>${escapeClosingTags(file.content, "style")}</style>`,
+      );
+    }
+  }
+
+  const cspMeta = `<meta http-equiv="Content-Security-Policy" content="${PREVIEW_CSP}" />`;
+  return html.includes("<head>")
+    ? html.replace("<head>", `<head>\n    ${cspMeta}`)
+    : `${cspMeta}\n${html}`;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -64,7 +64,10 @@ export {
   type WindowBounds,
   windowBoundsSchema,
 } from "./browser-tabs-schemas";
+export * from "./canvas-build-contract";
+export * from "./canvas-build-fixtures";
 export * from "./canvas-contracts";
+export * from "./canvas-preview";
 export type { CloudRunSource, PrAuthorshipMode } from "./cloud";
 export {
   CLOUD_PROMPT_PREFIX,

--- a/packages/workspace-server/package.json
+++ b/packages/workspace-server/package.json
@@ -34,6 +34,7 @@
     "@trpc/server": "catalog:",
     "better-sqlite3": "^12.8.0",
     "drizzle-orm": "^0.45.1",
+    "esbuild": "0.27.2",
     "fflate": "^0.8.2",
     "hono": "catalog:",
     "ignore": "^7.0.5",

--- a/packages/workspace-server/src/di/container.ts
+++ b/packages/workspace-server/src/di/container.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import { TypedContainer } from "@inversifyjs/strongly-typed";
+import { CanvasBuildService } from "../services/canvas-build/canvas-build";
 import { ConnectivityService } from "../services/connectivity/service";
 import { EnvironmentService } from "../services/environment/service";
 import { FocusService } from "../services/focus/service";
@@ -10,6 +11,7 @@ import { LOGS_SERVICE } from "../services/local-logs/identifiers";
 import { LocalLogsService } from "../services/local-logs/service";
 import { WatcherService } from "../services/watcher/service";
 import {
+  CANVAS_BUILD_SERVICE,
   CONNECTIVITY_SERVICE,
   ENVIRONMENT_SERVICE,
   FOCUS_SERVICE,
@@ -21,6 +23,7 @@ import {
 } from "./tokens";
 
 export interface WorkspaceServerBindings {
+  [CANVAS_BUILD_SERVICE]: CanvasBuildService;
   [FOCUS_SERVICE]: FocusService;
   [FOCUS_SYNC_SERVICE]: FocusSyncService;
   [GIT_SERVICE]: GitService;
@@ -42,3 +45,4 @@ container.bind(LOCAL_LOGS_SERVICE).to(LocalLogsService).inSingletonScope();
 container.bind(LOGS_SERVICE).toService(LOCAL_LOGS_SERVICE);
 container.bind(CONNECTIVITY_SERVICE).to(ConnectivityService).inSingletonScope();
 container.bind(ENVIRONMENT_SERVICE).to(EnvironmentService).inSingletonScope();
+container.bind(CANVAS_BUILD_SERVICE).to(CanvasBuildService).inSingletonScope();

--- a/packages/workspace-server/src/di/tokens.ts
+++ b/packages/workspace-server/src/di/tokens.ts
@@ -17,3 +17,6 @@ export const ENVIRONMENT_SERVICE = Symbol.for(
 export const BROWSER_TABS_SERVICE = Symbol.for(
   "posthog.workspace.browser-tabs-service",
 );
+export const CANVAS_BUILD_SERVICE = Symbol.for(
+  "posthog.workspace.canvas-build-service",
+);

--- a/packages/workspace-server/src/serve.ts
+++ b/packages/workspace-server/src/serve.ts
@@ -5,6 +5,7 @@ import { serve } from "@hono/node-server";
 import { createApp } from "./app";
 import { container } from "./di/container";
 import {
+  CANVAS_BUILD_SERVICE,
   CONNECTIVITY_SERVICE,
   ENVIRONMENT_SERVICE,
   FOCUS_SERVICE,
@@ -15,6 +16,7 @@ import {
   WATCHER_SERVICE,
 } from "./di/tokens";
 import { removeLegacyNodeShimDirs } from "./services/agent/legacy-node-shim";
+import type { CanvasBuildService } from "./services/canvas-build/canvas-build";
 import type { ConnectivityService } from "./services/connectivity/service";
 import type { EnvironmentService } from "./services/environment/service";
 import type { FocusService } from "./services/focus/service";
@@ -67,6 +69,7 @@ for (const dir of shimCleanup.failed) {
 }
 
 const router = createAppRouter({
+  canvasBuildService: container.get<CanvasBuildService>(CANVAS_BUILD_SERVICE),
   focusService: container.get<FocusService>(FOCUS_SERVICE),
   focusSyncService: container.get<FocusSyncService>(FOCUS_SYNC_SERVICE),
   gitService: container.get<GitService>(GIT_SERVICE),

--- a/packages/workspace-server/src/services/canvas-build/canvas-build.test.ts
+++ b/packages/workspace-server/src/services/canvas-build/canvas-build.test.ts
@@ -1,0 +1,112 @@
+import {
+  CANVAS_BUILD_CONTRACT_FIXTURES,
+  CANVAS_ENTRY_HTML,
+  CANVAS_FIXTURE_REACT_IMPORTS,
+  type CanvasBuildResult,
+  createCanvasStarterProject,
+} from "@posthog/shared";
+import { describe, expect, it } from "vitest";
+import { CanvasBuildService } from "./canvas-build";
+
+const service = new CanvasBuildService();
+
+function build(
+  project = createCanvasStarterProject(),
+): Promise<CanvasBuildResult> {
+  return service.buildCanvas({ project, mode: "validate" });
+}
+
+describe("CanvasBuildService", () => {
+  // The shared contract fixtures are the drift guard between this local
+  // adapter and the cloud build service: both must produce these outcomes.
+  it.each(CANVAS_BUILD_CONTRACT_FIXTURES.map((f) => [f.name, f] as const))(
+    "contract fixture: %s",
+    async (_name, fixture) => {
+      const result = await service.buildCanvas({
+        project: fixture.project,
+        mode: "validate",
+      });
+      expect(result.status).toBe(fixture.expected.status);
+      for (const code of fixture.expected.diagnosticCodes ?? []) {
+        expect(result.diagnostics.map((d) => d.code)).toContain(code);
+      }
+      if (fixture.expected.status === "failed") {
+        expect(result.files).toBeUndefined();
+      }
+    },
+  );
+
+  it("emits compiled, content-hashed assets and rewrites the entry html", async () => {
+    const result = await build();
+
+    expect(result.status).toBe("ready");
+    const files = result.files ?? [];
+    const html = files.find((f) => f.path === CANVAS_ENTRY_HTML);
+    const js = files.find((f) => f.path.endsWith(".js"));
+    const css = files.find((f) => f.path.endsWith(".css"));
+    expect(html && js && css).toBeTruthy();
+
+    // No runtime compilation: the artifact references the emitted chunk, not
+    // the TypeScript source, and the chunk is plain JS.
+    expect(html?.content).not.toContain("src/main.ts");
+    expect(html?.content).toContain(js?.path ?? "");
+    expect(js?.content).toContain("New canvas");
+    expect(js?.content).not.toContain(": string");
+
+    // Assets are content-addressed and the manifest mirrors them.
+    expect(js?.path).toMatch(
+      new RegExp(`-${js?.contentHash.slice(0, 10)}\\.js$`),
+    );
+    expect(result.manifest?.assets.map((a) => a.path)).toEqual(
+      files.map((f) => f.path),
+    );
+    expect(result.manifest?.entryHtml).toBe(CANVAS_ENTRY_HTML);
+  });
+
+  it("bundles multi-file react projects and pins platform deps via the import map", async () => {
+    const fixture = CANVAS_BUILD_CONTRACT_FIXTURES.find(
+      (f) => f.name === "react + quill application",
+    );
+    if (!fixture) throw new Error("react fixture missing");
+    const result = await service.buildCanvas({
+      project: fixture.project,
+      mode: "validate",
+    });
+
+    expect(result.status).toBe("ready");
+    const html = result.files?.find((f) => f.path === CANVAS_ENTRY_HTML);
+    const js = result.files?.find((f) => f.path.endsWith(".js"));
+    // App.tsx was bundled into the entry chunk — one module graph, no
+    // per-file loading and no browser Babel.
+    expect(js?.content).toContain("clicked");
+    // Platform deps stay external, resolved by the injected pinned import map.
+    const importMap = html?.content.match(
+      /<script type="importmap">(.*?)<\/script>/s,
+    );
+    expect(importMap).toBeTruthy();
+    const imports = Object.keys(JSON.parse(importMap?.[1] ?? "{}").imports);
+    for (const specifier of [
+      "react",
+      "react-dom/client",
+      "react/jsx-runtime",
+    ]) {
+      expect(CANVAS_FIXTURE_REACT_IMPORTS).toContain(specifier);
+      expect(imports).toContain(specifier);
+    }
+    // Only what the build kept external is offered to the runtime.
+    expect(imports).not.toContain("dayjs");
+  });
+
+  it("reports bundle errors with the failing file and line", async () => {
+    const project = createCanvasStarterProject();
+    project.files["src/main.ts"] =
+      "const ok = 1;\nconst broken = {;\nexport {};";
+
+    const result = await build(project);
+
+    expect(result.status).toBe("failed");
+    const error = result.diagnostics.find((d) => d.code === "bundle_error");
+    expect(error?.path).toBe("src/main.ts");
+    expect(error?.line).toBe(2);
+  });
+});

--- a/packages/workspace-server/src/services/canvas-build/canvas-build.ts
+++ b/packages/workspace-server/src/services/canvas-build/canvas-build.ts
@@ -1,0 +1,520 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import {
+  CANVAS_BUILD_CONTRACT_VERSION,
+  CANVAS_BUILD_TIMEOUT_MS,
+  CANVAS_PLATFORM_DEPENDENCIES,
+  type CanvasArtifactFile,
+  type CanvasBuildAdapter,
+  type CanvasBuildRequest,
+  type CanvasBuildResult,
+  type CanvasDiagnostic,
+  type CanvasSourceProject,
+  canvasRuntimeImportMap,
+  canvasSourceProjectSchema,
+  hasCanvasErrors,
+  MAX_CANVAS_ARTIFACT_FILE_BYTES,
+  MAX_CANVAS_ARTIFACT_TOTAL_BYTES,
+  validateCanvasSourceProject,
+} from "@posthog/shared";
+import * as esbuild from "esbuild";
+import { injectable } from "inversify";
+
+// The local/dev implementation of the shared canvas build contract. It owns
+// the one platform build recipe rooted at the project's entry HTML — agents
+// never supply build commands. Pipeline (mirrors the plan's build stages):
+//
+//   1. validate the source-project schema, paths, and size limits;
+//   2. resolve dependencies against the pre-admitted platform registry;
+//   3. bundle every module entry with esbuild over an in-memory FS —
+//      no network, no package installation, no lifecycle scripts;
+//   4. rewrite the entry HTML onto the emitted, content-hashed assets and
+//      inject the pinned import map for platform dependencies;
+//   5. scan emitted output for size budgets and forbidden URL schemes.
+//
+// Local builds validate and preview only. Cloud builds run the same contract
+// (and the same fixtures — see canvas-build-fixtures in @posthog/shared) and
+// remain the sole source of publishable artifacts.
+
+const MODULE_SCRIPT_RE =
+  /<script\s[^>]*type\s*=\s*["']module["'][^>]*\ssrc\s*=\s*["']([^"']+)["'][^>]*>\s*<\/script>/gi;
+const STYLESHEET_LINK_RE =
+  /<link\s[^>]*rel\s*=\s*["']stylesheet["'][^>]*\shref\s*=\s*["']([^"']+)["'][^>]*\/?>/gi;
+// Out-of-band code paths the artifact scan rejects outright.
+const FORBIDDEN_SCHEME_RE =
+  /(?:src|href)\s*=\s*["']\s*(javascript|data:text\/html|vbscript)/i;
+
+const RESOLVE_EXTENSIONS = [
+  "",
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  "/index.ts",
+  "/index.tsx",
+];
+
+const LOADERS: Record<string, esbuild.Loader> = {
+  ".ts": "ts",
+  ".tsx": "tsx",
+  ".js": "js",
+  ".jsx": "jsx",
+  ".css": "css",
+  ".json": "json",
+  ".svg": "text",
+  ".txt": "text",
+};
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function diagnostic(
+  severity: "error" | "warning",
+  code: string,
+  message: string,
+  file?: string,
+  line?: number,
+): CanvasDiagnostic {
+  return {
+    severity,
+    code,
+    message,
+    ...(file !== undefined ? { path: file } : {}),
+    ...(line !== undefined ? { line } : {}),
+  };
+}
+
+/** Normalize an HTML asset reference ("/src/main.ts", "./src/main.ts") to a project path. */
+function projectPathFromRef(ref: string): string {
+  return ref.replace(/^\.?\//, "");
+}
+
+/** Resolve a relative import against the importer's directory within the project. */
+function resolveRelative(
+  files: Record<string, string>,
+  importer: string,
+  specifier: string,
+): string | null {
+  const base = path.posix.normalize(
+    path.posix.join(path.posix.dirname(importer), specifier),
+  );
+  if (base.startsWith("..")) return null;
+  for (const extension of RESOLVE_EXTENSIONS) {
+    const candidate = base + extension;
+    if (candidate in files) return candidate;
+  }
+  return null;
+}
+
+@injectable()
+export class CanvasBuildService implements CanvasBuildAdapter {
+  async buildCanvas(request: CanvasBuildRequest): Promise<CanvasBuildResult> {
+    const diagnostics: CanvasDiagnostic[] = [];
+
+    // Stage 1 — schema + structural validation (shared with every adapter).
+    const parsed = canvasSourceProjectSchema.safeParse(request.project);
+    if (!parsed.success) {
+      return this.failed([
+        diagnostic(
+          "error",
+          "invalid_project",
+          `the source project does not match schema version ${CANVAS_BUILD_CONTRACT_VERSION}: ${parsed.error.issues[0]?.message ?? "invalid"}`,
+        ),
+      ]);
+    }
+    const project = parsed.data;
+    diagnostics.push(...validateCanvasSourceProject(project));
+
+    // Stage 2 — dependency resolution against the pre-admitted registry.
+    diagnostics.push(...this.resolveDependencies(project));
+    if (hasCanvasErrors(diagnostics)) return this.failed(diagnostics);
+
+    // Stage 3/4 — bundle and rewrite the entry HTML.
+    const build = await this.bundle(project, diagnostics);
+    if (build === null || hasCanvasErrors(diagnostics)) {
+      return this.failed(diagnostics);
+    }
+
+    // Stage 5 — output scan: budgets and forbidden schemes.
+    this.scanArtifact(build.files, diagnostics);
+    if (hasCanvasErrors(diagnostics)) return this.failed(diagnostics);
+
+    return {
+      contractVersion: CANVAS_BUILD_CONTRACT_VERSION,
+      status: "ready",
+      diagnostics,
+      manifest: {
+        entryHtml: project.entryHtml,
+        assets: build.files.map((file) => ({
+          path: file.path,
+          contentHash: file.contentHash,
+          sizeBytes: file.sizeBytes,
+        })),
+        dependencies: project.dependencies,
+        canvasSdkVersion: project.canvasSdkVersion,
+        // Capability declaration/extraction lands with the cloud build
+        // service; local previews run with the host bridge's own guards.
+        capabilities: {
+          posthog: { insights: [], inlineQueries: true, captureEvents: [] },
+          network: { origins: [] },
+        },
+      },
+      files: build.files,
+    };
+  }
+
+  private failed(diagnostics: CanvasDiagnostic[]): CanvasBuildResult {
+    return {
+      contractVersion: CANVAS_BUILD_CONTRACT_VERSION,
+      status: "failed",
+      diagnostics,
+    };
+  }
+
+  private resolveDependencies(
+    project: CanvasSourceProject,
+  ): CanvasDiagnostic[] {
+    const diagnostics: CanvasDiagnostic[] = [];
+    for (const [name, version] of Object.entries(project.dependencies)) {
+      const admission = CANVAS_PLATFORM_DEPENDENCIES[name];
+      if (!admission) {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "dependency_not_admitted",
+            `dependency "${name}" is not platform-supported — supported: ${Object.keys(
+              CANVAS_PLATFORM_DEPENDENCIES,
+            )
+              .sort()
+              .join(", ")}`,
+          ),
+        );
+      } else if (admission.version !== version) {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "dependency_version_mismatch",
+            `dependency "${name}" must be the platform-pinned version ${admission.version}, got ${version}`,
+          ),
+        );
+      }
+    }
+    return diagnostics;
+  }
+
+  private async bundle(
+    project: CanvasSourceProject,
+    diagnostics: CanvasDiagnostic[],
+  ): Promise<{ files: CanvasArtifactFile[] } | null> {
+    const files = project.files;
+    let html = files[project.entryHtml] ?? "";
+
+    const scriptRefs = [...html.matchAll(MODULE_SCRIPT_RE)].map((m) => m[1]);
+    const styleRefs = [...html.matchAll(STYLESHEET_LINK_RE)].map((m) => m[1]);
+    if (scriptRefs.length === 0 && styleRefs.length === 0) {
+      diagnostics.push(
+        diagnostic(
+          "error",
+          "no_entry_module",
+          `${project.entryHtml} references no module scripts or stylesheets — nothing to build`,
+          project.entryHtml,
+        ),
+      );
+      return null;
+    }
+
+    const declaredImports = canvasRuntimeImportMap(project.dependencies);
+    const artifact: CanvasArtifactFile[] = [];
+    const usedImports = new Set<string>();
+    const rewrites = new Map<string, string>();
+
+    for (const ref of [...scriptRefs, ...styleRefs]) {
+      const entryPath = projectPathFromRef(ref);
+      if (!(entryPath in files)) {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "entry_not_found",
+            `${project.entryHtml} references "${ref}" but the project has no file at ${entryPath}`,
+            project.entryHtml,
+          ),
+        );
+        continue;
+      }
+
+      const bundled = await this.bundleEntry(
+        entryPath,
+        files,
+        project,
+        declaredImports,
+        usedImports,
+        diagnostics,
+      );
+      if (bundled === null) continue;
+
+      const extension = bundled.kind === "css" ? "css" : "js";
+      const hash = sha256(bundled.content);
+      const emittedPath = `assets/${path.posix
+        .basename(entryPath)
+        .replace(/\.[^.]+$/, "")}-${hash.slice(0, 10)}.${extension}`;
+      artifact.push({
+        path: emittedPath,
+        content: bundled.content,
+        contentHash: hash,
+        sizeBytes: Buffer.byteLength(bundled.content, "utf8"),
+      });
+      rewrites.set(ref, `./${emittedPath}`);
+      if (bundled.css !== null) {
+        const cssHash = sha256(bundled.css);
+        const cssPath = `assets/${path.posix
+          .basename(entryPath)
+          .replace(/\.[^.]+$/, "")}-${cssHash.slice(0, 10)}.css`;
+        artifact.push({
+          path: cssPath,
+          content: bundled.css,
+          contentHash: cssHash,
+          sizeBytes: Buffer.byteLength(bundled.css, "utf8"),
+        });
+        html = html.replace(
+          "</head>",
+          `  <link rel="stylesheet" href="./${cssPath}" />\n</head>`,
+        );
+      }
+    }
+
+    if (hasCanvasErrors(diagnostics)) return null;
+
+    for (const [ref, emitted] of rewrites) {
+      html = html
+        .split(`"${ref}"`)
+        .join(`"${emitted}"`)
+        .split(`'${ref}'`)
+        .join(`'${emitted}'`);
+    }
+
+    // The import map must precede every module script so pinned platform
+    // dependencies resolve; only the specifiers the build actually kept
+    // external are included.
+    if (usedImports.size > 0) {
+      const imports = Object.fromEntries(
+        Object.entries(declaredImports).filter(([specifier]) =>
+          usedImports.has(specifier),
+        ),
+      );
+      const importMap = `<script type="importmap">${JSON.stringify({ imports })}</script>`;
+      html = html.includes("</head>")
+        ? html.replace("</head>", `  ${importMap}\n</head>`)
+        : `${importMap}\n${html}`;
+    }
+
+    const htmlHash = sha256(html);
+    return {
+      files: [
+        {
+          path: project.entryHtml,
+          content: html,
+          contentHash: htmlHash,
+          sizeBytes: Buffer.byteLength(html, "utf8"),
+        },
+        ...artifact,
+      ],
+    };
+  }
+
+  private async bundleEntry(
+    entryPath: string,
+    files: Record<string, string>,
+    project: CanvasSourceProject,
+    declaredImports: Record<string, string>,
+    usedImports: Set<string>,
+    diagnostics: CanvasDiagnostic[],
+  ): Promise<{
+    content: string;
+    css: string | null;
+    kind: "js" | "css";
+  } | null> {
+    const isCssEntry = entryPath.endsWith(".css");
+    // An in-memory FS plugin is the no-network, no-install isolation boundary:
+    // only project files and pre-admitted bare specifiers can resolve.
+    const virtualFs: esbuild.Plugin = {
+      name: "canvas-virtual-fs",
+      setup: (build) => {
+        build.onResolve({ filter: /.*/ }, (args) => {
+          if (args.kind === "entry-point") {
+            return { path: args.path, namespace: "canvas" };
+          }
+          if (args.path.startsWith(".") || args.path.startsWith("/")) {
+            const importer = args.importer;
+            const resolved = resolveRelative(
+              files,
+              importer,
+              args.path.startsWith("/")
+                ? `./${projectPathFromRef(args.path)}`
+                : args.path,
+            );
+            if (resolved === null) {
+              return {
+                errors: [
+                  {
+                    text: `cannot resolve "${args.path}" — the project has no matching file`,
+                  },
+                ],
+              };
+            }
+            return { path: resolved, namespace: "canvas" };
+          }
+          // Bare specifier: must be a declared, admitted dependency (or one of
+          // its runtime subpaths). Kept external and served via the import map.
+          const packageName = args.path.startsWith("@")
+            ? args.path.split("/").slice(0, 2).join("/")
+            : args.path.split("/")[0];
+          if (!(packageName in project.dependencies)) {
+            return {
+              errors: [
+                {
+                  text: `import_not_declared: "${args.path}" is not in the project's dependencies`,
+                },
+              ],
+            };
+          }
+          if (!(args.path in declaredImports)) {
+            return {
+              errors: [
+                {
+                  text: `import_not_declared: "${args.path}" is not an admitted entry point of ${packageName}`,
+                },
+              ],
+            };
+          }
+          usedImports.add(args.path);
+          return { path: args.path, external: true };
+        });
+        build.onLoad({ filter: /.*/, namespace: "canvas" }, (args) => {
+          const contents = files[args.path];
+          if (contents === undefined) return null;
+          const loader = LOADERS[path.posix.extname(args.path)] ?? "text";
+          return { contents, loader, resolveDir: "/" };
+        });
+      },
+    };
+
+    try {
+      const result = await Promise.race([
+        esbuild.build({
+          entryPoints: [entryPath],
+          bundle: true,
+          write: false,
+          format: "esm",
+          platform: "browser",
+          target: "es2022",
+          jsx: "automatic",
+          minify: true,
+          sourcemap: false,
+          logLevel: "silent",
+          outdir: "out",
+          plugins: [virtualFs],
+        }),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new Error(`build timed out after ${CANVAS_BUILD_TIMEOUT_MS}ms`),
+              ),
+            CANVAS_BUILD_TIMEOUT_MS,
+          ).unref?.(),
+        ),
+      ]);
+
+      let js: string | null = null;
+      let css: string | null = null;
+      for (const file of result.outputFiles ?? []) {
+        if (file.path.endsWith(".css")) css = file.text;
+        else js = file.text;
+      }
+      if (isCssEntry) {
+        return { content: css ?? "", css: null, kind: "css" };
+      }
+      return { content: js ?? "", css, kind: "js" };
+    } catch (error) {
+      for (const issue of this.esbuildIssues(error)) {
+        // Surface the specific import_not_declared code the virtual FS raised;
+        // everything else is a bundle error at the reported location.
+        const isUndeclared = issue.text.startsWith("import_not_declared:");
+        diagnostics.push(
+          diagnostic(
+            "error",
+            isUndeclared ? "import_not_declared" : "bundle_error",
+            isUndeclared
+              ? issue.text.replace("import_not_declared: ", "")
+              : issue.text,
+            issue.file ?? entryPath,
+            issue.line,
+          ),
+        );
+      }
+      return null;
+    }
+  }
+
+  private esbuildIssues(
+    error: unknown,
+  ): { text: string; file?: string; line?: number }[] {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "errors" in error &&
+      Array.isArray((error as esbuild.BuildFailure).errors)
+    ) {
+      return (error as esbuild.BuildFailure).errors.map((message) => ({
+        text: message.text,
+        // esbuild reports virtual-FS locations as "<namespace>:<path>".
+        file: message.location?.file?.replace(/^canvas:/, "") ?? undefined,
+        line: message.location?.line,
+      }));
+    }
+    return [{ text: error instanceof Error ? error.message : String(error) }];
+  }
+
+  private scanArtifact(
+    files: CanvasArtifactFile[],
+    diagnostics: CanvasDiagnostic[],
+  ): void {
+    let total = 0;
+    for (const file of files) {
+      total += file.sizeBytes;
+      if (file.sizeBytes > MAX_CANVAS_ARTIFACT_FILE_BYTES) {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "artifact_too_large",
+            `emitted file exceeds the ${MAX_CANVAS_ARTIFACT_FILE_BYTES / 1024} KB per-file budget`,
+            file.path,
+          ),
+        );
+      }
+      if (
+        file.path.endsWith(".html") &&
+        FORBIDDEN_SCHEME_RE.test(file.content)
+      ) {
+        diagnostics.push(
+          diagnostic(
+            "error",
+            "forbidden_url_scheme",
+            "the artifact references a forbidden URL scheme (javascript:, vbscript:, or data:text/html)",
+            file.path,
+          ),
+        );
+      }
+    }
+    if (total > MAX_CANVAS_ARTIFACT_TOTAL_BYTES) {
+      diagnostics.push(
+        diagnostic(
+          "error",
+          "artifact_too_large",
+          `the artifact exceeds the ${MAX_CANVAS_ARTIFACT_TOTAL_BYTES / 1024} KB total budget`,
+        ),
+      );
+    }
+  }
+}

--- a/packages/workspace-server/src/trpc.ts
+++ b/packages/workspace-server/src/trpc.ts
@@ -1,6 +1,11 @@
+import {
+  canvasBuildRequestSchema,
+  canvasBuildResultSchema,
+} from "@posthog/shared";
 import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
 import { z } from "zod";
+import type { CanvasBuildService } from "./services/canvas-build/canvas-build";
 import { connectivityStatusOutput } from "./services/connectivity/schemas";
 import type { ConnectivityService } from "./services/connectivity/service";
 import {
@@ -180,6 +185,7 @@ export {
 } from "./services/watcher/schemas";
 
 export interface WorkspaceServerServices {
+  canvasBuildService: CanvasBuildService;
   focusService: FocusService;
   focusSyncService: FocusSyncService;
   gitService: GitService;
@@ -191,6 +197,7 @@ export interface WorkspaceServerServices {
 }
 
 export function createAppRouter({
+  canvasBuildService: canvasBuildServiceInst,
   focusService: focusServiceInst,
   focusSyncService: focusSyncServiceInst,
   gitService: gitServiceInst,
@@ -200,6 +207,7 @@ export function createAppRouter({
   connectivityService: connectivityServiceInst,
   environmentService: environmentServiceInst,
 }: WorkspaceServerServices) {
+  const canvasBuildService = () => canvasBuildServiceInst;
   const focusService = () => focusServiceInst;
   const focusSyncService = () => focusSyncServiceInst;
   const gitService = () => gitServiceInst;
@@ -210,6 +218,16 @@ export function createAppRouter({
   const environmentService = () => environmentServiceInst;
 
   return t.router({
+    canvasBuild: t.router({
+      // The local implementation of the shared canvas build contract:
+      // validation + preview only. Cloud builds are authoritative for
+      // publication (see the canvas application build pipeline plan).
+      build: t.procedure
+        .input(canvasBuildRequestSchema)
+        .output(canvasBuildResultSchema)
+        .mutation(({ input }) => canvasBuildService().buildCanvas(input)),
+    }),
+
     focus: t.router({
       getSession: t.procedure
         .input(mainRepoPathInput)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1612,6 +1612,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.1(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(bun-types@1.3.14)
+      esbuild:
+        specifier: 0.27.2
+        version: 0.27.2
       fflate:
         specifier: ^0.8.2
         version: 0.8.2


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR chain (Graphite-style) — merge in this order:**
> - `posthog/posthog`: [#73725](https://github.com/PostHog/posthog/pull/73725) (phase 1) → [#73730](https://github.com/PostHog/posthog/pull/73730) (phase 3) → [#73731](https://github.com/PostHog/posthog/pull/73731) (phase 4)
> - `PostHog/code`: [#3824](https://github.com/PostHog/code/pull/3824) (phase 1) → [#3825](https://github.com/PostHog/code/pull/3825) (phase 2) → [#3826](https://github.com/PostHog/code/pull/3826) (phase 3) → [#3827](https://github.com/PostHog/code/pull/3827) (phase 4)
> - Cross-repo: each posthog PR should deploy before the same-phase code PR ships (skills/tools/endpoints must exist before clients rely on them).

## Problem

Phase 2 ("Deterministic local build and preview") of the canvas application build pipeline plan (#3823). Canvas previews still compile source in the browser (Babel + Tailwind JIT + esm.sh at runtime) and there is no build boundary an agent can validate against before publishing.

> [!NOTE]
> **Stacked PR — merge order:** #3824 (phase 1, contracts + core orchestration) → **this PR (phase 2)** → #3826 (phase 3b, build lifecycle client). Base branch is `posthog-code/canvas-build-pipeline-phase-1`; do not squash-merge this before its base.

## Changes

**`@posthog/shared` — the build contract (no I/O)**
- `canvas-build-contract.ts`: `CanvasBuildRequest`/`CanvasBuildResult` schemas, the `CanvasBuildAdapter` boundary (source in, artifact + diagnostics out — never shell commands), artifact size budgets, the pre-admitted platform dependency registry (pinned versions + runtime import maps), and the neutral web-project starter (`index.html` + `src/main.ts` + `src/style.css` — vanilla by default, React is an edit not a mode).
- `canvas-build-fixtures.ts`: contract fixtures (starter, React + Quill app, semantic HTML document, raw-WebGL experience, non-admitted package, undeclared import, syntax error, missing entry, oversized output) that every adapter — this local one and the future cloud builder — must produce identical outcomes for.
- `canvas-preview.ts`: folds a built artifact into one self-contained document (inlined assets, strict meta CSP, closing-tag escaping) for the existing null-origin iframe host — no Babel, no Tailwind JIT in candidate previews.

**`@posthog/workspace-server` — the local/dev adapter**
- `CanvasBuildService`: validates (shared stage-1), resolves dependencies against the admitted registry, bundles each HTML-referenced module entry with esbuild over an **in-memory FS** (no network, no package installation, no lifecycle scripts — only project files and admitted bare specifiers can resolve), rewrites the entry HTML onto content-hashed emitted assets, injects the pinned import map for externals, and scans output for size budgets and forbidden URL schemes. Structured diagnostics carry file + line (esbuild locations mapped back to project paths).
- Exposed as `canvasBuild.build` on the workspace tRPC server for dev/local-agent validation. Local builds validate and preview only — cloud builds (phase 3) stay authoritative for publication.

**`@posthog/core`** — a drift-guard test pinning the legacy freeform whitelist to the shared platform registry, so the two tiers can't diverge silently.

## How did you test this?

- `workspace-server`: 12 new tests — all nine shared contract fixtures through the adapter (the drift guard against a future cloud adapter), content-hashed asset emission + HTML rewrite (catches reintroducing runtime compilation), import-map pinning limited to externals actually used, and bundle errors carrying file/line. 730 existing tests still pass (the repo's git-integration tests can't run in this sandbox — git commit is blocked here; unrelated to this change).
- `shared`: 684 tests pass (new contract, fixture, and preview-renderer suites — the preview test locks the closing-tag escape that stops inlined code breaking out of its script element).
- `core`: 2513 tests pass (includes the new whitelist↔registry drift guard).
- `turbo typecheck` green for shared, workspace-server, core.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
