### PR TITLE
fix(mobile): enforce CSP on sandboxed MCP app HTML (port #3803)

### DIFF
--- a/apps/mobile/src/features/mcp/sandbox/mcpAppCsp.test.ts
+++ b/apps/mobile/src/features/mcp/sandbox/mcpAppCsp.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCspToHtml,
+  buildCspMetaTag,
+  buildCspString,
+  escapeAttr,
+  sanitizeDomain,
+} from "./mcpAppCsp";
+
+describe("sanitizeDomain", () => {
+  it.each([
+    ["example.com", "example.com"],
+    ["*.example.com", "*.example.com"],
+    ["example.com:8080", "example.com:8080"],
+    ["' unsafe-eval; script-src *;", "unsafe-evalscript-src*"],
+    ['" onload=alert(1)', "onloadalert1"],
+    ["example.com; frame-ancestors *", "example.comframe-ancestors*"],
+    ["example .com", "example.com"],
+  ])("sanitizes %j", (input, expected) => {
+    expect(sanitizeDomain(input)).toBe(expected);
+  });
+});
+
+describe("buildCspString", () => {
+  it.each([
+    ["default-src 'none'"],
+    ["script-src 'self' 'unsafe-inline'"],
+    ["style-src 'self' 'unsafe-inline'"],
+    ["img-src 'self' data:"],
+    ["media-src 'self' data:"],
+    ["connect-src 'none'"],
+    ["frame-src 'none'"],
+    ["form-action 'none'"],
+    ["base-uri 'none'"],
+    ["object-src 'none'"],
+  ])("default policy contains %s", (directive) => {
+    expect(buildCspString()).toContain(directive);
+  });
+
+  it.each([
+    ["connect-src 'none'"],
+    ["frame-src 'none'"],
+    ["form-action 'none'"],
+    ["base-uri 'none'"],
+    ["img-src 'self' data:"],
+  ])("uses the restrictive default %s for empty metadata", (directive) => {
+    expect(buildCspString({})).toContain(directive);
+  });
+
+  it("maps connectDomains to connect-src", () => {
+    expect(
+      buildCspString({
+        connectDomains: ["api.example.com", "*.cdn.example.com"],
+      }),
+    ).toContain("connect-src api.example.com *.cdn.example.com");
+  });
+
+  it("maps resourceDomains to img/media/font/script/style-src", () => {
+    const result = buildCspString({ resourceDomains: ["cdn.example.com"] });
+    expect(result).toContain("img-src 'self' data: cdn.example.com");
+    expect(result).toContain("media-src 'self' data: cdn.example.com");
+    expect(result).toContain("font-src cdn.example.com");
+    expect(result).toContain(
+      "script-src 'self' 'unsafe-inline' cdn.example.com",
+    );
+    expect(result).toContain(
+      "style-src 'self' 'unsafe-inline' cdn.example.com",
+    );
+  });
+
+  it("omits resourceDomains from script/style-src when not declared", () => {
+    const result = buildCspString({});
+    expect(result).toContain("script-src 'self' 'unsafe-inline'");
+    expect(result).not.toMatch(/script-src 'self' 'unsafe-inline' ;/);
+  });
+
+  it("maps frameDomains to frame-src", () => {
+    expect(buildCspString({ frameDomains: ["embed.example.com"] })).toContain(
+      "frame-src embed.example.com",
+    );
+  });
+
+  it("maps baseUriDomains to base-uri", () => {
+    expect(buildCspString({ baseUriDomains: ["example.com"] })).toContain(
+      "base-uri example.com",
+    );
+  });
+
+  it("always includes form-action 'none'", () => {
+    expect(buildCspString({ connectDomains: ["api.example.com"] })).toContain(
+      "form-action 'none'",
+    );
+  });
+
+  it("sanitizes injection attempts in domains", () => {
+    const result = buildCspString({
+      connectDomains: ["example.com; script-src 'unsafe-eval'"],
+    });
+    expect(result).toContain("connect-src example.comscript-srcunsafe-eval");
+    expect(result).not.toMatch(/;\s*script-src\s+'unsafe-eval'/);
+  });
+});
+
+describe("escapeAttr", () => {
+  it.each([
+    ['hello "world"', "hello &quot;world&quot;"],
+    ["hello 'world'", "hello &#39;world&#39;"],
+    ["a & b", "a &amp; b"],
+    ["<script>alert(1)</script>", "&lt;script&gt;alert(1)&lt;/script&gt;"],
+    ["default-src none", "default-src none"],
+  ])("escapes %j", (input, expected) => {
+    expect(escapeAttr(input)).toBe(expected);
+  });
+});
+
+describe("buildCspMetaTag", () => {
+  it("returns a valid meta tag with the default policy", () => {
+    const tag = buildCspMetaTag();
+    expect(tag).toMatch(
+      /^<meta http-equiv="Content-Security-Policy" content=".*">$/,
+    );
+    expect(tag).toContain("default-src");
+  });
+
+  it("escapes the CSP content in the attribute", () => {
+    const tag = buildCspMetaTag({ connectDomains: ["example.com"] });
+    expect(tag).toContain("connect-src example.com");
+    expect(tag).toMatch(/content="[^"]+"/);
+  });
+});
+
+describe("applyCspToHtml", () => {
+  it("prepends the CSP meta when there is no doctype", () => {
+    const out = applyCspToHtml("<html><body>hi</body></html>");
+    expect(out.startsWith(buildCspMetaTag())).toBe(true);
+  });
+
+  it("inserts the CSP meta after a leading doctype", () => {
+    const out = applyCspToHtml("<!doctype html><html><head></head></html>");
+    expect(out).toBe(
+      `<!doctype html>${buildCspMetaTag()}<html><head></head></html>`,
+    );
+  });
+
+  it("keeps leading whitespace and mixed-case doctype before the meta", () => {
+    const out = applyCspToHtml("  <!DOCTYPE html>\n<html></html>");
+    expect(out.startsWith("  <!DOCTYPE html>")).toBe(true);
+    expect(out.indexOf("<!DOCTYPE html>")).toBeLessThan(
+      out.indexOf(buildCspMetaTag()),
+    );
+  });
+});

--- a/apps/mobile/src/features/mcp/sandbox/mcpAppCsp.ts
+++ b/apps/mobile/src/features/mcp/sandbox/mcpAppCsp.ts
@@ -1,0 +1,85 @@
+import type { McpUiResourceCsp } from "@modelcontextprotocol/ext-apps/app-bridge";
+
+const DEFAULT_CSP =
+  "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; media-src 'self' data:; connect-src 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; base-uri 'none'";
+
+export function sanitizeDomain(domain: string): string {
+  return domain.replace(/[^a-zA-Z0-9.*:-]/g, "");
+}
+
+export function buildCspString(csp?: McpUiResourceCsp): string {
+  if (!csp) return DEFAULT_CSP;
+
+  const resourceDomains = csp.resourceDomains?.length
+    ? csp.resourceDomains.map(sanitizeDomain).join(" ")
+    : "";
+  const resourceSuffix = resourceDomains ? ` ${resourceDomains}` : "";
+
+  const directives: string[] = [
+    "default-src 'none'",
+    `script-src 'self' 'unsafe-inline'${resourceSuffix}`,
+    `style-src 'self' 'unsafe-inline'${resourceSuffix}`,
+    "object-src 'none'",
+    "form-action 'none'",
+  ];
+
+  if (csp.connectDomains?.length) {
+    directives.push(
+      `connect-src ${csp.connectDomains.map(sanitizeDomain).join(" ")}`,
+    );
+  } else {
+    directives.push("connect-src 'none'");
+  }
+
+  if (resourceDomains) {
+    directives.push(`img-src 'self' data: ${resourceDomains}`);
+    directives.push(`media-src 'self' data: ${resourceDomains}`);
+    directives.push(`font-src ${resourceDomains}`);
+  } else {
+    directives.push("img-src 'self' data:");
+    directives.push("media-src 'self' data:");
+  }
+
+  if (csp.frameDomains?.length) {
+    directives.push(
+      `frame-src ${csp.frameDomains.map(sanitizeDomain).join(" ")}`,
+    );
+  } else {
+    directives.push("frame-src 'none'");
+  }
+
+  if (csp.baseUriDomains?.length) {
+    directives.push(
+      `base-uri ${csp.baseUriDomains.map(sanitizeDomain).join(" ")}`,
+    );
+  } else {
+    directives.push("base-uri 'none'");
+  }
+
+  return directives.join("; ");
+}
+
+export function escapeAttr(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function buildCspMetaTag(csp?: McpUiResourceCsp): string {
+  return `<meta http-equiv="Content-Security-Policy" content="${escapeAttr(buildCspString(csp))}">`;
+}
+
+export function applyCspToHtml(html: string, csp?: McpUiResourceCsp): string {
+  const meta = buildCspMetaTag(csp);
+  // The doctype must stay first, or the frame drops into quirks mode.
+  const doctype = html.match(/^\s*<!doctype[^>]*>/i);
+  if (doctype) {
+    return (
+      html.slice(0, doctype[0].length) + meta + html.slice(doctype[0].length)
+    );
+  }
+  return meta + html;
+}

--- a/apps/mobile/src/features/mcp/sandbox/useMcpUiResource.ts
+++ b/apps/mobile/src/features/mcp/sandbox/useMcpUiResource.ts
@@ -1,5 +1,6 @@
 import {
   getToolUiResourceUri,
+  type McpUiResourceCsp,
   RESOURCE_MIME_TYPE,
 } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
@@ -67,7 +68,7 @@ export function useMcpUiResource({
       const permissions =
         (ui.permissions as Record<string, Record<string, unknown>>) ??
         undefined;
-      const csp = (ui.csp as Record<string, unknown> | undefined) ?? undefined;
+      const csp = ui.csp as McpUiResourceCsp | undefined;
 
       return {
         resource: { uri, html: text, csp, permissions },

--- a/apps/mobile/src/features/mcp/sandbox/useMobileAppBridge.ts
+++ b/apps/mobile/src/features/mcp/sandbox/useMobileAppBridge.ts
@@ -3,6 +3,7 @@ import {
   type McpUiDisplayMode,
   type McpUiHostCapabilities,
   type McpUiHostContext,
+  type McpUiResourceCsp,
 } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type {
   CallToolResult,
@@ -15,6 +16,7 @@ import type { EdgeInsets } from "react-native-safe-area-context";
 import type WebView from "react-native-webview";
 import { logger } from "@/lib/logger";
 import type { ThemeColors } from "@/lib/theme";
+import { applyCspToHtml } from "./mcpAppCsp";
 import { buildMcpHostStyles } from "./mcpAppTheme";
 import { WebViewTransport } from "./webViewTransport";
 
@@ -30,8 +32,7 @@ export type Phase =
 interface UiResource {
   uri: string;
   html: string;
-  /** Opaque `McpUiResourceCsp` shape — passed through to AppBridge unchanged. */
-  csp?: Record<string, unknown>;
+  csp?: McpUiResourceCsp;
   permissions?: Record<string, Record<string, unknown>>;
 }
 
@@ -256,7 +257,7 @@ export function useMobileAppBridge(
         bridgeRef.current = bridge;
 
         await bridge.sendSandboxResourceReady({
-          html: uiResource.html,
+          html: applyCspToHtml(uiResource.html, uiResource.csp),
           csp: uiResource.csp,
           permissions: uiResource.permissions,
         });

--- a/apps/mobile/src/features/mcp/types.ts
+++ b/apps/mobile/src/features/mcp/types.ts
@@ -1,6 +1,8 @@
 // Shared types for MCP server installations and marketplace templates.
 // Mirrors the PostHog cloud REST schema (see `apps/code/src/renderer/api/generated.ts`).
 
+import type { McpUiResourceCsp } from "@modelcontextprotocol/ext-apps/app-bridge";
+
 export type McpAuthType = "api_key" | "oauth" | "none";
 
 export type McpApprovalState = "approved" | "needs_approval" | "do_not_use";
@@ -105,8 +107,7 @@ export interface UpdateMcpServerInstallationOptions {
 export interface McpUiResource {
   uri: string;
   html: string;
-  /** Opaque CSP descriptor handed straight to AppBridge (`McpUiResourceCsp`). */
-  csp?: Record<string, unknown>;
+  csp?: McpUiResourceCsp;
   permissions?: Record<string, Record<string, unknown>>;
 }
 


### PR DESCRIPTION
## Problem

Desktop PR #3803 (`fix(security): Enforce CSP on sandboxed MCP app HTML`) hardened how MCP UI apps render inside the sandboxed frame. It partially touched mobile — the sandbox hardening in `sandboxProxyHtml.ts` (dropped `allow-same-origin`, `srcdoc` instead of `document.write()`, the `bridgeClosed` guard) was ported — but the **actual CSP enforcement was not**.

On mobile the resource's `csp` descriptor was only passed through and never used, so the untrusted MCP app HTML rendered in the WebView ran with **no Content-Security-Policy at all**. This closes that gap so mobile matches desktop's security posture.

## Changes

- Add `apps/mobile/src/features/mcp/sandbox/mcpAppCsp.ts`, a local mirror of desktop's `packages/ui/src/features/mcp-apps/utils/mcp-app-csp.ts`: same directives (connect/resource/frame/base-uri), same domain sanitization, same restrictive default policy when no CSP is supplied, and the same doctype-aware injection (the doctype must stay first or the frame drops into quirks mode).
- Apply it at the single seam where HTML is handed to the sandboxed WebView frame — `useMobileAppBridge.ts`, right before `sendSandboxResourceReady` (the mobile analogue of desktop's `useAppBridge` call site) — so every byte of HTML that reaches `srcdoc` carries the CSP meta tag.
- Tighten the `csp` type plumbing from `Record<string, unknown>` to the `McpUiResourceCsp` descriptor in `types.ts` and `useMobileAppBridge.ts`.
- Add colocated Vitest coverage for the builder/injector.

Kept local to `apps/mobile` rather than shared: mobile is React Native and cannot import the desktop (`packages/ui`, React DOM) implementation, and the task scope did not permit changing desktop files. **No desktop code was changed.**

## How did you test this?

- `pnpm --filter @posthog/mobile test` — all 60 test files / 524 tests pass (includes the new 39-case `mcpAppCsp.test.ts` covering the no-CSP default policy, doctype present, doctype absent, leading-whitespace/mixed-case doctype, and each supported directive shape).
- `tsc --noEmit` on the mobile app — no type errors in the changed files.
- `biome check` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
