### PR TITLE
fix(tasks): restore cloud artifact uploads

### DIFF
--- a/packages/agent/src/signed-commit-artefacts.test.ts
+++ b/packages/agent/src/signed-commit-artefacts.test.ts
@@ -1,7 +1,11 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   reportCommitArtefacts,
   reportTaskRunBranch,
+  resolveSandboxPosthogApi,
 } from "./signed-commit-artefacts";
 
 const ENV = {
@@ -12,6 +16,45 @@ const ENV = {
 
 // Point the env-file read at a path that never exists so only `env` is used.
 const NO_ENV_FILE = "/nonexistent/agent-env";
+
+describe("resolveSandboxPosthogApi", () => {
+  it("reads the rotating API key from the dedicated OAuth file", async () => {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "sandbox-posthog-api-"),
+    );
+    const envFilePath = path.join(directory, "agent-env");
+    const oauthEnvFilePath = path.join(directory, "agent-oauth-env");
+
+    try {
+      await writeFile(
+        envFilePath,
+        "POSTHOG_API_URL=https://us.posthog.com\0POSTHOG_PROJECT_ID=7\0",
+      );
+      await writeFile(
+        oauthEnvFilePath,
+        "POSTHOG_PERSONAL_API_KEY=pha_refreshed\0",
+      );
+
+      expect(
+        resolveSandboxPosthogApi({}, envFilePath, oauthEnvFilePath),
+      ).toEqual({
+        apiUrl: "https://us.posthog.com",
+        apiKey: "pha_refreshed",
+        projectId: 7,
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the process environment without credential files", () => {
+    expect(resolveSandboxPosthogApi(ENV, NO_ENV_FILE, NO_ENV_FILE)).toEqual({
+      apiUrl: "https://us.posthog.com",
+      apiKey: "pha_test",
+      projectId: 7,
+    });
+  });
+});
 
 const RESULT = {
   branch: "posthog-code/fix-foo",

--- a/packages/agent/src/signed-commit-artefacts.test.ts
+++ b/packages/agent/src/signed-commit-artefacts.test.ts
@@ -191,6 +191,83 @@ describe("reportCommitArtefacts", () => {
     }
   });
 
+  it("rereads the OAuth file when credentials rotate between requests", async () => {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "sandbox-posthog-api-"),
+    );
+    const oauthEnvFilePath = path.join(directory, "agent-oauth-env");
+    await writeFile(oauthEnvFilePath, "POSTHOG_PERSONAL_API_KEY=pha_initial\0");
+
+    try {
+      fetchMock.mockImplementationOnce(async () => {
+        await writeFile(
+          oauthEnvFilePath,
+          "POSTHOG_PERSONAL_API_KEY=pha_rotated\0",
+        );
+        return jsonResponse({ results: [{ id: "report-1" }] });
+      });
+      fetchMock.mockImplementation(async () =>
+        jsonResponse({ id: "artefact" }),
+      );
+
+      await reportCommitArtefacts({
+        taskId: "task-1",
+        result: { ...RESULT, commits: [RESULT.commits[0]] },
+        message: "fix: foo",
+        env: ENV,
+        envFilePath: NO_ENV_FILE,
+        oauthEnvFilePath,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(
+        (fetchMock.mock.calls[0]?.[1]?.headers as Headers).get("Authorization"),
+      ).toBe("Bearer pha_initial");
+      expect(
+        (fetchMock.mock.calls[1]?.[1]?.headers as Headers).get("Authorization"),
+      ).toBe("Bearer pha_rotated");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("rereads the OAuth file when retrying an auth failure", async () => {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "sandbox-posthog-api-"),
+    );
+    const oauthEnvFilePath = path.join(directory, "agent-oauth-env");
+    await writeFile(oauthEnvFilePath, "POSTHOG_PERSONAL_API_KEY=pha_initial\0");
+
+    try {
+      fetchMock.mockImplementationOnce(async () => {
+        await writeFile(
+          oauthEnvFilePath,
+          "POSTHOG_PERSONAL_API_KEY=pha_rotated\0",
+        );
+        return new Response(null, { status: 401 });
+      });
+      fetchMock.mockImplementationOnce(async () =>
+        jsonResponse({ results: [] }),
+      );
+
+      await reportCommitArtefacts({
+        taskId: "task-1",
+        result: RESULT,
+        message: "fix: foo",
+        env: ENV,
+        envFilePath: NO_ENV_FILE,
+        oauthEnvFilePath,
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(
+        (fetchMock.mock.calls[1]?.[1]?.headers as Headers).get("Authorization"),
+      ).toBe("Bearer pha_rotated");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("is a no-op without a task id", async () => {
     await reportCommitArtefacts({
       taskId: undefined,

--- a/packages/agent/src/signed-commit-artefacts.test.ts
+++ b/packages/agent/src/signed-commit-artefacts.test.ts
@@ -12,10 +12,26 @@ import {
   vi,
 } from "vitest";
 import {
+  parseSandboxEnv,
   reportCommitArtefacts,
   reportTaskRunBranch,
   resolveSandboxPosthogApi,
 } from "./signed-commit-artefacts";
+
+describe("parseSandboxEnv", () => {
+  it("parses NUL-delimited entries into an object", () => {
+    expect(parseSandboxEnv("FIRST=one\0SECOND=two\0")).toEqual({
+      FIRST: "one",
+      SECOND: "two",
+    });
+  });
+
+  it("preserves equals signs in values and ignores malformed entries", () => {
+    expect(
+      parseSandboxEnv("TOKEN=header.payload=signature\0invalid\0=value\0"),
+    ).toEqual({ TOKEN: "header.payload=signature" });
+  });
+});
 
 const ENV = {
   POSTHOG_API_URL: "https://us.posthog.com",

--- a/packages/agent/src/signed-commit-artefacts.test.ts
+++ b/packages/agent/src/signed-commit-artefacts.test.ts
@@ -1,7 +1,16 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import {
   reportCommitArtefacts,
   reportTaskRunBranch,
@@ -16,6 +25,18 @@ const ENV = {
 
 // Point the env-file read at a path that never exists so only `env` is used.
 const NO_ENV_FILE = "/nonexistent/agent-env";
+const TEST_OAUTH_ENV_FILE = path.join(
+  tmpdir(),
+  `posthog-agent-oauth-env-${process.pid}`,
+);
+
+beforeAll(async () => {
+  await writeFile(TEST_OAUTH_ENV_FILE, "POSTHOG_PERSONAL_API_KEY=pha_test\0");
+});
+
+afterAll(async () => {
+  await rm(TEST_OAUTH_ENV_FILE, { force: true });
+});
 
 describe("resolveSandboxPosthogApi", () => {
   it("reads the rotating API key from the dedicated OAuth file", async () => {
@@ -47,12 +68,10 @@ describe("resolveSandboxPosthogApi", () => {
     }
   });
 
-  it("falls back to the process environment without credential files", () => {
-    expect(resolveSandboxPosthogApi(ENV, NO_ENV_FILE, NO_ENV_FILE)).toEqual({
-      apiUrl: "https://us.posthog.com",
-      apiKey: "pha_test",
-      projectId: 7,
-    });
+  it("fails closed without the dedicated OAuth file", () => {
+    expect(
+      resolveSandboxPosthogApi(ENV, NO_ENV_FILE, NO_ENV_FILE),
+    ).toBeUndefined();
   });
 
   it("does not resurrect a stale token when the OAuth file is empty", async () => {
@@ -144,6 +163,7 @@ describe("reportCommitArtefacts", () => {
       message: "fix: foo",
       env: ENV,
       envFilePath: NO_ENV_FILE,
+      oauthEnvFilePath: TEST_OAUTH_ENV_FILE,
     });
 
     const lookupCalls = fetchMock.mock.calls.filter(([url]) =>
@@ -202,6 +222,7 @@ describe("reportCommitArtefacts", () => {
         message: "fix: foo",
         env: ENV,
         envFilePath: NO_ENV_FILE,
+        oauthEnvFilePath: TEST_OAUTH_ENV_FILE,
       }),
     ).resolves.toBeUndefined();
   });
@@ -225,6 +246,7 @@ describe("reportCommitArtefacts", () => {
       message: "fix: foo",
       env: ENV,
       envFilePath: NO_ENV_FILE,
+      oauthEnvFilePath: TEST_OAUTH_ENV_FILE,
     });
 
     // Both commits attempted despite the first failing.
@@ -260,6 +282,7 @@ describe("reportTaskRunBranch", () => {
       branch: "posthog-code/fix-foo",
       env: ENV,
       envFilePath: NO_ENV_FILE,
+      oauthEnvFilePath: TEST_OAUTH_ENV_FILE,
     });
 
     expect(fetchMock).toHaveBeenCalledOnce();

--- a/packages/agent/src/signed-commit-artefacts.test.ts
+++ b/packages/agent/src/signed-commit-artefacts.test.ts
@@ -54,6 +54,48 @@ describe("resolveSandboxPosthogApi", () => {
       projectId: 7,
     });
   });
+
+  it("does not resurrect a stale token when the OAuth file is empty", async () => {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "sandbox-posthog-api-"),
+    );
+    const envFilePath = path.join(directory, "agent-env");
+    const oauthEnvFilePath = path.join(directory, "agent-oauth-env");
+
+    try {
+      await writeFile(
+        envFilePath,
+        "POSTHOG_API_URL=https://us.posthog.com\0POSTHOG_PERSONAL_API_KEY=pha_stale\0POSTHOG_PROJECT_ID=7\0",
+      );
+      await writeFile(oauthEnvFilePath, "");
+
+      expect(
+        resolveSandboxPosthogApi(ENV, envFilePath, oauthEnvFilePath),
+      ).toBeUndefined();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the managed OAuth file is unreadable", async () => {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "sandbox-posthog-api-"),
+    );
+    const envFilePath = path.join(directory, "agent-env");
+
+    try {
+      await writeFile(
+        envFilePath,
+        "POSTHOG_API_URL=https://us.posthog.com\0POSTHOG_PROJECT_ID=7\0",
+      );
+
+      expect(
+        resolveSandboxPosthogApi(ENV, envFilePath, directory),
+      ).toBeUndefined();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
 });
 
 const RESULT = {

--- a/packages/agent/src/signed-commit-artefacts.ts
+++ b/packages/agent/src/signed-commit-artefacts.ts
@@ -42,22 +42,20 @@ function readSandboxEnvFile(envFilePath: string): Record<string, string> {
 }
 
 function readSandboxOauthToken(oauthEnvFilePath: string): string | undefined {
-  let raw: string;
   try {
-    raw = readFileSync(oauthEnvFilePath, "utf8");
+    const raw = readFileSync(oauthEnvFilePath, "utf8");
+    for (const entry of raw.split("\0")) {
+      const prefix = "POSTHOG_PERSONAL_API_KEY=";
+      if (entry.startsWith(prefix)) {
+        return entry.slice(prefix.length);
+      }
+    }
+    return "";
   } catch {
     // The dedicated credential channel is mandatory. Missing and unreadable
     // files both fail closed.
     return undefined;
   }
-
-  // The backend revokes OAuth access by truncating this managed file. Its
-  // presence is authoritative even when empty.
-  if (raw.trim() === "") {
-    return "";
-  }
-  const oauthEnv = readSandboxEnvFile(oauthEnvFilePath);
-  return oauthEnv.POSTHOG_PERSONAL_API_KEY ?? "";
 }
 
 export function resolveSandboxPosthogApi(
@@ -89,7 +87,10 @@ export function createSandboxPosthogClient(
   return new PostHogAPIClient({
     apiUrl: api.apiUrl,
     projectId: api.projectId,
-    getApiKey: () => api.apiKey,
+    getApiKey: () =>
+      readSandboxOauthToken(oauthEnvFilePath ?? SANDBOX_OAUTH_ENV_FILE) ?? "",
+    refreshApiKey: () =>
+      readSandboxOauthToken(oauthEnvFilePath ?? SANDBOX_OAUTH_ENV_FILE) ?? "",
   });
 }
 

--- a/packages/agent/src/signed-commit-artefacts.ts
+++ b/packages/agent/src/signed-commit-artefacts.ts
@@ -45,11 +45,10 @@ function readSandboxOauthToken(oauthEnvFilePath: string): string | undefined {
   let raw: string;
   try {
     raw = readFileSync(oauthEnvFilePath, "utf8");
-  } catch (error) {
-    // Only a missing file means the sandbox predates the dedicated credential
-    // channel. Any other read failure must fail closed instead of resurrecting
-    // the frozen launch-time token.
-    return (error as NodeJS.ErrnoException).code === "ENOENT" ? undefined : "";
+  } catch {
+    // The dedicated credential channel is mandatory. Missing and unreadable
+    // files both fail closed.
+    return undefined;
   }
 
   // The backend revokes OAuth access by truncating this managed file. Its
@@ -69,17 +68,13 @@ export function resolveSandboxPosthogApi(
   const fileEnv = readSandboxEnvFile(envFilePath);
   const oauthToken = readSandboxOauthToken(oauthEnvFilePath);
   const apiUrl = fileEnv.POSTHOG_API_URL ?? env.POSTHOG_API_URL;
-  const apiKey =
-    oauthToken ??
-    fileEnv.POSTHOG_PERSONAL_API_KEY ??
-    env.POSTHOG_PERSONAL_API_KEY;
   const projectId = Number(
     fileEnv.POSTHOG_PROJECT_ID ?? env.POSTHOG_PROJECT_ID,
   );
-  if (!apiUrl || !apiKey || !Number.isFinite(projectId) || projectId <= 0) {
+  if (!apiUrl || !oauthToken || !Number.isFinite(projectId) || projectId <= 0) {
     return undefined;
   }
-  return { apiUrl, apiKey, projectId };
+  return { apiUrl, apiKey: oauthToken, projectId };
 }
 
 export function createSandboxPosthogClient(
@@ -105,13 +100,18 @@ export async function reportCommitArtefacts(opts: {
   message: string;
   env?: Record<string, string | undefined>;
   envFilePath?: string;
+  oauthEnvFilePath?: string;
 }): Promise<void> {
   const { taskId, result, message } = opts;
   if (!taskId) {
     return; // Local/desktop run — no task to attribute or associate through.
   }
   try {
-    const client = createSandboxPosthogClient(opts.env, opts.envFilePath);
+    const client = createSandboxPosthogClient(
+      opts.env,
+      opts.envFilePath,
+      opts.oauthEnvFilePath,
+    );
     if (!client) {
       return; // No sandbox PostHog credentials — nothing to report to.
     }
@@ -146,12 +146,17 @@ export async function reportTaskRunBranch(opts: {
   branch: string;
   env?: Record<string, string | undefined>;
   envFilePath?: string;
+  oauthEnvFilePath?: string;
 }): Promise<void> {
   if (!opts.taskId || !opts.taskRunId) {
     return;
   }
   try {
-    const client = createSandboxPosthogClient(opts.env, opts.envFilePath);
+    const client = createSandboxPosthogClient(
+      opts.env,
+      opts.envFilePath,
+      opts.oauthEnvFilePath,
+    );
     if (!client) {
       return;
     }

--- a/packages/agent/src/signed-commit-artefacts.ts
+++ b/packages/agent/src/signed-commit-artefacts.ts
@@ -24,17 +24,20 @@ interface SandboxPosthogApi {
   projectId: number;
 }
 
+export function parseSandboxEnv(raw: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const entry of raw.split("\0")) {
+    const separator = entry.indexOf("=");
+    if (separator > 0) {
+      env[entry.slice(0, separator)] = entry.slice(separator + 1);
+    }
+  }
+  return env;
+}
+
 function readSandboxEnvFile(envFilePath: string): Record<string, string> {
   try {
-    const raw = readFileSync(envFilePath, "utf8");
-    const env: Record<string, string> = {};
-    for (const entry of raw.split("\0")) {
-      const eq = entry.indexOf("=");
-      if (eq > 0) {
-        env[entry.slice(0, eq)] = entry.slice(eq + 1);
-      }
-    }
-    return env;
+    return parseSandboxEnv(readFileSync(envFilePath, "utf8"));
   } catch {
     // No env file (local/desktop or test) — fall back to the process env only.
     return {};
@@ -44,13 +47,7 @@ function readSandboxEnvFile(envFilePath: string): Record<string, string> {
 function readSandboxOauthToken(oauthEnvFilePath: string): string | undefined {
   try {
     const raw = readFileSync(oauthEnvFilePath, "utf8");
-    for (const entry of raw.split("\0")) {
-      const prefix = "POSTHOG_PERSONAL_API_KEY=";
-      if (entry.startsWith(prefix)) {
-        return entry.slice(prefix.length);
-      }
-    }
-    return "";
+    return parseSandboxEnv(raw).POSTHOG_PERSONAL_API_KEY ?? "";
   } catch {
     // The dedicated credential channel is mandatory. Missing and unreadable
     // files both fail closed.

--- a/packages/agent/src/signed-commit-artefacts.ts
+++ b/packages/agent/src/signed-commit-artefacts.ts
@@ -3,6 +3,7 @@ import type { SignedCommitResult } from "@posthog/git/signed-commit";
 import { PostHogAPIClient } from "./posthog-api";
 
 const SANDBOX_ENV_FILE = "/tmp/agent-env";
+const SANDBOX_OAUTH_ENV_FILE = "/tmp/agent-oauth-env";
 
 /**
  * Best-effort "commit hook": after a successful signed-commit push, record one `commit`
@@ -11,11 +12,10 @@ const SANDBOX_ENV_FILE = "/tmp/agent-env";
  * endpoint reads the `X-PostHog-Task-Id` header, never the model.
  *
  * Credentials come from the sandbox environment (`POSTHOG_API_URL` /
- * `POSTHOG_PERSONAL_API_KEY` / `POSTHOG_PROJECT_ID`), preferring the live agentsh env file
- * for the key so a mid-session token refresh is picked up — the same pattern as
- * `resolveGithubToken`. Works identically from the Claude in-process server and the Codex
- * stdio child (both inherit the sandbox env). Never throws: a failed artefact post must not
- * fail the commit that already landed.
+ * `POSTHOG_PERSONAL_API_KEY` / `POSTHOG_PROJECT_ID`), preferring the dedicated live agentsh
+ * OAuth file for the key so a mid-session token refresh is picked up — the same pattern as
+ * `resolveGithubToken`. Never throws: a failed artefact post must not fail the commit that
+ * already landed.
  */
 
 interface SandboxPosthogApi {
@@ -44,11 +44,15 @@ function readSandboxEnvFile(envFilePath: string): Record<string, string> {
 export function resolveSandboxPosthogApi(
   env: Record<string, string | undefined> = process.env,
   envFilePath: string = SANDBOX_ENV_FILE,
+  oauthEnvFilePath: string = SANDBOX_OAUTH_ENV_FILE,
 ): SandboxPosthogApi | undefined {
   const fileEnv = readSandboxEnvFile(envFilePath);
+  const oauthFileEnv = readSandboxEnvFile(oauthEnvFilePath);
   const apiUrl = fileEnv.POSTHOG_API_URL ?? env.POSTHOG_API_URL;
   const apiKey =
-    fileEnv.POSTHOG_PERSONAL_API_KEY ?? env.POSTHOG_PERSONAL_API_KEY;
+    oauthFileEnv.POSTHOG_PERSONAL_API_KEY ??
+    fileEnv.POSTHOG_PERSONAL_API_KEY ??
+    env.POSTHOG_PERSONAL_API_KEY;
   const projectId = Number(
     fileEnv.POSTHOG_PROJECT_ID ?? env.POSTHOG_PROJECT_ID,
   );
@@ -61,8 +65,9 @@ export function resolveSandboxPosthogApi(
 export function createSandboxPosthogClient(
   env?: Record<string, string | undefined>,
   envFilePath?: string,
+  oauthEnvFilePath?: string,
 ): PostHogAPIClient | undefined {
-  const api = resolveSandboxPosthogApi(env, envFilePath);
+  const api = resolveSandboxPosthogApi(env, envFilePath, oauthEnvFilePath);
   if (!api) {
     return undefined;
   }

--- a/packages/agent/src/signed-commit-artefacts.ts
+++ b/packages/agent/src/signed-commit-artefacts.ts
@@ -41,16 +41,36 @@ function readSandboxEnvFile(envFilePath: string): Record<string, string> {
   }
 }
 
+function readSandboxOauthToken(oauthEnvFilePath: string): string | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(oauthEnvFilePath, "utf8");
+  } catch (error) {
+    // Only a missing file means the sandbox predates the dedicated credential
+    // channel. Any other read failure must fail closed instead of resurrecting
+    // the frozen launch-time token.
+    return (error as NodeJS.ErrnoException).code === "ENOENT" ? undefined : "";
+  }
+
+  // The backend revokes OAuth access by truncating this managed file. Its
+  // presence is authoritative even when empty.
+  if (raw.trim() === "") {
+    return "";
+  }
+  const oauthEnv = readSandboxEnvFile(oauthEnvFilePath);
+  return oauthEnv.POSTHOG_PERSONAL_API_KEY ?? "";
+}
+
 export function resolveSandboxPosthogApi(
   env: Record<string, string | undefined> = process.env,
   envFilePath: string = SANDBOX_ENV_FILE,
   oauthEnvFilePath: string = SANDBOX_OAUTH_ENV_FILE,
 ): SandboxPosthogApi | undefined {
   const fileEnv = readSandboxEnvFile(envFilePath);
-  const oauthFileEnv = readSandboxEnvFile(oauthEnvFilePath);
+  const oauthToken = readSandboxOauthToken(oauthEnvFilePath);
   const apiUrl = fileEnv.POSTHOG_API_URL ?? env.POSTHOG_API_URL;
   const apiKey =
-    oauthFileEnv.POSTHOG_PERSONAL_API_KEY ??
+    oauthToken ??
     fileEnv.POSTHOG_PERSONAL_API_KEY ??
     env.POSTHOG_PERSONAL_API_KEY;
   const projectId = Number(


### PR DESCRIPTION
## Problem

Cloud artifact uploads can report that storage is not configured before making any API or object-storage request. The sandbox credential refresh work in [PostHog/posthog#72540](https://github.com/PostHog/posthog/pull/72540) deliberately separated rotating credentials from general `/tmp/agent-env` metadata:

- GitHub credentials live in `/tmp/agent-github-env`
- the PostHog OAuth credential lives in `/tmp/agent-oauth-env`
- an existing but empty credential file is an explicit logout/revocation

The shared PostHog API client resolver still looked for `POSTHOG_PERSONAL_API_KEY` in `/tmp/agent-env` or the process-start environment. That misses refreshed credentials in Codex local-tool processes and could resurrect a stale process token after revocation.

Codex exposed the missing-key path after [#3844](https://github.com/PostHog/code/pull/3844) restored the task run ID passed to its local-tools process: calls then advanced to the storage-configuration guard because no PostHog API client could be constructed.

**Why:** Agent-created reports and other non-code deliverables need the current managed sandbox identity to prepare and finalize durable task artifact uploads. Credential refresh and revocation must both take effect without restarting the agent.

## Changes

- Read the rotating personal API key exclusively from `/tmp/agent-oauth-env`
- Resolve the key from one file snapshot for every request and authentication retry
- Require the managed OAuth credential file; missing, empty, or unreadable files all fail closed
- Keep non-secret API URL and project metadata resolution unchanged
- Share one tested NUL-delimited environment parser across metadata and credential files
- Add regression coverage for rotation between requests, authenticated retries, explicit revocation, and invalid managed files

## How did you test this?

- `pnpm --filter @posthog/agent exec vitest run src/signed-commit-artefacts.test.ts src/posthog-api.test.ts` (19 tests)
- `pnpm --filter @posthog/agent typecheck`
- `pnpm exec biome check packages/agent/src/signed-commit-artefacts.ts packages/agent/src/signed-commit-artefacts.test.ts`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
