### PR TITLE
fix(channels): keep foreign canvases out of me

### DIFF
--- a/packages/core/src/canvas/channelItems.test.ts
+++ b/packages/core/src/canvas/channelItems.test.ts
@@ -114,8 +114,8 @@ describe("buildChannelItems", () => {
   it("filters to the owner for the personal channel", () => {
     const items = build({
       dashboards: [
-        canvas({ id: "mine", createdBy: "Ada Lovelace" }),
-        canvas({ id: "theirs", createdBy: "Grace Hopper" }),
+        canvas({ id: "mine", createdByUuid: ME.uuid }),
+        canvas({ id: "theirs", createdByUuid: OTHER.uuid }),
       ],
       feedTasks: [
         task({ id: "mine-task", created_by: ME }),
@@ -124,6 +124,14 @@ describe("buildChannelItems", () => {
       ownedBy: { uuid: ME.uuid, name: "Ada Lovelace" },
     });
     expect(items.map((i) => i.id).sort()).toEqual(["mine", "mine-task"]);
+  });
+
+  it("never claims ownership from a matching display name", () => {
+    const items = build({
+      dashboards: [canvas({ id: "name-twin", createdBy: "Ada Lovelace" })],
+      ownedBy: { uuid: ME.uuid, name: "Ada Lovelace" },
+    });
+    expect(items).toEqual([]);
   });
 
   it("excludes items whose author is unknown from the personal channel", () => {

--- a/packages/core/src/canvas/channelItems.test.ts
+++ b/packages/core/src/canvas/channelItems.test.ts
@@ -121,7 +121,7 @@ describe("buildChannelItems", () => {
         task({ id: "mine-task", created_by: ME }),
         task({ id: "their-task", created_by: OTHER }),
       ],
-      ownedBy: { uuid: ME.uuid, name: "Ada Lovelace" },
+      ownedBy: { uuid: ME.uuid },
     });
     expect(items.map((i) => i.id).sort()).toEqual(["mine", "mine-task"]);
   });
@@ -129,7 +129,7 @@ describe("buildChannelItems", () => {
   it("never claims ownership from a matching display name", () => {
     const items = build({
       dashboards: [canvas({ id: "name-twin", createdBy: "Ada Lovelace" })],
-      ownedBy: { uuid: ME.uuid, name: "Ada Lovelace" },
+      ownedBy: { uuid: ME.uuid },
     });
     expect(items).toEqual([]);
   });
@@ -138,7 +138,7 @@ describe("buildChannelItems", () => {
     const items = build({
       dashboards: [canvas({ id: "orphan", createdBy: undefined })],
       feedTasks: [task({ id: "orphan-task", created_by: null })],
-      ownedBy: { uuid: ME.uuid, name: "Ada Lovelace" },
+      ownedBy: { uuid: ME.uuid },
     });
     expect(items).toEqual([]);
   });
@@ -162,7 +162,7 @@ function model(over: Partial<ChannelItemModel> = {}): ChannelItemModel {
 }
 
 describe("filterChannelItems", () => {
-  const me = { uuid: ME.uuid, name: "Ada Lovelace" };
+  const me = { uuid: ME.uuid };
 
   it("matches titles case-insensitively", () => {
     const items = [model({ title: "Ship IT" }), model({ title: "Other" })];
@@ -192,6 +192,24 @@ describe("filterChannelItems", () => {
     });
     expect(result.map((i) => i.id)).toEqual(expected);
   });
+
+  // The backend returns `created_by: null` once a creator is deleted, so an
+  // item with no uuid is "unknown", not "someone else".
+  it.each(["me", "others"] as const)(
+    "keeps a creator-less item out of createdBy=%s",
+    (createdBy) => {
+      const items = [
+        model({ id: "orphan", authorUser: null, authorUuid: null }),
+      ];
+      const result = filterChannelItems(items, {
+        query: "",
+        createdBy,
+        status: null,
+        me,
+      });
+      expect(result).toEqual([]);
+    },
+  );
 
   it("filters by run status, including not_started", () => {
     const items = [

--- a/packages/core/src/canvas/channelItems.test.ts
+++ b/packages/core/src/canvas/channelItems.test.ts
@@ -126,13 +126,13 @@ describe("buildChannelItems", () => {
     expect(items.map((i) => i.id).sort()).toEqual(["mine", "mine-task"]);
   });
 
-  it("keeps items whose author is unknown", () => {
+  it("excludes items whose author is unknown from the personal channel", () => {
     const items = build({
       dashboards: [canvas({ id: "orphan", createdBy: undefined })],
       feedTasks: [task({ id: "orphan-task", created_by: null })],
       ownedBy: { uuid: ME.uuid, name: "Ada Lovelace" },
     });
-    expect(items).toHaveLength(2);
+    expect(items).toEqual([]);
   });
 });
 
@@ -147,6 +147,7 @@ function model(over: Partial<ChannelItemModel> = {}): ChannelItemModel {
     rawStatus: null,
     authorUser: ME,
     authorName: null,
+    authorUuid: ME.uuid,
     templateId: null,
     ...over,
   };

--- a/packages/core/src/canvas/channelItems.test.ts
+++ b/packages/core/src/canvas/channelItems.test.ts
@@ -173,8 +173,8 @@ describe("filterChannelItems", () => {
     ["anyone", ["mine", "theirs"]],
   ] as const)("filters createdBy=%s", (createdBy, expected) => {
     const items = [
-      model({ id: "mine", authorUser: ME }),
-      model({ id: "theirs", authorUser: OTHER }),
+      model({ id: "mine", authorUser: ME, authorUuid: ME.uuid }),
+      model({ id: "theirs", authorUser: OTHER, authorUuid: OTHER.uuid }),
     ];
     const result = filterChannelItems(items, {
       query: "",

--- a/packages/core/src/canvas/channelItems.ts
+++ b/packages/core/src/canvas/channelItems.ts
@@ -24,11 +24,14 @@ export interface ChannelItemOwner {
   name: string | null;
 }
 
+// Ownership keys off the stable creator uuid for every item kind (canvases via
+// `createdByUuid`, tasks via `created_by.uuid` — both set in buildChannelItems).
+// `authorUser` is a display-only field and is never consulted here. Display-name
+// matching stays as a fallback for rows the backend returns without a uuid.
 function isOwnedBy(
-  item: Pick<ChannelItemModel, "authorUser" | "authorName" | "authorUuid">,
+  item: Pick<ChannelItemModel, "authorName" | "authorUuid">,
   owner: ChannelItemOwner,
 ): boolean {
-  if (item.authorUser) return item.authorUser.uuid === owner.uuid;
   if (item.authorUuid) return item.authorUuid === owner.uuid;
   if (item.authorName && owner.name) return item.authorName === owner.name;
   return false;

--- a/packages/core/src/canvas/channelItems.ts
+++ b/packages/core/src/canvas/channelItems.ts
@@ -15,6 +15,7 @@ export interface ChannelItemModel {
   rawStatus: TaskRunStatus | null;
   authorUser: UserBasic | null;
   authorName: string | null;
+  authorUuid: string | null;
   templateId: string | null;
 }
 
@@ -24,12 +25,13 @@ export interface ChannelItemOwner {
 }
 
 function isOwnedBy(
-  item: Pick<ChannelItemModel, "authorUser" | "authorName">,
+  item: Pick<ChannelItemModel, "authorUser" | "authorName" | "authorUuid">,
   owner: ChannelItemOwner,
 ): boolean {
   if (item.authorUser) return item.authorUser.uuid === owner.uuid;
+  if (item.authorUuid) return item.authorUuid === owner.uuid;
   if (item.authorName && owner.name) return item.authorName === owner.name;
-  return true;
+  return false;
 }
 
 export function buildChannelItems({
@@ -55,6 +57,7 @@ export function buildChannelItems({
     rawStatus: null,
     authorUser: null,
     authorName: d.createdBy ?? null,
+    authorUuid: d.createdByUuid ?? null,
     templateId: d.templateId,
   }));
 
@@ -72,6 +75,7 @@ export function buildChannelItems({
             rawStatus: task.latest_run?.status ?? null,
             authorUser: task.created_by ?? null,
             authorName: null,
+            authorUuid: task.created_by?.uuid ?? null,
             templateId: null,
           },
         ],

--- a/packages/core/src/canvas/channelItems.ts
+++ b/packages/core/src/canvas/channelItems.ts
@@ -24,17 +24,16 @@ export interface ChannelItemOwner {
   name: string | null;
 }
 
-// Ownership keys off the stable creator uuid for every item kind (canvases via
+// Ownership is decided solely by the stable creator uuid (canvases via
 // `createdByUuid`, tasks via `created_by.uuid` — both set in buildChannelItems).
-// `authorUser` is a display-only field and is never consulted here. Display-name
-// matching stays as a fallback for rows the backend returns without a uuid.
+// A display name is NOT an identity — two users can share one — so it must never
+// gate the private `#me` space. Items without a creator uuid fail closed
+// (excluded from #me); `authorName`/`authorUser` are display-only.
 function isOwnedBy(
-  item: Pick<ChannelItemModel, "authorName" | "authorUuid">,
+  item: Pick<ChannelItemModel, "authorUuid">,
   owner: ChannelItemOwner,
 ): boolean {
-  if (item.authorUuid) return item.authorUuid === owner.uuid;
-  if (item.authorName && owner.name) return item.authorName === owner.name;
-  return false;
+  return item.authorUuid != null && item.authorUuid === owner.uuid;
 }
 
 export function buildChannelItems({

--- a/packages/core/src/canvas/channelItems.ts
+++ b/packages/core/src/canvas/channelItems.ts
@@ -21,7 +21,6 @@ export interface ChannelItemModel {
 
 export interface ChannelItemOwner {
   uuid: string | null;
-  name: string | null;
 }
 
 // Ownership is decided solely by the stable creator uuid (canvases via
@@ -112,6 +111,10 @@ export function filterChannelItems(
       return false;
     }
     if (createdBy !== "anyone") {
+      // An item with no creator uuid (e.g. the backend returns `created_by:
+      // null` once a creator is deleted) belongs to neither bucket: it isn't
+      // mine, but "others" means a *known* other person, not "unknown".
+      if (item.authorUuid == null) return false;
       const mine = isOwnedBy(item, me);
       if (createdBy === "me" ? !mine : mine) return false;
     }

--- a/packages/core/src/canvas/dashboardSchemas.ts
+++ b/packages/core/src/canvas/dashboardSchemas.ts
@@ -23,6 +23,7 @@ export const dashboardRecordSchema = z.object({
   // Display name of whoever created the file-system row (from the backend's
   // `created_by` user). Absent for rows the API returns without a creator.
   createdBy: z.string().optional(),
+  createdByUuid: z.string().optional(),
   createdAt: z.number(),
   updatedAt: z.number(),
   // Epoch ms the canvas was pinned to its channel; absent = not pinned. Stored
@@ -49,9 +50,8 @@ export const dashboardFileMetaSchema = z.object({
   context: z.string().optional(),
   // Id of the task currently generating this canvas (see dashboardRecordSchema).
   generationTaskId: z.string().nullish(),
-  // Display name of the creator, stamped at create time. We can't rely on the
-  // FS row's `created_by` (the list endpoint doesn't expand it), so we store our
-  // own. Absent on boards created before this field existed.
+  // Display name of the creator, stamped at create time for compatibility with
+  // rows created before the API exposed its `created_by` user.
   createdBy: z.string().optional(),
   // Epoch ms. createdAt mirrors the row's created_at; updatedAt is ours because
   // the FileSystem row has no updated_at column to sort the dashboards list by.
@@ -73,6 +73,7 @@ export const dashboardSummarySchema = z.object({
   name: z.string(),
   templateId: z.string().default("freeform"),
   createdBy: z.string().optional(),
+  createdByUuid: z.string().optional(),
   updatedAt: z.number(),
   // The React source, included so the grid can render a live preview without an
   // N+1 of get()s (it rides in the FS row's meta, already loaded when listing).

--- a/packages/core/src/canvas/dashboardsService.test.ts
+++ b/packages/core/src/canvas/dashboardsService.test.ts
@@ -14,7 +14,10 @@ function dashboardRow(
   name: string,
   channelId: string,
   updatedAt: number,
-): FsEntryBase & { meta: Record<string, unknown> } {
+): FsEntryBase & {
+  meta: Record<string, unknown>;
+  created_by?: { uuid: string };
+} {
   return {
     id,
     path: `Channels/${channelId}/${name}`,
@@ -63,6 +66,18 @@ describe("DashboardsService.list", () => {
 
     expect(result.map((d) => d.id)).toEqual(["b", "c", "a"]);
     expect(result[0]).toMatchObject({ name: "Newer", channelId: "chan-1" });
+  });
+
+  it("maps the backend creator uuid onto summaries", async () => {
+    const row = dashboardRow("a", "Canvas", "chan-1", 100);
+    row.created_by = { uuid: "creator-uuid" };
+    const { fs } = fakeFs([row]);
+
+    const [result] = await new DashboardsService(fs, {} as never).list(
+      "chan-1",
+    );
+
+    expect(result.createdByUuid).toBe("creator-uuid");
   });
 });
 

--- a/packages/core/src/canvas/dashboardsService.test.ts
+++ b/packages/core/src/canvas/dashboardsService.test.ts
@@ -16,7 +16,7 @@ function dashboardRow(
   updatedAt: number,
 ): FsEntryBase & {
   meta: Record<string, unknown>;
-  created_by?: { uuid: string };
+  created_by?: { uuid: string } | null;
 } {
   return {
     id,
@@ -78,6 +78,20 @@ describe("DashboardsService.list", () => {
     );
 
     expect(result.createdByUuid).toBe("creator-uuid");
+  });
+
+  // The backend sends `created_by: null` once the creator is deleted. Leaving
+  // the uuid undefined is what makes such a row fail closed out of #me.
+  it("leaves the creator uuid undefined when the row has no creator", async () => {
+    const row = dashboardRow("a", "Canvas", "chan-1", 100);
+    row.created_by = null;
+    const { fs } = fakeFs([row]);
+
+    const [result] = await new DashboardsService(fs, {} as never).list(
+      "chan-1",
+    );
+
+    expect(result.createdByUuid).toBeUndefined();
   });
 });
 

--- a/packages/core/src/canvas/dashboardsService.ts
+++ b/packages/core/src/canvas/dashboardsService.ts
@@ -28,6 +28,7 @@ interface FsEntry extends FsEntryBase {
   // The backend's creator user (standard PostHog UserBasic shape). Absent on
   // rows the API returns without an expanded creator.
   created_by?: {
+    uuid: string;
     first_name?: string | null;
     last_name?: string | null;
     email?: string | null;
@@ -88,6 +89,7 @@ export class DashboardsService {
           name,
           templateId,
           createdBy,
+          createdByUuid,
           updatedAt,
           code,
           generationTaskId,
@@ -98,6 +100,7 @@ export class DashboardsService {
           name,
           templateId,
           createdBy,
+          createdByUuid,
           updatedAt,
           code,
           generationTaskId,
@@ -793,6 +796,7 @@ function toRecord(entry: FsEntry): DashboardRecord {
     generationTaskId: meta.generationTaskId,
     // Prefer our stamped meta; fall back to the FS row's creator if present.
     createdBy: meta.createdBy ?? creatorName(entry.created_by),
+    createdByUuid: entry.created_by?.uuid,
     createdAt,
     updatedAt: meta.updatedAt ?? createdAt,
     pinnedAt: meta.pinnedAt,

--- a/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -22,6 +22,7 @@ function item(overrides: Partial<ChannelItemModel> = {}): ChannelItemModel {
     rawStatus: null,
     authorUser: null,
     authorName: null,
+    authorUuid: "user-uuid",
     templateId: null,
     ...overrides,
   };

--- a/packages/ui/src/features/canvas/hooks/useChannelItems.test.tsx
+++ b/packages/ui/src/features/canvas/hooks/useChannelItems.test.tsx
@@ -65,13 +65,14 @@ import { useChannelItems } from "./useChannelItems";
 
 const ME = { uuid: "me-uuid", first_name: "Ada", last_name: "Lovelace" };
 
-function canvas(id: string, createdBy?: string) {
+function canvas(id: string, createdBy?: string, createdByUuid?: string) {
   return {
     id,
     channelId: "c1",
     name: id,
     templateId: "freeform",
     createdBy,
+    createdByUuid,
     createdAt: 0,
     updatedAt: 1_000,
   };
@@ -126,8 +127,8 @@ describe("useChannelItems", () => {
     };
     mocks.dashboards = {
       dashboards: [
-        canvas("mine", "Ada Lovelace"),
-        canvas("theirs", "Grace Hopper"),
+        canvas("mine", "Ada Lovelace", ME.uuid),
+        canvas("theirs", "Grace Hopper", "other-uuid"),
       ],
       isLoading: false,
     };

--- a/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
+++ b/packages/ui/src/features/canvas/hooks/useChannelItems.tsx
@@ -18,7 +18,6 @@ import {
   PERSONAL_CHANNEL_NAME,
   useBackendChannel,
 } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
-import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";
 import { toast } from "@posthog/ui/primitives/toast";
 import { useNavigate } from "@tanstack/react-router";
@@ -69,12 +68,10 @@ export function useChannelItems(channelId: string): {
   });
 
   const meUuid = currentUser?.uuid ?? null;
-  const meName = currentUser ? userDisplayName(currentUser) : null;
-  const me = useMemo<ChannelItemOwner>(
-    () => ({ uuid: meUuid, name: meName }),
-    [meUuid, meName],
-  );
-  const viewerKnown = meUuid != null || meName != null;
+  const me = useMemo<ChannelItemOwner>(() => ({ uuid: meUuid }), [meUuid]);
+  // Only a uuid establishes identity — ownership compares uuids, so a viewer
+  // resolved without one can't be matched against anything and reads as unknown.
+  const viewerKnown = meUuid != null;
 
   const items = useMemo<ChannelItemModel[]>(
     () =>


### PR DESCRIPTION
## Problem

The personal `#me` space classifies canvases with missing creator metadata as owned by the viewer, allowing foreign legacy canvases to appear there.

## Changes

- Decide ownership **solely** by the stable creator uuid (`authorUuid`), uniformly for canvases and tasks.
- Remove display-name matching from ownership: a shared/auto-generated name is not an identity, and using it to gate the private `#me` space could leak canvases between two users with the same name.
- Fail closed — items with no creator uuid don't appear in anyone's `#me`. `authorName`/`authorUser` are kept for display only.

Depends on [PostHog/posthog#74282](https://github.com/PostHog/posthog/pull/74282) for creator UUIDs in file-system responses. Safe to merge first: until it lands, uuid-less canvases fail closed (they're excluded from `#me` rather than mis-attributed).

## How did you test this?

- `pnpm --filter @posthog/core exec vitest run src/canvas/channelItems.test.ts src/canvas/dashboardsService.test.ts`
- `pnpm --filter @posthog/core typecheck`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm build`
- Biome check on all changed files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
