### PR TITLE
feat(spaces): add Loops and Configure to global navigation

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -1,5 +1,11 @@
-import { BellIcon, EnvelopeSimple, Lightning } from "@phosphor-icons/react";
+import {
+  BellIcon,
+  EnvelopeSimple,
+  Lightning,
+  RepeatIcon,
+} from "@phosphor-icons/react";
 import { cn } from "@posthog/quill";
+import { LOOPS_FLAG } from "@posthog/shared";
 import {
   ANALYTICS_EVENTS,
   type SidebarNavItem,
@@ -10,12 +16,14 @@ import {
   SHORTCUTS,
 } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { useCommandCenterActiveCount } from "@posthog/ui/features/command-center/useCommandCenterActiveCount";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import { CountBadge } from "@posthog/ui/primitives/CountBadge";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import {
   navigateToActivity,
   navigateToInbox,
+  navigateToLoops,
   navigateToWebsiteCommandCenter,
 } from "@posthog/ui/router/navigationBridge";
 import { useAppView } from "@posthog/ui/router/useAppView";
@@ -64,6 +72,7 @@ function NavIcon({
 
 export function ChannelNav() {
   const view = useAppView();
+  const loopsEnabled = useFeatureFlag(LOOPS_FLAG, import.meta.env.DEV);
 
   const { counts } = useInboxAllReports({
     ignoreFilters: true,
@@ -118,6 +127,19 @@ export function ChannelNav() {
           />
         }
       />
+      {loopsEnabled ? (
+        <NavIcon
+          icon={
+            <RepeatIcon
+              size={16}
+              weight={view.type === "loops" ? "fill" : "regular"}
+            />
+          }
+          label="Loops"
+          isActive={view.type === "loops"}
+          onClick={withTrack("loops", navigateToLoops)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -3,6 +3,7 @@ import {
   EnvelopeSimple,
   Lightning,
   RepeatIcon,
+  SlidersHorizontal,
 } from "@phosphor-icons/react";
 import { cn } from "@posthog/quill";
 import { LOOPS_FLAG } from "@posthog/shared";
@@ -18,6 +19,7 @@ import {
 import { useCommandCenterActiveCount } from "@posthog/ui/features/command-center/useCommandCenterActiveCount";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
+import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { CountBadge } from "@posthog/ui/primitives/CountBadge";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import {
@@ -140,6 +142,12 @@ export function ChannelNav() {
           onClick={withTrack("loops", navigateToLoops)}
         />
       ) : null}
+      <NavIcon
+        icon={<SlidersHorizontal size={16} />}
+        label="Configure"
+        isActive={false}
+        onClick={withTrack("configure", () => openSettings("agents"))}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

Global Loops and Configure are available from the space-specific sidebar but missing from the compact global navigation, making them harder to reach consistently from the Channels layout.

**Why:** Loops and configuration should remain accessible as users move between spaces.

## Changes

- Add a feature-flagged Loops icon and a Configure icon to the global channel navigation.
- Reuse the existing routes, settings entry point, icons, active state, and navigation analytics.

## How did you test this?

- `pnpm exec biome check packages/ui/src/features/canvas/components/ChannelNav.tsx`
- `git diff --check`
- Attempted `pnpm --filter @posthog/ui typecheck`; blocked by missing fresh-clone workspace package build outputs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*