### PR TITLE
feat(spaces): add task context menus to space sidebar

### DIFF
--- a/packages/core/src/context-menu/context-menu.test.ts
+++ b/packages/core/src/context-menu/context-menu.test.ts
@@ -142,6 +142,17 @@ describe("ContextMenuService.showTaskContextMenu", () => {
     );
   });
 
+  it("can hide Archive prior tasks for task lists without that action", async () => {
+    const menu = new FakeContextMenu();
+    makeService(menu).showTaskContextMenu({
+      ...baseTask,
+      showArchivePrior: false,
+    });
+    await menu.shown;
+    expect(labels(menu.lastItems)).not.toContain("Archive prior tasks");
+    expect(labels(menu.lastItems)).toContain("Archive");
+  });
+
   it("resolves to null when the menu is dismissed", async () => {
     const menu = new FakeContextMenu();
     const result = makeService(menu).showTaskContextMenu(baseTask);

--- a/packages/core/src/context-menu/context-menu.ts
+++ b/packages/core/src/context-menu/context-menu.ts
@@ -117,6 +117,7 @@ export class ContextMenuService {
       canStop,
       isInCommandCenter,
       hasEmptyCommandCenterCell,
+      showArchivePrior = true,
       channels,
     } = input;
     const { apps, lastUsedAppId } = await this.getExternalAppsData();
@@ -162,7 +163,7 @@ export class ContextMenuService {
       ...(!isInCommandCenter
         ? [
             this.separator(),
-            this.item(
+            this.item<TaskAction>(
               "Add to Command Center",
               { type: "add-to-command-center" as const },
               { enabled: hasEmptyCommandCenterCell ?? true },
@@ -172,19 +173,23 @@ export class ContextMenuService {
       ...fileToItems,
       this.separator(),
       this.item("Archive", { type: "archive" }),
-      this.item(
-        "Archive prior tasks",
-        { type: "archive-prior" },
-        {
-          confirm: {
-            title: "Archive Prior Tasks",
-            message: "Archive all tasks older than this one?",
-            detail:
-              "This will archive every task created before this one. You can unarchive them later.",
-            confirmLabel: "Archive",
-          },
-        },
-      ),
+      ...(showArchivePrior
+        ? [
+            this.item<TaskAction>(
+              "Archive prior tasks",
+              { type: "archive-prior" },
+              {
+                confirm: {
+                  title: "Archive Prior Tasks",
+                  message: "Archive all tasks older than this one?",
+                  detail:
+                    "This will archive every task created before this one. You can unarchive them later.",
+                  confirmLabel: "Archive",
+                },
+              },
+            ),
+          ]
+        : []),
     ]);
   }
 

--- a/packages/core/src/context-menu/schemas.ts
+++ b/packages/core/src/context-menu/schemas.ts
@@ -9,6 +9,7 @@ export const taskContextMenuInput = z.object({
   canStop: z.boolean().optional(),
   isInCommandCenter: z.boolean().optional(),
   hasEmptyCommandCenterCell: z.boolean().optional(),
+  showArchivePrior: z.boolean().optional(),
   // Top-level desktop_file_system channels available as "File to…" targets.
   // Omit (or pass empty) to hide the submenu entirely.
   channels: z.array(z.object({ id: z.string(), name: z.string() })).optional(),

--- a/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -1,8 +1,8 @@
 import type { ChannelItemModel } from "@posthog/core/canvas/channelItems";
 import type { TaskRunStatus } from "@posthog/shared/domain-types";
 import { Theme } from "@radix-ui/themes";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { ChannelItemRow } from "./ChannelItemRow";
 
 const actions = {
@@ -72,5 +72,24 @@ describe("ChannelItemRow", () => {
     expect(running).toHaveClass("ph-shimmer");
     // The glyph is wrapped, not replaced — no spinner swapped in its place.
     expect(running.querySelector("svg")).not.toBeNull();
+  });
+
+  it("opens the task context menu from the row", () => {
+    const onContextMenu = vi.fn();
+
+    render(
+      <Theme>
+        <ChannelItemRow
+          actions={actions}
+          isActive={false}
+          item={item()}
+          onContextMenu={onContextMenu}
+        />
+      </Theme>,
+    );
+
+    fireEvent.contextMenu(screen.getByText("Investigate signup drop-off"));
+
+    expect(onContextMenu).toHaveBeenCalledOnce();
   });
 });

--- a/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -11,6 +11,7 @@ import { formatRelativeTimeShort } from "@posthog/shared";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
 import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { InlineEditInput } from "@posthog/ui/features/sidebar/components/items/TaskItem";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
 import { NestedButton } from "@posthog/ui/primitives/NestedButton";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
@@ -70,10 +71,18 @@ export function ChannelItemRow({
   item,
   isActive,
   actions,
+  isEditing = false,
+  onContextMenu,
+  onEditSubmit,
+  onEditCancel,
 }: {
   item: ChannelItemModel;
   isActive: boolean;
   actions: ChannelItemActions;
+  isEditing?: boolean;
+  onContextMenu?: (event: React.MouseEvent) => void;
+  onEditSubmit?: (newTitle: string) => void;
+  onEditCancel?: () => void;
 }) {
   const icon = itemIcon(item);
   const statusLabel = runStatusLabel(item.rawStatus);
@@ -85,6 +94,19 @@ export function ChannelItemRow({
   ) : (
     icon
   );
+
+  if (isEditing) {
+    return (
+      <InlineEditInput
+        depth={0}
+        icon={rowIcon}
+        label={item.title}
+        isActive={isActive}
+        onSubmit={(newTitle) => onEditSubmit?.(newTitle)}
+        onCancel={() => onEditCancel?.()}
+      />
+    );
+  }
 
   return (
     <PreviewCard.Root>
@@ -100,6 +122,7 @@ export function ChannelItemRow({
               label={<span>{item.title}</span>}
               isActive={isActive}
               onClick={() => actions.open(item)}
+              onContextMenu={onContextMenu}
               endContent={
                 <>
                   <span className={TIMESTAMP_CLASS}>

--- a/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -33,10 +33,12 @@ import { ChannelBackRow } from "@posthog/ui/features/canvas/components/ChannelBa
 import { ChannelItemRow } from "@posthog/ui/features/canvas/components/ChannelItemRow";
 import { ChannelsFab } from "@posthog/ui/features/canvas/components/ChannelsFab";
 import { useChannelItems } from "@posthog/ui/features/canvas/hooks/useChannelItems";
+import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
 import { useTaskContextMenu } from "@posthog/ui/features/tasks/useTaskContextMenu";
 import { useRenameTask } from "@posthog/ui/features/tasks/useTaskMutations";
+import { navigateToCommandCenter } from "@posthog/ui/router/navigationBridge";
 import { logger } from "@posthog/ui/shell/logger";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { type ReactNode, useMemo, useState } from "react";
@@ -206,6 +208,10 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
   const { showContextMenu, editingTaskId, setEditingTaskId } =
     useTaskContextMenu();
   const { renameTask } = useRenameTask();
+  const commandCenterCells = useCommandCenterStore((state) => state.cells);
+  const assignTaskToCommandCenter = useCommandCenterStore(
+    (state) => state.assignTask,
+  );
 
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -246,8 +252,17 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
           ? (event) =>
               void showContextMenu(item, event, {
                 isPinned: item.pinned,
+                isInCommandCenter: commandCenterCells.includes(item.id),
+                hasEmptyCommandCenterCell: commandCenterCells.includes(null),
+                showArchivePrior: false,
                 onTogglePin: () => actions.togglePin(item),
                 onArchive: () => actions.archive(item),
+                onAddToCommandCenter: () => {
+                  const cellIndex = commandCenterCells.indexOf(null);
+                  if (cellIndex === -1) return;
+                  assignTaskToCommandCenter(cellIndex, item.id);
+                  navigateToCommandCenter();
+                },
               })
           : undefined
       }

--- a/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -35,6 +35,9 @@ import { ChannelsFab } from "@posthog/ui/features/canvas/components/ChannelsFab"
 import { useChannelItems } from "@posthog/ui/features/canvas/hooks/useChannelItems";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
+import { useTaskContextMenu } from "@posthog/ui/features/tasks/useTaskContextMenu";
+import { useRenameTask } from "@posthog/ui/features/tasks/useTaskMutations";
+import { logger } from "@posthog/ui/shell/logger";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { type ReactNode, useMemo, useState } from "react";
 
@@ -52,6 +55,7 @@ const cnHeaderButton = (active: boolean) =>
   cn(HEADER_ICON_BUTTON_CLASS, active && "bg-fill-selected text-foreground");
 
 const RECENTS_CAP = 30;
+const log = logger.scope("channel-sidebar");
 
 function RecentSectionHeader({
   searchOpen,
@@ -199,6 +203,9 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
 
   const { items, actions, me, isLoading, channelMissing } =
     useChannelItems(channelId);
+  const { showContextMenu, editingTaskId, setEditingTaskId } =
+    useTaskContextMenu();
+  const { renameTask } = useRenameTask();
 
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -225,6 +232,43 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
         { query, createdBy: createdByFilter, status: statusFilter, me },
       ).slice(0, RECENTS_CAP),
     [items, query, createdByFilter, statusFilter, me],
+  );
+
+  const taskRow = (item: (typeof items)[number]) => (
+    <ChannelItemRow
+      key={item.key}
+      item={item}
+      isActive={item.key === activeKey}
+      actions={actions}
+      isEditing={item.kind === "task" && editingTaskId === item.id}
+      onContextMenu={
+        item.kind === "task"
+          ? (event) =>
+              void showContextMenu(item, event, {
+                isPinned: item.pinned,
+                onTogglePin: () => actions.togglePin(item),
+                onArchive: () => actions.archive(item),
+              })
+          : undefined
+      }
+      onEditSubmit={
+        item.kind === "task"
+          ? async (newTitle) => {
+              setEditingTaskId(null);
+              try {
+                await renameTask({
+                  taskId: item.id,
+                  currentTitle: item.title,
+                  newTitle,
+                });
+              } catch (error) {
+                log.error("Failed to rename task", error);
+              }
+            }
+          : undefined
+      }
+      onEditCancel={() => setEditingTaskId(null)}
+    />
   );
 
   const sectionRow = (
@@ -313,14 +357,7 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
             <>
               <MenuLabel>Pinned</MenuLabel>
               <div className="flex flex-col gap-px">
-                {pinnedItems.map((item) => (
-                  <ChannelItemRow
-                    key={item.key}
-                    item={item}
-                    isActive={item.key === activeKey}
-                    actions={actions}
-                  />
-                ))}
+                {pinnedItems.map(taskRow)}
               </div>
             </>
           )}
@@ -343,14 +380,7 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
               />
               {recentItems.length > 0 ? (
                 <div className="flex flex-col gap-px">
-                  {recentItems.map((item) => (
-                    <ChannelItemRow
-                      key={item.key}
-                      item={item}
-                      isActive={item.key === activeKey}
-                      actions={actions}
-                    />
-                  ))}
+                  {recentItems.map(taskRow)}
                 </div>
               ) : (
                 <Empty className="border-0 py-6">

--- a/packages/ui/src/features/canvas/hooks/useChannelFeed.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelFeed.ts
@@ -5,9 +5,10 @@ import { useMemo } from "react";
 // Feeds are multiplayer: poll fast enough that a teammate's new task card and
 // run-status flips feel live without a dedicated push channel.
 const CHANNEL_FEED_POLL_INTERVAL_MS = 5_000;
+export const channelFeedQueryRoot = ["channel-feed"] as const;
 
 export function channelFeedQueryKey(channelId: string | undefined) {
-  return ["channel-feed", channelId ?? "none"] as const;
+  return [...channelFeedQueryRoot, channelId ?? "none"] as const;
 }
 
 /**

--- a/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -221,7 +221,7 @@ export function TaskItem({
   );
 }
 
-function InlineEditInput({
+export function InlineEditInput({
   depth,
   icon,
   label,

--- a/packages/ui/src/features/tasks/useTaskContextMenu.ts
+++ b/packages/ui/src/features/tasks/useTaskContextMenu.ts
@@ -49,6 +49,7 @@ export function useTaskContextMenu() {
         runId?: string;
         isInCommandCenter?: boolean;
         hasEmptyCommandCenterCell?: boolean;
+        showArchivePrior?: boolean;
         onTogglePin?: () => void;
         onStop?: (taskId: string, taskTitle: string, runId?: string) => void;
         onArchive?: (taskId: string) => void;
@@ -68,6 +69,7 @@ export function useTaskContextMenu() {
         runId,
         isInCommandCenter,
         hasEmptyCommandCenterCell,
+        showArchivePrior,
         onTogglePin,
         onStop,
         onArchive,
@@ -85,6 +87,7 @@ export function useTaskContextMenu() {
           canStop,
           isInCommandCenter,
           hasEmptyCommandCenterCell,
+          showArchivePrior,
           channels: channels.map(({ id, name }) => ({ id, name })),
         });
 

--- a/packages/ui/src/features/tasks/useTaskMutations.test.tsx
+++ b/packages/ui/src/features/tasks/useTaskMutations.test.tsx
@@ -1,5 +1,6 @@
 import type { Schemas } from "@posthog/api-client";
 import type { Task } from "@posthog/shared/domain-types";
+import { channelFeedQueryKey } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { act, type ReactNode } from "react";
@@ -70,6 +71,7 @@ describe("useRenameTask", () => {
     const listKey = taskKeys.list();
     const summaryKey = taskKeys.summaries([TASK_ID]);
     const detailKey = taskKeys.detail(TASK_ID);
+    const channelFeedKey = channelFeedQueryKey("channel-1");
     queryClient.setQueryData<Task[]>(listKey, [
       createTask(),
       createTask({ id: OTHER_TASK_ID, title: "Other" }),
@@ -79,6 +81,7 @@ describe("useRenameTask", () => {
       createSummary({ id: OTHER_TASK_ID, title: "Other" }),
     ]);
     queryClient.setQueryData<Task>(detailKey, createTask());
+    queryClient.setQueryData<Task[]>(channelFeedKey, [createTask()]);
 
     await act(async () => {
       await result.current.renameTask({
@@ -107,6 +110,12 @@ describe("useRenameTask", () => {
       title: "Renamed",
       title_manually_set: true,
     });
+    expect(queryClient.getQueryData<Task[]>(channelFeedKey)?.[0]).toMatchObject(
+      {
+        title: "Renamed",
+        title_manually_set: true,
+      },
+    );
 
     expect(mockUpdateTask).toHaveBeenCalledWith(TASK_ID, {
       title: "Renamed",
@@ -123,11 +132,13 @@ describe("useRenameTask", () => {
     const listKey = taskKeys.list();
     const summaryKey = taskKeys.summaries([TASK_ID]);
     const detailKey = taskKeys.detail(TASK_ID);
+    const channelFeedKey = channelFeedQueryKey("channel-1");
     queryClient.setQueryData<Task[]>(listKey, [createTask()]);
     queryClient.setQueryData<Schemas.TaskSummary[]>(summaryKey, [
       createSummary(),
     ]);
     queryClient.setQueryData<Task>(detailKey, createTask());
+    queryClient.setQueryData<Task[]>(channelFeedKey, [createTask()]);
 
     let caught: unknown;
     await act(async () => {
@@ -153,6 +164,9 @@ describe("useRenameTask", () => {
       queryClient.getQueryData<Schemas.TaskSummary[]>(summaryKey)?.[0].title,
     ).toBe("Original title");
     expect(queryClient.getQueryData<Task>(detailKey)?.title).toBe(
+      "Original title",
+    );
+    expect(queryClient.getQueryData<Task[]>(channelFeedKey)?.[0].title).toBe(
       "Original title",
     );
 

--- a/packages/ui/src/features/tasks/useTaskMutations.ts
+++ b/packages/ui/src/features/tasks/useTaskMutations.ts
@@ -15,6 +15,7 @@ import {
 } from "@posthog/core/tasks/taskRename";
 import { useService } from "@posthog/di/react";
 import type { Task } from "@posthog/shared/domain-types";
+import { channelFeedQueryRoot } from "@posthog/ui/features/canvas/hooks/useChannelFeed";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { useAuthenticatedMutation } from "@posthog/ui/hooks/useAuthenticatedMutation";
 import { useQueryClient } from "@tanstack/react-query";
@@ -66,6 +67,9 @@ export function useRenameTask() {
       const previousListQueries = queryClient.getQueriesData<Task[]>({
         queryKey: taskKeys.lists(),
       });
+      const previousChannelFeedQueries = queryClient.getQueriesData<Task[]>({
+        queryKey: channelFeedQueryRoot,
+      });
       const previousSummaryQueries = queryClient.getQueriesData<
         Schemas.TaskSummary[]
       >({
@@ -77,6 +81,10 @@ export function useRenameTask() {
 
       queryClient.setQueriesData<Task[]>(
         { queryKey: taskKeys.lists() },
+        (old) => applyRenameToList(old, taskId, newTitle),
+      );
+      queryClient.setQueriesData<Task[]>(
+        { queryKey: channelFeedQueryRoot },
         (old) => applyRenameToList(old, taskId, newTitle),
       );
       queryClient.setQueriesData<Schemas.TaskSummary[]>(
@@ -102,14 +110,22 @@ export function useRenameTask() {
         const listTitles = queryClient
           .getQueriesData<Task[]>({ queryKey: taskKeys.lists() })
           .map(([, tasks]) => getTaskTitle(tasks, taskId));
+        const channelFeedTitles = queryClient
+          .getQueriesData<Task[]>({ queryKey: channelFeedQueryRoot })
+          .map(([, tasks]) => getTaskTitle(tasks, taskId));
         const rollbackSession = shouldRollbackSessionTitle({
           detailTitle: queryClient.getQueryData<Task>(taskKeys.detail(taskId))
             ?.title,
-          listTitles,
+          listTitles: [...listTitles, ...channelFeedTitles],
           newTitle,
         });
 
         for (const [queryKey, data] of previousListQueries) {
+          queryClient.setQueryData<Task[] | undefined>(queryKey, (current) =>
+            rollbackListData(current, data ?? [], taskId, newTitle),
+          );
+        }
+        for (const [queryKey, data] of previousChannelFeedQueries) {
           queryClient.setQueryData<Task[] | undefined>(queryKey, (current) =>
             rollbackListData(current, data ?? [], taskId, newTitle),
           );


### PR DESCRIPTION
## Problem

Tasks in a space’s pinned and recent sections did not expose the task actions available in the previous task list.

## Changes

- Reuse the existing task context-menu flow for task rows in both space sections.
- Keep context-menu rename inline in the space sidebar.
- Add coverage for right-clicking a space task row.

**Why:** Task actions should remain consistently accessible as users move to the new space layout.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck`
- `pnpm --filter @posthog/ui exec vitest run src/features/canvas/components/ChannelItemRow.test.tsx`
- `pnpm exec biome check --write packages/ui/src/features/canvas/components/ChannelSidebar.tsx packages/ui/src/features/canvas/components/ChannelItemRow.tsx packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx packages/ui/src/features/sidebar/components/items/TaskItem.tsx`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*