### PR TITLE
fix(mobile): unbreak EAS builds (Node 22 pin + Metro resolution for @posthog/shared)

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -4,20 +4,27 @@
     "appVersionSource": "remote"
   },
   "build": {
+    "base": {
+      "node": "22.19.0"
+    },
     "development": {
+      "extends": "base",
       "developmentClient": true,
       "distribution": "internal"
     },
     "preview": {
+      "extends": "base",
       "distribution": "internal"
     },
     "production": {
+      "extends": "base",
       "autoIncrement": true,
       "android": {
         "buildType": "app-bundle"
       }
     },
     "play-registration": {
+      "extends": "base",
       "distribution": "internal",
       "android": {
         "buildType": "apk"

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -16,12 +16,9 @@ config.resolver.nodeModulesPaths = [
   path.resolve(monorepoRoot, "node_modules"),
 ];
 
-// Force React to resolve from monorepo root, and alias workspace packages
-// directly to their TypeScript source so Babel can transpile them (Metro
-// does not consume the ESM `dist/` build cleanly).
+// Force React to resolve from monorepo root
 config.resolver.extraNodeModules = {
   react: path.resolve(monorepoRoot, "node_modules/react"),
-  "@posthog/shared": path.resolve(monorepoRoot, "packages/shared/src/index.ts"),
 };
 
 // Apply NativeWind first so its resolver/transformer changes are in place
@@ -40,6 +37,37 @@ nativeWindConfig.resolver = {
   ...nativeWindConfig.resolver,
   assetExts: nativeWindConfig.resolver.assetExts.filter((ext) => ext !== "svg"),
   sourceExts: [...nativeWindConfig.resolver.sourceExts, "svg"],
+};
+
+// Resolve @posthog/shared to its TypeScript source so Babel transpiles it.
+// Its package.json `exports` point at `dist/`, which is only present after a
+// `pnpm build` -- EAS Build never runs one, so bundling there fails outright.
+// This must be a resolveRequest hook rather than an `extraNodeModules` alias:
+// pnpm symlinks the package into node_modules, so Metro resolves it there
+// first and never consults the alias, and an alias also cannot map subpath
+// imports like `@posthog/shared/domain-types`.
+const SHARED_PACKAGE = "@posthog/shared";
+const sharedSrc = path.resolve(monorepoRoot, "packages/shared/src");
+const upstreamResolveRequest = nativeWindConfig.resolver.resolveRequest;
+
+nativeWindConfig.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (
+    moduleName === SHARED_PACKAGE ||
+    moduleName.startsWith(`${SHARED_PACKAGE}/`)
+  ) {
+    const subpath = moduleName.slice(SHARED_PACKAGE.length + 1) || "index";
+    return context.resolveRequest(
+      context,
+      path.join(sharedSrc, subpath),
+      platform,
+    );
+  }
+
+  return (upstreamResolveRequest ?? context.resolveRequest)(
+    context,
+    moduleName,
+    platform,
+  );
 };
 
 module.exports = nativeWindConfig;


### PR DESCRIPTION
## Problem

The `Mobile Build` workflow fails for both iOS and Android ([run 30437663255](https://github.com/PostHog/code/actions/runs/30437663255)). GitHub Actions only reports `Unknown error. See logs of the Install dependencies build phase`, so both real failures were hidden in the EAS build logs. There are **two independent breaks**, and both were introduced after the last green mobile build (`b7401932`, 2026-05-22).

### 1. EAS runs Node 20, the repo needs Node 22

```
node_modules/better-sqlite3 install: gyp ERR! configure error
gyp ERR! stack TypeError: webidl.util.markAsUncloneable is not a function
gyp ERR! stack at new CacheStorage (node_modules/node-gyp/node_modules/undici/lib/web/cache/cachestorage.js:20:17)
gyp ERR! node -v v20.19.4
ELIFECYCLE  Command failed with exit code 1.
```

`node-gyp@12.4.0` depends on `undici@8.4.1`, whose `engines` is `node: >=22.19.0` — looser than node-gyp's own `^20.17.0 || >=22.9.0`. pnpm doesn't enforce engines, so it installs and then throws at runtime. EAS Build runs Node v20.19.4 (its default image version); `apps/mobile` had no `.nvmrc` and no `node` field in `eas.json`, and EAS doesn't read the root `engines.node`. `node-pty` fails first, then `better-sqlite3`, then the install aborts.

CI never caught it because the workflow's own install step runs on `node-version: 22` — only the remote install on the EAS builder fails. Introduced when `node-gyp@12.4.0` entered the lockfile in #2795.

### 2. Metro can't resolve `@posthog/shared`

With the Node pin in place the install passes and the build gets as far as bundling, where it fails on both platforms:

```
Error: While trying to resolve module `@posthog/shared` from file
`apps/mobile/src/features/inbox/components/FilterSheet.tsx`, the package
`apps/mobile/node_modules/@posthog/shared/package.json` was successfully found.
However, this package itself specifies a `main` module field that could not be resolved.
```

`@posthog/shared`'s `exports` point at `dist/`, which only exists after a `pnpm build`. EAS never runs one, and `dist/` is gitignored so it isn't uploaded either. `metro.config.js` already meant to sidestep this by aliasing the package to its TypeScript source, but the `extraNodeModules` alias never fires — pnpm symlinks the package into `apps/mobile/node_modules`, so Metro resolves it there first and never consults the alias. The alias also can't express subpath imports: `@posthog/shared/domain-types` was being rewritten to the nonexistent `src/index.ts/domain-types`, which is where the dozens of "invalid package.json configuration" warnings came from.

At the last green build `apps/mobile` didn't depend on `@posthog/shared` at all — the dependency was added afterwards and has never bundled on EAS.

## Changes

- `eas.json`: added a `base` build profile pinning `node` to `22.19.0` (matching the root `engines.node`), extended by all four profiles.
- `metro.config.js`: replaced the dead `extraNodeModules` alias with a `resolveRequest` hook mapping `@posthog/shared` and its subpaths onto `packages/shared/src`, keeping the source-resolution intent the original comment describes.

Worth a follow-up, out of scope here: the mobile EAS build uploads the whole monorepo and runs a root `pnpm install`, so it compiles the desktop app's native toolchain (`better-sqlite3`, `node-pty`, `tree-sitter-cli`, `electron-winstaller`) plus `apps/code`'s postinstall. None of that is needed for an Expo build, and it's why an Electron-side dependency bump broke mobile in the first place.

## How did you test this?

- Pulled the raw EAS logs for the failing builds and confirmed the node-gyp/undici failure on Node v20.19.4 on both platforms.
- Ran a `preview` EAS build with only the Node pin: `INSTALL_DEPENDENCIES` completed on both platforms with zero gyp errors (phases went from ~9 to 21–23), which both confirms fix 1 and surfaced fix 2.
- Reproduced the bundling failure locally by hiding `packages/shared/dist` (mirroring the EAS state) and running `expo export` — byte-for-byte the same error as the builder.
- With the Metro fix and `dist/` still hidden, `expo export` succeeds for **both** `--platform android` and `--platform ios`, with zero `@posthog/shared` resolution warnings. Also re-verified with `dist/` restored, so both local-dev and clean-checkout states bundle.
- Full `preview` EAS build running off this branch with both fixes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
