### PR TITLE
feat(chat-thread): copy a turn from its footer, a message from its menu

### DIFF
--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -26,6 +26,7 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
   cn,
   Tooltip,
@@ -99,6 +100,10 @@ import {
   useOptimisticItemsForTask,
   useSessionIsCloud,
 } from "@posthog/ui/features/sessions/sessionStore";
+import {
+  useSessionViewActions,
+  useShowRawLogs,
+} from "@posthog/ui/features/sessions/sessionViewStore";
 import { useThreadScrollRequest } from "@posthog/ui/features/sessions/threadNavigationStore";
 import type { UserMessageAttachment } from "@posthog/ui/features/sessions/userMessageTypes";
 import {
@@ -486,6 +491,10 @@ function UserBubble({
  * Right-click a message to copy it. Replaces the per-message copy button that used to float in the
  * message's right rail — the turn footer covers the common case, so a single message's copy lives
  * here instead of costing every row a hover affordance.
+ *
+ * This menu sits inside `SessionView`'s own context menu and wins the event over it, so it also
+ * carries that menu's raw-logs toggle; without it, right-clicking a message would be the one spot
+ * in the session where the toggle went missing.
  */
 function MessageContextMenu({
   value,
@@ -495,6 +504,8 @@ function MessageContextMenu({
   children: ReactElement;
 }) {
   const { copy } = useCopy();
+  const showRawLogs = useShowRawLogs();
+  const { setShowRawLogs } = useSessionViewActions();
   return (
     <ContextMenu>
       <ContextMenuTrigger render={children} />
@@ -502,6 +513,11 @@ function MessageContextMenu({
         <ContextMenuItem onClick={() => copy(value)}>
           <Copy size={14} />
           Copy message
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onClick={() => setShowRawLogs(!showRawLogs)}>
+          <Scroll size={14} />
+          {showRawLogs ? "Back to conversation" : "Show raw logs"}
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -637,7 +637,7 @@ const ThreadRow = memo(function ThreadRow({
     <ChatMessageScrollerItem
       messageId={item.id}
       scrollAnchor={item.type === "user_message"}
-      className="mx-auto w-full px-2.5 py-1 empty:hidden"
+      className="mx-auto w-full py-1 empty:hidden"
       style={{ maxWidth: CHAT_CONTENT_MAX_WIDTH }}
     >
       <ThreadItemBody

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -8,6 +8,7 @@ import {
 import { WorkerPoolContextProvider } from "@pierre/diffs/react";
 import { useService } from "@posthog/di/react";
 import {
+  Button,
   ChatBubble,
   ChatBubbleContent,
   ChatMarker,
@@ -22,7 +23,14 @@ import {
   ChatMessageScrollerItem,
   ChatMessageScrollerProvider,
   ChatMessageScrollerViewport,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
   cn,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   useChatMessageScroller,
   useChatMessageScrollerScrollable,
   useChatMessageScrollerVisibility,
@@ -62,6 +70,7 @@ import {
   type ThreadScrollResume,
   type TurnRow,
 } from "@posthog/ui/features/sessions/components/chat-thread/threadVirtualization";
+import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
 import { usePromptRecallSource } from "@posthog/ui/features/sessions/components/chat-thread/usePromptRecallSource";
 import { VirtualThreadScrollBody } from "@posthog/ui/features/sessions/components/chat-thread/VirtualThreadScrollBody";
 import { GitActionMessage } from "@posthog/ui/features/sessions/components/GitActionMessage";
@@ -103,9 +112,9 @@ import {
   DIFF_WORKER_FACTORY,
   type DiffWorkerFactory,
 } from "@posthog/ui/shell/diffWorkerHost";
-import { IconButton, Tooltip } from "@radix-ui/themes";
 import {
   memo,
+  type ReactElement,
   type ReactNode,
   type RefObject,
   useCallback,
@@ -238,19 +247,56 @@ function formatTimestamp(ts: number): string {
 }
 
 /**
- * Hover-revealed timestamp rendered right-aligned under agent-side content (the end-aligned user
- * bubble keeps its own right-aligned footer). Sits inside a `group` container so it fades in only
- * while that container is hovered. Shown once per completed agent turn (under the turn card)
- * rather than on every message — per-row it was too noisy.
+ * Hover-revealed footer under a completed agent turn: the turn's timestamp plus a button copying
+ * the whole turn. Rendered right-aligned under agent-side content — the end-aligned user bubble
+ * keeps its own footer — inside a `group` container, so it fades in only while that turn is
+ * hovered. Once per turn rather than per row, which was too noisy.
  */
-function RowTimestamp({ timestamp }: { timestamp?: number }) {
+function TurnFooter({
+  timestamp,
+  copyText,
+}: {
+  timestamp?: number;
+  copyText?: string;
+}) {
   if (timestamp == null) return null;
   return (
     <ChatMessageFooter className="mt-2 items-center justify-end gap-1 pl-0 opacity-0 transition-opacity group-hover:opacity-100">
       <span className="text-muted-foreground">
         {formatTimestamp(timestamp)}
       </span>
+      {copyText && <CopyButton value={copyText} label="Copy turn" />}
     </ChatMessageFooter>
+  );
+}
+
+/**
+ * Shared copy affordance for the message and turn footers. Stays muted whether idle or just-copied —
+ * the icon swap is the confirmation, so the row never lights up in a colour the thread doesn't use
+ * elsewhere.
+ */
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const { copied, copy } = useCopy();
+  const [hovered, setHovered] = useState(false);
+  return (
+    // Held open for the life of the `copied` window so the confirmation lands even when the click
+    // moves the pointer off the button; hover drives it the rest of the time.
+    <Tooltip open={copied || hovered} onOpenChange={setHovered}>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="default"
+            size="icon-xs"
+            aria-label={label}
+            onClick={() => copy(value)}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            {copied ? <Check size={12} /> : <Copy size={12} />}
+          </Button>
+        }
+      />
+      <TooltipContent>{copied ? "Copied!" : label}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -337,135 +383,128 @@ function UserBubble({
   }, [displayContent, isExpanded]);
 
   return (
-    <ChatMessage align="end" className="group">
-      <ChatMessageContent className="gap-1 pr-9">
-        {showHeaderChips && (
-          <ChatMessageHeader className="flex-wrap gap-1">
-            {showChannelContextTag && channelContext && (
-              <MentionChip
-                icon={<FileText size={12} />}
-                label={`${
-                  channelContext.mention.name
-                    ? `#${channelContext.mention.name} `
-                    : ""
-                }CONTEXT.md`}
-                onClick={
-                  taskId
-                    ? () =>
-                        openChannelContextInSplit(taskId, {
-                          channelName: channelContext.mention.name,
-                          body: channelContext.mention.body,
-                        })
-                    : undefined
-                }
-              />
-            )}
-            {showCanvasInstructionsTag && canvasInstructions && (
-              <MentionChip
-                icon={<Scroll size={12} />}
-                label="Canvas instructions"
-                onClick={
-                  taskId
-                    ? () =>
-                        openCanvasInstructionsInSplit(taskId, {
-                          body: canvasInstructions.body,
-                        })
-                    : undefined
-                }
-              />
-            )}
-          </ChatMessageHeader>
-        )}
-        <ChatBubble
-          align="end"
-          variant="default"
-          className={cn(
-            "rounded-lg ring-(--gray-11) ring-0 ring-inset transition-shadow",
-            keyboardFocused && "ring-[3px]",
-          )}
-        >
-          <ChatBubbleContent>
-            <div
-              ref={textRef}
-              className={cn(
-                "[&_p]:my-0",
-                !isExpanded && "max-h-[5lh] overflow-hidden",
-                // Fade the clamped text out at the bottom so it reads as "continues below". Only
-                // when actually overflowing — a short collapsed message shouldn't fade. The mask is
-                // paint-only, so it doesn't affect the overflow measurement above.
-                !isExpanded &&
-                  isOverflowing &&
-                  "[mask-image:linear-gradient(to_bottom,black_45%,transparent)]",
-              )}
-            >
-              {containsFileMentions ? (
-                parseFileMentions(displayContent)
-              ) : (
-                <ChatMarkdown content={displayContent} />
-              )}
-            </div>
-            {attachments.length > 0 && !containsFileMentions && (
-              <div className="mt-1.5">
-                <UserMessageAttachments attachments={attachments} />
-              </div>
-            )}
-            {isOverflowing && (
-              <button
-                type="button"
-                onClick={() => setIsExpanded((v) => !v)}
-                className="mt-1 flex items-center gap-0.5 text-muted-foreground text-sm hover:text-foreground"
-              >
-                Show {isExpanded ? "less" : "more"}
-                <CaretDown
-                  className={cn("size-3", isExpanded && "rotate-180")}
+    <MessageContextMenu value={displayContent}>
+      <ChatMessage align="end" className="group">
+        <ChatMessageContent className="gap-1">
+          {showHeaderChips && (
+            <ChatMessageHeader className="flex-wrap gap-1">
+              {showChannelContextTag && channelContext && (
+                <MentionChip
+                  icon={<FileText size={12} />}
+                  label={`${
+                    channelContext.mention.name
+                      ? `#${channelContext.mention.name} `
+                      : ""
+                  }CONTEXT.md`}
+                  onClick={
+                    taskId
+                      ? () =>
+                          openChannelContextInSplit(taskId, {
+                            channelName: channelContext.mention.name,
+                            body: channelContext.mention.body,
+                          })
+                      : undefined
+                  }
                 />
-              </button>
+              )}
+              {showCanvasInstructionsTag && canvasInstructions && (
+                <MentionChip
+                  icon={<Scroll size={12} />}
+                  label="Canvas instructions"
+                  onClick={
+                    taskId
+                      ? () =>
+                          openCanvasInstructionsInSplit(taskId, {
+                            body: canvasInstructions.body,
+                          })
+                      : undefined
+                  }
+                />
+              )}
+            </ChatMessageHeader>
+          )}
+          <ChatBubble
+            align="end"
+            variant="default"
+            className={cn(
+              "rounded-lg ring-(--gray-11) ring-0 ring-inset transition-shadow",
+              keyboardFocused && "ring-[3px]",
             )}
-          </ChatBubbleContent>
-        </ChatBubble>
-        {timestamp != null && (
-          <ChatMessageFooter className="opacity-0 transition-opacity group-hover:opacity-100">
-            {formatTimestamp(timestamp)}
-          </ChatMessageFooter>
-        )}
-      </ChatMessageContent>
-      <MessageCopyButton
-        value={displayContent}
-        revealClassName="group-hover:opacity-100"
-      />
-    </ChatMessage>
+          >
+            <ChatBubbleContent>
+              <div
+                ref={textRef}
+                className={cn(
+                  "[&_p]:my-0",
+                  !isExpanded && "max-h-[5lh] overflow-hidden",
+                  // Fade the clamped text out at the bottom so it reads as "continues below". Only
+                  // when actually overflowing — a short collapsed message shouldn't fade. The mask is
+                  // paint-only, so it doesn't affect the overflow measurement above.
+                  !isExpanded &&
+                    isOverflowing &&
+                    "[mask-image:linear-gradient(to_bottom,black_45%,transparent)]",
+                )}
+              >
+                {containsFileMentions ? (
+                  parseFileMentions(displayContent)
+                ) : (
+                  <ChatMarkdown content={displayContent} />
+                )}
+              </div>
+              {attachments.length > 0 && !containsFileMentions && (
+                <div className="mt-1.5">
+                  <UserMessageAttachments attachments={attachments} />
+                </div>
+              )}
+              {isOverflowing && (
+                <button
+                  type="button"
+                  onClick={() => setIsExpanded((v) => !v)}
+                  className="mt-1 flex items-center gap-0.5 text-muted-foreground text-sm hover:text-foreground"
+                >
+                  Show {isExpanded ? "less" : "more"}
+                  <CaretDown
+                    className={cn("size-3", isExpanded && "rotate-180")}
+                  />
+                </button>
+              )}
+            </ChatBubbleContent>
+          </ChatBubble>
+          {timestamp != null && (
+            <ChatMessageFooter className="items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+              {formatTimestamp(timestamp)}
+              <CopyButton value={displayContent} label="Copy message" />
+            </ChatMessageFooter>
+          )}
+        </ChatMessageContent>
+      </ChatMessage>
+    </MessageContextMenu>
   );
 }
 
 /**
- * Copy icon that floats into a message's right rail on hover. The hover-group qualifier differs by
- * message type (`group` for user bubbles, `group/msg` for agent prose), so callers pass their own
- * `revealClassName` (the `group-hover*:opacity-100` utility).
+ * Right-click a message to copy it. Replaces the per-message copy button that used to float in the
+ * message's right rail — the turn footer covers the common case, so a single message's copy lives
+ * here instead of costing every row a hover affordance.
  */
-function MessageCopyButton({
+function MessageContextMenu({
   value,
-  revealClassName,
+  children,
 }: {
   value: string;
-  revealClassName: string;
+  children: ReactElement;
 }) {
-  const { copied, copy } = useCopy();
+  const { copy } = useCopy();
   return (
-    <Tooltip content={copied ? "Copied!" : "Copy message"}>
-      <IconButton
-        size="1"
-        variant="ghost"
-        color={copied ? "green" : "gray"}
-        onClick={() => copy(value)}
-        className={cn(
-          "absolute top-1 right-1 cursor-pointer opacity-0 transition-opacity",
-          revealClassName,
-        )}
-        aria-label="Copy message"
-      >
-        {copied ? <Check size={14} /> : <Copy size={14} />}
-      </IconButton>
-    </Tooltip>
+    <ContextMenu>
+      <ContextMenuTrigger render={children} />
+      <ContextMenuContent>
+        <ContextMenuItem onClick={() => copy(value)}>
+          <Copy size={14} />
+          Copy message
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
@@ -488,25 +527,21 @@ const AgentProse = memo(function AgentProse({
   const smoothed = useSmoothedText(text);
 
   return (
-    <ChatMessage align="start" className="group/msg">
-      <ChatMessageContent className="gap-1 pr-9">
-        <ChatBubble variant="ghost">
-          <ChatBubbleContent>
-            {isStreaming ? (
-              <ChatStreamingMarkdown content={smoothed} />
-            ) : (
-              <ChatMarkdown content={text} />
-            )}
-          </ChatBubbleContent>
-        </ChatBubble>
-      </ChatMessageContent>
-      {isStreaming ? null : (
-        <MessageCopyButton
-          value={text}
-          revealClassName="group-hover/msg:opacity-100"
-        />
-      )}
-    </ChatMessage>
+    <MessageContextMenu value={text}>
+      <ChatMessage align="start" className="group/msg">
+        <ChatMessageContent className="gap-1">
+          <ChatBubble variant="ghost">
+            <ChatBubbleContent>
+              {isStreaming ? (
+                <ChatStreamingMarkdown content={smoothed} />
+              ) : (
+                <ChatMarkdown content={text} />
+              )}
+            </ChatBubbleContent>
+          </ChatBubble>
+        </ChatMessageContent>
+      </ChatMessage>
+    </MessageContextMenu>
   );
 });
 
@@ -591,7 +626,10 @@ const ThreadRow = memo(function ThreadRow({
             </div>
           ))}
         </div>
-        <RowTimestamp timestamp={completedTurnTimestamp(item)} />
+        <TurnFooter
+          timestamp={completedTurnTimestamp(item)}
+          copyText={buildTurnCopyText(item.items) ?? undefined}
+        />
       </ChatMessageScrollerItem>
     );
   }
@@ -927,7 +965,10 @@ const FlatRowView = memo(
           keyboardFocused={keyboardFocused}
         />
         {row.turnTimestamp != null && (
-          <RowTimestamp timestamp={row.turnTimestamp} />
+          <TurnFooter
+            timestamp={row.turnTimestamp}
+            copyText={row.turnCopyText}
+          />
         )}
       </ChatMessageScrollerItem>
     );

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -74,6 +74,7 @@ import {
 import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
 import { usePromptRecallSource } from "@posthog/ui/features/sessions/components/chat-thread/usePromptRecallSource";
 import { VirtualThreadScrollBody } from "@posthog/ui/features/sessions/components/chat-thread/VirtualThreadScrollBody";
+import { copyFromContextMenu } from "@posthog/ui/features/sessions/components/copyContextTarget";
 import { GitActionMessage } from "@posthog/ui/features/sessions/components/GitActionMessage";
 import { GitActionResult } from "@posthog/ui/features/sessions/components/GitActionResult";
 import { isUserInitiatedConversationItem } from "@posthog/ui/features/sessions/components/isUserInitiatedConversationItem";
@@ -112,6 +113,7 @@ import {
 } from "@posthog/ui/features/sessions/useSessionTaskId";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { SkillButtonActionMessage } from "@posthog/ui/features/skill-buttons/components/SkillButtonActionMessage";
+import { toast } from "@posthog/ui/primitives/toast";
 import { useCopy } from "@posthog/ui/primitives/useCopy";
 import {
   DIFF_WORKER_FACTORY,
@@ -213,14 +215,16 @@ function groupToolRuns(items: ConversationItem[]): ThreadItem[] {
  * Collapse each contiguous run of non-user rows into one {@link AgentTurn}, broken only by a
  * user-initiated row (which stays standalone so it remains the scroll anchor for the sticky header
  * and auto-follow). The turn block renders as a single muted card, tightening the spacing between
- * the agent's successive replies and tool calls.
+ * the agent's successive replies and tool calls. Each turn records the user-initiated row that
+ * opened it, so "Copy turn" can lead with the prompt the turn answered.
  */
 function groupIntoTurns(rows: ThreadItem[]): TurnRow[] {
   const out: TurnRow[] = [];
   let buffer: ThreadItem[] = [];
+  let prompt: ThreadItem | undefined;
   const flush = () => {
     if (buffer.length > 0) {
-      out.push({ type: "agent_turn", id: buffer[0].id, items: buffer });
+      out.push({ type: "agent_turn", id: buffer[0].id, items: buffer, prompt });
       buffer = [];
     }
   };
@@ -232,6 +236,7 @@ function groupIntoTurns(rows: ThreadItem[]): TurnRow[] {
     if (isUserInitiatedConversationItem(row)) {
       flush();
       out.push(row);
+      prompt = row;
     } else {
       buffer.push(row);
     }
@@ -495,6 +500,10 @@ function UserBubble({
  * This menu sits inside `SessionView`'s own context menu and wins the event over it, so it also
  * carries that menu's raw-logs toggle; without it, right-clicking a message would be the one spot
  * in the session where the toggle went missing.
+ *
+ * The write goes through {@link copyFromContextMenu}: a synchronous write from a closing menu
+ * rejects while focus is still being restored, and both outcomes surface as toasts — a silent
+ * failure would leave the clipboard's previous contents where the user believes the message is.
  */
 function MessageContextMenu({
   value,
@@ -503,14 +512,20 @@ function MessageContextMenu({
   value: string;
   children: ReactElement;
 }) {
-  const { copy } = useCopy();
   const showRawLogs = useShowRawLogs();
   const { setShowRawLogs } = useSessionViewActions();
   return (
     <ContextMenu>
       <ContextMenuTrigger render={children} />
       <ContextMenuContent>
-        <ContextMenuItem onClick={() => copy(value)}>
+        <ContextMenuItem
+          onClick={() =>
+            copyFromContextMenu(value, {
+              onSuccess: () => toast.success("Copied"),
+              onError: () => toast.error("Couldn't copy"),
+            })
+          }
+        >
           <Copy size={14} />
           Copy message
         </ContextMenuItem>
@@ -644,7 +659,11 @@ const ThreadRow = memo(function ThreadRow({
         </div>
         <TurnFooter
           timestamp={completedTurnTimestamp(item)}
-          copyText={buildTurnCopyText(item.items) ?? undefined}
+          copyText={
+            buildTurnCopyText(
+              item.prompt ? [item.prompt, ...item.items] : item.items,
+            ) ?? undefined
+          }
         />
       </ChatMessageScrollerItem>
     );

--- a/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -45,8 +45,12 @@ function toolGroup(id: string, tools: SessionUpdateItem[]): ToolGroupItem {
   return { type: "tool_group", id, tools };
 }
 
-function agentTurn(id: string, items: TurnRow[]): AgentTurn {
-  return { type: "agent_turn", id, items: items as AgentTurn["items"] };
+function agentTurn(
+  id: string,
+  items: TurnRow[],
+  prompt?: ConversationItem,
+): AgentTurn {
+  return { type: "agent_turn", id, items: items as AgentTurn["items"], prompt };
 }
 
 describe("flattenTurnRows", () => {
@@ -106,6 +110,23 @@ describe("flattenTurnRows", () => {
       undefined,
       "first\n\nlast",
     ]);
+  });
+
+  it("leads the copy text with the prompt that opened the turn", () => {
+    const done = agentTurn(
+      "d",
+      [
+        sessionUpdate("d1", {
+          turnComplete: true,
+          timestamp: 1,
+          text: "reply",
+        }),
+      ],
+      userMessage("u1"),
+    );
+    expect(flattenTurnRows([done]).at(-1)?.turnCopyText).toBe(
+      "msg u1\n\nreply",
+    );
   });
 
   it("leaves copy text off a turn that is still streaming", () => {

--- a/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -21,14 +21,15 @@ function sessionUpdate(
   {
     turnComplete = false,
     timestamp,
-  }: { turnComplete?: boolean; timestamp?: number } = {},
+    text,
+  }: { turnComplete?: boolean; timestamp?: number; text?: string } = {},
 ): SessionUpdateItem {
   return {
     type: "session_update",
     id,
     update: {
       sessionUpdate: "agent_message_chunk",
-      content: { type: "text", text: `text ${id}` },
+      content: { type: "text", text: text ?? `text ${id}` },
     } as SessionUpdateItem["update"],
     turnContext: {
       toolCalls: new Map(),
@@ -89,6 +90,29 @@ describe("flattenTurnRows", () => {
     ]);
     const flat = flattenTurnRows([done]);
     expect(flat.map((r) => r.turnTimestamp)).toEqual([undefined, 1234]);
+  });
+
+  it("carries the turn's copy text on the same row as its timestamp", () => {
+    const done = agentTurn("d", [
+      sessionUpdate("d1", { text: "first" }),
+      sessionUpdate("d2", {
+        turnComplete: true,
+        timestamp: 1234,
+        text: "last",
+      }),
+    ]);
+    const flat = flattenTurnRows([done]);
+    expect(flat.map((r) => r.turnCopyText)).toEqual([
+      undefined,
+      "first\n\nlast",
+    ]);
+  });
+
+  it("leaves copy text off a turn that is still streaming", () => {
+    const streaming = agentTurn("s", [
+      sessionUpdate("s1", { text: "partial" }),
+    ]);
+    expect(flattenTurnRows([streaming])[0].turnCopyText).toBeUndefined();
   });
 
   it("reads a trailing tool group's timestamp from its last tool", () => {

--- a/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -9,7 +9,16 @@ export type ThreadItem = ConversationItem | ToolGroupItem;
  * A contiguous run of non-user rows (assistant prose, tools, git actions, ...) shown as one
  * block with tight internal spacing. Broken only by a user message.
  */
-export type AgentTurn = { type: "agent_turn"; id: string; items: ThreadItem[] };
+export type AgentTurn = {
+  type: "agent_turn";
+  id: string;
+  items: ThreadItem[];
+  /**
+   * The user-initiated row that opened this turn — grouping emits it as a standalone row, so
+   * without it "Copy turn" would carry the agent's prose but not the prompt it answers.
+   */
+  prompt?: ThreadItem;
+};
 
 /** Top-level row: a standalone user message, or a grouped agent turn. */
 export type TurnRow = ThreadItem | AgentTurn;
@@ -104,7 +113,9 @@ export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
       const copyText =
         timestamp == null
           ? undefined
-          : (buildTurnCopyText(row.items) ?? undefined);
+          : (buildTurnCopyText(
+              row.prompt ? [row.prompt, ...row.items] : row.items,
+            ) ?? undefined);
       for (let i = 0; i < row.items.length; i++) {
         const item = row.items[i];
         const isTrailing = i === row.items.length - 1;

--- a/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -1,5 +1,6 @@
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
+import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
 
 /** A row is either a parsed conversation item or a synthesized group of tool calls. */
 export type ThreadItem = ConversationItem | ToolGroupItem;
@@ -74,6 +75,8 @@ export interface FlatThreadRow {
   isTrailingInTurn: boolean;
   /** Set on the last row of a completed turn; renders the turn's hover timestamp under it. */
   turnTimestamp?: number;
+  /** Set alongside {@link turnTimestamp}: the whole turn as plain text, for its copy button. */
+  turnCopyText?: string;
 }
 
 /**
@@ -98,6 +101,10 @@ export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
   for (const row of rows) {
     if (row.type === "agent_turn") {
       const timestamp = completedTurnTimestamp(row);
+      const copyText =
+        timestamp == null
+          ? undefined
+          : (buildTurnCopyText(row.items) ?? undefined);
       for (let i = 0; i < row.items.length; i++) {
         const item = row.items[i];
         const isTrailing = i === row.items.length - 1;
@@ -107,6 +114,7 @@ export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
           inTurn: true,
           isTrailingInTurn: isTrailing,
           turnTimestamp: isTrailing ? timestamp : undefined,
+          turnCopyText: isTrailing ? copyText : undefined,
         });
       }
       continue;

--- a/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.test.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.test.ts
@@ -1,0 +1,78 @@
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
+import { describe, expect, it } from "vitest";
+import { buildTurnCopyText } from "./turnCopyText";
+
+function userMessage(id: string, content: string): ConversationItem {
+  return { type: "user_message", id, content, timestamp: 0 };
+}
+
+function agentText(id: string, text: string): ConversationItem {
+  return {
+    type: "session_update",
+    id,
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text },
+    },
+    turnContext: {
+      toolCalls: new Map(),
+      childItems: new Map(),
+      turnCancelled: false,
+      turnComplete: true,
+    },
+  } as ConversationItem;
+}
+
+function toolCall(id: string): ConversationItem {
+  return {
+    type: "session_update",
+    id,
+    update: {
+      sessionUpdate: "tool_call",
+      toolCallId: id,
+      title: "Read file",
+      status: "completed",
+    },
+    turnContext: {
+      toolCalls: new Map(),
+      childItems: new Map(),
+      turnCancelled: false,
+      turnComplete: true,
+    },
+  } as ConversationItem;
+}
+
+function toolGroup(id: string): ToolGroupItem {
+  return { type: "tool_group", id, tools: [] } as unknown as ToolGroupItem;
+}
+
+describe("buildTurnCopyText", () => {
+  it("joins the rows' prose in order", () => {
+    const text = buildTurnCopyText([
+      agentText("a1", "first paragraph"),
+      agentText("a2", "second paragraph"),
+    ]);
+
+    expect(text).toBe("first paragraph\n\nsecond paragraph");
+  });
+
+  it("skips tool calls, tool groups and other non-prose rows", () => {
+    const text = buildTurnCopyText([
+      userMessage("u1", "do the thing"),
+      toolCall("t1"),
+      toolGroup("g1"),
+      agentText("a1", "done"),
+    ]);
+
+    expect(text).toBe("do the thing\n\ndone");
+  });
+
+  it.each([
+    ["no items", [] as ConversationItem[]],
+    ["tools only", [toolCall("t1"), toolGroup("g1")]],
+    ["blank prose", [userMessage("u1", "   "), agentText("a1", "\n")]],
+  ])("returns null when there is nothing to copy: %s", (_label, items) => {
+    expect(buildTurnCopyText(items)).toBeNull();
+  });
+});

--- a/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.ts
+++ b/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.ts
@@ -1,0 +1,31 @@
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
+
+/**
+ * Plain-text transcript of a turn's rows: user prompts and agent prose, in order.
+ *
+ * Tool calls, thoughts and status rows are left out — this is for pasting an answer somewhere else,
+ * not for reproducing the run. Returns null when the rows carry no prose.
+ */
+export function buildTurnCopyText(
+  items: Array<ConversationItem | ToolGroupItem>,
+): string | null {
+  const parts: string[] = [];
+
+  for (const item of items) {
+    if (item.type === "user_message") {
+      const content = item.content.trim();
+      if (content) parts.push(content);
+      continue;
+    }
+    if (item.type !== "session_update") continue;
+    const update = item.update;
+    if (update.sessionUpdate !== "agent_message_chunk") continue;
+    if (update.content.type !== "text") continue;
+    const text = update.content.text.trim();
+    if (text) parts.push(text);
+  }
+
+  if (parts.length === 0) return null;
+  return parts.join("\n\n");
+}


### PR DESCRIPTION
## What

Every message row carried a hover copy button floating in its right rail, plus 36px of reserved padding (`pr-9`) so the button had somewhere to sit. Both are gone. Copy now lives in two places:

<img width="828" height="1056" alt="2026-07-27 13 59 09" src="https://github.com/user-attachments/assets/dd99c3ba-02ec-4e02-ae9f-971bc3392b21"/>

- **"Copy turn"** in each completed turn's hover footer, beside the timestamp. Copies that turn as plain text — the prompt and the agent's prose; tool calls, thoughts and status rows are skipped (`buildTurnCopyText`, 5 tests). The windowed body carries the same text on the row that already carries the turn timestamp, so both renderers behave the same.
- **"Copy message"** in each user message's own footer, and on right-click for any user or agent message (`MessageContextMenu`).

The message context menu also carries `SessionView`'s **raw-logs toggle**. That menu sits inside `SessionView`'s own and wins the event, so without it, right-clicking a message was the one spot in the session where "Show raw logs" went missing. It reads the same `sessionViewStore` state, so it stays in sync with the outer menu.

## Styling

Both buttons are one shared `CopyButton`: quill `Button` (`variant="default"` `size="icon-xs"`) + quill `Tooltip`, `text-muted-foreground` in every state. No Radix `IconButton`, no `color="green"` — `@radix-ui/themes` is no longer imported by `ChatThread.tsx` at all.

Confirmation is an anchored quill toast ("Copied!") above the button, fired off the `copied` flag rather than the click — a rejected clipboard write (unfocused document, blocked permission) never claims success. It dismisses on unmount so a toast can't outlive its anchor. The context-menu copy goes through the deferred `copyFromContextMenu` (a synchronous write from a closing menu rejects while focus is being restored) and reports both outcomes as toasts.

Row padding: the thread gutter that landed with the minimap (#3829) reserves space on both sides of the scroll content, so message rows drop their own `px` and user rows and turn cards share one edge.

## Known gap

`SessionView`'s generic **"Copy"** item — selection, or the GitHub link under the cursor — is still shadowed on messages; right-clicking a bubble always offers "Copy message". ⌘C still copies a selection. Happy to make "Copy message" selection-aware, or add a separate item, if that's worth it.

## Testing

Rebased onto `main` now that the minimap (#3829) has merged, so the diff here is only the copy work. Full UI suite (2333 tests) and workspace typecheck pass after the rebase. Driven in the running app over CDP: 11 turn buttons and 11 message buttons render, clicking each puts the right text on the clipboard (a message's own text; 2075 chars of prose for a turn), the icon ticks, and the "Copied!" toast renders anchored directly above the button (button at y=748, toast at y=714). Right-click on a message gives `["Copy message", "Show raw logs"]`; the toggle opens the raw-logs view, and the outer menu there returns to the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYPVPkN4Lm3gygchrpcoqr