### PR TITLE
fix(spaces): keep space data warm across navigation

### DIFF
--- a/packages/ui/src/features/canvas/hooks/spaceQueryPolicy.ts
+++ b/packages/ui/src/features/canvas/hooks/spaceQueryPolicy.ts
@@ -1,0 +1,5 @@
+// Space collections stay visible while they revalidate. Only mounted (active)
+// space queries poll; inactive spaces remain cached for fast switching.
+export const SPACE_QUERY_STALE_TIME_MS = 15_000;
+export const SPACE_QUERY_GC_TIME_MS = 30 * 60_000;
+export const SPACE_QUERY_REFETCH_INTERVAL_MS = 15_000;

--- a/packages/ui/src/features/canvas/hooks/useChannelFeed.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelFeed.ts
@@ -1,6 +1,10 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { useMemo } from "react";
+import {
+  SPACE_QUERY_GC_TIME_MS,
+  SPACE_QUERY_STALE_TIME_MS,
+} from "./spaceQueryPolicy";
 
 // Feeds are multiplayer: poll fast enough that a teammate's new task card and
 // run-status flips feel live without a dedicated push channel.
@@ -24,7 +28,9 @@ export function useChannelFeed(channelId: string | undefined): {
       client.getTasks({ channel: channelId }) as unknown as Promise<Task[]>,
     {
       enabled: !!channelId,
+      gcTime: SPACE_QUERY_GC_TIME_MS,
       refetchInterval: CHANNEL_FEED_POLL_INTERVAL_MS,
+      staleTime: SPACE_QUERY_STALE_TIME_MS,
     },
   );
   const tasks = useMemo(

--- a/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
@@ -2,6 +2,11 @@ import type { ChannelTaskRecord } from "@posthog/core/canvas/channelTaskSchemas"
 import { useHostTRPC } from "@posthog/host-router/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import {
+  SPACE_QUERY_GC_TIME_MS,
+  SPACE_QUERY_REFETCH_INTERVAL_MS,
+  SPACE_QUERY_STALE_TIME_MS,
+} from "./spaceQueryPolicy";
 
 /** Tasks filed to a channel — backed by desktop_file_system rows. */
 export function useChannelTasks(channelId: string | undefined): {
@@ -12,7 +17,12 @@ export function useChannelTasks(channelId: string | undefined): {
   const { data, isLoading } = useQuery(
     trpc.channelTasks.list.queryOptions(
       { channelId: channelId ?? "" },
-      { enabled: !!channelId, staleTime: 5_000 },
+      {
+        enabled: !!channelId,
+        gcTime: SPACE_QUERY_GC_TIME_MS,
+        refetchInterval: SPACE_QUERY_REFETCH_INTERVAL_MS,
+        staleTime: SPACE_QUERY_STALE_TIME_MS,
+      },
     ),
   );
   return { tasks: data ?? [], isLoading };
@@ -31,7 +41,10 @@ export function usePrefetchChannelTasks(): (channelId: string) => void {
       void queryClient.prefetchQuery(
         trpc.channelTasks.list.queryOptions(
           { channelId },
-          { staleTime: 5_000 },
+          {
+            gcTime: SPACE_QUERY_GC_TIME_MS,
+            staleTime: SPACE_QUERY_STALE_TIME_MS,
+          },
         ),
       );
     },

--- a/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelTasks.ts
@@ -1,5 +1,6 @@
 import type { ChannelTaskRecord } from "@posthog/core/canvas/channelTaskSchemas";
 import { useHostTRPC } from "@posthog/host-router/react";
+import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import {
@@ -20,6 +21,7 @@ export function useChannelTasks(channelId: string | undefined): {
       {
         enabled: !!channelId,
         gcTime: SPACE_QUERY_GC_TIME_MS,
+        meta: AUTH_SCOPED_QUERY_META,
         refetchInterval: SPACE_QUERY_REFETCH_INTERVAL_MS,
         staleTime: SPACE_QUERY_STALE_TIME_MS,
       },
@@ -43,6 +45,7 @@ export function usePrefetchChannelTasks(): (channelId: string) => void {
           { channelId },
           {
             gcTime: SPACE_QUERY_GC_TIME_MS,
+            meta: AUTH_SCOPED_QUERY_META,
             staleTime: SPACE_QUERY_STALE_TIME_MS,
           },
         ),

--- a/packages/ui/src/features/canvas/hooks/useDashboards.ts
+++ b/packages/ui/src/features/canvas/hooks/useDashboards.ts
@@ -4,6 +4,7 @@ import type {
 } from "@posthog/core/canvas/dashboardSchemas";
 import type { FreeformVersion } from "@posthog/core/canvas/freeformSchemas";
 import { useHostTRPC } from "@posthog/host-router/react";
+import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
 import { useDashboardEditStore } from "@posthog/ui/features/canvas/stores/dashboardEditStore";
 import { toast } from "@posthog/ui/primitives/toast";
 import { logger } from "@posthog/ui/shell/logger";
@@ -44,6 +45,7 @@ export function useDashboards(
       {
         enabled: !!channelId,
         gcTime: SPACE_QUERY_GC_TIME_MS,
+        meta: AUTH_SCOPED_QUERY_META,
         refetchInterval:
           options?.poll === false ? false : SPACE_QUERY_REFETCH_INTERVAL_MS,
         staleTime: SPACE_QUERY_STALE_TIME_MS,
@@ -68,6 +70,7 @@ export function usePrefetchDashboards(): (channelId: string) => void {
           { channelId },
           {
             gcTime: SPACE_QUERY_GC_TIME_MS,
+            meta: AUTH_SCOPED_QUERY_META,
             staleTime: SPACE_QUERY_STALE_TIME_MS,
           },
         ),

--- a/packages/ui/src/features/canvas/hooks/useDashboards.ts
+++ b/packages/ui/src/features/canvas/hooks/useDashboards.ts
@@ -10,6 +10,11 @@ import { logger } from "@posthog/ui/shell/logger";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
+import {
+  SPACE_QUERY_GC_TIME_MS,
+  SPACE_QUERY_REFETCH_INTERVAL_MS,
+  SPACE_QUERY_STALE_TIME_MS,
+} from "./spaceQueryPolicy";
 
 const log = logger.scope("dashboards");
 
@@ -33,7 +38,12 @@ export function useDashboards(channelId: string | undefined): {
   const { data, isLoading } = useQuery(
     trpc.dashboards.list.queryOptions(
       { channelId: channelId ?? "" },
-      { enabled: !!channelId, staleTime: 5_000 },
+      {
+        enabled: !!channelId,
+        gcTime: SPACE_QUERY_GC_TIME_MS,
+        refetchInterval: SPACE_QUERY_REFETCH_INTERVAL_MS,
+        staleTime: SPACE_QUERY_STALE_TIME_MS,
+      },
     ),
   );
   return { dashboards: data ?? [], isLoading };
@@ -50,7 +60,13 @@ export function usePrefetchDashboards(): (channelId: string) => void {
   return useCallback(
     (channelId: string) => {
       void queryClient.prefetchQuery(
-        trpc.dashboards.list.queryOptions({ channelId }, { staleTime: 5_000 }),
+        trpc.dashboards.list.queryOptions(
+          { channelId },
+          {
+            gcTime: SPACE_QUERY_GC_TIME_MS,
+            staleTime: SPACE_QUERY_STALE_TIME_MS,
+          },
+        ),
       );
     },
     [trpc, queryClient],

--- a/packages/ui/src/features/canvas/hooks/useDashboards.ts
+++ b/packages/ui/src/features/canvas/hooks/useDashboards.ts
@@ -30,7 +30,10 @@ export function isPlaceholderCanvasName(name: string): boolean {
 }
 
 /** Saved canvases for a channel (file-backed freeform React apps). */
-export function useDashboards(channelId: string | undefined): {
+export function useDashboards(
+  channelId: string | undefined,
+  options?: { poll?: boolean },
+): {
   dashboards: DashboardSummary[];
   isLoading: boolean;
 } {
@@ -41,7 +44,8 @@ export function useDashboards(channelId: string | undefined): {
       {
         enabled: !!channelId,
         gcTime: SPACE_QUERY_GC_TIME_MS,
-        refetchInterval: SPACE_QUERY_REFETCH_INTERVAL_MS,
+        refetchInterval:
+          options?.poll === false ? false : SPACE_QUERY_REFETCH_INTERVAL_MS,
         staleTime: SPACE_QUERY_STALE_TIME_MS,
       },
     ),

--- a/packages/ui/src/features/loops/components/LoopContextFields.tsx
+++ b/packages/ui/src/features/loops/components/LoopContextFields.tsx
@@ -23,7 +23,7 @@ export function LoopContextFields({
   disabled,
 }: LoopContextFieldsProps) {
   const { channels } = useChannels();
-  const { dashboards } = useDashboards(value?.folderId);
+  const { dashboards } = useDashboards(value?.folderId, { poll: false });
   const hasCanvases = dashboards.length > 0;
 
   const selectContext = (folderId: string) => {


### PR DESCRIPTION
## Problem

Switching between recently visited spaces refetched their collaborative collections instead of immediately reusing cached data.

**Why:** Space switching should feel immediate without delaying updates made by teammates.

## Changes

- Retain inactive space collections for fast return navigation.
- Revalidate active space tasks and canvases on a short interval while preserving cached content.

## How did you test this?

- `pnpm exec biome check` on the changed hooks
- `pnpm --filter @posthog/ui typecheck`
- `pnpm --filter @posthog/ui test` (2,299 tests)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*