### PR TITLE
fix(mobile): show task PRs recorded in pr_urls (port #3873)

### DIFF
--- a/apps/mobile/src/app/task/[id].tsx
+++ b/apps/mobile/src/app/task/[id].tsx
@@ -16,8 +16,8 @@ import {
   isModalModelId,
   isSupportedReasoningEffort,
   KIMI_MODEL_FLAG,
-  type SupportedReasoningEffort,
   readPrUrls,
+  type SupportedReasoningEffort,
   serializeCloudPrompt,
   type Task,
 } from "@posthog/shared";

--- a/apps/mobile/src/app/task/[id].tsx
+++ b/apps/mobile/src/app/task/[id].tsx
@@ -17,6 +17,7 @@ import {
   isSupportedReasoningEffort,
   KIMI_MODEL_FLAG,
   type SupportedReasoningEffort,
+  readPrUrls,
   serializeCloudPrompt,
   type Task,
 } from "@posthog/shared";
@@ -696,7 +697,7 @@ export default function TaskDetailScreen() {
     [router],
   );
 
-  const prUrl = task?.latest_run?.output?.pr_url as string | undefined;
+  const prUrl = readPrUrls(task?.latest_run?.output)[0];
 
   const activityPhase = getSessionActivityPhase({ retrying, session });
   const isConnecting = activityPhase === "connecting";

--- a/apps/mobile/src/features/tasks/components/TaskItem.test.tsx
+++ b/apps/mobile/src/features/tasks/components/TaskItem.test.tsx
@@ -73,23 +73,53 @@ describe("TaskItem", () => {
     );
   }
 
-  it("shows the PR badge with the parsed number when a PR url is present", () => {
-    const renderer = render(
-      makeTask({
-        output: { pr_url: "https://github.com/PostHog/code/pull/2422" },
-      }),
+  function badgeNumber(renderer: ReturnType<typeof create>, label: string) {
+    return renderer.root.findAll(
+      (node) => String(node.type) === "Text" && node.props.children === label,
     );
+  }
+
+  it.each([
+    [
+      "pr_url is set",
+      { pr_url: "https://github.com/PostHog/code/pull/2422" },
+      "#2422",
+    ],
+    [
+      "pr_urls is set",
+      { pr_urls: ["https://github.com/PostHog/code/pull/2422"] },
+      "#2422",
+    ],
+    [
+      "both fields point at the same PR",
+      {
+        pr_url: "https://github.com/PostHog/code/pull/2422",
+        pr_urls: ["https://github.com/PostHog/code/pull/2422"],
+      },
+      "#2422",
+    ],
+    [
+      "pr_urls lists several PRs (shows the first)",
+      {
+        pr_urls: [
+          "https://github.com/PostHog/code/pull/2422",
+          "https://github.com/PostHog/code/pull/2423",
+        ],
+      },
+      "#2422",
+    ],
+  ])("shows the PR badge when %s", (_label, output, expected) => {
+    const renderer = render(makeTask({ output }));
 
     expect(prIcons(renderer)).toHaveLength(1);
-    const number = renderer.root.findAll(
-      (node) => String(node.type) === "Text" && node.props.children === "#2422",
-    );
-    expect(number).toHaveLength(1);
+    expect(badgeNumber(renderer, expected)).toHaveLength(1);
   });
 
   it.each([
     ["the task has no run", makeTask()],
     ["the run has no output", makeTask({ output: null })],
+    ["pr_urls is empty", makeTask({ output: { pr_urls: [] } })],
+    ["pr_url is an empty string", makeTask({ output: { pr_url: "" } })],
     [
       "the url is a GitHub issue, not a PR",
       makeTask({

--- a/apps/mobile/src/features/tasks/components/TaskItem.tsx
+++ b/apps/mobile/src/features/tasks/components/TaskItem.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@components/text";
-import type { Task } from "@posthog/shared";
+import { type Task, readPrUrls } from "@posthog/shared";
 import { differenceInHours, format, formatDistanceToNow } from "date-fns";
 import { Check, GitPullRequest } from "phosphor-react-native";
 import { memo } from "react";
@@ -46,8 +46,8 @@ function TaskItemComponent({
     hoursSinceCreated < 24
       ? formatDistanceToNow(createdAt, { addSuffix: true })
       : format(createdAt, "MMM d");
-  const prUrl = task.latest_run?.output?.pr_url;
-  const prRef = typeof prUrl === "string" ? parseGithubIssueUrl(prUrl) : null;
+  const prUrl = readPrUrls(task.latest_run?.output)[0];
+  const prRef = prUrl ? parseGithubIssueUrl(prUrl) : null;
 
   return (
     <Pressable

--- a/apps/mobile/src/features/tasks/components/TaskItem.tsx
+++ b/apps/mobile/src/features/tasks/components/TaskItem.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@components/text";
-import { type Task, readPrUrls } from "@posthog/shared";
+import { readPrUrls, type Task } from "@posthog/shared";
 import { differenceInHours, format, formatDistanceToNow } from "date-fns";
 import { Check, GitPullRequest } from "phosphor-react-native";
 import { memo } from "react";

--- a/apps/mobile/src/features/tasks/components/TaskStatusIcon.test.ts
+++ b/apps/mobile/src/features/tasks/components/TaskStatusIcon.test.ts
@@ -35,14 +35,36 @@ function makeTask(latestRun?: Partial<NonNullable<Task["latest_run"]>>): Task {
 }
 
 describe("getTaskStatusIconKind", () => {
-  it("prioritizes PR over cloud status", () => {
+  it.each([
+    ["pr_url only", { pr_url: "https://github.com/PostHog/code/pull/1" }],
+    ["pr_urls only", { pr_urls: ["https://github.com/PostHog/code/pull/2"] }],
+    [
+      "both fields",
+      {
+        pr_url: "https://github.com/PostHog/code/pull/1",
+        pr_urls: ["https://github.com/PostHog/code/pull/2"],
+      },
+    ],
+  ])("prioritizes PR over cloud status (%s)", (_label, output) => {
     const task = makeTask({
       environment: "cloud",
       status: "in_progress",
-      output: { pr_url: "https://github.com/PostHog/code/pull/123" },
+      output,
     });
 
     expect(getTaskStatusIconKind(task)).toBe("pr");
+  });
+
+  it.each([
+    ["output has no PR fields", { commit: "abc123" }],
+    ["pr_urls is empty", { pr_urls: [] }],
+    ["pr_url is an empty string", { pr_url: "" }],
+  ])("does not return pr when %s", (_label, output) => {
+    expect(
+      getTaskStatusIconKind(
+        makeTask({ environment: "cloud", status: "in_progress", output }),
+      ),
+    ).toBe("chat");
   });
 
   it("shows chat for cloud tasks without a PR, regardless of run status", () => {

--- a/apps/mobile/src/features/tasks/components/taskStatusIconKind.ts
+++ b/apps/mobile/src/features/tasks/components/taskStatusIconKind.ts
@@ -1,4 +1,4 @@
-import type { Task } from "@posthog/shared";
+import { type Task, readPrUrls } from "@posthog/shared";
 
 export type TaskStatusIconKind =
   | "pr"
@@ -9,11 +9,12 @@ export type TaskStatusIconKind =
   | "chat";
 
 export function getTaskStatusIconKind(task: Task): TaskStatusIconKind {
-  const prUrl = task.latest_run?.output?.pr_url as string | undefined;
+  const hasPr = readPrUrls(task.latest_run?.output).length > 0;
   const status = task.latest_run?.status;
   const environment = task.latest_run?.environment;
 
-  if (prUrl) {
+  // Match desktop semantics, but let PR win when a cloud task also has one.
+  if (hasPr) {
     return "pr";
   }
 

--- a/apps/mobile/src/features/tasks/components/taskStatusIconKind.ts
+++ b/apps/mobile/src/features/tasks/components/taskStatusIconKind.ts
@@ -1,4 +1,4 @@
-import { type Task, readPrUrls } from "@posthog/shared";
+import { readPrUrls, type Task } from "@posthog/shared";
 
 export type TaskStatusIconKind =
   | "pr"


### PR DESCRIPTION
## Problem

On mobile, a task run's pull request was read only from `latest_run.output.pr_url`. Cloud task runs increasingly record PRs in `output.pr_urls` (an array — and the only field populated for runs that opened more than one PR). Runs with only `pr_urls` set therefore showed no PR link, no PR badge, and no PR status icon on mobile.

This ports the desktop fix #3873, which switched to the shared `readPrUrls` helper for the same reason.

## Changes

Route all three mobile PR surfaces through `readPrUrls` from `@posthog/shared` (already a dependency), which merges `pr_urls` and `pr_url` with dedupe:

- **Task detail header** (`app/task/[id].tsx`) — surfaces a PR when only `pr_urls` is set; shows the first PR's diff/status badges.
- **Task list row** (`TaskItem.tsx`) — shows the PR badge for any PR, first when several exist.
- **Status icon** (`taskStatusIconKind.ts`) — returns `"pr"` when any PR URL exists in either field.

## How did you test this?

- `pnpm --filter @posthog/mobile test` — 543 passing, including extended `TaskItem` and `TaskStatusIcon` cases covering `pr_url` only, `pr_urls` only (one and several), both fields (same and different URLs), neither, empty array, and empty string.
- `pnpm --filter @posthog/mobile lint` (biome) — clean.
- `tsc --noEmit` — no new type errors introduced (pre-existing baseline unchanged).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
