### PR TITLE
fix(spaces): quill up the spaces nav, list highlight and search field

### DIFF
--- a/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -72,7 +72,7 @@ function UserMessageRow({
   timestamp: string;
 }) {
   return (
-    <ThreadItem>
+    <ThreadItem className="rounded-none">
       <ThreadItemGutter>
         <UserAvatar user={author} size="lg" className="sticky top-2" />
       </ThreadItemGutter>

--- a/packages/ui/src/features/canvas/components/ChannelBackRow.test.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelBackRow.test.tsx
@@ -59,8 +59,9 @@ describe("ChannelBackRow", () => {
     expect(useChannelPaneStore.getState().pane).toBe("list");
   });
 
-  // #me can't be unstarred, but the well stays filled so the row doesn't
-  // change height (and everything below it shift) when you switch channels.
+  // #me can't be starred, so its well is empty — but the well is still there,
+  // so the row doesn't change height (and everything below it shift) when you
+  // switch spaces.
   it("offers a star on shared channels only", () => {
     renderRow(ENG.id);
     expect(screen.getByRole("button", { name: "Star space" })).toBeTruthy();

--- a/packages/ui/src/features/canvas/components/ChannelBackRow.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelBackRow.tsx
@@ -107,16 +107,11 @@ export function ChannelBackRow({ channelId }: { channelId: string }) {
         />
         <TooltipContent side="bottom">Back to spaces</TooltipContent>
       </Tooltip>
+      {/* #me can't be starred, so its well stays empty — a greyed-out star read
+          as a control you were being denied. The well itself is unconditional
+          (see the button's reserved span), which is what keeps the row the same
+          height on every space. */}
       {showStar && current && <RowStar channel={current} />}
-      {/* Inert star for #me, so the row reads the same on every channel. */}
-      {current && !showStar && (
-        <span
-          aria-hidden
-          className="-translate-y-1/2 pointer-events-none absolute top-1/2 right-[6px] flex size-6 items-center justify-center text-muted-foreground opacity-40"
-        >
-          <StarIcon size={14} weight="fill" />
-        </span>
-      )}
     </div>
   );
 }

--- a/packages/ui/src/features/canvas/components/ChannelBackRow.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelBackRow.tsx
@@ -1,5 +1,10 @@
 import { CaretLeftIcon, StarIcon } from "@phosphor-icons/react";
-import { Skeleton } from "@posthog/quill";
+import {
+  Skeleton,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { channelGlyph } from "@posthog/ui/features/canvas/components/channelGlyph";
 import { useChannelStarToggle } from "@posthog/ui/features/canvas/hooks/useChannelStars";
@@ -10,7 +15,6 @@ import {
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { PERSONAL_CHANNEL_NAME } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { showChannelList } from "@posthog/ui/features/canvas/stores/channelPaneStore";
-import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { track } from "@posthog/ui/shell/analytics";
 
 // An overlay rather than a sibling: the back button fills the row, and nesting
@@ -53,49 +57,55 @@ export function ChannelBackRow({ channelId }: { channelId: string }) {
 
   return (
     <div className="relative mx-2 mt-1">
-      <Tooltip content="Back to spaces" side="bottom">
-        <button
-          type="button"
-          aria-label="Back to spaces"
-          onClick={() => {
-            track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
-              action_type: "browse_channels",
-              surface: "sidebar",
-              channel_id: channelId,
-            });
-            showChannelList();
-          }}
-          // Fixed height with an unconditional star well: sized off its
-          // contents, a starrable channel ran 4px taller than #me and
-          // everything below shifted on switch. No border — it's a row in the
-          // sidebar like the ones under it, not a control sitting on top.
-          className="flex h-8 w-full items-center gap-1.5 rounded-md px-2 text-left transition-colors hover:bg-fill-hover"
-        >
-          <CaretLeftIcon
-            size={12}
-            className="shrink-0 text-muted-foreground"
-            weight="bold"
-          />
-          <span className="flex w-4 shrink-0 items-center justify-center">
-            {channelGlyph(current?.name, {
-              size: 14,
-              space: spacesLayout,
-              className: "text-muted-foreground",
-            })}
-          </span>
-          <span className="min-w-0 flex-1 truncate font-semibold text-[13px] text-foreground">
-            {current ? (
-              current.name
-            ) : isLoading ? (
-              // A placeholder word here would read as a real channel named
-              // "channel"; a skeleton says "still loading" honestly.
-              <Skeleton className="h-3.5 w-24" />
-            ) : (
-              "Unavailable"
-            )}
-          </span>
-          <span aria-hidden className="size-6 shrink-0" />
-        </button>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              aria-label="Back to spaces"
+              onClick={() => {
+                track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                  action_type: "browse_channels",
+                  surface: "sidebar",
+                  channel_id: channelId,
+                });
+                showChannelList();
+              }}
+              // Fixed height with an unconditional star well: sized off its
+              // contents, a starrable channel ran 4px taller than #me and
+              // everything below shifted on switch. No border — it's a row in
+              // the sidebar like the ones under it, not a control sitting on
+              // top.
+              className="flex h-8 w-full items-center gap-1.5 rounded-md px-2 text-left transition-colors hover:bg-fill-hover"
+            >
+              <CaretLeftIcon
+                size={12}
+                className="shrink-0 text-muted-foreground"
+                weight="bold"
+              />
+              <span className="flex w-4 shrink-0 items-center justify-center">
+                {channelGlyph(current?.name, {
+                  size: 14,
+                  space: spacesLayout,
+                  className: "text-muted-foreground",
+                })}
+              </span>
+              <span className="min-w-0 flex-1 truncate font-semibold text-[13px] text-foreground">
+                {current ? (
+                  current.name
+                ) : isLoading ? (
+                  // A placeholder word here would read as a real channel named
+                  // "channel"; a skeleton says "still loading" honestly.
+                  <Skeleton className="h-3.5 w-24" />
+                ) : (
+                  "Unavailable"
+                )}
+              </span>
+              <span aria-hidden className="size-6 shrink-0" />
+            </button>
+          }
+        />
+        <TooltipContent side="bottom">Back to spaces</TooltipContent>
       </Tooltip>
       {showStar && current && <RowStar channel={current} />}
       {/* Inert star for #me, so the row reads the same on every channel. */}

--- a/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -5,7 +5,14 @@ import {
   RepeatIcon,
   SlidersHorizontal,
 } from "@phosphor-icons/react";
-import { Button } from "@posthog/quill";
+import {
+  Button,
+  Kbd,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@posthog/quill";
 import { LOOPS_FLAG } from "@posthog/shared";
 import {
   ANALYTICS_EVENTS,
@@ -21,7 +28,6 @@ import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFla
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { CountBadge } from "@posthog/ui/primitives/CountBadge";
-import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import {
   navigateToActivity,
   navigateToInbox,
@@ -53,22 +59,30 @@ function NavIcon({
   badge?: ReactNode;
 }) {
   return (
-    <Tooltip content={label} shortcut={shortcut} side="bottom">
+    <Tooltip>
       {/* quill's Button, with the sidebar's selected-row treatment — the same
           `data-selected` pairing the channel rows use, so the nav and the list
           below it read as one control set in either theme. `relative` is for
           the count badge, which pins to the button's corner. */}
-      <Button
-        variant="default"
-        size="icon"
-        aria-label={label}
-        data-selected={isActive || undefined}
-        onClick={onClick}
-        className="relative shrink-0 text-muted-foreground data-selected:bg-fill-selected data-selected:text-foreground"
-      >
-        {icon}
-        {badge}
-      </Button>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="default"
+            size="icon"
+            aria-label={label}
+            data-selected={isActive || undefined}
+            onClick={onClick}
+            className="relative shrink-0 text-muted-foreground data-selected:bg-fill-selected data-selected:text-foreground"
+          >
+            {icon}
+            {badge}
+          </Button>
+        }
+      />
+      <TooltipContent side="bottom">
+        {label}
+        {shortcut && <Kbd className="ml-1.5">{shortcut}</Kbd>}
+      </TooltipContent>
     </Tooltip>
   );
 }
@@ -98,60 +112,72 @@ export function ChannelNav() {
   const isCommandCenter = view.type === "command-center";
 
   return (
-    <div className="flex shrink-0 gap-2 px-2 pt-2 pb-1">
-      <NavIcon
-        icon={
-          <EnvelopeSimple size={16} weight={isInbox ? "fill" : "regular"} />
-        }
-        label="Inbox"
-        shortcut={formatHotkey(SHORTCUTS.INBOX)}
-        isActive={isInbox}
-        onClick={withTrack("inbox", navigateToInbox)}
-        badge={<CountBadge count={counts.pulls} className={ICON_BADGE_CLASS} />}
-      />
-      <NavIcon
-        icon={<BellIcon size={16} weight={isActivity ? "fill" : "regular"} />}
-        label="Activity"
-        isActive={isActivity}
-        onClick={withTrack("activity", navigateToActivity)}
-        badge={
-          <CountBadge count={unseenActivity} className={ICON_BADGE_CLASS} />
-        }
-      />
-      <NavIcon
-        icon={
-          <Lightning size={16} weight={isCommandCenter ? "fill" : "regular"} />
-        }
-        label="Command Center"
-        isActive={isCommandCenter}
-        onClick={withTrack("command_center", navigateToWebsiteCommandCenter)}
-        badge={
-          <CountBadge
-            count={commandCenterCount}
-            tone="neutral"
-            className={ICON_BADGE_CLASS}
-          />
-        }
-      />
-      {loopsEnabled ? (
+    // One provider for the row: once any tooltip is up, moving to its
+    // neighbour reveals that one immediately instead of serving the warm-up
+    // delay again. Per-tooltip providers (the old primitive mounted its own)
+    // cannot do that — the skip window is provider state, and isolated
+    // providers never share it.
+    <TooltipProvider delay={400}>
+      <div className="flex shrink-0 gap-2 px-2 pt-2 pb-1">
         <NavIcon
           icon={
-            <RepeatIcon
+            <EnvelopeSimple size={16} weight={isInbox ? "fill" : "regular"} />
+          }
+          label="Inbox"
+          shortcut={formatHotkey(SHORTCUTS.INBOX)}
+          isActive={isInbox}
+          onClick={withTrack("inbox", navigateToInbox)}
+          badge={
+            <CountBadge count={counts.pulls} className={ICON_BADGE_CLASS} />
+          }
+        />
+        <NavIcon
+          icon={<BellIcon size={16} weight={isActivity ? "fill" : "regular"} />}
+          label="Activity"
+          isActive={isActivity}
+          onClick={withTrack("activity", navigateToActivity)}
+          badge={
+            <CountBadge count={unseenActivity} className={ICON_BADGE_CLASS} />
+          }
+        />
+        <NavIcon
+          icon={
+            <Lightning
               size={16}
-              weight={view.type === "loops" ? "fill" : "regular"}
+              weight={isCommandCenter ? "fill" : "regular"}
             />
           }
-          label="Loops"
-          isActive={view.type === "loops"}
-          onClick={withTrack("loops", navigateToLoops)}
+          label="Command Center"
+          isActive={isCommandCenter}
+          onClick={withTrack("command_center", navigateToWebsiteCommandCenter)}
+          badge={
+            <CountBadge
+              count={commandCenterCount}
+              tone="neutral"
+              className={ICON_BADGE_CLASS}
+            />
+          }
         />
-      ) : null}
-      <NavIcon
-        icon={<SlidersHorizontal size={16} />}
-        label="Configure"
-        isActive={false}
-        onClick={withTrack("configure", () => openSettings("agents"))}
-      />
-    </div>
+        {loopsEnabled ? (
+          <NavIcon
+            icon={
+              <RepeatIcon
+                size={16}
+                weight={view.type === "loops" ? "fill" : "regular"}
+              />
+            }
+            label="Loops"
+            isActive={view.type === "loops"}
+            onClick={withTrack("loops", navigateToLoops)}
+          />
+        ) : null}
+        <NavIcon
+          icon={<SlidersHorizontal size={16} />}
+          label="Configure"
+          isActive={false}
+          onClick={withTrack("configure", () => openSettings("agents"))}
+        />
+      </div>
+    </TooltipProvider>
   );
 }

--- a/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -5,7 +5,7 @@ import {
   RepeatIcon,
   SlidersHorizontal,
 } from "@phosphor-icons/react";
-import { cn } from "@posthog/quill";
+import { Button } from "@posthog/quill";
 import { LOOPS_FLAG } from "@posthog/shared";
 import {
   ANALYTICS_EVENTS,
@@ -54,20 +54,21 @@ function NavIcon({
 }) {
   return (
     <Tooltip content={label} shortcut={shortcut} side="bottom">
-      <button
-        type="button"
+      {/* quill's Button, with the sidebar's selected-row treatment — the same
+          `data-selected` pairing the channel rows use, so the nav and the list
+          below it read as one control set in either theme. `relative` is for
+          the count badge, which pins to the button's corner. */}
+      <Button
+        variant="default"
+        size="icon"
         aria-label={label}
+        data-selected={isActive || undefined}
         onClick={onClick}
-        className={cn(
-          "relative flex size-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-100",
-          isActive
-            ? "bg-fill-selected text-foreground"
-            : "text-muted-foreground hover:bg-fill-hover hover:text-foreground",
-        )}
+        className="relative shrink-0 text-muted-foreground data-selected:bg-fill-selected data-selected:text-foreground"
       >
         {icon}
         {badge}
-      </button>
+      </Button>
     </Tooltip>
   );
 }
@@ -92,16 +93,19 @@ export function ChannelNav() {
     action();
   };
 
+  const isInbox = view.type === "inbox";
   const isActivity = view.type === "activity";
   const isCommandCenter = view.type === "command-center";
 
   return (
     <div className="flex shrink-0 gap-2 px-2 pt-2 pb-1">
       <NavIcon
-        icon={<EnvelopeSimple size={16} />}
+        icon={
+          <EnvelopeSimple size={16} weight={isInbox ? "fill" : "regular"} />
+        }
         label="Inbox"
         shortcut={formatHotkey(SHORTCUTS.INBOX)}
-        isActive={view.type === "inbox"}
+        isActive={isInbox}
         onClick={withTrack("inbox", navigateToInbox)}
         badge={<CountBadge count={counts.pulls} className={ICON_BADGE_CLASS} />}
       />

--- a/packages/ui/src/features/canvas/components/ChannelsFab.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsFab.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Kbd,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -27,7 +28,6 @@ import {
 } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { isContentEmpty } from "@posthog/ui/features/message-editor/content";
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
-import { Tooltip as ShortcutTooltip } from "@posthog/ui/primitives/Tooltip";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
 import { useRouterState } from "@tanstack/react-router";
@@ -96,24 +96,21 @@ export function ChannelsFab({ channelId }: { channelId?: string }) {
   return (
     <>
       <DropdownMenu>
-        {channelsLayout ? (
-          // The draft dot needs saying out loud, and the button is where the
-          // create shortcut is worth advertising.
-          <ShortcutTooltip
-            content={hasDraft ? "Create — you have a draft" : "Create"}
-            shortcut={formatHotkey(SHORTCUTS.NEW_TASK)}
-            side="top"
-          >
-            <DropdownMenuTrigger render={trigger} />
-          </ShortcutTooltip>
-        ) : (
-          <Tooltip>
-            <TooltipTrigger render={<DropdownMenuTrigger render={trigger} />} />
-            <TooltipContent side="top" align="center">
-              Create something new
-            </TooltipContent>
-          </Tooltip>
-        )}
+        <Tooltip>
+          <TooltipTrigger render={<DropdownMenuTrigger render={trigger} />} />
+          <TooltipContent side="top" align="center">
+            {channelsLayout ? (
+              <>
+                {/* The draft dot needs saying out loud, and the button is where
+                    the create shortcut is worth advertising. */}
+                {hasDraft ? "Create — you have a draft" : "Create"}
+                <Kbd className="ml-1.5">{formatHotkey(SHORTCUTS.NEW_TASK)}</Kbd>
+              </>
+            ) : (
+              "Create something new"
+            )}
+          </TooltipContent>
+        </Tooltip>
         <DropdownMenuContent
           align={channelId ? "end" : "center"}
           side="top"

--- a/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -142,12 +142,17 @@ function SpaceRowSurface({
   return (
     <AutocompleteItem
       value={optionValue}
-      // quill wraps an option's children in its own flex row; widening it is
-      // what keeps the shortcut hint at the row's right edge and lets the name
-      // truncate, exactly as they do in the button above.
       className={cn(
         "w-full min-w-0 data-selected:bg-fill-selected data-selected:text-foreground",
+        // quill wraps an option's children in its own flex row; widening it is
+        // what keeps the shortcut hint at the row's right edge and lets the
+        // name truncate, exactly as they do in the button above.
         "[&>span]:w-full [&>span]:gap-2",
+        // quill highlights an option with an offset focus ring, which suits a
+        // popup listbox but reads as a stray outline on a sidebar row — and at
+        // dark-theme contrast it outshouts the selected row it sits next to.
+        // Same fill the rows already hover to, matching ProjectSwitcher's list.
+        "ring-offset-0 data-highlighted:border-transparent data-highlighted:bg-fill-hover data-highlighted:ring-0",
         className,
       )}
       // The two branches take the same handlers typed against different

--- a/packages/ui/src/features/command/CommandSearchBar.tsx
+++ b/packages/ui/src/features/command/CommandSearchBar.tsx
@@ -18,12 +18,12 @@ export function CommandSearchBar({ onClick }: { onClick: () => void }) {
   return (
     // The row is a window-drag region; the field has to opt out of it or the
     // press that should open the menu drags the window instead.
-    <div className="no-drag min-w-0 flex-1 px-3">
+    <div className="no-drag mt-px min-w-0 flex-1 px-3">
       <button
         type="button"
         aria-label="Search"
         onClick={onClick}
-        className="mx-auto flex h-7 w-full max-w-140 items-center gap-2 rounded-sm border border-border bg-fill-hover pr-1 pl-2"
+        className="mx-auto flex h-7 w-full max-w-120 items-center gap-2 rounded-sm bg-fill-hover pr-1 pl-2 hover:bg-fill-selected dark:hover:bg-input/80"
       >
         <MagnifyingGlass size={14} className="shrink-0" />
         <span className="min-w-0 flex-1 truncate text-left text-[13px]">

--- a/packages/ui/src/features/command/CommandSearchBar.tsx
+++ b/packages/ui/src/features/command/CommandSearchBar.tsx
@@ -1,0 +1,38 @@
+import { MagnifyingGlass } from "@phosphor-icons/react";
+import { Kbd } from "@posthog/quill";
+import {
+  formatHotkey,
+  SHORTCUTS,
+} from "@posthog/ui/features/command/keyboard-shortcuts";
+
+/**
+ * The search field over the content pane — a target you aim at, not an icon you
+ * hunt for. It opens the command menu rather than typing into anything, so it is
+ * a button wearing a field's clothes: the placeholder and the shortcut hint are
+ * what tell you the menu is behind it.
+ *
+ * It fills the title bar's middle, which is the content column's width, and caps
+ * itself so a wide window leaves it centred rather than stretched.
+ */
+export function CommandSearchBar({ onClick }: { onClick: () => void }) {
+  return (
+    // The row is a window-drag region; the field has to opt out of it or the
+    // press that should open the menu drags the window instead.
+    <div className="no-drag min-w-0 flex-1 px-3">
+      <button
+        type="button"
+        aria-label="Search"
+        onClick={onClick}
+        className="mx-auto flex h-7 w-full max-w-140 items-center gap-2 rounded-sm border border-border bg-card pr-1 pl-2 hover:bg-card/50 dark:bg-fill-hover dark:hover:bg-input/80"
+      >
+        <MagnifyingGlass size={14} className="shrink-0" />
+        <span className="min-w-0 flex-1 truncate text-left text-[13px]">
+          Search
+        </span>
+        <Kbd className="shrink-0 rounded-xs opacity-60">
+          {formatHotkey(SHORTCUTS.COMMAND_MENU)}
+        </Kbd>
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/features/command/CommandSearchBar.tsx
+++ b/packages/ui/src/features/command/CommandSearchBar.tsx
@@ -23,7 +23,7 @@ export function CommandSearchBar({ onClick }: { onClick: () => void }) {
         type="button"
         aria-label="Search"
         onClick={onClick}
-        className="mx-auto flex h-7 w-full max-w-140 items-center gap-2 rounded-sm border border-border bg-card pr-1 pl-2 hover:bg-card/50 dark:bg-fill-hover dark:hover:bg-input/80"
+        className="mx-auto flex h-7 w-full max-w-140 items-center gap-2 rounded-sm border border-border bg-fill-hover pr-1 pl-2"
       >
         <MagnifyingGlass size={14} className="shrink-0" />
         <span className="min-w-0 flex-1 truncate text-left text-[13px]">

--- a/packages/ui/src/router/routes/__root.tsx
+++ b/packages/ui/src/router/routes/__root.tsx
@@ -2,7 +2,6 @@ import {
   ArrowSquareOut,
   CaretLeftIcon,
   CaretRightIcon,
-  MagnifyingGlass,
 } from "@phosphor-icons/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { Button, ButtonGroup } from "@posthog/quill";
@@ -35,12 +34,9 @@ import { useCanvasDeepLink } from "@posthog/ui/features/canvas/hooks/useCanvasDe
 import { useChannelDeepLink } from "@posthog/ui/features/canvas/hooks/useChannelDeepLink";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { CommandMenu } from "@posthog/ui/features/command/CommandMenu";
+import { CommandSearchBar } from "@posthog/ui/features/command/CommandSearchBar";
 import { GlobalFilePicker } from "@posthog/ui/features/command/GlobalFilePicker";
 import { KeyboardShortcutsSheet } from "@posthog/ui/features/command/KeyboardShortcutsSheet";
-import {
-  formatHotkey,
-  SHORTCUTS,
-} from "@posthog/ui/features/command/keyboard-shortcuts";
 import { ConnectivityBanner } from "@posthog/ui/features/connectivity/ConnectivityBanner";
 import { useNewTaskDeepLink } from "@posthog/ui/features/deep-links/useNewTaskDeepLink";
 import { useOpenTargetDeepLink } from "@posthog/ui/features/deep-links/useOpenTargetDeepLink";
@@ -66,7 +62,6 @@ import { UpdateAvailableModal } from "@posthog/ui/features/updates/UpdateAvailab
 import { WhatsNewModal } from "@posthog/ui/features/updates/WhatsNewModal";
 import { useWorkspaces } from "@posthog/ui/features/workspace/useWorkspace";
 import LogosLandscape from "@posthog/ui/primitives/Logo";
-import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { useAppView } from "@posthog/ui/router/useAppView";
 import { openTask, openTaskInput } from "@posthog/ui/router/useOpenTask";
 import { track } from "@posthog/ui/shell/analytics";
@@ -399,58 +394,38 @@ function RootLayout() {
                 )}
               </Button>
             </Flex>
-            {(localWorkspaces || channelsLayout) && (
-              <Flex align="center" gap="2" className="no-drag">
-                {/* Search rides the title bar rather than the sidebar nav —
-                    it's chrome, not a destination — and leads the history
-                    controls so those stay against the sidebar edge. */}
-                {channelsLayout && (
-                  <Tooltip
-                    content="Search"
-                    shortcut={formatHotkey(SHORTCUTS.COMMAND_MENU)}
-                    side="bottom"
-                  >
-                    <Button
-                      variant="outline"
-                      size="icon-sm"
-                      aria-label="Search"
-                      onClick={toggleCommandMenu}
-                    >
-                      <MagnifyingGlass size={14} />
-                    </Button>
-                  </Tooltip>
-                )}
-                {localWorkspaces && (
-                  <ButtonGroup className="no-drag">
-                    <Button
-                      variant="outline"
-                      size="icon-sm"
-                      aria-label="Back"
-                      disabled={!canGoBack}
-                      onClick={() => router.history.back()}
-                    >
-                      <CaretLeftIcon size={14} />
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="icon-sm"
-                      aria-label="Forward"
-                      disabled={!canGoForward}
-                      onClick={() => router.history.forward()}
-                    >
-                      <CaretRightIcon size={14} />
-                    </Button>
-                  </ButtonGroup>
-                )}
-              </Flex>
+            {localWorkspaces && (
+              <ButtonGroup className="no-drag">
+                <Button
+                  variant="outline"
+                  size="icon-sm"
+                  aria-label="Back"
+                  disabled={!canGoBack}
+                  onClick={() => router.history.back()}
+                >
+                  <CaretLeftIcon size={14} />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="icon-sm"
+                  aria-label="Forward"
+                  disabled={!canGoForward}
+                  onClick={() => router.history.forward()}
+                >
+                  <CaretRightIcon size={14} />
+                </Button>
+              </ButtonGroup>
             )}
           </Flex>
           {/* The new layout has no global tab strip (tabs live inside the
-              task view); search/inbox/activity live in the sidebar nav. The
-              strip is also the only global owner of Cmd+W, so something has to
-              keep holding that key when it isn't mounted. */}
+              task view); inbox/activity live in the sidebar nav. The strip is
+              also the only global owner of Cmd+W, so something has to keep
+              holding that key when it isn't mounted. */}
           {channelsLayout ? (
-            <TabShortcutFallback enabled />
+            <>
+              <TabShortcutFallback enabled />
+              <CommandSearchBar onClick={toggleCommandMenu} />
+            </>
           ) : (
             <BrowserTabStrip />
           )}


### PR DESCRIPTION
Design nits on the spaces layout, following #3864. All behind `code-spaces-layout`.

<img width="1740" height="1208" alt="2026-07-28 16 13 32" src="https://github.com/user-attachments/assets/603d6e10-416f-463c-ac35-5f61384b3fc8" />

<img width="1740" height="1208" alt="2026-07-28 16 12 26" src="https://github.com/user-attachments/assets/988aa33d-d4c4-4a78-9795-7158b1f80ec9" />

## What changes

- **The search field moves over the content pane** — out of the `< >` group in the title bar, into a Slack-style field spanning the content column. It's a button wearing a field's clothes: magnifier, placeholder, `⌘K` hint. Opens the same command menu.
- **The nav icons are quill Buttons**, with the `data-selected` treatment the channel rows already use, so the nav and the list read as one control set in either theme.
- **The list's highlight is quill's list convention, not its popup one.** quill renders every `AutocompleteItem` with `data-highlighted:ring-2 ring-offset-1` — right for a floating listbox, a stray outline on a sidebar row, and loud enough at dark-theme contrast to outshout the selected row beside it. Overridden to the hover fill, matching `ProjectSwitcher`.
- **One tooltip provider across the three nav icons.** `primitives/Tooltip` mounts a provider inside *every* tooltip, and the skip-delay window is provider state — three isolated providers never share it, so every hop between neighbours paid the full warm-up again. They move to quill's `Tooltip` under a single provider.
- **The last two sidebar tooltips move to quill too** — the create FAB and the "Back to spaces" row still rendered the old dark card. The FAB carried both implementations (quill off the layout, legacy on it); its branches collapse into one quill tooltip that only chooses the text.
- **The Inbox envelope fills when active**, like the bell and the bolt; it was the only icon left at a fixed weight.

## Notes

`--fill-selected` and `--fill-hover` are per-theme tokens (6%/10% and 4%/7% of `foreground`), so highlight sits below selected in weight in both light and dark. The light-mode gap is the narrow one — worth an eyeball.

The other call sites of `primitives/Tooltip` have the same isolated-provider limitation; only these three changed here.

## Testing

Typecheck clean; 306 tests pass across canvas + command.

1. Hover Inbox, then slide across Activity → Command Center — each tooltip appears instantly. Step away and back — full delay again.
2. Arrow through the spaces list — highlight is a fill, no outline ring; the space you're in stays distinguishable. Check both themes.
3. Search field stays centred over the content column as the window resizes and the sidebar is dragged wider; click and ⌘K both open the menu; the bar beside it still drags the window.
4. Flag off — tab strip back, no search field, nav untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
