### PR TITLE
fix(git): record every PR created for a local task

### DIFF
--- a/apps/code/src/main/di/container.ts
+++ b/apps/code/src/main/di/container.ts
@@ -584,6 +584,11 @@ container
       getWorkspace: (taskId) => workspace().getWorkspace(taskId),
       linkBranch: (taskId, branch, source) =>
         workspace().linkBranch(taskId, branch, source),
+      accumulatePrUrl: (taskId, prUrl) => {
+        void ctx
+          .get<IGitPrStatus>(GIT_PR_STATUS_PROVIDER)
+          .accumulatePrUrl(taskId, prUrl);
+      },
     };
   });
 container.load(gitHostModule);

--- a/packages/core/src/git-pr/git-pr.test.ts
+++ b/packages/core/src/git-pr/git-pr.test.ts
@@ -126,6 +126,7 @@ function makeHost(over: Partial<CreatePrHost> = {}): CreatePrHost {
       prUrl: "https://github.com/o/r/pull/1",
     }),
     linkBranch: vi.fn(),
+    accumulatePrUrl: vi.fn(),
     getPrState: vi.fn().mockResolvedValue({ prStatus: "open" }),
     ...over,
   };
@@ -163,6 +164,10 @@ describe("GitPrService.createPr", () => {
     });
     expect(host.push).toHaveBeenCalledWith("/repo", undefined);
     expect(host.linkBranch).toHaveBeenCalledWith("task-1", "feature", "user");
+    expect(host.accumulatePrUrl).toHaveBeenCalledWith(
+      "task-1",
+      "https://github.com/o/r/pull/1",
+    );
     expect(onProgress).toHaveBeenLastCalledWith(
       "complete",
       "Pull request created",

--- a/packages/core/src/git-pr/git-pr.ts
+++ b/packages/core/src/git-pr/git-pr.ts
@@ -333,6 +333,9 @@ Rules:
       if (linkedBranch) {
         host.linkBranch(input.taskId, linkedBranch, "user");
       }
+      if (result.data.prUrl) {
+        host.accumulatePrUrl(input.taskId, result.data.prUrl);
+      }
     }
 
     onProgress(

--- a/packages/core/src/git-pr/identifiers.ts
+++ b/packages/core/src/git-pr/identifiers.ts
@@ -100,5 +100,6 @@ export interface CreatePrHost {
     env?: Record<string, string>,
   ): Promise<{ success: boolean; message: string; prUrl: string | null }>;
   linkBranch(taskId: string, branch: string, source: "user"): void;
+  accumulatePrUrl(taskId: string, prUrl: string): void;
   getPrState(directoryPath: string): Promise<unknown>;
 }

--- a/packages/core/src/git/git-host.ts
+++ b/packages/core/src/git/git-host.ts
@@ -185,6 +185,8 @@ export class GitHostService extends TypedEventEmitter<GitServiceEvents> {
         }),
       linkBranch: (taskId, branch, source) =>
         this.workspaceLookup.linkBranch(taskId, branch, source),
+      accumulatePrUrl: (taskId, prUrl) =>
+        this.workspaceLookup.accumulatePrUrl(taskId, prUrl),
       getPrState: (dir) => this.getPrStateSnapshot(dir),
     };
   }

--- a/packages/core/src/git/host-git.ts
+++ b/packages/core/src/git/host-git.ts
@@ -47,4 +47,5 @@ export interface GitPrWorkspaceInfo {
 export interface GitWorkspaceLookup {
   getWorkspace(taskId: string): Promise<GitPrWorkspaceInfo | null>;
   linkBranch(taskId: string, branch: string, source: "user"): void;
+  accumulatePrUrl(taskId: string, prUrl: string): void;
 }

--- a/packages/host-router/src/ports/git-pr-status.ts
+++ b/packages/host-router/src/ports/git-pr-status.ts
@@ -14,4 +14,5 @@ export interface IGitPrStatus {
   ): Promise<TaskPrStatus>;
   getCachedPrUrl(taskId: string): CachedPrUrlOutput;
   setPrimaryPrUrl(taskId: string, prUrl: string): Promise<void>;
+  accumulatePrUrl(taskId: string, prUrl: string): Promise<void>;
 }

--- a/packages/ui/src/features/git-interaction/utils/resolveTaskPrUrls.test.ts
+++ b/packages/ui/src/features/git-interaction/utils/resolveTaskPrUrls.test.ts
@@ -38,6 +38,11 @@ describe("resolveTaskPrUrls", () => {
       { primaryUrl: PR_1, otherUrls: [PR_2] },
     ],
     [
+      "two accumulated local PRs surface an Other PRs entry",
+      { cloudUrls: [], cachedUrls: [PR_1, PR_2], currentBranchUrl: PR_2 },
+      { primaryUrl: PR_1, otherUrls: [PR_2] },
+    ],
+    [
       "dedupes across sources preserving cloud order",
       {
         cloudUrls: [PR_1, PR_2],

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -2228,7 +2228,7 @@ For git operations while detached:
       this.fetchGhLogin(session.repoPath),
     ]);
     if (!wasCreatedRecently(attribution.createdAt, Date.now())) return;
-    if (ghLogin && !wasCreatedByLogin(attribution.author, ghLogin)) return;
+    if (!wasCreatedByLogin(attribution.author, ghLogin)) return;
 
     this.log.info("Detected PR URL created during run", { taskRunId, prUrl });
 

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -2228,7 +2228,7 @@ For git operations while detached:
       this.fetchGhLogin(session.repoPath),
     ]);
     if (!wasCreatedRecently(attribution.createdAt, Date.now())) return;
-    if (!wasCreatedByLogin(attribution.author, ghLogin)) return;
+    if (ghLogin && !wasCreatedByLogin(attribution.author, ghLogin)) return;
 
     this.log.info("Detected PR URL created during run", { taskRunId, prUrl });
 

--- a/packages/workspace-server/src/services/git/task-pr-status.test.ts
+++ b/packages/workspace-server/src/services/git/task-pr-status.test.ts
@@ -274,3 +274,89 @@ describe("TaskPrStatusService.setPrimaryPrUrl", () => {
     });
   });
 });
+
+describe("TaskPrStatusService.accumulatePrUrl", () => {
+  const PR_A = "https://github.com/acme/repo/pull/1";
+  const PR_B = "https://github.com/acme/repo/pull/2";
+
+  function makeService(existingUrls: string[]) {
+    const urls = [...existingUrls];
+    const gitService = {
+      getPrDetailsByUrl: vi
+        .fn()
+        .mockResolvedValue({ state: "open", merged: false, draft: false }),
+    } as unknown as GitService;
+    const workspaceService = { emit: vi.fn() };
+    const workspaceRepo = {
+      findByTaskId: vi.fn().mockReturnValue({ id: "ws-1" }),
+      updatePrCache: vi.fn((_taskId, update) => {
+        if (update.prUrl && update.accumulate && !urls.includes(update.prUrl)) {
+          urls.push(update.prUrl);
+        }
+      }),
+      getPrUrls: vi.fn(() => [...urls]),
+    };
+    const service = new TaskPrStatusService(
+      gitService,
+      workspaceRepo as unknown as IWorkspaceRepository,
+      workspaceService as unknown as WorkspaceService,
+    );
+    return { service, gitService, workspaceService, workspaceRepo };
+  }
+
+  it("records the first PR as a fresh accumulate and emits it", async () => {
+    const { service, workspaceService, workspaceRepo } = makeService([]);
+
+    await service.accumulatePrUrl("task-1", PR_A);
+
+    expect(workspaceRepo.updatePrCache).toHaveBeenCalledWith("task-1", {
+      prUrl: PR_A,
+      prState: "open",
+      accumulate: true,
+    });
+    expect(workspaceService.emit).toHaveBeenCalledWith("taskPrInfoChanged", {
+      taskId: "task-1",
+      prUrl: PR_A,
+      prUrls: [PR_A],
+      prState: "open",
+    });
+  });
+
+  it("appends a second distinct PR so both survive", async () => {
+    const { service, workspaceService } = makeService([PR_A]);
+
+    await service.accumulatePrUrl("task-1", PR_B);
+
+    expect(workspaceService.emit).toHaveBeenCalledWith("taskPrInfoChanged", {
+      taskId: "task-1",
+      prUrl: PR_B,
+      prUrls: [PR_A, PR_B],
+      prState: "open",
+    });
+  });
+
+  it("is idempotent when re-accumulating an existing PR", async () => {
+    const { service, workspaceService } = makeService([PR_A]);
+
+    await service.accumulatePrUrl("task-1", PR_A);
+
+    expect(workspaceService.emit).toHaveBeenCalledWith("taskPrInfoChanged", {
+      taskId: "task-1",
+      prUrl: PR_A,
+      prUrls: [PR_A],
+      prState: "open",
+    });
+  });
+
+  it("does nothing when the task has no workspace row", async () => {
+    const { service, gitService, workspaceService, workspaceRepo } =
+      makeService([]);
+    workspaceRepo.findByTaskId.mockReturnValue(null);
+
+    await service.accumulatePrUrl("task-1", PR_A);
+
+    expect(gitService.getPrDetailsByUrl).not.toHaveBeenCalled();
+    expect(workspaceRepo.updatePrCache).not.toHaveBeenCalled();
+    expect(workspaceService.emit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workspace-server/src/services/git/task-pr-status.ts
+++ b/packages/workspace-server/src/services/git/task-pr-status.ts
@@ -69,6 +69,27 @@ export class TaskPrStatusService {
     });
   }
 
+  async accumulatePrUrl(taskId: string, prUrl: string): Promise<void> {
+    if (!this.workspaceRepo.findByTaskId(taskId)) return;
+    const details = await this.gitService
+      .getPrDetailsByUrl(prUrl)
+      .catch(() => null);
+    const prState: SidebarPrState = details
+      ? mapPrState(details.state, details.merged, details.draft)
+      : null;
+    this.workspaceRepo.updatePrCache(taskId, {
+      prUrl,
+      prState,
+      accumulate: true,
+    });
+    this.workspaceService.emit("taskPrInfoChanged", {
+      taskId,
+      prUrl,
+      prUrls: this.workspaceRepo.getPrUrls(taskId),
+      prState,
+    });
+  }
+
   private async computeWorktreeHasDiff(taskId: string): Promise<boolean> {
     const workspace = await this.workspaceService.getWorkspace(taskId);
     if (


### PR DESCRIPTION
## Problem

On a **local (desktop worktree) task** that produced two PRs, the task header shows only **one** PR badge (the latest / current branch) with **no "Other PRs" submenu**. Multi‑PR‑per‑task support exists (#3227) via a `pr_urls` array, but for local tasks nothing recorded a PR *at creation time*.

`pr_urls` was only populated as a side effect of polling `getPrStatus` on the **currently checked‑out branch** during revalidation. So if the agent opens PR #1 on branch A, then continues and opens PR #2 on branch B before any revalidation fires while A is current, PR #1 is never recorded — only PR #2 survives, and there's nothing to populate the submenu.

## Fix

1. **Event‑driven capture (primary).** The Create‑PR saga now accumulates the created PR URL the moment the PR is made, independent of which branch is later checked out — mirroring how cloud already works. New `accumulatePrUrl` seam: `CreatePrHost` → `GitWorkspaceLookup` → `IGitPrStatus` → `TaskPrStatusService.accumulatePrUrl` (does `updatePrCache(..., accumulate: true)` + emits `taskPrInfoChanged`), wired in the composition root. No schema change — the `pr_urls` column already exists. Array order is preserved, so promote‑to‑primary and dedupe still hold.

2. **Local agent hardening.** `attachPrIfCreatedThisRun` enforced the author match unconditionally, so a genuinely agent‑created PR was silently dropped whenever `gh api user` returned no login. Now the author check applies only when a login actually resolved (matching `agent-server.ts`); the 5‑minute recency gate still scopes attribution.

## Tests
- New `TaskPrStatusService.accumulatePrUrl` suite: first PR sets primary + `pr_urls=[A]`; second distinct PR yields `[A,B]`; re‑accumulating A is idempotent; no‑op when the task has no workspace row.
- Saga test asserts `accumulatePrUrl` is called on success.
- Explicit `resolveTaskPrUrls` regression case for two accumulated local PRs surfacing an "Other PRs" entry.

## Verification
- Typecheck: `@posthog/core`, `@posthog/workspace-server`, `@posthog/host-router`, `apps/code` — clean.
- Tests: core (2503), ui (2164), `task-pr-status` (12) — pass.
- Lint clean, zero `noRestrictedImports` in `packages/core`; no new host‑boundary violations.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*