### PR TITLE
fix(sessions): reuse file Markdown styling for artifacts

### DIFF
--- a/packages/ui/src/features/code-editor/components/CodeEditorPanel.tsx
+++ b/packages/ui/src/features/code-editor/components/CodeEditorPanel.tsx
@@ -17,8 +17,6 @@ import type { Task } from "@posthog/shared/domain-types";
 import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import { useCallback, useMemo, useState } from "react";
 import type { Components } from "react-markdown";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { PanelMessage } from "../../../primitives/PanelMessage";
 import { SafeImagePreview } from "../../../primitives/SafeImagePreview";
 import { Tooltip } from "../../../primitives/Tooltip";
@@ -38,6 +36,7 @@ import {
 import { useFileEnrichment } from "../hooks/useFileEnrichment";
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { EnrichmentPopover } from "./EnrichmentPopover";
+import { MarkdownDocumentPreview } from "./MarkdownDocumentPreview";
 import {
   SelectionCommentOverlay,
   useSelectionComposer,
@@ -363,14 +362,10 @@ export function CodeEditorPanel({
           <Box className="flex-1 overflow-hidden">{sourceView}</Box>
         ) : renderableKind === "markdown" ? (
           <Box className="flex-1 overflow-auto">
-            <Box className="plan-markdown max-w-[750px]" p="5">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
-                components={markdownComponents}
-              >
-                {fileContent}
-              </ReactMarkdown>
-            </Box>
+            <MarkdownDocumentPreview
+              content={fileContent}
+              components={markdownComponents}
+            />
           </Box>
         ) : (
           <HtmlFilePreview content={fileContent} />

--- a/packages/ui/src/features/code-editor/components/CodeEditorPanel.tsx
+++ b/packages/ui/src/features/code-editor/components/CodeEditorPanel.tsx
@@ -1,4 +1,3 @@
-import { Check, Code, Copy, Eye } from "@phosphor-icons/react";
 import { getRenderableKind } from "@posthog/core/code-editor/fileKind";
 import {
   collapseFileState,
@@ -14,8 +13,8 @@ import {
   parseImageDataUrl,
 } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
-import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
-import { useCallback, useMemo, useState } from "react";
+import { Box, Flex } from "@radix-ui/themes";
+import { useCallback, useMemo } from "react";
 import type { Components } from "react-markdown";
 import { PanelMessage } from "../../../primitives/PanelMessage";
 import { SafeImagePreview } from "../../../primitives/SafeImagePreview";
@@ -35,6 +34,7 @@ import {
 } from "../hooks/useFileContent";
 import { useFileEnrichment } from "../hooks/useFileEnrichment";
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
+import { DocumentPreviewHeader } from "./DocumentPreviewHeader";
 import { EnrichmentPopover } from "./EnrichmentPopover";
 import { MarkdownDocumentPreview } from "./MarkdownDocumentPreview";
 import {
@@ -118,7 +118,6 @@ export function CodeEditorPanel({
   const toggleKind = useFilePreviewStore((s) => s.toggleKind);
   const openFileInSplit = usePanelLayoutStore((s) => s.openFileInSplit);
   const expandToFile = useFileTreeStore((s) => s.expandToFile);
-  const [copied, setCopied] = useState(false);
 
   const composer = useSelectionComposer();
   const handleAddSelectionToChat = useCallback(
@@ -305,11 +304,6 @@ export function CodeEditorPanel({
   );
 
   if (isRenderable) {
-    const handleCopySource = () => {
-      navigator.clipboard.writeText(fileContent);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    };
     const handleToggleRendered = () => {
       if (renderableKind) {
         toggleKind(renderableKind);
@@ -318,46 +312,12 @@ export function CodeEditorPanel({
 
     return (
       <Flex direction="column" height="100%" className="overflow-hidden">
-        <Flex
-          px="3"
-          py="2"
-          align="center"
-          justify="between"
-          className="shrink-0 border-b border-b-(--gray-6)"
-        >
-          <Text
-            color="gray"
-            className="font-[var(--code-font-family)] text-[13px]"
-          >
-            {filePath}
-          </Text>
-          <Flex align="center" gap="1">
-            <Tooltip content={showRendered ? "View source" : "View preview"}>
-              <IconButton
-                size="1"
-                variant="ghost"
-                color="gray"
-                className="cursor-pointer"
-                onClick={handleToggleRendered}
-                aria-label={showRendered ? "View source" : "View preview"}
-              >
-                {showRendered ? <Code size={14} /> : <Eye size={14} />}
-              </IconButton>
-            </Tooltip>
-            <Tooltip content={copied ? "Copied" : "Copy source"}>
-              <IconButton
-                size="1"
-                variant="ghost"
-                color="gray"
-                className="cursor-pointer"
-                onClick={handleCopySource}
-                aria-label="Copy source"
-              >
-                {copied ? <Check size={14} /> : <Copy size={14} />}
-              </IconButton>
-            </Tooltip>
-          </Flex>
-        </Flex>
+        <DocumentPreviewHeader
+          label={filePath}
+          content={fileContent}
+          showRendered={showRendered}
+          onToggleRendered={handleToggleRendered}
+        />
         {!showRendered ? (
           <Box className="flex-1 overflow-hidden">{sourceView}</Box>
         ) : renderableKind === "markdown" ? (

--- a/packages/ui/src/features/code-editor/components/DocumentPreviewHeader.tsx
+++ b/packages/ui/src/features/code-editor/components/DocumentPreviewHeader.tsx
@@ -1,0 +1,64 @@
+import { Check, Code, Copy, Eye } from "@phosphor-icons/react";
+import { Flex, IconButton, Text } from "@radix-ui/themes";
+import { useState } from "react";
+import { Tooltip } from "../../../primitives/Tooltip";
+
+export function DocumentPreviewHeader({
+  label,
+  content,
+  showRendered,
+  onToggleRendered,
+}: {
+  label: string;
+  content: string;
+  showRendered: boolean;
+  onToggleRendered: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopySource = () => {
+    navigator.clipboard.writeText(content);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Flex
+      px="3"
+      py="2"
+      align="center"
+      justify="between"
+      className="shrink-0 border-b border-b-(--gray-6)"
+    >
+      <Text color="gray" className="font-[var(--code-font-family)] text-[13px]">
+        {label}
+      </Text>
+      <Flex align="center" gap="1">
+        <Tooltip content={showRendered ? "View source" : "View preview"}>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            className="cursor-pointer"
+            onClick={onToggleRendered}
+            aria-label={showRendered ? "View source" : "View preview"}
+          >
+            {showRendered ? <Code size={14} /> : <Eye size={14} />}
+          </IconButton>
+        </Tooltip>
+        <Tooltip content={copied ? "Copied" : "Copy source"}>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color="gray"
+            className="cursor-pointer"
+            onClick={handleCopySource}
+            aria-label="Copy source"
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+          </IconButton>
+        </Tooltip>
+      </Flex>
+    </Flex>
+  );
+}

--- a/packages/ui/src/features/code-editor/components/MarkdownDocumentPreview.tsx
+++ b/packages/ui/src/features/code-editor/components/MarkdownDocumentPreview.tsx
@@ -10,7 +10,7 @@ export function MarkdownDocumentPreview({
   components?: Components;
 }) {
   return (
-    <div className="plan-markdown max-w-[750px] p-5">
+    <div className="plan-markdown mx-auto max-w-[750px] p-5">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {content}
       </ReactMarkdown>

--- a/packages/ui/src/features/code-editor/components/MarkdownDocumentPreview.tsx
+++ b/packages/ui/src/features/code-editor/components/MarkdownDocumentPreview.tsx
@@ -1,0 +1,19 @@
+import type { Components } from "react-markdown";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export function MarkdownDocumentPreview({
+  content,
+  components,
+}: {
+  content: string;
+  components?: Components;
+}) {
+  return (
+    <div className="plan-markdown max-w-[750px] p-5">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
+++ b/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
@@ -1,11 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ArtifactPreview } from "./ArtifactPreview";
-import {
-  artifactHtmlDocument,
-  artifactPreviewBlob,
-  markdownDocument,
-} from "./artifactPreviewDocument";
+import { artifactHtmlDocument, artifactPreviewBlob } from "./artifactPreviewDocument";
 
 const previewBlob = new Blob(["<h1>Artifact content</h1>"], {
   type: "text/html",
@@ -32,6 +28,12 @@ vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
 
 vi.mock("@tanstack/react-query", () => ({
   useQuery,
+}));
+
+vi.mock("../../code-editor/components/CodeMirrorEditor", () => ({
+  CodeMirrorEditor: ({ content }: { content: string }) => (
+    <div data-testid="source-view">{content}</div>
+  ),
 }));
 
 describe("ArtifactPreview", () => {
@@ -215,17 +217,31 @@ describe("ArtifactPreview", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders GFM Markdown while escaping embedded HTML", () => {
-    const document = markdownDocument(
-      "# Report\n\n**Ready**\n\n| Name | Value |\n| --- | --- |\n| Cost | 12 |\n\n<script>alert('no')</script>",
+  it("renders Markdown artifacts with the file preview styling", () => {
+    useQuery.mockReturnValue({
+      data: "# Report\n\n**Ready**\n\n| Name | Value |\n| --- | --- |\n| Cost | 12 |",
+      isLoading: false,
+      isError: false,
+    });
+
+    const { container } = render(
+      <ArtifactPreview
+        taskId="task-1"
+        runId="run-1"
+        artifactId="artifact-1"
+        name="report.md"
+      />,
     );
 
-    expect(document).toContain("<h1>Report</h1>");
-    expect(document).toContain("<strong>Ready</strong>");
-    expect(document).toContain("<table>");
-    expect(document).toContain("&lt;script&gt;");
-    expect(document).not.toContain("<script>");
-    expect(document).toContain("default-src &#39;none&#39;");
+    expect(screen.getByRole("heading", { name: "Report" })).toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(container.querySelector(".plan-markdown.mx-auto")).toBeInTheDocument();
+    expect(screen.getByText("report.md")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "View source" }));
+
+    expect(screen.getByTestId("source-view")).toHaveTextContent("# Report");
+    expect(screen.getByRole("button", { name: "View preview" })).toBeInTheDocument();
   });
 
   it("blocks network subresources in HTML artifacts", () => {

--- a/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
+++ b/packages/ui/src/features/sessions/components/ArtifactPreview.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ArtifactPreview } from "./ArtifactPreview";
-import { artifactHtmlDocument, artifactPreviewBlob } from "./artifactPreviewDocument";
+import {
+  artifactHtmlDocument,
+  artifactPreviewBlob,
+} from "./artifactPreviewDocument";
 
 const previewBlob = new Blob(["<h1>Artifact content</h1>"], {
   type: "text/html",
@@ -235,13 +238,17 @@ describe("ArtifactPreview", () => {
 
     expect(screen.getByRole("heading", { name: "Report" })).toBeInTheDocument();
     expect(screen.getByRole("table")).toBeInTheDocument();
-    expect(container.querySelector(".plan-markdown.mx-auto")).toBeInTheDocument();
+    expect(
+      container.querySelector(".plan-markdown.mx-auto"),
+    ).toBeInTheDocument();
     expect(screen.getByText("report.md")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "View source" }));
 
     expect(screen.getByTestId("source-view")).toHaveTextContent("# Report");
-    expect(screen.getByRole("button", { name: "View preview" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "View preview" }),
+    ).toBeInTheDocument();
   });
 
   it("blocks network subresources in HTML artifacts", () => {

--- a/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
+++ b/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
@@ -10,10 +10,20 @@ import {
   useAuthStateValue,
 } from "@posthog/ui/features/auth/store";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import { Flex } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { ZoomableImage } from "../../../primitives/SafeImagePreview";
+import { CodeMirrorEditor } from "../../code-editor/components/CodeMirrorEditor";
+import { DocumentPreviewHeader } from "../../code-editor/components/DocumentPreviewHeader";
+import { MarkdownDocumentPreview } from "../../code-editor/components/MarkdownDocumentPreview";
 import { artifactPreviewBlob } from "./artifactPreviewDocument";
+
+const MARKDOWN_EXTENSIONS = new Set(["md", "mdx", "markdown"]);
+
+function extension(filename: string): string {
+  return filename.split(".").pop()?.toLowerCase() ?? "";
+}
 
 function ArtifactPreviewError() {
   return (
@@ -50,6 +60,7 @@ export function ArtifactPreview({
   name: string;
 }) {
   const sessionService = useService<SessionService>(SESSION_SERVICE);
+  const [showRendered, setShowRendered] = useState(true);
   const authIdentity = useAuthStateValue(getAuthIdentity);
   const { data, isLoading, isError } = useQuery({
     queryKey: ["artifactPreview", authIdentity, taskId, runId, artifactId],
@@ -62,7 +73,11 @@ export function ArtifactPreview({
       if (!url) throw new Error("Artifact is unavailable");
       const response = await fetch(url);
       if (!response.ok) throw new Error("Artifact preview failed");
-      return artifactPreviewBlob(await response.blob(), name);
+      const blob = await response.blob();
+      if (MARKDOWN_EXTENSIONS.has(extension(name))) {
+        return blob.text();
+      }
+      return artifactPreviewBlob(blob, name);
     },
     enabled: authIdentity !== null,
     staleTime: Infinity,
@@ -70,7 +85,7 @@ export function ArtifactPreview({
     meta: AUTH_SCOPED_QUERY_META,
   });
   const previewUrl = useMemo(
-    () => (data ? URL.createObjectURL(data) : null),
+    () => (data instanceof Blob ? URL.createObjectURL(data) : null),
     [data],
   );
 
@@ -85,6 +100,30 @@ export function ArtifactPreview({
       <div className="flex h-full items-center justify-center">
         <Spinner />
       </div>
+    );
+  }
+  if (typeof data === "string") {
+    return (
+      <Flex direction="column" height="100%" className="overflow-hidden">
+        <DocumentPreviewHeader
+          label={name}
+          content={data}
+          showRendered={showRendered}
+          onToggleRendered={() => setShowRendered((rendered) => !rendered)}
+        />
+        {showRendered ? (
+          <div className="flex-1 overflow-auto">
+            <MarkdownDocumentPreview
+              content={data}
+              components={{ img: () => null }}
+            />
+          </div>
+        ) : (
+          <div className="flex-1 overflow-hidden">
+            <CodeMirrorEditor content={data} filePath={name} readOnly />
+          </div>
+        )}
+      </Flex>
     );
   }
   if (isError || !previewUrl) {

--- a/packages/ui/src/features/sessions/components/artifactPreviewDocument.ts
+++ b/packages/ui/src/features/sessions/components/artifactPreviewDocument.ts
@@ -1,11 +1,5 @@
 import { getImageMimeType, isAllowedImageMimeType } from "@posthog/shared";
-import { createElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { applyCspToHtml } from "../../mcp-apps/utils/mcp-app-csp";
-
-const MARKDOWN_EXTENSIONS = new Set(["md", "mdx", "markdown"]);
 
 function extension(filename: string): string {
   return filename.split(".").pop()?.toLowerCase() ?? "";
@@ -14,16 +8,6 @@ function extension(filename: string): string {
 export function artifactHtmlDocument(html: string): string {
   return applyCspToHtml(html);
 }
-
-export function markdownDocument(markdown: string): string {
-  const content = renderToStaticMarkup(
-    createElement(ReactMarkdown, { remarkPlugins: [remarkGfm] }, markdown),
-  );
-  return artifactHtmlDocument(`<!doctype html><html><head><meta charset="utf-8"><meta name="color-scheme" content="light dark"><style>
-    :root{font:15px/1.6 system-ui,sans-serif;color-scheme:light dark}body{box-sizing:border-box;margin:0 auto;max-width:900px;padding:32px;color:CanvasText;background:Canvas}h1,h2{border-bottom:1px solid color-mix(in srgb,CanvasText 18%,transparent);padding-bottom:.3em}h1{font-size:2em}h2{font-size:1.5em}h3{font-size:1.25em}a{color:LinkText}blockquote{margin-left:0;padding-left:1em;border-left:4px solid color-mix(in srgb,CanvasText 25%,transparent);color:GrayText}pre,code{font-family:ui-monospace,SFMono-Regular,Consolas,monospace}code{border-radius:4px;background:color-mix(in srgb,CanvasText 8%,transparent);padding:.15em .3em}pre{overflow:auto;border-radius:6px;background:color-mix(in srgb,CanvasText 8%,transparent);padding:16px}pre code{background:none;padding:0}table{border-spacing:0;border-collapse:collapse}th,td{border:1px solid color-mix(in srgb,CanvasText 20%,transparent);padding:6px 12px}img{max-width:100%}hr{border:0;border-top:1px solid color-mix(in srgb,CanvasText 20%,transparent)}
-  </style></head><body>${content}</body></html>`);
-}
-
 export async function artifactPreviewBlob(
   blob: Blob,
   filename: string,
@@ -35,11 +19,6 @@ export async function artifactPreviewBlob(
 
   if (isAllowedImageMimeType(imageMimeType)) {
     return new Blob([blob], { type: imageMimeType });
-  }
-  if (MARKDOWN_EXTENSIONS.has(extension(filename))) {
-    return new Blob([markdownDocument(await blob.text())], {
-      type: "text/html",
-    });
   }
   if (["html", "htm"].includes(extension(filename))) {
     return new Blob([artifactHtmlDocument(await blob.text())], {


### PR DESCRIPTION
## Problem

Markdown artifacts use a separate preview style that is less consistent with Markdown files opened from the file explorer.

**Why:** Keep Markdown documents visually consistent regardless of how they are opened.

## Show me!!

| Before | After |
|--------|--------|
| <img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/6c562f44-ff41-4dae-8e9f-be9590a3a3da" /> | <img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/c3e2eec5-2152-47b0-8c40-752656352dc0" /> | 


## Changes

- Share the existing file Markdown preview between files and artifacts.
- Keep HTML artifacts in their sandboxed iframe.

## How did you test this?

- `pnpm exec biome check ...`
- `pnpm --dir packages/ui exec vitest run src/features/sessions/components/ArtifactPreview.test.tsx`
- `pnpm --dir packages/ui typecheck`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*