### PR TITLE
feat(mobile): preview generated task artifacts (port #3837)

### DIFF
--- a/apps/mobile/src/app/task/[id].tsx
+++ b/apps/mobile/src/app/task/[id].tsx
@@ -795,6 +795,7 @@ export default function TaskDetailScreen() {
         <TaskSessionView
           events={session?.events ?? []}
           taskId={taskId}
+          runId={task?.latest_run?.id}
           pendingPermissions={session?.pendingPermissions}
           isConnecting={isConnecting}
           isThinking={isThinking}

--- a/apps/mobile/src/features/chat/components/MarkdownImage.test.tsx
+++ b/apps/mobile/src/features/chat/components/MarkdownImage.test.tsx
@@ -1,0 +1,72 @@
+import { createElement } from "react";
+import { Image } from "react-native";
+import { act, create } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { openExternalUrl } from "@/lib/openExternalUrl";
+import { MarkdownImage } from "./MarkdownImage";
+
+vi.mock("@/lib/openExternalUrl", () => ({ openExternalUrl: vi.fn() }));
+
+vi.mock("@/lib/theme", () => ({
+  useThemeColors: () => ({ gray: { 9: "#777", 11: "#555" } }),
+}));
+
+vi.mock("phosphor-react-native", () => ({
+  ArrowSquareOut: (props: Record<string, unknown>) =>
+    createElement("ArrowSquareOut", props),
+  ImageBroken: (props: Record<string, unknown>) =>
+    createElement("ImageBroken", props),
+}));
+
+function render(props: {
+  url: string;
+  alt?: string;
+  disableRemoteImages?: boolean;
+}) {
+  let renderer: ReturnType<typeof create> | null = null;
+  act(() => {
+    renderer = create(createElement(MarkdownImage, props));
+  });
+  if (!renderer) throw new Error("Renderer not created");
+  return renderer as ReturnType<typeof create>;
+}
+
+describe("MarkdownImage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches image size for remote images by default", () => {
+    const getSize = vi.spyOn(Image, "getSize").mockImplementation(() => {});
+    render({ url: "http://127.0.0.1/secret", alt: "x" });
+    expect(getSize).toHaveBeenCalledWith(
+      "http://127.0.0.1/secret",
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+
+  it("does not fetch remote images when disableRemoteImages is set", () => {
+    const getSize = vi.spyOn(Image, "getSize").mockImplementation(() => {});
+    const tree = JSON.stringify(
+      render({
+        url: "http://127.0.0.1/secret",
+        alt: "sneaky",
+        disableRemoteImages: true,
+      }).toJSON(),
+    );
+    expect(getSize).not.toHaveBeenCalled();
+    // Renders a tap-to-open placeholder that shows the alt text.
+    expect(tree).toContain("sneaky");
+    expect(openExternalUrl).not.toHaveBeenCalled();
+  });
+
+  it("still fetches non-remote images even when disableRemoteImages is set", () => {
+    const getSize = vi.spyOn(Image, "getSize").mockImplementation(() => {});
+    render({
+      url: "data:image/png;base64,AAAA",
+      disableRemoteImages: true,
+    });
+    expect(getSize).toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/features/chat/components/MarkdownImage.tsx
+++ b/apps/mobile/src/features/chat/components/MarkdownImage.tsx
@@ -1,4 +1,4 @@
-import { ImageBroken } from "phosphor-react-native";
+import { ArrowSquareOut, ImageBroken } from "phosphor-react-native";
 import { useEffect, useState } from "react";
 import { ActivityIndicator, Image, Pressable, Text, View } from "react-native";
 import { openExternalUrl } from "@/lib/openExternalUrl";
@@ -7,6 +7,12 @@ import { useThemeColors } from "@/lib/theme";
 interface MarkdownImageProps {
   url: string;
   alt?: string;
+  // When true, remote (http/https) images are not fetched automatically.
+  // Untrusted content (e.g. a generated artifact) could otherwise make the
+  // device issue requests to arbitrary Internet or local-network URLs just by
+  // being previewed. Instead we render a placeholder that only opens the image
+  // externally on an explicit user tap.
+  disableRemoteImages?: boolean;
 }
 
 type LoadState =
@@ -16,11 +22,21 @@ type LoadState =
 
 const MAX_HEIGHT = 320;
 
-export function MarkdownImage({ url, alt }: MarkdownImageProps) {
+function isRemoteUrl(url: string): boolean {
+  return url.startsWith("http://") || url.startsWith("https://");
+}
+
+export function MarkdownImage({
+  url,
+  alt,
+  disableRemoteImages,
+}: MarkdownImageProps) {
   const themeColors = useThemeColors();
+  const deferred = Boolean(disableRemoteImages) && isRemoteUrl(url);
   const [state, setState] = useState<LoadState>({ status: "loading" });
 
   useEffect(() => {
+    if (deferred) return;
     let cancelled = false;
     setState({ status: "loading" });
     Image.getSize(
@@ -38,7 +54,23 @@ export function MarkdownImage({ url, alt }: MarkdownImageProps) {
     return () => {
       cancelled = true;
     };
-  }, [url]);
+  }, [url, deferred]);
+
+  if (deferred) {
+    return (
+      <Pressable
+        onPress={() => openExternalUrl(url)}
+        accessibilityRole="button"
+        accessibilityLabel={alt ? `Open image: ${alt}` : "Open image"}
+        className="flex-row items-center gap-2 rounded-md border border-gray-6 bg-gray-2 px-3 py-2 active:opacity-70"
+      >
+        <ArrowSquareOut size={16} color={themeColors.gray[9]} />
+        <Text className="flex-1 text-[12px] text-gray-11" numberOfLines={1}>
+          {alt || "Tap to open image"}
+        </Text>
+      </Pressable>
+    );
+  }
 
   if (state.status === "error") {
     return (

--- a/apps/mobile/src/features/chat/components/MarkdownText.tsx
+++ b/apps/mobile/src/features/chat/components/MarkdownText.tsx
@@ -18,6 +18,11 @@ const BARE_POSTHOG_REF_PATTERN =
 
 interface MarkdownTextProps {
   content: string;
+  // When true, remote images embedded in the markdown are not fetched
+  // automatically. Set this for untrusted content (e.g. generated artifact
+  // previews) so opening the preview can't make the device issue requests to
+  // arbitrary URLs; images render as a tap-to-open placeholder instead.
+  disableRemoteImages?: boolean;
 }
 
 function HighlightedCode({
@@ -419,7 +424,10 @@ function renderInline(
   return nodes.length > 0 ? nodes : [text];
 }
 
-export function MarkdownText({ content }: MarkdownTextProps) {
+export function MarkdownText({
+  content,
+  disableRemoteImages,
+}: MarkdownTextProps) {
   const blocks = parseBlocks(content);
   const cloudRegion = useAuthStore((state) => state.cloudRegion);
   const posthogUrlOptions = useMemo<ParsePostHogUrlOptions>(
@@ -612,7 +620,12 @@ export function MarkdownText({ content }: MarkdownTextProps) {
 
           case "image":
             return block.url ? (
-              <MarkdownImage key={key} url={block.url} alt={block.alt} />
+              <MarkdownImage
+                key={key}
+                url={block.url}
+                alt={block.alt}
+                disableRemoteImages={disableRemoteImages}
+              />
             ) : null;
 
           case "hr":

--- a/apps/mobile/src/features/tasks/components/ArtifactPreview.tsx
+++ b/apps/mobile/src/features/tasks/components/ArtifactPreview.tsx
@@ -125,10 +125,12 @@ export function ArtifactPreview({
             <WebView
               originWhitelist={["*"]}
               source={{ html: applyCspToHtml(text ?? "") }}
-              // Untrusted agent output: no scripts, and any attempt to navigate
-              // out (links, redirects) is handed to the system browser rather
-              // than loaded inside the sandbox. The injected CSP blocks remote
-              // resource loads on top of that.
+              // Untrusted agent output: no scripts, and the sandbox never
+              // navigates to a remote page. Only a genuine tap ("click") opens
+              // externally — automatic redirects (e.g. a <meta http-equiv=
+              // "refresh">) are dropped so previewing a file can't silently
+              // launch an attacker URL. The injected CSP blocks remote resource
+              // loads on top of that.
               javaScriptEnabled={false}
               setSupportMultipleWindows={false}
               onShouldStartLoadWithRequest={(req) => {
@@ -136,7 +138,7 @@ export function ArtifactPreview({
                   req.url.startsWith("http://") ||
                   req.url.startsWith("https://")
                 ) {
-                  openExternalUrl(req.url);
+                  if (req.navigationType === "click") openExternalUrl(req.url);
                   return false;
                 }
                 return true;

--- a/apps/mobile/src/features/tasks/components/ArtifactPreview.tsx
+++ b/apps/mobile/src/features/tasks/components/ArtifactPreview.tsx
@@ -119,7 +119,7 @@ export function ArtifactPreview({
               className="flex-1"
               contentContainerStyle={{ padding: 16 }}
             >
-              <MarkdownText content={text ?? ""} />
+              <MarkdownText content={text ?? ""} disableRemoteImages />
             </ScrollView>
           ) : (
             <WebView

--- a/apps/mobile/src/features/tasks/components/ArtifactPreview.tsx
+++ b/apps/mobile/src/features/tasks/components/ArtifactPreview.tsx
@@ -1,0 +1,178 @@
+import type { TaskRunArtifact } from "@posthog/shared";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowSquareOut, Warning, X } from "phosphor-react-native";
+import {
+  ActivityIndicator,
+  Image,
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import WebView from "react-native-webview";
+import { MarkdownText } from "@/features/chat";
+import { applyCspToHtml } from "@/features/mcp/sandbox/mcpAppCsp";
+import { openExternalUrl } from "@/lib/openExternalUrl";
+import { useThemeColors } from "@/lib/theme";
+import { useCloudAttachmentPreview } from "../hooks/useCloudAttachmentPreview";
+import { artifactPreviewKind } from "../utils/artifactPreview";
+
+interface ArtifactPreviewProps {
+  taskId: string;
+  runId: string;
+  artifact: TaskRunArtifact;
+  onClose: () => void;
+}
+
+export function ArtifactPreview({
+  taskId,
+  runId,
+  artifact,
+  onClose,
+}: ArtifactPreviewProps) {
+  const insets = useSafeAreaInsets();
+  const themeColors = useThemeColors();
+  const name = artifact.name ?? "artifact";
+  const kind = artifactPreviewKind(name);
+
+  const { data: url, isLoading: urlLoading } = useCloudAttachmentPreview(
+    taskId,
+    artifact.id ? { runId, artifactId: artifact.id } : undefined,
+  );
+
+  // Markdown and HTML render from the file's text; images and the external
+  // fallback only need the presigned URL.
+  const needsText = kind === "markdown" || kind === "html";
+  const {
+    data: text,
+    isLoading: textLoading,
+    isError: textError,
+  } = useQuery({
+    queryKey: ["artifactText", url],
+    enabled: needsText && Boolean(url),
+    staleTime: Infinity,
+    retry: false,
+    queryFn: async (): Promise<string> => {
+      const response = await fetch(url ?? "");
+      if (!response.ok) throw new Error("Artifact fetch failed");
+      return response.text();
+    },
+  });
+
+  const loading = urlLoading || (needsText && textLoading);
+
+  return (
+    <Modal
+      visible
+      animationType="slide"
+      presentationStyle="fullScreen"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
+        <View className="flex-row items-center gap-3 px-4 pb-2">
+          <Text
+            className="flex-1 font-semibold text-[16px] text-gray-12"
+            numberOfLines={1}
+          >
+            {name}
+          </Text>
+          {url ? (
+            <Pressable
+              onPress={() => openExternalUrl(url)}
+              hitSlop={8}
+              className="active:opacity-60"
+              accessibilityLabel="Open externally"
+            >
+              <ArrowSquareOut size={20} color={themeColors.gray[12]} />
+            </Pressable>
+          ) : null}
+          <Pressable
+            onPress={onClose}
+            hitSlop={8}
+            className="active:opacity-60"
+            accessibilityLabel="Close preview"
+          >
+            <X size={20} color={themeColors.gray[12]} />
+          </Pressable>
+        </View>
+
+        <View className="flex-1" style={{ paddingBottom: insets.bottom }}>
+          {loading ? (
+            <View className="flex-1 items-center justify-center">
+              <ActivityIndicator color={themeColors.accent[9]} />
+            </View>
+          ) : !url || textError || kind === "unsupported" ? (
+            <Unsupported
+              url={url}
+              onShare={() => url && openExternalUrl(url)}
+            />
+          ) : kind === "image" ? (
+            <Image
+              source={{ uri: url }}
+              resizeMode="contain"
+              style={{ flex: 1, width: "100%" }}
+            />
+          ) : kind === "markdown" ? (
+            <ScrollView
+              className="flex-1"
+              contentContainerStyle={{ padding: 16 }}
+            >
+              <MarkdownText content={text ?? ""} />
+            </ScrollView>
+          ) : (
+            <WebView
+              originWhitelist={["*"]}
+              source={{ html: applyCspToHtml(text ?? "") }}
+              // Untrusted agent output: no scripts, and any attempt to navigate
+              // out (links, redirects) is handed to the system browser rather
+              // than loaded inside the sandbox. The injected CSP blocks remote
+              // resource loads on top of that.
+              javaScriptEnabled={false}
+              setSupportMultipleWindows={false}
+              onShouldStartLoadWithRequest={(req) => {
+                if (
+                  req.url.startsWith("http://") ||
+                  req.url.startsWith("https://")
+                ) {
+                  openExternalUrl(req.url);
+                  return false;
+                }
+                return true;
+              }}
+              style={{ flex: 1, backgroundColor: "#fff" }}
+            />
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function Unsupported({
+  url,
+  onShare,
+}: {
+  url: string | null | undefined;
+  onShare: () => void;
+}) {
+  const themeColors = useThemeColors();
+  return (
+    <View className="flex-1 items-center justify-center gap-4 px-8">
+      <Warning size={28} color={themeColors.gray[9]} />
+      <Text className="text-center text-[14px] text-gray-11">
+        This file can't be previewed here.
+      </Text>
+      {url ? (
+        <Pressable
+          onPress={onShare}
+          className="flex-row items-center gap-2 rounded-lg bg-gray-3 px-4 py-2.5 active:opacity-70"
+        >
+          <ArrowSquareOut size={16} color={themeColors.gray[12]} />
+          <Text className="text-[14px] text-gray-12">Open externally</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/features/tasks/components/TaskArtifacts.test.tsx
+++ b/apps/mobile/src/features/tasks/components/TaskArtifacts.test.tsx
@@ -1,0 +1,65 @@
+import type { TaskRunArtifact } from "@posthog/shared";
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+import { TaskArtifacts } from "./TaskArtifacts";
+
+const mockUseTaskArtifacts = vi.fn();
+
+vi.mock("../hooks/useTaskArtifacts", () => ({
+  useTaskArtifacts: (...args: unknown[]) => mockUseTaskArtifacts(...args),
+}));
+
+vi.mock("./ArtifactPreview", () => ({
+  ArtifactPreview: (props: Record<string, unknown>) =>
+    createElement("ArtifactPreview", props),
+}));
+
+vi.mock("../api", () => ({ presignTaskRunArtifact: vi.fn() }));
+
+vi.mock("@/lib/openExternalUrl", () => ({ openExternalUrl: vi.fn() }));
+
+vi.mock("phosphor-react-native", () => ({
+  ArrowSquareOut: (props: Record<string, unknown>) =>
+    createElement("ArrowSquareOut", props),
+  File: (props: Record<string, unknown>) => createElement("File", props),
+}));
+
+vi.mock("@/lib/theme", () => ({
+  useThemeColors: () => ({ gray: { 9: "#777", 11: "#555" } }),
+}));
+
+function render(artifacts: TaskRunArtifact[] | undefined) {
+  mockUseTaskArtifacts.mockReturnValue({ data: artifacts });
+  let renderer: ReturnType<typeof create> | null = null;
+  act(() => {
+    renderer = create(
+      createElement(TaskArtifacts, {
+        taskId: "t1",
+        runId: "r1",
+        enabled: true,
+      }),
+    );
+  });
+  if (!renderer) throw new Error("Renderer not created");
+  return JSON.stringify((renderer as ReturnType<typeof create>).toJSON());
+}
+
+describe("TaskArtifacts", () => {
+  it("renders nothing when there are no artifacts", () => {
+    expect(render([])).toBe("null");
+    expect(render(undefined)).toBe("null");
+  });
+
+  it("lists artifact names and sizes", () => {
+    const output = render([
+      { id: "a1", name: "report.md", type: "output", size: 2_400 },
+      { id: "a2", name: "chart.png", type: "output", size: 512 },
+    ]);
+    expect(output).toContain("Files");
+    expect(output).toContain("report.md");
+    expect(output).toContain("chart.png");
+    expect(output).toContain("2 KB");
+    expect(output).toContain("512 B");
+  });
+});

--- a/apps/mobile/src/features/tasks/components/TaskArtifacts.tsx
+++ b/apps/mobile/src/features/tasks/components/TaskArtifacts.tsx
@@ -1,0 +1,107 @@
+import type { TaskRunArtifact } from "@posthog/shared";
+import { ArrowSquareOut, File as FileIcon } from "phosphor-react-native";
+import { useCallback, useState } from "react";
+import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
+import { openExternalUrl } from "@/lib/openExternalUrl";
+import { useThemeColors } from "@/lib/theme";
+import { presignTaskRunArtifact } from "../api";
+import { useTaskArtifacts } from "../hooks/useTaskArtifacts";
+import { formatArtifactSize } from "../utils/artifactPreview";
+import { ArtifactPreview } from "./ArtifactPreview";
+
+interface TaskArtifactsProps {
+  taskId: string | undefined;
+  runId: string | undefined;
+  // Gate the manifest fetch on a terminal run, mirroring desktop.
+  enabled: boolean;
+}
+
+export function TaskArtifacts({ taskId, runId, enabled }: TaskArtifactsProps) {
+  const themeColors = useThemeColors();
+  const { data: artifacts } = useTaskArtifacts(taskId, runId, enabled);
+  const [preview, setPreview] = useState<TaskRunArtifact | null>(null);
+  const [sharingId, setSharingId] = useState<string | null>(null);
+
+  const shareArtifact = useCallback(
+    async (artifact: TaskRunArtifact): Promise<void> => {
+      if (!taskId || !runId || !artifact.storage_path) return;
+      setSharingId(artifact.id ?? artifact.storage_path);
+      try {
+        const url = await presignTaskRunArtifact(
+          taskId,
+          runId,
+          artifact.storage_path,
+        );
+        openExternalUrl(url);
+      } catch {
+        Alert.alert("Couldn't open file", "Please try again.");
+      } finally {
+        setSharingId(null);
+      }
+    },
+    [taskId, runId],
+  );
+
+  if (!taskId || !runId || !artifacts || artifacts.length === 0) return null;
+
+  return (
+    <View className="mx-4 mb-2 rounded-lg border border-gray-5 bg-gray-2 p-3">
+      <Text className="mb-2 font-semibold text-[13px] text-gray-12">Files</Text>
+      <View className="gap-1">
+        {artifacts.map((artifact) => {
+          const sharingKey = artifact.id ?? artifact.storage_path;
+          const size = formatArtifactSize(artifact.size);
+          const canPreview = Boolean(artifact.id);
+          return (
+            <View
+              key={sharingKey ?? artifact.name}
+              className="flex-row items-center gap-3 rounded-md bg-background px-2 py-1.5"
+            >
+              <Pressable
+                className="min-w-0 flex-1 flex-row items-center gap-2 active:opacity-70"
+                disabled={!canPreview}
+                onPress={() => setPreview(artifact)}
+              >
+                <FileIcon size={16} color={themeColors.gray[11]} />
+                <Text
+                  className="flex-shrink text-[13px] text-gray-12"
+                  numberOfLines={1}
+                >
+                  {artifact.name ?? "artifact"}
+                </Text>
+                {size ? (
+                  <Text className="text-[12px] text-gray-9">{size}</Text>
+                ) : null}
+              </Pressable>
+              <Pressable
+                hitSlop={8}
+                className="active:opacity-60"
+                disabled={!artifact.storage_path}
+                onPress={() => void shareArtifact(artifact)}
+                accessibilityLabel="Open externally"
+              >
+                {sharingId === sharingKey ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={themeColors.gray[11]}
+                  />
+                ) : (
+                  <ArrowSquareOut size={16} color={themeColors.gray[11]} />
+                )}
+              </Pressable>
+            </View>
+          );
+        })}
+      </View>
+
+      {preview?.id ? (
+        <ArtifactPreview
+          taskId={taskId}
+          runId={runId}
+          artifact={preview}
+          onClose={() => setPreview(null)}
+        />
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/features/tasks/components/TaskSessionView.test.tsx
+++ b/apps/mobile/src/features/tasks/components/TaskSessionView.test.tsx
@@ -56,6 +56,11 @@ vi.mock("./CloudMessageAttachment", () => ({
     createElement("CloudMessageAttachment", props),
 }));
 
+vi.mock("./TaskArtifacts", () => ({
+  TaskArtifacts: (props: Record<string, unknown>) =>
+    createElement("TaskArtifacts", props),
+}));
+
 function renderTaskSessionView(
   props: Parameters<typeof TaskSessionView>[0],
 ): ReturnType<typeof create> {

--- a/apps/mobile/src/features/tasks/components/TaskSessionView.tsx
+++ b/apps/mobile/src/features/tasks/components/TaskSessionView.tsx
@@ -34,6 +34,7 @@ import { CloudMessageAttachment } from "./CloudMessageAttachment";
 import { PlanApprovalCard } from "./PlanApprovalCard";
 import { PlanStatusBar } from "./PlanStatusBar";
 import { QuestionCard } from "./QuestionCard";
+import { TaskArtifacts } from "./TaskArtifacts";
 import { TerminalStatusBanner } from "./TerminalStatusBanner";
 
 interface PermissionResponseArgs {
@@ -56,6 +57,8 @@ interface OptimisticUserMessage {
 interface TaskSessionViewProps {
   events: SessionEvent[];
   taskId?: string;
+  // Latest run id, used to list the run's generated output artifacts.
+  runId?: string;
   pendingPermissions?: Record<string, CloudPendingPermissionRequest>;
   isConnecting?: boolean;
   isThinking?: boolean;
@@ -804,6 +807,7 @@ function ConnectingIndicator() {
 export function TaskSessionView({
   events,
   taskId,
+  runId,
   pendingPermissions,
   isConnecting,
   isThinking,
@@ -1017,6 +1021,28 @@ export function TaskSessionView({
     ],
   );
 
+  // Memoized so a live session's frequent re-renders (streaming, timers) don't
+  // reconcile the banner + artifacts subtree on every tick.
+  const listHeader = useMemo(
+    () => (
+      <>
+        {terminalStatus ? (
+          <TerminalStatusBanner
+            terminalStatus={terminalStatus}
+            lastError={lastError}
+            onRetry={onRetry}
+          />
+        ) : null}
+        <TaskArtifacts
+          taskId={taskId}
+          runId={runId}
+          enabled={!!terminalStatus}
+        />
+      </>
+    ),
+    [terminalStatus, lastError, onRetry, taskId, runId],
+  );
+
   return (
     <View className="flex-1">
       <PlanStatusBar plan={plan} />
@@ -1035,15 +1061,7 @@ export function TaskSessionView({
         maxToRenderPerBatch={15}
         windowSize={21}
         initialNumToRender={30}
-        ListHeaderComponent={
-          terminalStatus ? (
-            <TerminalStatusBanner
-              terminalStatus={terminalStatus}
-              lastError={lastError}
-              onRetry={onRetry}
-            />
-          ) : null
-        }
+        ListHeaderComponent={listHeader}
       />
       {/* Thinking/connecting indicators pinned to the bottom of the list area.
           The Composer is a sibling below TaskSessionView in flex flow, so

--- a/apps/mobile/src/features/tasks/hooks/useTaskArtifacts.ts
+++ b/apps/mobile/src/features/tasks/hooks/useTaskArtifacts.ts
@@ -1,0 +1,31 @@
+import type { TaskRunArtifact } from "@posthog/shared";
+import { useQuery } from "@tanstack/react-query";
+import { getProjectId } from "@/lib/api";
+import { getTaskRun } from "../api";
+
+// Matches the manifest staleness used for attachment previews so both share the
+// same ["taskRunArtifacts", …] cache entry and refetch on the same schedule.
+const ARTIFACTS_STALE_MS = 50 * 60 * 1000;
+
+/**
+ * Lists a run's generated output artifacts. `enabled` should gate on a terminal
+ * run status — mirrors desktop, which only fetches the manifest once the run
+ * has finished producing files.
+ */
+export function useTaskArtifacts(
+  taskId: string | undefined,
+  runId: string | undefined,
+  enabled: boolean,
+) {
+  const projectId = getProjectId();
+
+  return useQuery({
+    queryKey: ["taskRunArtifacts", projectId, taskId, runId],
+    enabled: enabled && Boolean(taskId && runId),
+    staleTime: ARTIFACTS_STALE_MS,
+    retry: false,
+    queryFn: async (): Promise<TaskRunArtifact[]> =>
+      (await getTaskRun(taskId ?? "", runId ?? "")).artifacts ?? [],
+    select: (artifacts) => artifacts.filter((a) => a.type === "output"),
+  });
+}

--- a/apps/mobile/src/features/tasks/utils/artifactPreview.test.ts
+++ b/apps/mobile/src/features/tasks/utils/artifactPreview.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ArtifactPreviewKind,
+  artifactPreviewKind,
+  formatArtifactSize,
+} from "./artifactPreview";
+
+describe("artifactPreviewKind", () => {
+  it.each<[string, ArtifactPreviewKind]>([
+    ["chart.png", "image"],
+    ["photo.JPEG", "image"],
+    ["diagram.webp", "image"],
+    ["report.md", "markdown"],
+    ["notes.markdown", "markdown"],
+    ["doc.MDX", "markdown"],
+    ["page.html", "html"],
+    ["page.htm", "html"],
+    ["data.csv", "unsupported"],
+    ["archive.zip", "unsupported"],
+    ["noextension", "unsupported"],
+  ])("maps %s to %s", (fileName, expected) => {
+    expect(artifactPreviewKind(fileName)).toBe(expected);
+  });
+});
+
+describe("formatArtifactSize", () => {
+  it.each<[number | undefined, string | null]>([
+    [undefined, null],
+    [0, "0 B"],
+    [512, "512 B"],
+    [1_500, "2 KB"],
+    [2_400_000, "2.4 MB"],
+  ])("formats %s as %s", (size, expected) => {
+    expect(formatArtifactSize(size)).toBe(expected);
+  });
+});

--- a/apps/mobile/src/features/tasks/utils/artifactPreview.ts
+++ b/apps/mobile/src/features/tasks/utils/artifactPreview.ts
@@ -1,0 +1,24 @@
+import { isRasterImageFile } from "@posthog/shared";
+
+export type ArtifactPreviewKind = "image" | "markdown" | "html" | "unsupported";
+
+const MARKDOWN_EXTENSIONS = new Set(["md", "mdx", "markdown"]);
+
+function extension(fileName: string): string {
+  return fileName.split(".").pop()?.toLowerCase() ?? "";
+}
+
+export function artifactPreviewKind(fileName: string): ArtifactPreviewKind {
+  if (isRasterImageFile(fileName)) return "image";
+  const ext = extension(fileName);
+  if (MARKDOWN_EXTENSIONS.has(ext)) return "markdown";
+  if (ext === "html" || ext === "htm") return "html";
+  return "unsupported";
+}
+
+export function formatArtifactSize(size: number | undefined): string | null {
+  if (size === undefined) return null;
+  if (size < 1_000) return `${size} B`;
+  if (size < 1_000_000) return `${Math.round(size / 1_000)} KB`;
+  return `${(size / 1_000_000).toFixed(1)} MB`;
+}


### PR DESCRIPTION
## Problem

Mobile had no surface at all for a cloud run's **generated output artifacts** — they were never listed or viewable. Desktop [#3837](https://github.com/PostHog/code/pull/3837) added inline preview of generated artifacts beside chat; this ports that capability to the mobile app so users can inspect what a run produced (HTML, Markdown, images) without leaving the app.

## Changes

Self-contained mobile feature under `apps/mobile/src/features/tasks`:

- **Lists** `type === "output"` artifacts for a task's latest run in the session view, once the run reaches a terminal status. Reuses the existing run-artifact manifest cache (shared query key with `useCloudAttachmentPreview`, so no extra network) and the presign endpoint that was already wired up. Each row shows file name, icon and size, styled like the existing attachment chips.
- **Tap to preview** in a mobile-native full-screen modal (not desktop's panel/tab system, which isn't portable):
  - Images render natively.
  - Markdown reuses the existing `MarkdownText` renderer.
  - HTML/other browser-viewable content renders inside a **hardened, sandboxed WebView** — artifact bytes are untrusted agent output, so scripts are disabled, an enforced CSP (reusing the MCP-app CSP helper from #3836) blocks remote resource loads, and any attempted navigation is handed to the system browser rather than loaded in the sandbox.
  - Anything not previewable falls back to opening externally.
- **Keeps an open/share action** available for every artifact via the system browser (the existing external-open pattern; there is no native share dependency in the app today).

Parameterised tests cover the artifact-kind → preview-mode matrix (image / Markdown / HTML / unsupported) and size formatting, plus a render test for the list.

**Why:** requested as a port of desktop #3837 so the mobile app reaches parity for inspecting run output.

## How did you test this?

- `pnpm --filter @posthog/mobile test` — all mobile suites pass (38 files / 250 tests), including the new `artifactPreview` and `TaskArtifacts` tests.
- Biome lint/format clean on the changed files.
- `tsc` typecheck clean on the changed source files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
