### PR TITLE
Fix message copy action in Command Center

### DIFF
--- a/packages/ui/src/features/sessions/components/session-update/AgentMessage.test.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/AgentMessage.test.tsx
@@ -1,0 +1,25 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { AgentMessage } from "./AgentMessage";
+
+describe("AgentMessage", () => {
+  it("keeps the copy action inside the message rail", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <Theme>
+        <AgentMessage content="Assistant response" />
+      </Theme>,
+    );
+
+    const copyButton = screen.getByLabelText("Copy message");
+    expect(copyButton.parentElement).toHaveClass("right-1");
+    expect(copyButton.parentElement).not.toHaveClass("left-full");
+
+    await userEvent.click(copyButton);
+    expect(writeText).toHaveBeenCalledWith("Assistant response");
+  });
+});

--- a/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
@@ -70,7 +70,7 @@ export const AgentMessage = memo(function AgentMessage({
   }, [content]);
 
   return (
-    <Box className="group/msg relative pl-3 text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]">
+    <Box className="group/msg relative pr-9 pl-3 text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]">
       {isStreaming ? (
         <StreamingMarkdown
           content={smoothed}
@@ -82,7 +82,7 @@ export const AgentMessage = memo(function AgentMessage({
           componentsOverride={agentComponents}
         />
       )}
-      <Box className="absolute top-1 left-full ml-2 opacity-0 transition-opacity group-hover/msg:opacity-100">
+      <Box className="absolute top-1 right-1 opacity-0 transition-opacity group-hover/msg:opacity-100">
         <Tooltip content={copied ? "Copied!" : "Copy message"}>
           <IconButton
             size="1"


### PR DESCRIPTION
## Problem

The assistant-message copy action is positioned outside the message bounds and gets clipped in compact Command Center conversations.

**Why:** People should have the same copy affordance whether they view a task standalone or in the Command Center.

## Changes

Keep the hover copy action inside the assistant message rail and reserve enough space to prevent it from covering message content. Add a regression test for the placement and clipboard behavior.

## How did you test this?

- `pnpm --filter @posthog/shared build`
- `pnpm --filter @posthog/ui exec vitest run src/features/sessions/components/session-update/AgentMessage.test.tsx`
- `pnpm exec biome check packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx packages/ui/src/features/sessions/components/session-update/AgentMessage.test.tsx`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*