### PR TITLE
fix(agent): preserve task run ID for artifact uploads

### DIFF
--- a/packages/agent/src/adapters/codex-app-server/local-tools-mcp-server.ts
+++ b/packages/agent/src/adapters/codex-app-server/local-tools-mcp-server.ts
@@ -34,6 +34,7 @@ if (!ctxEnv) {
 let parsed: {
   cwd: string;
   taskId?: string;
+  taskRunId?: string;
   token?: string;
   baseBranch?: string;
 };
@@ -51,6 +52,7 @@ const ctx: LocalToolCtx = {
   cwd: parsed.cwd,
   token: parsed.token ?? readGithubTokenFromEnv(),
   taskId: parsed.taskId,
+  taskRunId: parsed.taskRunId,
   baseBranch: parsed.baseBranch,
 };
 


### PR DESCRIPTION
## Problem

Codex artifact uploads were enabled with a task run ID in the parent process, but the spawned MCP server discarded that ID and rejected every upload as unavailable.

## Changes

Preserve `taskRunId` when decoding and forwarding the local-tool context.

**Why:** Generated files should be deliverable from Codex cloud tasks through the existing artifact upload tool.

<img width="747" height="190" alt="image" src="https://github.com/user-attachments/assets/bb2705c9-4cd5-465b-81d7-f514da0b95bb" />

## How did you test this?

- Built `@posthog/agent`
- Ran the focused upload-artifact tests
- Invoked the bundled MCP server directly before and after the fix; the call advanced from the missing-session error to the expected local storage-configuration guard

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*