### PR TITLE
chore(ci): raise stale bot operations-per-run cap

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
+          operations-per-run: 300
           days-before-pr-stale: 7
           days-before-pr-close: 7
           days-before-issue-stale: -1


### PR DESCRIPTION
## Problem

The stale workflow uses the actions/stale default of 30 operations per run. With ~120 open PRs it exhausts the budget on freshly-eligible PRs every run ("No more operations left! Exiting...") and never reaches long-idle ones like #2307, so they are never marked stale.

## Changes

Set `operations-per-run: 300` so each run can sweep the full PR backlog.

## How did you test this?

Confirmed the cap in the 2026-07-28 run log (31 operations, then early exit). Config-only change, next scheduled run exercises it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?