### PR TITLE
fix(mobile): surface attachment problems in the composer (port #3838)

### DIFF
--- a/apps/mobile/src/app/task/index.tsx
+++ b/apps/mobile/src/app/task/index.tsx
@@ -15,9 +15,10 @@ import {
   Sparkle,
   StopIcon,
 } from "phosphor-react-native";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   Pressable,
   ScrollView,
   TextInput,
@@ -43,6 +44,7 @@ import {
   pickPhotoFromLibrary,
 } from "@/features/tasks/composer/attachments/pickers";
 import type { PendingAttachment } from "@/features/tasks/composer/attachments/types";
+import { validateAttachment } from "@/features/tasks/composer/attachments/validation";
 import { DotBackground } from "@/features/tasks/composer/DotBackground";
 import {
   DEFAULT_EXECUTION_MODE,
@@ -205,6 +207,19 @@ export default function NewTaskScreen() {
   const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
   const [attachmentSheetOpen, setAttachmentSheetOpen] = useState(false);
 
+  // Errors are a pure function of the picked attachments, so derive rather
+  // than mirror them in state.
+  const attachmentErrors = useMemo(
+    () =>
+      Object.fromEntries(
+        attachments.flatMap((att) => {
+          const reason = validateAttachment(att);
+          return reason ? [[att.id, reason]] : [];
+        }),
+      ),
+    [attachments],
+  );
+
   const appendTranscript = useCallback((transcript: string) => {
     setPrompt((prev) => (prev ? `${prev} ${transcript}` : transcript));
   }, []);
@@ -236,7 +251,10 @@ export default function NewTaskScreen() {
     async (picker: () => Promise<PendingAttachment | null>) => {
       try {
         const att = await picker();
-        if (att) setAttachments((prev) => [...prev, att]);
+        if (!att) return;
+        setAttachments((prev) => [...prev, att]);
+        const reason = validateAttachment(att);
+        if (reason) Alert.alert("Attachment problem", reason);
       } catch (err) {
         log.error("Failed to pick attachment", err);
       }
@@ -265,6 +283,13 @@ export default function NewTaskScreen() {
   const handleCreateTask = useCallback(async () => {
     const hasContent = !!prompt.trim() || attachments.length > 0;
     if (!hasContent || !isRepositorySelectionComplete(selection) || creating) {
+      return;
+    }
+    if (attachments.some((att) => validateAttachment(att))) {
+      Alert.alert(
+        "Attachment can't be sent",
+        "Remove the highlighted attachment before sending.",
+      );
       return;
     }
 
@@ -560,6 +585,7 @@ export default function NewTaskScreen() {
               <AttachmentsBar
                 attachments={attachments}
                 onRemove={removeAttachment}
+                errors={attachmentErrors}
               />
               <TextInput
                 className="px-4 pt-3.5 pb-3 text-[15px] text-gray-12"

--- a/apps/mobile/src/features/tasks/composer/TaskChatComposer.tsx
+++ b/apps/mobile/src/features/tasks/composer/TaskChatComposer.tsx
@@ -18,11 +18,13 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 import {
   ActivityIndicator,
+  Alert,
   Animated,
   Easing,
   Keyboard,
@@ -43,6 +45,7 @@ import {
   pickPhotoFromLibrary,
 } from "./attachments/pickers";
 import type { PendingAttachment } from "./attachments/types";
+import { validateAttachment } from "./attachments/validation";
 import {
   DEFAULT_EXECUTION_MODE,
   DEFAULT_MODEL,
@@ -187,6 +190,19 @@ export function TaskChatComposer({
   const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
   const [attachmentSheetOpen, setAttachmentSheetOpen] = useState(false);
 
+  // Errors are a pure function of the picked attachments, so derive rather
+  // than mirror them in state.
+  const attachmentErrors = useMemo(
+    () =>
+      Object.fromEntries(
+        attachments.flatMap((att) => {
+          const reason = validateAttachment(att);
+          return reason ? [[att.id, reason]] : [];
+        }),
+      ),
+    [attachments],
+  );
+
   // Mirror composer state into refs so a failed send can read the current
   // value after awaiting, rather than the value captured when it was sent.
   const messageRef = useRef(message);
@@ -234,6 +250,13 @@ export function TaskChatComposer({
 
   const handleSend = () => {
     if (!hasContent || disabled) return;
+    if (attachments.some((att) => validateAttachment(att))) {
+      Alert.alert(
+        "Attachment can't be sent",
+        "Remove the highlighted attachment before sending.",
+      );
+      return;
+    }
     const submitted: ComposerContent = { text: message.trim(), attachments };
     const submissionId = ++submissionRef.current;
     Keyboard.dismiss();
@@ -256,7 +279,10 @@ export function TaskChatComposer({
   ) => {
     try {
       const att = await picker();
-      if (att) setAttachments((prev) => [...prev, att]);
+      if (!att) return;
+      setAttachments((prev) => [...prev, att]);
+      const reason = validateAttachment(att);
+      if (reason) Alert.alert("Attachment problem", reason);
     } catch (err) {
       log.error("Failed to pick attachment", err);
     }
@@ -325,6 +351,7 @@ export function TaskChatComposer({
             <AttachmentsBar
               attachments={attachments}
               onRemove={removeAttachment}
+              errors={attachmentErrors}
             />
             <TextInput
               className="px-4 pt-3.5 pb-3 text-[15px] text-gray-12"

--- a/apps/mobile/src/features/tasks/composer/attachments/AttachmentsBar.tsx
+++ b/apps/mobile/src/features/tasks/composer/attachments/AttachmentsBar.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@components/text";
-import { FileText, X } from "phosphor-react-native";
+import { FileText, WarningCircle, X } from "phosphor-react-native";
 import { Image, Pressable, ScrollView, View } from "react-native";
 import { useThemeColors } from "@/lib/theme";
 import type { PendingAttachment } from "./types";
@@ -7,6 +7,8 @@ import type { PendingAttachment } from "./types";
 interface AttachmentsBarProps {
   attachments: PendingAttachment[];
   onRemove: (id: string) => void;
+  /** Reason keyed by attachment id when it failed pick-time validation. */
+  errors?: Record<string, string>;
 }
 
 function truncate(name: string, max = 18): string {
@@ -18,7 +20,11 @@ function truncate(name: string, max = 18): string {
   return `${name.slice(0, max - 1)}…`;
 }
 
-export function AttachmentsBar({ attachments, onRemove }: AttachmentsBarProps) {
+export function AttachmentsBar({
+  attachments,
+  onRemove,
+  errors,
+}: AttachmentsBarProps) {
   const themeColors = useThemeColors();
   if (attachments.length === 0) return null;
 
@@ -33,43 +39,60 @@ export function AttachmentsBar({ attachments, onRemove }: AttachmentsBarProps) {
         gap: 8,
       }}
     >
-      {attachments.map((att) => (
-        <View
-          key={att.id}
-          className="relative h-16 rounded-lg border border-gray-6 bg-gray-2"
-          style={{ minWidth: 64 }}
-        >
-          {att.kind === "image" ? (
-            <Image
-              source={{ uri: att.uri }}
-              className="h-16 w-16 rounded-lg"
-              resizeMode="cover"
-            />
-          ) : (
-            <View className="h-16 w-32 flex-row items-center gap-2 px-2">
-              <FileText
-                size={20}
-                color={themeColors.gray[11]}
-                weight="regular"
-              />
-              <Text
-                className="flex-1 text-[12px] text-gray-12"
-                numberOfLines={2}
-              >
-                {truncate(att.fileName, 22)}
-              </Text>
-            </View>
-          )}
-          <Pressable
-            onPress={() => onRemove(att.id)}
-            hitSlop={8}
-            accessibilityLabel={`Remove ${att.fileName}`}
-            className="-top-1.5 -right-1.5 absolute h-5 w-5 items-center justify-center rounded-full bg-gray-12 active:opacity-80"
+      {attachments.map((att) => {
+        const error = errors?.[att.id];
+        return (
+          <View
+            key={att.id}
+            className={`relative h-16 rounded-lg border bg-gray-2 ${
+              error ? "border-status-error" : "border-gray-6"
+            }`}
+            style={{ minWidth: 64 }}
           >
-            <X size={12} color={themeColors.background} weight="bold" />
-          </Pressable>
-        </View>
-      ))}
+            {att.kind === "image" ? (
+              <Image
+                source={{ uri: att.uri }}
+                className="h-16 w-16 rounded-lg"
+                resizeMode="cover"
+              />
+            ) : (
+              <View className="h-16 w-32 flex-row items-center gap-2 px-2">
+                <FileText
+                  size={20}
+                  color={themeColors.gray[11]}
+                  weight="regular"
+                />
+                <Text
+                  className="flex-1 text-[12px] text-gray-12"
+                  numberOfLines={2}
+                >
+                  {truncate(att.fileName, 22)}
+                </Text>
+              </View>
+            )}
+            {error ? (
+              <View
+                accessibilityLabel={`Attachment can't be sent: ${error}`}
+                className="absolute inset-0 items-center justify-center rounded-lg bg-black/40"
+              >
+                <WarningCircle
+                  size={20}
+                  color={themeColors.status.error}
+                  weight="fill"
+                />
+              </View>
+            ) : null}
+            <Pressable
+              onPress={() => onRemove(att.id)}
+              hitSlop={8}
+              accessibilityLabel={`Remove ${att.fileName}`}
+              className="-top-1.5 -right-1.5 absolute h-5 w-5 items-center justify-center rounded-full bg-gray-12 active:opacity-80"
+            >
+              <X size={12} color={themeColors.background} weight="bold" />
+            </Pressable>
+          </View>
+        );
+      })}
     </ScrollView>
   );
 }

--- a/apps/mobile/src/features/tasks/composer/attachments/buildCloudPrompt.ts
+++ b/apps/mobile/src/features/tasks/composer/attachments/buildCloudPrompt.ts
@@ -1,73 +1,16 @@
+import {
+  estimateBase64Bytes,
+  getFileExtension,
+  MAX_CLAUDE_IMAGE_BYTES,
+} from "@posthog/shared";
 import * as FileSystem from "expo-file-system/legacy";
 import type { CloudPromptBlock, PendingAttachment } from "./types";
+import { isTextAttachment } from "./validation";
 
 const MAX_EMBEDDED_TEXT_CHARS = 100_000;
-const MAX_EMBEDDED_IMAGE_BYTES = 5 * 1024 * 1024;
-
-const TEXT_MIME_PREFIXES = ["text/"];
-const TEXT_MIME_TYPES = new Set([
-  "application/json",
-  "application/xml",
-  "application/javascript",
-  "application/typescript",
-  "application/x-sh",
-  "application/x-yaml",
-  "application/x-toml",
-]);
-const TEXT_EXTENSIONS = new Set([
-  "c",
-  "cc",
-  "cfg",
-  "conf",
-  "cpp",
-  "cs",
-  "css",
-  "csv",
-  "env",
-  "gitignore",
-  "go",
-  "h",
-  "hpp",
-  "html",
-  "ini",
-  "java",
-  "js",
-  "json",
-  "jsx",
-  "log",
-  "md",
-  "mjs",
-  "py",
-  "rb",
-  "rs",
-  "scss",
-  "sh",
-  "sql",
-  "svg",
-  "toml",
-  "ts",
-  "tsx",
-  "txt",
-  "xml",
-  "yaml",
-  "yml",
-  "zsh",
-]);
-
-function getExt(fileName: string): string {
-  const dot = fileName.lastIndexOf(".");
-  return dot >= 0 ? fileName.slice(dot + 1).toLowerCase() : "";
-}
-
-function isTextAttachment(mimeType: string, fileName: string): boolean {
-  const mt = mimeType.toLowerCase();
-  if (TEXT_MIME_PREFIXES.some((p) => mt.startsWith(p))) return true;
-  if (TEXT_MIME_TYPES.has(mt)) return true;
-  return TEXT_EXTENSIONS.has(getExt(fileName));
-}
 
 function getTextMimeType(fileName: string, fallback: string): string {
-  const ext = getExt(fileName);
+  const ext = getFileExtension(fileName);
   switch (ext) {
     case "json":
       return "application/json";
@@ -87,17 +30,12 @@ function truncateText(text: string): string {
   return `${text.slice(0, MAX_EMBEDDED_TEXT_CHARS)}\n\n[Attachment truncated to ${MAX_EMBEDDED_TEXT_CHARS.toLocaleString()} characters for this cloud prompt.]`;
 }
 
-function estimateBase64Bytes(base64: string): number {
-  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
-  return Math.floor((base64.length * 3) / 4) - padding;
-}
-
 async function buildBlock(att: PendingAttachment): Promise<CloudPromptBlock> {
   if (att.kind === "image") {
     const base64 = await FileSystem.readAsStringAsync(att.uri, {
       encoding: FileSystem.EncodingType.Base64,
     });
-    if (estimateBase64Bytes(base64) > MAX_EMBEDDED_IMAGE_BYTES) {
+    if (estimateBase64Bytes(base64) > MAX_CLAUDE_IMAGE_BYTES) {
       throw new Error(
         `${att.fileName} is too large for a cloud image attachment (max 5 MB).`,
       );

--- a/apps/mobile/src/features/tasks/composer/attachments/validation.test.ts
+++ b/apps/mobile/src/features/tasks/composer/attachments/validation.test.ts
@@ -1,0 +1,78 @@
+import { MAX_CLAUDE_IMAGE_BYTES } from "@posthog/shared";
+import { describe, expect, it } from "vitest";
+import type { PendingAttachment } from "./types";
+import { validateAttachment } from "./validation";
+
+function attachment(overrides: Partial<PendingAttachment>): PendingAttachment {
+  return {
+    kind: "document",
+    id: "a1",
+    uri: "file://x",
+    fileName: "notes.txt",
+    mimeType: "text/plain",
+    ...overrides,
+  } as PendingAttachment;
+}
+
+describe("validateAttachment", () => {
+  it.each([
+    {
+      name: "oversized image is rejected",
+      att: attachment({
+        kind: "image",
+        fileName: "huge.png",
+        mimeType: "image/png",
+        sizeBytes: MAX_CLAUDE_IMAGE_BYTES + 1,
+      }),
+      valid: false,
+    },
+    {
+      name: "supported image within the size limit is accepted",
+      att: attachment({
+        kind: "image",
+        fileName: "photo.jpg",
+        mimeType: "image/jpeg",
+        sizeBytes: 1024,
+      }),
+      valid: true,
+    },
+    {
+      name: "image with unknown size is accepted (checked again at send)",
+      att: attachment({
+        kind: "image",
+        fileName: "photo.jpg",
+        mimeType: "image/jpeg",
+        sizeBytes: undefined,
+      }),
+      valid: true,
+    },
+    {
+      name: "unsupported binary document is rejected",
+      att: attachment({
+        fileName: "archive.zip",
+        mimeType: "application/zip",
+      }),
+      valid: false,
+    },
+    {
+      name: "text document is accepted by mime type",
+      att: attachment({ fileName: "data", mimeType: "text/csv" }),
+      valid: true,
+    },
+    {
+      name: "code document is accepted by extension",
+      att: attachment({
+        fileName: "main.ts",
+        mimeType: "application/octet-stream",
+      }),
+      valid: true,
+    },
+  ])("$name", ({ att, valid }) => {
+    const reason = validateAttachment(att);
+    if (valid) {
+      expect(reason).toBeNull();
+    } else {
+      expect(reason).toContain(att.fileName);
+    }
+  });
+});

--- a/apps/mobile/src/features/tasks/composer/attachments/validation.ts
+++ b/apps/mobile/src/features/tasks/composer/attachments/validation.ts
@@ -1,0 +1,78 @@
+import { getFileExtension, MAX_CLAUDE_IMAGE_BYTES } from "@posthog/shared";
+import type { PendingAttachment } from "./types";
+
+const TEXT_MIME_PREFIXES = ["text/"];
+const TEXT_MIME_TYPES = new Set([
+  "application/json",
+  "application/xml",
+  "application/javascript",
+  "application/typescript",
+  "application/x-sh",
+  "application/x-yaml",
+  "application/x-toml",
+]);
+const TEXT_EXTENSIONS = new Set([
+  "c",
+  "cc",
+  "cfg",
+  "conf",
+  "cpp",
+  "cs",
+  "css",
+  "csv",
+  "env",
+  "gitignore",
+  "go",
+  "h",
+  "hpp",
+  "html",
+  "ini",
+  "java",
+  "js",
+  "json",
+  "jsx",
+  "log",
+  "md",
+  "mjs",
+  "py",
+  "rb",
+  "rs",
+  "scss",
+  "sh",
+  "sql",
+  "svg",
+  "toml",
+  "ts",
+  "tsx",
+  "txt",
+  "xml",
+  "yaml",
+  "yml",
+  "zsh",
+]);
+
+export function isTextAttachment(mimeType: string, fileName: string): boolean {
+  const mt = mimeType.toLowerCase();
+  if (TEXT_MIME_PREFIXES.some((p) => mt.startsWith(p))) return true;
+  if (TEXT_MIME_TYPES.has(mt)) return true;
+  return TEXT_EXTENSIONS.has(getFileExtension(fileName));
+}
+
+/**
+ * Cheap pick-time check for problems that would otherwise only surface when
+ * `buildCloudPromptBlocks` reads the bytes at send-time. Uses the size and
+ * mime/extension the picker already returns, so it never reads the file.
+ * Returns a human-readable reason, or `null` when the attachment is usable.
+ */
+export function validateAttachment(att: PendingAttachment): string | null {
+  if (att.kind === "image") {
+    if (att.sizeBytes != null && att.sizeBytes > MAX_CLAUDE_IMAGE_BYTES) {
+      return `${att.fileName} is too large to attach (max 5 MB).`;
+    }
+    return null;
+  }
+  if (!isTextAttachment(att.mimeType, att.fileName)) {
+    return `${att.fileName} isn't supported. Cloud attachments only support text and image files.`;
+  }
+  return null;
+}


### PR DESCRIPTION
## Problem

Porting desktop PR [#3838](https://github.com/PostHog/code/pull/3838) (`fix(sessions): upload cloud attachments before sending`) to the mobile app.

On mobile, attachment problems were only discovered at **send** time: `buildCloudPromptBlocks` reads each file lazily and throws if an image's base64 exceeds 5 MB or a document isn't text-readable. So you could add a file, write a prompt, tap send, and only then learn the attachment was unusable — with a generic failure.

**Why:** surface attachment problems the moment a file is picked, so the user finds out immediately and can fix it before composing, matching the desktop change.

## Changes

Mobile's attachment pipeline is deliberately different from desktop's: it does **not** upload run artifacts from the composer — it embeds attachments as base64/text blocks in the cloud prompt at send time, reading bytes lazily so it never holds large base64 in memory. This PR keeps that constraint and ports only the portable, valuable part of #3838: *stop discovering problems at send time, and show per-attachment state in the bar.*

- **Validate at pick time** (`attachments/validation.ts`, new). A cheap, byte-free `validateAttachment` runs right after the picker returns, using the `sizeBytes` + mime/extension the picker already provides — an oversized image or a non-text document is flagged without ever reading the file. The send-time checks in `buildCloudPromptBlocks` stay as a backstop (they read the real bytes, which the picker's size only approximates).
- **Per-attachment status in `AttachmentsBar`.** A failed attachment gets a red border + warning-icon overlay with an accessibility label carrying the reason, and stays removable. The reason is also surfaced inline via an alert at pick time (the pattern already used in `pickers.ts`).
- **Block sending known-bad attachments.** Both composer entry points (new-task screen and the task-detail `TaskChatComposer`) refuse to send while any attachment fails validation, with a clear message, instead of throwing deep inside `buildCloudPromptBlocks`.
- Shared the validation constants/helpers between the new pick-time check and the existing send-time backstop, and reused `@posthog/shared`'s `MAX_CLAUDE_IMAGE_BYTES`, `getFileExtension`, and `estimateBase64Bytes` rather than keeping mobile-local copies.

Two pieces of #3838 have no sensible mobile analogue and were intentionally skipped:
- **Eager upload/preparation on add.** Desktop prepares (uploads) attachments to the cloud run as soon as they're added. Mobile reads bytes lazily at send time by design to avoid holding large base64 in memory, so there's no async "uploading" state — the only per-attachment status that applies is "error". Validation at pick time is synchronous and cheap.
- **Optimistic-message rollback.** Mobile already restores the composer on a failed send (PR #3787); verified, no gap to fill.

## How did you test this?

- Added `attachments/validation.test.ts` — parameterised (`it.each`) over the validation matrix: oversized image, supported image, image with unknown size, unsupported binary document, text-by-mime, code-by-extension.
- `pnpm --filter @posthog/mobile test` — full mobile suite, 539 tests pass.
- `tsc --noEmit` on the changed files — clean.
- `biome check` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
