### PR TITLE
fix(loops): Reintroduce main loops UI in the spaces view

### DIFF
--- a/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
@@ -63,9 +63,11 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
   const contextName = channel?.name ?? channelId;
   const isPersonal = contextName === PERSONAL_CHANNEL_NAME;
   const authenticatedClient = useOptionalAuthenticatedClient();
-  const { data: currentUser, isLoading: currentUserLoading } = useCurrentUser({
-    client: authenticatedClient,
-  });
+  const {
+    data: currentUser,
+    isLoading: currentUserLoading,
+    isError: currentUserError,
+  } = useCurrentUser({ client: authenticatedClient });
 
   useSetHeaderContent(
     useMemo(() => <ChannelHeader channelId={channelId} />, [channelId]),
@@ -169,7 +171,7 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
 
           {isLoading || (isPersonal && currentUserLoading) ? (
             <LoopsSkeleton />
-          ) : isError ? (
+          ) : isError || (isPersonal && currentUserError) ? (
             <LoopsEmptyNotice
               title="Couldn't load loops"
               hint="The loops API returned an error. Try again in a moment."

--- a/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
@@ -12,11 +12,14 @@ import {
 } from "../../loops/components/LoopFallbacks";
 import { LoopRow } from "../../loops/components/LoopRow";
 import { LoopsEmptyState } from "../../loops/components/LoopsEmptyState";
+import { LoopTemplatesSection } from "../../loops/components/LoopTemplatesSection";
 import { useLoopLimits, useLoops } from "../../loops/hooks/useLoops";
 import { useLoopDraftStore } from "../../loops/loopDraftStore";
 import { defaultLoopContextOutputs } from "../../loops/loopFormTypes";
+import type { LoopTemplate } from "../../loops/loopTemplates";
 import { useChannels } from "../hooks/useChannels";
 import { useOrgMembers } from "../hooks/useOrgMembers";
+import { PERSONAL_CHANNEL_NAME } from "../hooks/useTaskChannels";
 
 function contextQuickStarts(name: string): { label: string; prompt: string }[] {
   return [
@@ -52,6 +55,7 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
   const { channels } = useChannels();
   const channel = channels.find((c) => c.id === channelId);
   const contextName = channel?.name ?? channelId;
+  const isPersonal = contextName === PERSONAL_CHANNEL_NAME;
 
   useSetHeaderContent(
     useMemo(() => <ChannelHeader channelId={channelId} />, [channelId]),
@@ -82,13 +86,26 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
     navigateToNewLoop();
   };
 
+  const startFromTemplate = (template: LoopTemplate) => {
+    useLoopDraftStore.getState().setPrefill({
+      description: template.description,
+      ...template.build(),
+      contextTarget: {
+        folderId: channelId,
+        name: contextName,
+        outputs: defaultLoopContextOutputs(),
+      },
+    });
+    navigateToNewLoop();
+  };
+
   return (
     <Flex direction="column" className="h-full min-h-0">
       <div className="min-h-0 flex-1 overflow-auto">
         <Flex
           direction="column"
           gap="6"
-          className="@container mx-auto w-full max-w-3xl px-8 py-8"
+          className="@container mx-auto w-full max-w-5xl px-8 py-8"
         >
           <div className="flex @min-[640px]:flex-row flex-col items-start @min-[640px]:items-center justify-between gap-3">
             <Flex
@@ -98,7 +115,7 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
             >
               <Flex align="center" gap="2" wrap="wrap">
                 <Heading className="font-bold text-2xl">
-                  Automate #{contextName}
+                  {isPersonal ? "Loops" : `Automate #${contextName}`}
                 </Heading>
                 <Flex
                   align="center"
@@ -115,8 +132,9 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
                 </Flex>
               </Flex>
               <Text color="gray" className="text-sm">
-                Build a loop that posts its runs to this context's feed, or
-                keeps its context.md or a canvas up to date.
+                Put your work on autopilot. Loops run on a schedule, on an API
+                call, or when something happens on GitHub. You can finally close
+                the laptop!
               </Text>
             </Flex>
             <Button
@@ -160,8 +178,12 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
               </Flex>
             </Flex>
           ) : (
-            <LoopsEmptyState contextName={contextName} />
+            <LoopsEmptyState
+              contextName={isPersonal ? undefined : contextName}
+            />
           )}
+
+          <LoopTemplatesSection onSelect={startFromTemplate} />
         </Flex>
       </div>
 
@@ -169,7 +191,7 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
         <Flex
           direction="column"
           gap="2"
-          className="mx-auto w-full max-w-3xl px-8 pt-3 pb-6"
+          className="mx-auto w-full max-w-5xl px-8 pt-3 pb-6"
         >
           <LoopBuilderComposer
             context={{ folderId: channelId, name: contextName }}

--- a/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
@@ -1,6 +1,4 @@
 import { CloudIcon, PlusIcon } from "@phosphor-icons/react";
-import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
-import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { Button } from "@posthog/ui/primitives/Button";
@@ -14,10 +12,6 @@ import {
 } from "../../loops/components/LoopFallbacks";
 import { LoopRow } from "../../loops/components/LoopRow";
 import { LoopsEmptyState } from "../../loops/components/LoopsEmptyState";
-import {
-  LoopListTabs,
-  splitLoopsByOwnership,
-} from "../../loops/components/LoopsListView";
 import { LoopTemplatesSection } from "../../loops/components/LoopTemplatesSection";
 import { useLoopLimits, useLoops } from "../../loops/hooks/useLoops";
 import { useLoopDraftStore } from "../../loops/loopDraftStore";
@@ -62,18 +56,11 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
   const channel = channels.find((c) => c.id === channelId);
   const contextName = channel?.name ?? channelId;
   const isPersonal = contextName === PERSONAL_CHANNEL_NAME;
-  const authenticatedClient = useOptionalAuthenticatedClient();
-  const {
-    data: currentUser,
-    isLoading: currentUserLoading,
-    isError: currentUserError,
-  } = useCurrentUser({ client: authenticatedClient });
 
   useSetHeaderContent(
     useMemo(() => <ChannelHeader channelId={channelId} />, [channelId]),
   );
 
-  const allLoops = loops ?? [];
   const attachedLoops = useMemo(
     () =>
       (loops ?? []).filter(
@@ -81,18 +68,12 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
       ),
     [loops, channelId],
   );
-  const { personalLoops, teamLoops } = splitLoopsByOwnership(
-    allLoops,
-    currentUser?.id ?? null,
-  );
   const {
     members,
     isLoading: membersLoading,
     isError: membersError,
     isComplete: membersComplete,
-  } = useOrgMembers({
-    enabled: isPersonal ? allLoops.length > 0 : attachedLoops.length > 0,
-  });
+  } = useOrgMembers({ enabled: attachedLoops.length > 0 });
 
   const startBlank = () => {
     useLoopDraftStore.getState().setPrefill({
@@ -169,26 +150,13 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
             </Button>
           </div>
 
-          {isLoading || (isPersonal && currentUserLoading) ? (
+          {isLoading ? (
             <LoopsSkeleton />
-          ) : isError || (isPersonal && currentUserError) ? (
+          ) : isError ? (
             <LoopsEmptyNotice
               title="Couldn't load loops"
               hint="The loops API returned an error. Try again in a moment."
             />
-          ) : isPersonal ? (
-            allLoops.length > 0 ? (
-              <LoopListTabs
-                personalLoops={personalLoops}
-                teamLoops={teamLoops}
-                members={members}
-                membersLoading={membersLoading}
-                membersError={membersError}
-                membersComplete={membersComplete}
-              />
-            ) : (
-              <LoopsEmptyState />
-            )
           ) : attachedLoops.length > 0 ? (
             <Flex direction="column" gap="3">
               <Text className="font-medium text-[12px] text-gray-10 uppercase tracking-wide">
@@ -210,7 +178,9 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
               </Flex>
             </Flex>
           ) : (
-            <LoopsEmptyState contextName={contextName} />
+            <LoopsEmptyState
+              contextName={isPersonal ? undefined : contextName}
+            />
           )}
 
           <LoopTemplatesSection onSelect={startFromTemplate} />

--- a/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelLoops.tsx
@@ -1,4 +1,6 @@
 import { CloudIcon, PlusIcon } from "@phosphor-icons/react";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { Button } from "@posthog/ui/primitives/Button";
@@ -12,6 +14,10 @@ import {
 } from "../../loops/components/LoopFallbacks";
 import { LoopRow } from "../../loops/components/LoopRow";
 import { LoopsEmptyState } from "../../loops/components/LoopsEmptyState";
+import {
+  LoopListTabs,
+  splitLoopsByOwnership,
+} from "../../loops/components/LoopsListView";
 import { LoopTemplatesSection } from "../../loops/components/LoopTemplatesSection";
 import { useLoopLimits, useLoops } from "../../loops/hooks/useLoops";
 import { useLoopDraftStore } from "../../loops/loopDraftStore";
@@ -56,11 +62,16 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
   const channel = channels.find((c) => c.id === channelId);
   const contextName = channel?.name ?? channelId;
   const isPersonal = contextName === PERSONAL_CHANNEL_NAME;
+  const authenticatedClient = useOptionalAuthenticatedClient();
+  const { data: currentUser, isLoading: currentUserLoading } = useCurrentUser({
+    client: authenticatedClient,
+  });
 
   useSetHeaderContent(
     useMemo(() => <ChannelHeader channelId={channelId} />, [channelId]),
   );
 
+  const allLoops = loops ?? [];
   const attachedLoops = useMemo(
     () =>
       (loops ?? []).filter(
@@ -68,12 +79,18 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
       ),
     [loops, channelId],
   );
+  const { personalLoops, teamLoops } = splitLoopsByOwnership(
+    allLoops,
+    currentUser?.id ?? null,
+  );
   const {
     members,
     isLoading: membersLoading,
     isError: membersError,
     isComplete: membersComplete,
-  } = useOrgMembers({ enabled: attachedLoops.length > 0 });
+  } = useOrgMembers({
+    enabled: isPersonal ? allLoops.length > 0 : attachedLoops.length > 0,
+  });
 
   const startBlank = () => {
     useLoopDraftStore.getState().setPrefill({
@@ -150,13 +167,26 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
             </Button>
           </div>
 
-          {isLoading ? (
+          {isLoading || (isPersonal && currentUserLoading) ? (
             <LoopsSkeleton />
           ) : isError ? (
             <LoopsEmptyNotice
               title="Couldn't load loops"
               hint="The loops API returned an error. Try again in a moment."
             />
+          ) : isPersonal ? (
+            allLoops.length > 0 ? (
+              <LoopListTabs
+                personalLoops={personalLoops}
+                teamLoops={teamLoops}
+                members={members}
+                membersLoading={membersLoading}
+                membersError={membersError}
+                membersComplete={membersComplete}
+              />
+            ) : (
+              <LoopsEmptyState />
+            )
           ) : attachedLoops.length > 0 ? (
             <Flex direction="column" gap="3">
               <Text className="font-medium text-[12px] text-gray-10 uppercase tracking-wide">
@@ -178,9 +208,7 @@ export function WebsiteChannelLoops({ channelId }: { channelId: string }) {
               </Flex>
             </Flex>
           ) : (
-            <LoopsEmptyState
-              contextName={isPersonal ? undefined : contextName}
-            />
+            <LoopsEmptyState contextName={contextName} />
           )}
 
           <LoopTemplatesSection onSelect={startFromTemplate} />

--- a/packages/ui/src/features/loops/components/LoopsEmptyState.tsx
+++ b/packages/ui/src/features/loops/components/LoopsEmptyState.tsx
@@ -12,8 +12,8 @@ const GETTING_STARTED_STEPS = [
 export function LoopsEmptyState({ contextName }: { contextName?: string }) {
   return (
     <div className="@container">
-      <div className="flex @min-[720px]:flex-row flex-col items-center @min-[720px]:gap-0 gap-6 rounded-(--radius-3) border border-gray-6 border-dashed @min-[720px]:px-8 px-5 py-8">
-        <Flex justify="center" className="@min-[720px]:w-2/5 w-full shrink-0">
+      <div className="flex @min-[560px]:flex-row flex-col items-center @min-[560px]:gap-0 gap-6 rounded-(--radius-3) border border-gray-6 border-dashed @min-[560px]:px-8 px-5 py-8">
+        <Flex justify="center" className="@min-[560px]:w-2/5 w-full shrink-0">
           <img src={loopHog} alt="" className="h-auto w-52 object-contain" />
         </Flex>
         <Flex

--- a/packages/ui/src/features/loops/components/LoopsListView.tsx
+++ b/packages/ui/src/features/loops/components/LoopsListView.tsx
@@ -183,24 +183,6 @@ interface LoopsListViewPresentationProps {
   onBuilderSessionStopped?: (taskId: string) => void;
 }
 
-export function splitLoopsByOwnership(
-  loops: LoopSchemas.Loop[],
-  currentUserId: number | null,
-): { personalLoops: LoopSchemas.Loop[]; teamLoops: LoopSchemas.Loop[] } {
-  return {
-    personalLoops: loops.filter(
-      (loop) =>
-        loop.visibility === "personal" ||
-        (currentUserId !== null && loop.created_by_id === currentUserId),
-    ),
-    teamLoops: loops.filter(
-      (loop) =>
-        loop.visibility === "team" &&
-        (currentUserId === null || loop.created_by_id !== currentUserId),
-    ),
-  };
-}
-
 export function LoopsListViewPresentation({
   loops,
   currentUserId = null,
@@ -217,9 +199,15 @@ export function LoopsListViewPresentation({
   onResumeBuilderSession,
   onBuilderSessionStopped,
 }: LoopsListViewPresentationProps) {
-  const { personalLoops, teamLoops } = splitLoopsByOwnership(
-    loops,
-    currentUserId,
+  const personalLoops = loops.filter(
+    (loop) =>
+      loop.visibility === "personal" ||
+      (currentUserId !== null && loop.created_by_id === currentUserId),
+  );
+  const teamLoops = loops.filter(
+    (loop) =>
+      loop.visibility === "team" &&
+      (currentUserId === null || loop.created_by_id !== currentUserId),
   );
 
   return (
@@ -318,7 +306,7 @@ export function LoopsListViewPresentation({
   );
 }
 
-export function LoopListTabs({
+function LoopListTabs({
   personalLoops,
   teamLoops,
   members,

--- a/packages/ui/src/features/loops/components/LoopsListView.tsx
+++ b/packages/ui/src/features/loops/components/LoopsListView.tsx
@@ -183,6 +183,24 @@ interface LoopsListViewPresentationProps {
   onBuilderSessionStopped?: (taskId: string) => void;
 }
 
+export function splitLoopsByOwnership(
+  loops: LoopSchemas.Loop[],
+  currentUserId: number | null,
+): { personalLoops: LoopSchemas.Loop[]; teamLoops: LoopSchemas.Loop[] } {
+  return {
+    personalLoops: loops.filter(
+      (loop) =>
+        loop.visibility === "personal" ||
+        (currentUserId !== null && loop.created_by_id === currentUserId),
+    ),
+    teamLoops: loops.filter(
+      (loop) =>
+        loop.visibility === "team" &&
+        (currentUserId === null || loop.created_by_id !== currentUserId),
+    ),
+  };
+}
+
 export function LoopsListViewPresentation({
   loops,
   currentUserId = null,
@@ -199,15 +217,9 @@ export function LoopsListViewPresentation({
   onResumeBuilderSession,
   onBuilderSessionStopped,
 }: LoopsListViewPresentationProps) {
-  const personalLoops = loops.filter(
-    (loop) =>
-      loop.visibility === "personal" ||
-      (currentUserId !== null && loop.created_by_id === currentUserId),
-  );
-  const teamLoops = loops.filter(
-    (loop) =>
-      loop.visibility === "team" &&
-      (currentUserId === null || loop.created_by_id !== currentUserId),
+  const { personalLoops, teamLoops } = splitLoopsByOwnership(
+    loops,
+    currentUserId,
   );
 
   return (
@@ -306,7 +318,7 @@ export function LoopsListViewPresentation({
   );
 }
 
-function LoopListTabs({
+export function LoopListTabs({
   personalLoops,
   teamLoops,
   members,


### PR DESCRIPTION
## Problem

The space-scoped Loops tab lost the templates, the ownership tabs and the wider layout from the main Loops page. Loops without a space attachment were missing from #me entirely.

## Changes

Reintroduces the main Loops page pieces into the spaces view: the template grid (seeding the wizard with the space attached), the My loops / Team loops tabs in #me and the matching header copy and width.

## How did you test this?

Verified #me and a team space in the running app over CDP. Typecheck, biome and the full @posthog/ui vitest suite pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?