### PR TITLE
fix: show all task PRs in artifacts pane

### DIFF
--- a/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
+++ b/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
@@ -83,6 +83,26 @@ describe("TaskArtifactsList", () => {
     expect(state.reviewModes[task.id]).toBe("split");
   });
 
+  it("lists every PR produced by the same run", () => {
+    mocks.runs = [
+      {
+        ...run("run-1"),
+        output: {
+          pr_url: "https://github.com/acme/repo/pull/1",
+          pr_urls: [
+            "https://github.com/acme/repo/pull/1",
+            "https://github.com/acme/other-repo/pull/2",
+          ],
+        },
+      } as TaskRun,
+    ];
+
+    render(<TaskArtifactsList task={task} timeline={[]} />);
+
+    expect(screen.getByText("Pull request #1")).toBeTruthy();
+    expect(screen.getByText("Pull request #2")).toBeTruthy();
+  });
+
   it("lists the files the agent uploaded, with their size", () => {
     mocks.runs = [
       run("run-1", { artifacts: [outputFile({ id: "a", size: 16861 })] }),

--- a/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
+++ b/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
@@ -16,6 +16,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@posthog/quill";
+import { readPrUrls } from "@posthog/shared";
 import type {
   Task,
   TaskRun,
@@ -92,8 +93,7 @@ function buildRows(
   // every copy would bury the current one under its own drafts.
   const newestByName = new Map<string, { file: RunArtifact; runId: string }>();
   for (const run of allRuns) {
-    const outputPr = run.output?.pr_url;
-    if (typeof outputPr === "string" && outputPr) {
+    for (const outputPr of readPrUrls(run.output)) {
       addPr(outputPr, `output-pr:${outputPr}`);
     }
     for (const file of readRunOutputs(run)) {


### PR DESCRIPTION
## Problem

Tasks that create multiple pull requests only show the primary PR in the artifacts pane.

## Changes

Read the run’s accumulated PR URL list when building artifact rows, while retaining legacy singular-field compatibility.

## How did you test this?

- `pnpm exec vitest run src/features/canvas/components/TaskArtifactsList.test.tsx` (10 tests passed)
- `pnpm exec biome check src/features/canvas/components/TaskArtifactsList.tsx src/features/canvas/components/TaskArtifactsList.test.tsx`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*