### PR TITLE
fix(agent): restore Claude Opus 5 reasoning efforts

### DIFF
--- a/packages/shared/src/reasoning-effort.test.ts
+++ b/packages/shared/src/reasoning-effort.test.ts
@@ -7,6 +7,8 @@ describe("isSupportedReasoningEffort", () => {
     ["codex", "gpt-5.6-sol", "max", true],
     ["codex", "gpt-5.4", "max", false],
     ["claude", "claude-opus-4-8", "xhigh", true],
+    ["claude", "claude-opus-5", "high", true],
+    ["claude", "claude-opus-5", "max", true],
     ["claude", "claude-sonnet-4-6", "xhigh", false],
     ["claude", "@cf/zai-org/glm-5.2", "high", true],
     ["claude", "@cf/zai-org/glm-5.2", "max", true],

--- a/packages/shared/src/reasoning-effort.ts
+++ b/packages/shared/src/reasoning-effort.ts
@@ -25,6 +25,7 @@ const CLAUDE_MODEL_EFFORTS: Readonly<
 > = {
   "claude-opus-4-7": ["low", "medium", "high", "xhigh", "max"],
   "claude-opus-4-8": ["low", "medium", "high", "xhigh", "max"],
+  "claude-opus-5": ["low", "medium", "high", "xhigh", "max"],
   "claude-sonnet-4-6": ["low", "medium", "high"],
   "claude-sonnet-5": ["low", "medium", "high", "xhigh", "max"],
   "claude-fable-5": ["low", "medium", "high", "xhigh", "max"],


### PR DESCRIPTION
## Problem

Cloud tasks configured with Claude Opus 5 and an explicit reasoning effort fail while starting the agent server. The shared model-policy extraction in #3616 omitted Opus 5 from the Claude effort map.

## Changes

- Restore all supported reasoning efforts for `claude-opus-5`
- Add regression coverage for the failing `high` setting and extended effort support
