### PR TITLE
feat(canvas): first-class inlined asset imports in the build recipe (phase 4)

### DIFF
--- a/packages/shared/src/canvas-build-fixtures.ts
+++ b/packages/shared/src/canvas-build-fixtures.ts
@@ -126,6 +126,27 @@ export const CANVAS_BUILD_CONTRACT_FIXTURES: CanvasBuildContractFixture[] = [
     expected: { status: "ready" },
   },
   {
+    name: "asset imports (svg data-url + json)",
+    project: project({
+      [CANVAS_ENTRY_HTML]: HTML_SHELL(
+        '    <div id="root"></div>\n    <script type="module" src="/src/main.ts"></script>',
+      ),
+      "src/main.ts": [
+        'import logo from "./logo.svg";',
+        'import config from "./config.json";',
+        'const img = document.createElement("img");',
+        "img.src = logo;",
+        "img.alt = config.title;",
+        'document.getElementById("root")?.append(img);',
+        "export {};",
+      ].join("\n"),
+      "src/logo.svg":
+        '<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><rect width="8" height="8" fill="#f54d00"/></svg>',
+      "src/config.json": '{ "title": "hedgehog" }',
+    }),
+    expected: { status: "ready" },
+  },
+  {
     name: "import of a non-admitted package",
     project: project(
       {

--- a/packages/workspace-server/src/services/canvas-build/canvas-build.test.ts
+++ b/packages/workspace-server/src/services/canvas-build/canvas-build.test.ts
@@ -97,6 +97,24 @@ describe("CanvasBuildService", () => {
     expect(imports).not.toContain("dayjs");
   });
 
+  it("inlines svg and json asset imports into the bundle", async () => {
+    const fixture = CANVAS_BUILD_CONTRACT_FIXTURES.find(
+      (f) => f.name === "asset imports (svg data-url + json)",
+    );
+    if (!fixture) throw new Error("asset fixture missing");
+    const result = await service.buildCanvas({
+      project: fixture.project,
+      mode: "validate",
+    });
+
+    expect(result.status).toBe("ready");
+    const js = result.files?.find((f) => f.path.endsWith(".js"));
+    // The svg became a data URL and the json a literal — no asset fetches at
+    // runtime and nothing left for the sandbox CSP to block.
+    expect(js?.content).toContain("data:image/svg+xml");
+    expect(js?.content).toContain("hedgehog");
+  });
+
   it("reports bundle errors with the failing file and line", async () => {
     const project = createCanvasStarterProject();
     project.files["src/main.ts"] =

--- a/packages/workspace-server/src/services/canvas-build/canvas-build.ts
+++ b/packages/workspace-server/src/services/canvas-build/canvas-build.ts
@@ -61,7 +61,10 @@ const LOADERS: Record<string, esbuild.Loader> = {
   ".jsx": "jsx",
   ".css": "css",
   ".json": "json",
-  ".svg": "text",
+  // Inlined assets: importing an svg yields a data URL usable directly as an
+  // img/css source. Binary formats need a binary source representation and
+  // land with the build-service schema evolution.
+  ".svg": "dataurl",
   ".txt": "text",
 };
 


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR chain (Graphite-style) — merge in this order:**
> - `posthog/posthog`: [#73725](https://github.com/PostHog/posthog/pull/73725) (phase 1) → [#73730](https://github.com/PostHog/posthog/pull/73730) (phase 3) → [#73731](https://github.com/PostHog/posthog/pull/73731) (phase 4)
> - `PostHog/code`: [#3824](https://github.com/PostHog/code/pull/3824) (phase 1) → [#3825](https://github.com/PostHog/code/pull/3825) (phase 2) → [#3826](https://github.com/PostHog/code/pull/3826) (phase 3) → [#3827](https://github.com/PostHog/code/pull/3827) (phase 4)
> - Cross-repo: each posthog PR should deploy before the same-phase code PR ships (skills/tools/endpoints must exist before clients rely on them).

## Problem

Phase 4 ("Package and runtime expansion") of the canvas application build pipeline plan (#3823), the slice implementable ahead of production admission data: canvases couldn't import assets — an svg logo or a json config had no supported path through the build recipe.

> [!NOTE]
> **Stacked PR — merge order:** #3824 (phase 1) → #3825 (phase 2) → #3826 (phase 3) → **this PR (phase 4)**. Base branch is `posthog-code/canvas-build-pipeline-phase-3`.

## Changes

- svg imports compile to **data URLs** (usable directly as `img.src` / CSS values); json imports were already literals. Both inline into the bundle, so the artifact stays self-contained — no runtime asset fetches and nothing new for the sandbox CSP to allow.
- A new shared contract fixture ("asset imports") binds the future cloud adapter to inline them identically.

Deliberately not here: binary asset formats (png/woff2), web workers, and WebAssembly need a binary file representation in the source-project schema, and the plan's package-policy expansion is driven by observed admission failures — both belong to the build-service iteration once production data exists.

## How did you test this?

- New adapter test: the asset fixture builds ready and the emitted chunk contains the svg data URL and the json value (guards a loader regression silently turning assets into broken text imports).
- All 10 shared contract fixtures pass through the local adapter (14 tests total); `shared` suite 684 passed; `turbo typecheck` green for shared + workspace-server.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
