### PR TITLE
chore(skills): let merging-prs enqueue before approval

### DIFF
--- a/.claude/skills/merging-prs/SKILL.md
+++ b/.claude/skills/merging-prs/SKILL.md
@@ -81,10 +81,10 @@ sleep 60
 - Watch the **check run + PR state**, not `gh pr checks --watch`: the queue runs
   CI on Trunk's own draft/`trunk-merge/**` branch, so this PR's own checks don't
   reflect the queue's testing.
-- If it's parked waiting on a human review, don't burn the full window polling.
-  Report that it's queued and will merge on approval, then hand back — unless the
-  developer explicitly asked you to watch it until it lands.
-- Stop at the timeout with a status summary rather than looping forever.
+- If it's parked in `Queued` waiting on a human review, say so once and slow the
+  cadence to ~5 minutes. Keep watching — the merge still has to be reported.
+- Stop at the timeout with a status summary rather than looping forever. If it
+  was still waiting on review, say that's why and offer to keep watching.
 
 ## 4. Handle failure
 

--- a/.claude/skills/merging-prs/SKILL.md
+++ b/.claude/skills/merging-prs/SKILL.md
@@ -12,7 +12,7 @@ To merge, you enqueue the PR with a comment, then watch it until Trunk lands it.
 
 When a developer says "merge this PR", "merge it when it's ready", "land it",
 "ship it", or "babysit this PR", do the full loop below — enqueue **and** watch
-to completion, reporting the outcome. See also [docs/merge-queue.md](../../../docs/merge-queue.md).
+to completion, reporting the outcome.
 
 `<n>` below is the PR number. Resolve the repo slug once if you need it:
 `REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)`.
@@ -29,7 +29,20 @@ gh pr view <n> --json state,isDraft,mergeable,reviewDecision,statusCheckRollup
 - **Failing required checks** (`statusCheckRollup`) → the queue will just reject
   it. Report which checks are red and stop; fix them first. **Pending** checks
   are fine — the queue waits for them.
+- **Not yet approved** (`reviewDecision` empty or `REVIEW_REQUIRED`) → fine,
+  enqueue anyway. See below.
 - **Merge conflicts** (`mergeable == "CONFLICTING"`) → report and stop; rebase first.
+
+Enqueueing before approval is safe, and is the closest thing this repo has to
+auto-merge. A submitted PR sits in Trunk's `Queued` state until GitHub's branch
+protection on `main` is satisfied — one approving review, code-owner review, and
+the required checks (`build`, `quality`, `unit-test`, `integration-test`,
+`typecheck`) — and Trunk merges it once they land. Trunk is not a bypass actor on
+those rules, so it cannot merge an unapproved or red PR.
+
+The catch: **pushing new commits drops the PR from the queue.** If review
+feedback is likely, either wait for approval before enqueueing, or re-enqueue
+with `/trunk merge` after each push.
 
 ## 2. Enqueue
 
@@ -68,6 +81,9 @@ sleep 60
 - Watch the **check run + PR state**, not `gh pr checks --watch`: the queue runs
   CI on Trunk's own draft/`trunk-merge/**` branch, so this PR's own checks don't
   reflect the queue's testing.
+- If it's parked waiting on a human review, don't burn the full window polling.
+  Report that it's queued and will merge on approval, then hand back — unless the
+  developer explicitly asked you to watch it until it lands.
 - Stop at the timeout with a status summary rather than looping forever.
 
 ## 4. Handle failure


### PR DESCRIPTION
## Problem

`.claude/skills/merging-prs/SKILL.md` told the agent to stop at preflight if a PR wasn't approved yet. That's stricter than the queue actually requires, and it costs the "submit it now, let it land when it's green and approved" workflow.

## What the queue actually does

A submitted PR sits in Trunk's `Queued` state until GitHub's branch protection on `main` is satisfied, then Trunk tests and merges it — effectively auto-merge.

That's safe here because the `trunk-io` app (id `120106`) is a bypass actor **only** on the `Trunk merge` ruleset (the one blocking direct pushes to `main`). It is not a bypass actor on:

- **Require pull request** — 1 approving review + code-owner review
- **Require status checks** — `build`, `quality`, `unit-test`, `integration-test`, `typecheck`

So Trunk cannot merge an unapproved or red PR; it waits.

## Changes

- Preflight: an unapproved PR is no longer a stop condition — enqueue anyway.
- Documents the enqueue-early behaviour, and the catch that **pushing new commits drops the PR from the queue** (re-enqueue after each push).
- Poll loop: if the PR is parked waiting on a human review, report and hand back instead of burning the full 45–60 min window.
- Drops a link to `docs/merge-queue.md`, which doesn't exist in this repo.

`AGENTS.md`'s "Merging PRs" section is unchanged — it doesn't say anything about when to enqueue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)