### PR TITLE
feat(canvas): build lifecycle polling and diagnostics surface (phase 3)

### DIFF
--- a/packages/core/src/canvas/canvasBuildSchemas.test.ts
+++ b/packages/core/src/canvas/canvasBuildSchemas.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type CanvasBuildLifecycle,
+  type CanvasBuildRecord,
+  hasActiveCanvasBuild,
+  latestFinishedCanvasBuild,
+} from "./canvasBuildSchemas";
+import { DashboardsService } from "./dashboardsService";
+import type { DesktopFsClient } from "./desktopFsClient";
+
+function build(
+  id: string,
+  buildStatus: CanvasBuildRecord["buildStatus"],
+): CanvasBuildRecord {
+  return {
+    id,
+    sourceVersionId: `sv-${id}`,
+    buildStatus,
+    diagnostics: [],
+    pinned: false,
+    createdAt: "2026-07-26T00:00:00Z",
+    finishedAt:
+      buildStatus === "queued" || buildStatus === "building"
+        ? null
+        : "2026-07-26T00:01:00Z",
+  };
+}
+
+function lifecycle(builds: CanvasBuildRecord[]): CanvasBuildLifecycle {
+  return { publishedBuildId: null, currentSourceVersionId: null, builds };
+}
+
+describe("canvas build lifecycle", () => {
+  // hasActiveCanvasBuild drives the polling interval: a wrong answer either
+  // polls forever or stops while a build is still running.
+  it.each([
+    ["queued build keeps polling", [build("b1", "queued")], true],
+    [
+      "running build keeps polling",
+      [build("b1", "building"), build("b0", "ready")],
+      true,
+    ],
+    [
+      "settled lifecycle stops polling",
+      [build("b1", "failed"), build("b0", "ready")],
+      false,
+    ],
+    ["no builds stops polling", [], false],
+  ])("%s", (_name, builds, active) => {
+    expect(hasActiveCanvasBuild(lifecycle(builds))).toBe(active);
+  });
+
+  it("surfaces the newest finished build, skipping in-flight ones", () => {
+    const finished = latestFinishedCanvasBuild(
+      lifecycle([
+        build("b2", "queued"),
+        build("b1", "failed"),
+        build("b0", "ready"),
+      ]),
+    );
+    expect(finished?.id).toBe("b1");
+  });
+
+  it("maps the builds endpoint's snake_case body to the client shape", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            published_build_id: "b0",
+            current_source_version_id: "sv-1",
+            builds: [
+              {
+                id: "b1",
+                source_version_id: "sv-1",
+                build_status: "failed",
+                diagnostics: [
+                  {
+                    severity: "error",
+                    code: "import_not_allowed",
+                    message: "no lodash",
+                  },
+                ],
+                pinned: false,
+                created_at: "2026-07-26T00:00:00Z",
+                finished_at: "2026-07-26T00:01:00Z",
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+    const service = new DashboardsService(
+      { fetch: fetchMock } as unknown as DesktopFsClient,
+      {} as never,
+    );
+
+    const result = await service.getBuilds("canvas-1");
+
+    expect(fetchMock).toHaveBeenCalledWith("canvas-1/canvas/builds/");
+    expect(result.publishedBuildId).toBe("b0");
+    expect(result.builds[0]).toMatchObject({
+      id: "b1",
+      sourceVersionId: "sv-1",
+      buildStatus: "failed",
+    });
+    expect(result.builds[0].diagnostics[0].code).toBe("import_not_allowed");
+  });
+});

--- a/packages/core/src/canvas/canvasBuildSchemas.ts
+++ b/packages/core/src/canvas/canvasBuildSchemas.ts
@@ -1,0 +1,49 @@
+import {
+  canvasBuildStatusSchema,
+  canvasDiagnosticSchema,
+} from "@posthog/shared";
+import { z } from "zod";
+
+// Client-facing shape of a canvas's build lifecycle (the desktop_file_system
+// canvas/builds endpoint, normalized to camelCase by DashboardsService).
+
+export const canvasBuildRecordSchema = z.object({
+  id: z.string(),
+  sourceVersionId: z.string(),
+  buildStatus: canvasBuildStatusSchema,
+  diagnostics: z.array(canvasDiagnosticSchema),
+  pinned: z.boolean(),
+  createdAt: z.string(),
+  finishedAt: z.string().nullable(),
+});
+export type CanvasBuildRecord = z.infer<typeof canvasBuildRecordSchema>;
+
+export const canvasBuildLifecycleSchema = z.object({
+  /** The live (last successful, still-eligible) build, null until one completes. */
+  publishedBuildId: z.string().nullable(),
+  /** The source-version row the canvas's head points at. */
+  currentSourceVersionId: z.string().nullable(),
+  /** Most recent builds, newest first. */
+  builds: z.array(canvasBuildRecordSchema),
+});
+export type CanvasBuildLifecycle = z.infer<typeof canvasBuildLifecycleSchema>;
+
+/** True while any build is still queued or running (keep polling). */
+export function hasActiveCanvasBuild(lifecycle: CanvasBuildLifecycle): boolean {
+  return lifecycle.builds.some(
+    (build) =>
+      build.buildStatus === "queued" || build.buildStatus === "building",
+  );
+}
+
+/** The newest finished build, used to surface success/failure diagnostics. */
+export function latestFinishedCanvasBuild(
+  lifecycle: CanvasBuildLifecycle,
+): CanvasBuildRecord | null {
+  return (
+    lifecycle.builds.find(
+      (build) =>
+        build.buildStatus === "ready" || build.buildStatus === "failed",
+    ) ?? null
+  );
+}

--- a/packages/core/src/canvas/dashboardsService.ts
+++ b/packages/core/src/canvas/dashboardsService.ts
@@ -1,6 +1,10 @@
 import type { AuthService } from "@posthog/core/auth/auth";
 import { AUTH_SERVICE } from "@posthog/core/auth/auth.module";
 import { inject, injectable } from "inversify";
+import {
+  type CanvasBuildLifecycle,
+  canvasBuildLifecycleSchema,
+} from "./canvasBuildSchemas";
 import type {
   DashboardFileMeta,
   DashboardRecord,
@@ -337,6 +341,40 @@ export class DashboardsService {
     if (!res.ok) {
       throw new Error(`Failed to set channel home canvas (${res.status})`);
     }
+  }
+
+  // Read a canvas's build lifecycle (pointers + recent builds). Publishing
+  // queues a build server-side; callers poll this until it settles.
+  async getBuilds(id: string): Promise<CanvasBuildLifecycle> {
+    const res = await this.fs.fetch(`${encodeURIComponent(id)}/canvas/builds/`);
+    if (!res.ok)
+      throw new Error(`Failed to load canvas builds (${res.status})`);
+    const body = (await res.json()) as {
+      published_build_id: string | null;
+      current_source_version_id: string | null;
+      builds: {
+        id: string;
+        source_version_id: string;
+        build_status: string;
+        diagnostics?: unknown[];
+        pinned: boolean;
+        created_at: string;
+        finished_at: string | null;
+      }[];
+    };
+    return canvasBuildLifecycleSchema.parse({
+      publishedBuildId: body.published_build_id,
+      currentSourceVersionId: body.current_source_version_id,
+      builds: body.builds.map((build) => ({
+        id: build.id,
+        sourceVersionId: build.source_version_id,
+        buildStatus: build.build_status,
+        diagnostics: build.diagnostics ?? [],
+        pinned: build.pinned,
+        createdAt: build.created_at,
+        finishedAt: build.finished_at,
+      })),
+    });
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/core/src/canvas/services.ts
+++ b/packages/core/src/canvas/services.ts
@@ -1,3 +1,4 @@
+import type { CanvasBuildLifecycle } from "./canvasBuildSchemas";
 import type { ChannelTaskRecord } from "./channelTaskSchemas";
 import type { DashboardRecord, DashboardSummary } from "./dashboardSchemas";
 import type {
@@ -45,6 +46,8 @@ export interface IDashboardsService {
     taskId: string | null;
   }): Promise<DashboardRecord>;
   setPinned(input: { id: string; pinned: boolean }): Promise<DashboardRecord>;
+  // Read a canvas's build lifecycle (pointers + recent builds).
+  getBuilds(id: string): Promise<CanvasBuildLifecycle>;
   rename(input: { id: string; name: string }): Promise<DashboardRecord>;
   // Idempotently create + seed a channel's home canvas, returning it.
   ensureHomeCanvas(channelId: string): Promise<DashboardRecord>;

--- a/packages/host-router/src/routers/dashboards.router.ts
+++ b/packages/host-router/src/routers/dashboards.router.ts
@@ -1,3 +1,4 @@
+import { canvasBuildLifecycleSchema } from "@posthog/core/canvas/canvasBuildSchemas";
 import {
   createDashboardInput,
   dashboardIdInput,
@@ -29,6 +30,14 @@ export const dashboardsRouter = router({
     .output(dashboardRecordSchema.nullable())
     .query(({ ctx, input }) =>
       ctx.container.get<IDashboardsService>(DASHBOARDS_SERVICE).get(input.id),
+    ),
+  builds: publicProcedure
+    .input(dashboardIdInput)
+    .output(canvasBuildLifecycleSchema)
+    .query(({ ctx, input }) =>
+      ctx.container
+        .get<IDashboardsService>(DASHBOARDS_SERVICE)
+        .getBuilds(input.id),
     ),
   create: publicProcedure
     .input(createDashboardInput)

--- a/packages/ui/src/features/canvas/freeform/CanvasBuildStatus.tsx
+++ b/packages/ui/src/features/canvas/freeform/CanvasBuildStatus.tsx
@@ -1,0 +1,66 @@
+import {
+  CheckCircleIcon,
+  SpinnerGapIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+import {
+  hasActiveCanvasBuild,
+  latestFinishedCanvasBuild,
+} from "@posthog/core/canvas/canvasBuildSchemas";
+import { useCanvasBuilds } from "@posthog/ui/features/canvas/hooks/useCanvasBuilds";
+import { Flex, Text, Tooltip } from "@radix-ui/themes";
+
+// Compact build indicator for the canvas toolbar: spinner while a queued
+// publish builds, a quiet check once the live build is current, and the
+// error diagnostics (in a tooltip) when the latest build failed — the canvas
+// keeps rendering the last good build in that case.
+export function CanvasBuildStatus({ dashboardId }: { dashboardId: string }) {
+  const { lifecycle } = useCanvasBuilds(dashboardId);
+  if (!lifecycle || lifecycle.builds.length === 0) return null;
+
+  if (hasActiveCanvasBuild(lifecycle)) {
+    return (
+      <Flex align="center" gap="1">
+        <SpinnerGapIcon size={14} className="animate-spin text-gray-9" />
+        <Text size="1" className="text-gray-10">
+          Building
+        </Text>
+      </Flex>
+    );
+  }
+
+  const latest = latestFinishedCanvasBuild(lifecycle);
+  if (!latest) return null;
+
+  if (latest.buildStatus === "failed") {
+    const errors = latest.diagnostics
+      .filter((diagnostic) => diagnostic.severity === "error")
+      .slice(0, 3)
+      .map((diagnostic) => diagnostic.message)
+      .join("\n");
+    return (
+      <Tooltip
+        content={`Latest build failed — the previous version stays live.\n${errors}`}
+      >
+        <Flex align="center" gap="1" data-testid="canvas-build-failed">
+          <WarningCircleIcon size={14} className="text-red-9" />
+          <Text size="1" className="text-red-10">
+            Build failed
+          </Text>
+        </Flex>
+      </Tooltip>
+    );
+  }
+
+  if (lifecycle.publishedBuildId === latest.id) {
+    return (
+      <Tooltip content="The live build is up to date.">
+        <Flex align="center" gap="1" data-testid="canvas-build-ready">
+          <CheckCircleIcon size={14} className="text-green-9" />
+        </Flex>
+      </Tooltip>
+    );
+  }
+
+  return null;
+}

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -44,6 +44,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
 import { useCallback, useMemo, useRef, useState } from "react";
+import { CanvasBuildStatus } from "./CanvasBuildStatus";
 import { CanvasFramePlaceholder } from "./CanvasFramePlaceholder";
 import { CanvasGenerateHero } from "./CanvasGenerateHero";
 import { CanvasPermissionDialog } from "./CanvasPermissionDialog";
@@ -311,6 +312,7 @@ export function FreeformCanvasView({
               )}
             </Flex>
             <Flex align="center" gap="2">
+              <CanvasBuildStatus dashboardId={dashboardId} />
               {isGenerating && effectiveTaskId ? (
                 <>
                   <SpinnerGapIcon

--- a/packages/ui/src/features/canvas/hooks/useCanvasBuilds.ts
+++ b/packages/ui/src/features/canvas/hooks/useCanvasBuilds.ts
@@ -1,0 +1,35 @@
+import {
+  type CanvasBuildLifecycle,
+  hasActiveCanvasBuild,
+} from "@posthog/core/canvas/canvasBuildSchemas";
+import { useHostTRPC } from "@posthog/host-router/react";
+import { useQuery } from "@tanstack/react-query";
+
+// Poll while a build is in flight (publishes queue a server-side build), then
+// settle down — the lifecycle only changes again on the next publish.
+const ACTIVE_POLL_MS = 2_000;
+
+/** A canvas's build lifecycle, polled while a build is queued or running. */
+export function useCanvasBuilds(
+  dashboardId: string | undefined,
+  options?: { enabled?: boolean },
+): {
+  lifecycle: CanvasBuildLifecycle | undefined;
+  isLoading: boolean;
+} {
+  const trpc = useHostTRPC();
+  const { data, isLoading } = useQuery(
+    trpc.dashboards.builds.queryOptions(
+      { id: dashboardId ?? "" },
+      {
+        enabled: !!dashboardId && (options?.enabled ?? true),
+        staleTime: ACTIVE_POLL_MS,
+        refetchInterval: (query) =>
+          query.state.data && hasActiveCanvasBuild(query.state.data)
+            ? ACTIVE_POLL_MS
+            : false,
+      },
+    ),
+  );
+  return { lifecycle: data, isLoading };
+}


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR chain (Graphite-style) — merge in this order:**
> - `posthog/posthog`: [#73725](https://github.com/PostHog/posthog/pull/73725) (phase 1) → [#73730](https://github.com/PostHog/posthog/pull/73730) (phase 3) → [#73731](https://github.com/PostHog/posthog/pull/73731) (phase 4)
> - `PostHog/code`: [#3824](https://github.com/PostHog/code/pull/3824) (phase 1) → [#3825](https://github.com/PostHog/code/pull/3825) (phase 2) → [#3826](https://github.com/PostHog/code/pull/3826) (phase 3) → [#3827](https://github.com/PostHog/code/pull/3827) (phase 4)
> - Cross-repo: each posthog PR should deploy before the same-phase code PR ships (skills/tools/endpoints must exist before clients rely on them).

## Problem

Phase 3's client half of the canvas application build pipeline plan (#3823): after guarded publishing gained a server-side build lifecycle ([PostHog/posthog#73730](https://github.com/PostHog/posthog/pull/73730)), the app has no way to see whether a publish's build is queued, live, or failed — and failed builds (which keep the previous version live) would be invisible.

> [!NOTE]
> **Stacked PR — merge order:** #3824 (phase 1) → #3825 (phase 2) → **this PR (phase 3)**. Base branch is `posthog-code/canvas-build-pipeline-phase-2`. Functionally this also needs [PostHog/posthog#73730](https://github.com/PostHog/posthog/pull/73730) deployed (it degrades gracefully — no builds endpoint means no indicator).

## Changes

- **`@posthog/core`** — `canvasBuildSchemas.ts`: the client-facing build lifecycle shape plus the two selectors the UI depends on (`hasActiveCanvasBuild` drives polling; `latestFinishedCanvasBuild` picks what to surface), and `DashboardsService.getBuilds` mapping the endpoint's snake_case body onto it (zod-validated).
- **`@posthog/host-router`** — `dashboards.builds` query procedure.
- **`@posthog/ui`** — `useCanvasBuilds` (react-query, 2s refetch while a build is queued/building, settles once terminal) and `CanvasBuildStatus` in the canvas toolbar: spinner while building, a quiet check when the live build is current, and a "Build failed" indicator whose tooltip carries the error diagnostics — making the "last good build stays live" behavior visible instead of silent.

## How did you test this?

- `canvasBuildSchemas.test.ts` (6 tests): the polling predicate across queued/building/settled/empty lifecycles (a wrong answer polls forever or stops mid-build), newest-finished selection skipping in-flight builds, and the snake_case → client-shape mapping including diagnostics (guards endpoint/client drift).
- Full suites: `core` 2519 passed, `ui` 2135 passed; `turbo typecheck` green for core, host-router, ui, code, web.
- Not verified by me: the rendered toolbar indicator against a live backend (this sandbox can't run the desktop app) — the component is behavior-thin over the tested selectors.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
