### PR TITLE
Remove "Looping" from agent thinking messages

### DIFF
--- a/apps/mobile/src/features/chat/utils/thinkingMessages.ts
+++ b/apps/mobile/src/features/chat/utils/thinkingMessages.ts
@@ -60,7 +60,6 @@ export const THINKING_MESSAGES = [
   "Blooming",
   "Sparking",
   "Nesting",
-  "Looping",
   "Wiring",
   "Snipping",
   "Zoning",

--- a/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
+++ b/packages/ui/src/features/sessions/components/GeneratingIndicator.tsx
@@ -61,7 +61,6 @@ const THINKING_MESSAGES = [
   "Blooming",
   "Sparking",
   "Nesting",
-  "Looping",
   "Wiring",
   "Snipping",
   "Zoning",


### PR DESCRIPTION
## Problem

The word "Looping" showing while the agent is thinking is misleading — it collides with the "loops" feature and implies the agent is running a loop when it isn't. Raised in a Slack thread.

## Changes

Removed `"Looping"` from the `THINKING_MESSAGES` list in both places it lives (the mobile chat util and the shared `GeneratingIndicator` component). All other status words are unchanged.

## How did you test this?

No tests run — this is a one-word deletion from a static string array.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785268756876369?thread_ts=1785268756.876369&cid=C09G8Q32R6F)*