### PR TITLE
fix(loops): resolve creators on channel pages

### DIFF
--- a/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
@@ -16,6 +16,7 @@ import { useLoopLimits, useLoops } from "../../loops/hooks/useLoops";
 import { useLoopDraftStore } from "../../loops/loopDraftStore";
 import { defaultLoopContextOutputs } from "../../loops/loopFormTypes";
 import { useChannels } from "../hooks/useChannels";
+import { useOrgMembers } from "../hooks/useOrgMembers";
 
 function contextQuickStarts(name: string): { label: string; prompt: string }[] {
   return [
@@ -63,6 +64,12 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
       ),
     [loops, channelId],
   );
+  const {
+    members,
+    isLoading: membersLoading,
+    isError: membersError,
+    isComplete: membersComplete,
+  } = useOrgMembers({ enabled: attachedLoops.length > 0 });
 
   const startBlank = () => {
     useLoopDraftStore.getState().setPrefill({
@@ -139,7 +146,16 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
               </Text>
               <Flex direction="column" gap="2">
                 {attachedLoops.map((loop) => (
-                  <LoopRow key={loop.id} loop={loop} />
+                  <LoopRow
+                    key={loop.id}
+                    loop={loop}
+                    creator={members.find(
+                      (member) => member.id === loop.created_by_id,
+                    )}
+                    creatorLoading={membersLoading}
+                    creatorError={membersError}
+                    creatorLookupComplete={membersComplete}
+                  />
                 ))}
               </Flex>
             </Flex>


### PR DESCRIPTION
## Problem

Channel-attached loops showed active creators as former organization members because the page did not resolve loop owners.

**Why:** Creator attribution should stay consistent between the main Loops page and channel Loops tabs.

## Changes

Resolve organization members for attached loops and pass creator lookup state to each loop row.

## How did you test this?

- `pnpm biome check packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx`
- `pnpm build:deps`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm --filter @posthog/ui test -- --run packages/ui/src/features/loops/components/LoopsListView.test.tsx` (2,298 tests passed)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*