### PR TITLE
fix(canvas): client races surfaced by review — star order, eviction, build status, home seed

### DIFF
--- a/packages/core/src/canvas/canvasBuildSchemas.test.ts
+++ b/packages/core/src/canvas/canvasBuildSchemas.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   type CanvasBuildLifecycle,
   type CanvasBuildRecord,
+  currentHeadBuildFailure,
   hasActiveCanvasBuild,
   latestFinishedCanvasBuild,
   publishedCanvasBuild,
@@ -71,6 +72,32 @@ describe("canvas build lifecycle", () => {
     value.publishedBuildId = "b0";
 
     expect(publishedCanvasBuild(value)).toBe(ready);
+  });
+
+  it("surfaces a failed build of the current head even when an older published build is also ready", () => {
+    // b_old (sv-old) is the pinned/published live build; a newer publish (b_new,
+    // sv-new = current head) failed. latestFinishedCanvasBuild returns the first
+    // finished build in array order, which here is the ready b_old — position,
+    // not version identity — so it would hide the failure. currentHeadBuildFailure
+    // keys off the current version's own build.
+    const value = lifecycle([
+      build("b_old", "ready"),
+      build("b_new", "failed"),
+    ]);
+    value.builds[0].sourceVersionId = "sv-old";
+    value.builds[1].sourceVersionId = "sv-new";
+    value.publishedBuildId = "b_old";
+    value.currentVersionId = "sv-new";
+
+    expect(latestFinishedCanvasBuild(value)?.id).toBe("b_old");
+    expect(currentHeadBuildFailure(value)?.id).toBe("b_new");
+  });
+
+  it("returns null when the current head built fine or is still in flight", () => {
+    const value = lifecycle([build("b1", "building")]);
+    value.currentVersionId = "sv-1";
+
+    expect(currentHeadBuildFailure(value)).toBeNull();
   });
 
   it("maps the builds endpoint's snake_case body to the client shape", async () => {

--- a/packages/core/src/canvas/canvasBuildSchemas.ts
+++ b/packages/core/src/canvas/canvasBuildSchemas.ts
@@ -71,3 +71,23 @@ export function latestFinishedCanvasBuild(
     ) ?? null
   );
 }
+
+/**
+ * The failed build of the canvas's CURRENT head, if it failed. This is the
+ * build whose outcome the author actually cares about — a failed newest
+ * publish must surface even when an older (e.g. pinned/published) build is the
+ * first finished row in the list, because `latestFinishedCanvasBuild` picks by
+ * array position, not version identity.
+ */
+export function currentHeadBuildFailure(
+  lifecycle: CanvasBuildLifecycle,
+): CanvasBuildRecord | null {
+  if (!lifecycle.currentVersionId) return null;
+  return (
+    lifecycle.builds.find(
+      (build) =>
+        build.sourceVersionId === lifecycle.currentVersionId &&
+        build.buildStatus === "failed",
+    ) ?? null
+  );
+}

--- a/packages/core/src/canvas/dashboardsService.test.ts
+++ b/packages/core/src/canvas/dashboardsService.test.ts
@@ -1,7 +1,7 @@
 import { transform } from "esbuild";
 import { describe, expect, it, vi } from "vitest";
 import { DashboardsService } from "./dashboardsService";
-import type { ProjectApiClient } from "./projectApiClient";
+import { type ProjectApiClient, ProjectApiError } from "./projectApiClient";
 
 // A canvas as the PostHog canvases API returns it.
 function apiCanvas(overrides: Record<string, unknown> = {}) {
@@ -169,6 +169,80 @@ describe("DashboardsService.ensureHomeCanvas", () => {
     await expect(
       transform(body.project.files["src/canvas.tsx"], { loader: "tsx" }),
     ).resolves.toBeDefined();
+  });
+});
+
+describe("DashboardsService.ensureHomeCanvas races", () => {
+  it("reuses the winner's canvas when create loses the is_home uniqueness race (409)", async () => {
+    let lookups = 0;
+    const { api } = fakeApi({
+      // First lookup: none. After the 409, the winner's home canvas exists.
+      "canvases/?channel=chan-1&is_home=true": () => {
+        lookups += 1;
+        return lookups === 1
+          ? []
+          : [
+              apiCanvas({
+                id: "home-winner",
+                is_home: true,
+                current_version_id: "v1",
+              }),
+            ];
+      },
+      "canvases/": () => {
+        throw new ProjectApiError("Failed to create canvas (409)", 409);
+      },
+    });
+    const service = new DashboardsService(api);
+
+    const record = await service.ensureHomeCanvas("chan-1");
+
+    expect(record.id).toBe("home-winner");
+  });
+
+  it("rethrows a non-409 create failure instead of masking it as a race", async () => {
+    const { api } = fakeApi({
+      "canvases/?channel=chan-1&is_home=true": [],
+      "canvases/": () => {
+        throw new ProjectApiError("Failed to create canvas (403)", 403);
+      },
+    });
+    const service = new DashboardsService(api);
+
+    await expect(service.ensureHomeCanvas("chan-1")).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+
+  it("retries the seed publish once on a 409 version conflict", async () => {
+    const home = apiCanvas({
+      id: "home-1",
+      is_home: true,
+      current_version_id: null,
+    });
+    let publishCalls = 0;
+    const { api } = fakeApi({
+      "canvases/?channel=chan-1&is_home=true": [home],
+      "canvases/home-1/publish/": (init?: RequestInit) => {
+        publishCalls += 1;
+        if (publishCalls === 1) {
+          throw new ProjectApiError("Failed to seed home canvas (409)", 409);
+        }
+        const body = JSON.parse(String(init?.body));
+        return { current_version_id: body.expected_current_version_id ?? "v1" };
+      },
+      "canvases/home-1/": apiCanvas({
+        id: "home-1",
+        is_home: true,
+        current_version_id: "v-fresh",
+      }),
+    });
+    const service = new DashboardsService(api);
+
+    const record = await service.ensureHomeCanvas("chan-1");
+
+    expect(publishCalls).toBe(2);
+    expect(record.id).toBe("home-1");
   });
 });
 

--- a/packages/core/src/canvas/dashboardsService.ts
+++ b/packages/core/src/canvas/dashboardsService.ts
@@ -18,7 +18,11 @@ import type {
   DashboardRecord,
 } from "./dashboardSchemas";
 import { FREEFORM_TEMPLATE_ID } from "./freeformSchemas";
-import { PROJECT_API_CLIENT, type ProjectApiClient } from "./projectApiClient";
+import {
+  apiErrorStatus,
+  PROJECT_API_CLIENT,
+  type ProjectApiClient,
+} from "./projectApiClient";
 
 // Display name (canvas h1) of a channel's auto-created home canvas.
 const HOME_CANVAS_NAME = "Home";
@@ -306,8 +310,11 @@ export class DashboardsService {
           templateId: FREEFORM_TEMPLATE_ID,
           isHome: true,
         });
-      } catch {
-        // Lost the uniqueness race — another client created it; reuse theirs.
+      } catch (error) {
+        // Only the is_home uniqueness race (409) means another client created
+        // it; reuse theirs. Any other failure (auth, capacity, network) must
+        // surface, not be masked as a race.
+        if (apiErrorStatus(error) !== 409) throw error;
         record = await this.findHomeCanvas(channelId);
         if (!record) throw new Error("Failed to create home canvas");
       }
@@ -358,19 +365,31 @@ export class DashboardsService {
         network: { origins: [] },
       },
     };
-    await this.api.json<unknown>(
-      `canvases/${encodeURIComponent(record.id)}/publish/`,
-      "seed home canvas",
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          project,
-          prompt: "Default home board",
-          expected_current_version_id: record.currentVersionId ?? null,
-        }),
-      },
-    );
+    const publish = (expectedVersionId: string | null) =>
+      this.api.json<unknown>(
+        `canvases/${encodeURIComponent(record.id)}/publish/`,
+        "seed home canvas",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            project,
+            prompt: "Default home board",
+            expected_current_version_id: expectedVersionId,
+          }),
+        },
+      );
+    try {
+      await publish(record.currentVersionId ?? null);
+    } catch (error) {
+      // A concurrent seed can win the guarded publish between our read and
+      // POST. On the 409 version conflict, re-read the head and retry once
+      // against the fresh version id rather than failing the channel open.
+      if (apiErrorStatus(error) !== 409) throw error;
+      const fresh = await this.get(record.id);
+      await publish(fresh?.currentVersionId ?? null);
+      return fresh ?? record;
+    }
     const fresh = await this.get(record.id);
     return fresh ?? record;
   }

--- a/packages/core/src/canvas/dashboardsService.ts
+++ b/packages/core/src/canvas/dashboardsService.ts
@@ -386,9 +386,8 @@ export class DashboardsService {
       // POST. On the 409 version conflict, re-read the head and retry once
       // against the fresh version id rather than failing the channel open.
       if (apiErrorStatus(error) !== 409) throw error;
-      const fresh = await this.get(record.id);
-      await publish(fresh?.currentVersionId ?? null);
-      return fresh ?? record;
+      const conflicted = await this.get(record.id);
+      await publish(conflicted?.currentVersionId ?? null);
     }
     const fresh = await this.get(record.id);
     return fresh ?? record;

--- a/packages/core/src/canvas/projectApiClient.ts
+++ b/packages/core/src/canvas/projectApiClient.ts
@@ -8,6 +8,22 @@ export const PROJECT_API_CLIENT = Symbol.for(
 
 const MAX_PAGES = 50;
 
+/** An API call that failed with an HTTP status (so callers can branch on it). */
+export class ProjectApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "ProjectApiError";
+  }
+}
+
+/** The status code of a ProjectApiError, or null for a non-API error. */
+export function apiErrorStatus(error: unknown): number | null {
+  return error instanceof ProjectApiError ? error.status : null;
+}
+
 /**
  * Thin shared client for the current PostHog project's REST API. Resolves the
  * project + auth, then forwards to authenticated fetch. Owners of typed
@@ -36,7 +52,11 @@ export class ProjectApiClient {
     init?: RequestInit,
   ): Promise<T> {
     const res = await this.fetch(path, init);
-    if (!res.ok) throw new Error(`Failed to ${errorLabel} (${res.status})`);
+    if (!res.ok)
+      throw new ProjectApiError(
+        `Failed to ${errorLabel} (${res.status})`,
+        res.status,
+      );
     return (await res.json()) as T;
   }
 

--- a/packages/ui/src/features/canvas/freeform/CanvasBuildStatus.tsx
+++ b/packages/ui/src/features/canvas/freeform/CanvasBuildStatus.tsx
@@ -6,7 +6,10 @@ import {
   WarningCircleIcon,
   XIcon,
 } from "@phosphor-icons/react";
-import { latestFinishedCanvasBuild } from "@posthog/core/canvas/canvasBuildSchemas";
+import {
+  currentHeadBuildFailure,
+  latestFinishedCanvasBuild,
+} from "@posthog/core/canvas/canvasBuildSchemas";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { Button } from "@posthog/quill";
 import type { CanvasDiagnostic } from "@posthog/shared";
@@ -114,7 +117,11 @@ export function CanvasBuildStatus({
     );
   }
 
-  const latest = latestFinishedCanvasBuild(lifecycle);
+  // Surface a failed build of the CURRENT head even when an older (pinned /
+  // published) finished build appears first in the list — array position must
+  // not hide a failed newest publish.
+  const failedHead = currentHeadBuildFailure(lifecycle);
+  const latest = failedHead ?? latestFinishedCanvasBuild(lifecycle);
   if (!latest) return null;
 
   if (latest.buildStatus === "failed") {

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -111,6 +111,16 @@ export function FreeformCanvasView({
   const setBrowseVersion = useFreeformChatStore((s) => s.setBrowseVersion);
   const setRuntimeError = useFreeformChatStore((s) => s.setRuntimeError);
 
+  // Protect this thread from LRU eviction while the view is open — a burst of
+  // background patches must never drop the canvas the user is looking at.
+  useEffect(() => {
+    const store = useFreeformChatStore.getState();
+    store.setThreadMounted(threadId, true);
+    return () => {
+      useFreeformChatStore.getState().setThreadMounted(threadId, false);
+    };
+  }, [threadId]);
+
   // Right-hand panel state (persisted minimize + width). `startedTaskId` is a
   // local bridge so the composer floats to the side immediately on submit,
   // before the canvas record's polled generationTaskId catches up.
@@ -237,26 +247,33 @@ export function FreeformCanvasView({
   // Pin the artifact to one signed URL per build: every lifecycle refetch mints
   // a fresh URL for the same artifact, and adopting each one would reload the
   // iframe on every 2s poll while a build runs. Adopt only when the published
-  // build itself changes — or when a refresh was explicitly requested because
-  // the pinned URL expired. Adjusted during render (not an effect) so the swap
+  // build itself changes. Adjusted during render (not an effect) so the swap
   // can't flash a stale frame.
   const [pinnedArtifact, setPinnedArtifact] = useState<PinnedArtifact | null>(
     null,
   );
-  const wantFreshArtifactUrlRef = useRef(false);
+  // A nonce that, when bumped, remounts the artifact frame so it revalidates
+  // against the live token endpoint (ETag/304 makes this cheap) — the recovery
+  // path when the pinned URL expired. Remounting, not URL-string compare, is
+  // what guarantees a wedged iframe actually retries: the token endpoint is the
+  // authority, and a new URL for the same bucket would be byte-identical.
+  const [artifactRefreshKey, setArtifactRefreshKey] = useState(0);
+  // Track the refresh key the current pin was adopted under, so a remount also
+  // re-stamps the pin's mint time (otherwise the expiry timer would keep firing
+  // on a URL that's already been recovered).
+  const [pinnedForRefreshKey, setPinnedForRefreshKey] = useState(-1);
   if (publishedBuild?.artifactUrl) {
-    const shouldAdopt =
+    const adoptFresh =
       !pinnedArtifact ||
       pinnedArtifact.buildId !== publishedBuild.id ||
-      (wantFreshArtifactUrlRef.current &&
-        pinnedArtifact.url !== publishedBuild.artifactUrl);
-    if (shouldAdopt) {
-      wantFreshArtifactUrlRef.current = false;
+      pinnedForRefreshKey !== artifactRefreshKey;
+    if (adoptFresh) {
       setPinnedArtifact({
         buildId: publishedBuild.id,
         url: publishedBuild.artifactUrl,
         mintedAt: buildsUpdatedAt || Date.now(),
       });
+      setPinnedForRefreshKey(artifactRefreshKey);
     }
   } else if (lifecycle && pinnedArtifact) {
     // The lifecycle says there's no published build anymore — drop the pin.
@@ -280,10 +297,15 @@ export function FreeformCanvasView({
       if (Date.now() - renderedArtifact.mintedAt < ARTIFACT_URL_FRESH_MS) {
         return;
       }
-      wantFreshArtifactUrlRef.current = true;
-      void queryClient.invalidateQueries({
-        queryKey: trpc.dashboards.builds.queryKey({ id: dashboardId }),
-      });
+      // Refetch mints the current bucket's URL (re-checking the token server-
+      // side even when the browser would reframe from cache), then remount the
+      // frame so it revalidates against those endpoints. The remount, not a URL
+      // string change, is what un-wedges a frame whose module fetches hung.
+      void queryClient
+        .invalidateQueries({
+          queryKey: trpc.dashboards.builds.queryKey({ id: dashboardId }),
+        })
+        .then(() => setArtifactRefreshKey((k) => k + 1));
     }, ARTIFACT_READY_GRACE_MS);
     return () => clearTimeout(timer);
   }, [renderedArtifact, dashboardId, queryClient, trpc]);
@@ -707,6 +729,7 @@ export function FreeformCanvasView({
           ) : pinnedArtifact ? (
             <Box className="h-full w-full">
               <BuiltCanvas
+                key={`${pinnedArtifact.buildId}:${artifactRefreshKey}`}
                 artifactUrl={pinnedArtifact.url}
                 onDataRequest={onDataRequest}
                 onError={onError}

--- a/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -9,6 +9,7 @@ import {
   WarningIcon,
 } from "@phosphor-icons/react";
 import {
+  currentHeadBuildFailure,
   hasActiveCanvasBuild,
   latestFinishedCanvasBuild,
   publishedCanvasBuild,
@@ -89,6 +90,10 @@ interface PinnedArtifact {
   url: string;
   /** Epoch ms the pinned URL was minted (the builds fetch that produced it). */
   mintedAt: number;
+  /** The refresh nonce the pin was adopted under, so a remount also re-stamps
+   * the pin's mint time (otherwise the expiry timer would keep firing on a URL
+   * that's already been recovered). */
+  refreshKey: number;
 }
 
 // A freeform (React-in-iframe) canvas. The rendered output is, in priority
@@ -258,22 +263,18 @@ export function FreeformCanvasView({
   // what guarantees a wedged iframe actually retries: the token endpoint is the
   // authority, and a new URL for the same bucket would be byte-identical.
   const [artifactRefreshKey, setArtifactRefreshKey] = useState(0);
-  // Track the refresh key the current pin was adopted under, so a remount also
-  // re-stamps the pin's mint time (otherwise the expiry timer would keep firing
-  // on a URL that's already been recovered).
-  const [pinnedForRefreshKey, setPinnedForRefreshKey] = useState(-1);
   if (publishedBuild?.artifactUrl) {
     const adoptFresh =
       !pinnedArtifact ||
       pinnedArtifact.buildId !== publishedBuild.id ||
-      pinnedForRefreshKey !== artifactRefreshKey;
+      pinnedArtifact.refreshKey !== artifactRefreshKey;
     if (adoptFresh) {
       setPinnedArtifact({
         buildId: publishedBuild.id,
         url: publishedBuild.artifactUrl,
         mintedAt: buildsUpdatedAt || Date.now(),
+        refreshKey: artifactRefreshKey,
       });
-      setPinnedForRefreshKey(artifactRefreshKey);
     }
   } else if (lifecycle && pinnedArtifact) {
     // The lifecycle says there's no published build anymore — drop the pin.
@@ -502,6 +503,7 @@ export function FreeformCanvasView({
     !!lifecycle &&
     lifecycle.builds.length > 0 &&
     (hasActiveCanvasBuild(lifecycle) ||
+      !!currentHeadBuildFailure(lifecycle) ||
       latestFinishedCanvasBuild(lifecycle)?.buildStatus === "failed");
   const showToolbar = interactive || hasBuildSignal;
 

--- a/packages/ui/src/features/canvas/hooks/useChannelStars.test.tsx
+++ b/packages/ui/src/features/canvas/hooks/useChannelStars.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@posthog/ui/primitives/toast", () => ({
 
 import { useChannelStars, useChannelStarToggle } from "./useChannelStars";
 import type { Channel } from "./useChannels";
+import { TASK_CHANNELS_QUERY_KEY } from "./useTaskChannels";
 
 function taskChannel(id: string, name: string, starred = false): TaskChannel {
   return {
@@ -114,5 +115,75 @@ describe("useChannelStars", () => {
     await waitFor(() =>
       expect(stars.result.current.starredChannelIds.has("1")).toBe(false),
     );
+  });
+
+  it("settles to the user's LAST click when star/unstar resolve out of order", async () => {
+    mockClient.getTaskChannels.mockResolvedValue([taskChannel("1", "alpha")]);
+    // Keep the post-mutation refetch from overwriting the optimistic write
+    // with a stale snapshot, which is exactly what hides the race.
+    let resolveStar!: () => void;
+    let resolveUnstar!: () => void;
+    mockClient.starTaskChannel
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((res) => {
+            resolveStar = res;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((res) => {
+            resolveUnstar = res;
+          }),
+      );
+
+    // Seed the shared channels cache via the list hook, then hang any refetch
+    // so only the mutation writes (not a refetched snapshot) decide the cache.
+    const stars = renderHook(() => useChannelStars(), { wrapper });
+    await waitFor(() => expect(stars.result.current.isLoading).toBe(false));
+    await waitFor(() =>
+      expect(queryClient.getQueryData(TASK_CHANNELS_QUERY_KEY)).toBeTruthy(),
+    );
+    mockClient.getTaskChannels.mockReturnValue(new Promise(() => {}));
+
+    // Two rapid toggles: star then unstar, modelled with explicit isStarred so
+    // both mutations fire (a single component's stale closure is a separate UI
+    // quirk; this isolates the resolve-order race).
+    const first = renderHook(
+      () => useChannelStarToggle(channel("1", "alpha", false)),
+      { wrapper },
+    );
+    const second = renderHook(
+      () => useChannelStarToggle(channel("1", "alpha", true)),
+      { wrapper },
+    );
+
+    act(() => {
+      first.result.current.toggleStar(); // star
+      second.result.current.toggleStar(); // unstar
+    });
+    // Optimistic write applies immediately from the last click.
+    await waitFor(() =>
+      expect(
+        queryClient
+          .getQueryData<{ id: string; starred: boolean }[]>(
+            TASK_CHANNELS_QUERY_KEY,
+          )
+          ?.find((c) => c.id === "1")?.starred,
+      ).toBe(false),
+    );
+
+    // Resolve in REVERSE order: unstar first, star last. With the last-resolved
+    // wins bug, the star (wrong, older intent) would overwrite the cache.
+    await act(async () => {
+      resolveUnstar();
+      resolveStar();
+    });
+
+    const cached = queryClient
+      .getQueryData<{ id: string; starred: boolean }[]>(TASK_CHANNELS_QUERY_KEY)
+      ?.find((c) => c.id === "1");
+    // The cache must reflect the last click (unstar), not the late star.
+    expect(cached?.starred).toBe(false);
   });
 });

--- a/packages/ui/src/features/canvas/hooks/useChannelStars.ts
+++ b/packages/ui/src/features/canvas/hooks/useChannelStars.ts
@@ -39,10 +39,24 @@ export function useChannelStarMutations() {
       await client.starTaskChannel(input.channelId, input.starred);
       return input;
     },
-    onSuccess: ({ channelId, starred }) => {
+    // Optimistic update: apply the click the moment it's made and roll back on
+    // error. Writing here (not onSuccess) means the last CLICK wins, not the
+    // last request to resolve — two rapid toggles resolving out of order can't
+    // revert the sidebar to the earlier intent.
+    onMutate: async ({ channelId, starred }) => {
+      await queryClient.cancelQueries({ queryKey: TASK_CHANNELS_QUERY_KEY });
+      const previous = queryClient.getQueryData<TaskChannel[]>(
+        TASK_CHANNELS_QUERY_KEY,
+      );
       queryClient.setQueryData<TaskChannel[]>(TASK_CHANNELS_QUERY_KEY, (old) =>
         old?.map((c) => (c.id === channelId ? { ...c, starred } : c)),
       );
+      return { previous };
+    },
+    onError: (_error, _input, context) => {
+      queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, context?.previous);
+    },
+    onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: TASK_CHANNELS_QUERY_KEY });
     },
   });

--- a/packages/ui/src/features/canvas/stores/freeformChatStore.test.ts
+++ b/packages/ui/src/features/canvas/stores/freeformChatStore.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useFreeformChatStore } from "./freeformChatStore";
+
+function reset() {
+  useFreeformChatStore.setState({ threads: {}, threadOrder: [] });
+}
+
+function browse(threadId: string) {
+  useFreeformChatStore.getState().setBrowseVersion(threadId, "v1");
+}
+
+describe("freeformChatStore eviction", () => {
+  beforeEach(reset);
+
+  it("evicts the least recently used threads beyond the cap", () => {
+    for (let i = 0; i < 12; i++) browse(`dashboard:${i}`);
+    const { threads, threadOrder } = useFreeformChatStore.getState();
+    // Cap is 8: the oldest four are gone, the most recent survive.
+    expect(threadOrder).toHaveLength(8);
+    expect(threads["dashboard:0"]).toBeUndefined();
+    expect(threads["dashboard:11"]).toBeDefined();
+  });
+
+  it("never evicts a thread with a mounted view", () => {
+    // Mount thread 0, then churn far more than the cap through other threads.
+    useFreeformChatStore.getState().setThreadMounted("dashboard:0", true);
+    browse("dashboard:0");
+    for (let i = 1; i < 12; i++) browse(`dashboard:${i}`);
+
+    const { threads } = useFreeformChatStore.getState();
+    expect(threads["dashboard:0"]).toBeDefined();
+    expect(threads["dashboard:0"].browseVersionId).toBe("v1");
+  });
+
+  it("stops protecting a thread once its view unmounts", () => {
+    useFreeformChatStore.getState().setThreadMounted("dashboard:0", true);
+    browse("dashboard:0");
+    useFreeformChatStore.getState().setThreadMounted("dashboard:0", false);
+    for (let i = 1; i < 12; i++) browse(`dashboard:${i}`);
+
+    expect(
+      useFreeformChatStore.getState().threads["dashboard:0"],
+    ).toBeUndefined();
+  });
+});

--- a/packages/ui/src/features/canvas/stores/freeformChatStore.ts
+++ b/packages/ui/src/features/canvas/stores/freeformChatStore.ts
@@ -29,10 +29,15 @@ interface FreeformChatStore {
   /** MRU access order for eviction, oldest first. Store state (not a module
    * closure) so devtools/tests see it and HMR can't desync it from `threads`. */
   threadOrder: string[];
+  /** Threads with a live view. Eviction skips these even past the cap, so an
+   * open canvas can never lose its browse/runtimeError to a patch burst. */
+  mountedThreadIds: string[];
 
   /** Browse a historical source version (null = back to the head). */
   setBrowseVersion: (threadId: string, versionId: string | null) => void;
   setRuntimeError: (threadId: string, message: string | null) => void;
+  /** Register/unregister a mounted canvas view against its thread. */
+  setThreadMounted: (threadId: string, mounted: boolean) => void;
 }
 
 /** The dashboardId a thread is keyed on ("dashboard:<id>" → "<id>"). */
@@ -43,7 +48,9 @@ export function dashboardIdOf(threadId: string): string {
 export const useFreeformChatStore = create<FreeformChatStore>()((set) => {
   // Every patch refreshes the thread's recency and evicts the least recently
   // used threads beyond the cap. The thread just patched is always the most
-  // recent, so it can never evict itself out from under a mounted view.
+  // recent, so it can never evict itself; mounted threads are never evicted at
+  // all, so a burst of patches to background threads can't blow away a view the
+  // user has open.
   const patch = (
     threadId: string,
     fn: (prev: FreeformThreadState) => FreeformThreadState,
@@ -57,9 +64,19 @@ export const useFreeformChatStore = create<FreeformChatStore>()((set) => {
         ...s.threads,
         [threadId]: fn(s.threads[threadId] ?? EMPTY_FREEFORM_THREAD),
       };
-      while (threadOrder.length > MAX_THREADS) {
-        const oldest = threadOrder.shift();
-        if (oldest !== undefined) delete threads[oldest];
+      const mounted = new Set(s.mountedThreadIds);
+      let index = 0;
+      while (
+        threadOrder.length - mountedCount(threadOrder, mounted) > MAX_THREADS &&
+        index < threadOrder.length
+      ) {
+        const candidate = threadOrder[index];
+        if (mounted.has(candidate)) {
+          index++;
+          continue;
+        }
+        threadOrder.splice(index, 1);
+        delete threads[candidate];
       }
       return { threads, threadOrder };
     });
@@ -68,6 +85,7 @@ export const useFreeformChatStore = create<FreeformChatStore>()((set) => {
   return {
     threads: {},
     threadOrder: [],
+    mountedThreadIds: [],
 
     setBrowseVersion: (threadId, versionId) => {
       patch(threadId, (prev) => ({ ...prev, browseVersionId: versionId }));
@@ -76,8 +94,20 @@ export const useFreeformChatStore = create<FreeformChatStore>()((set) => {
     setRuntimeError: (threadId, message) => {
       patch(threadId, (prev) => ({ ...prev, runtimeError: message }));
     },
+
+    setThreadMounted: (threadId, mounted) => {
+      set((s) => ({
+        mountedThreadIds: mounted
+          ? [...new Set([...s.mountedThreadIds, threadId])]
+          : s.mountedThreadIds.filter((id) => id !== threadId),
+      }));
+    },
   };
 });
+
+function mountedCount(order: string[], mounted: ReadonlySet<string>): number {
+  return order.reduce((count, id) => (mounted.has(id) ? count + 1 : count), 0);
+}
 
 export function useFreeformThread(threadId: string): FreeformThreadState {
   return useFreeformChatStore(

--- a/packages/ui/src/features/canvas/stores/freeformChatStore.ts
+++ b/packages/ui/src/features/canvas/stores/freeformChatStore.ts
@@ -65,11 +65,9 @@ export const useFreeformChatStore = create<FreeformChatStore>()((set) => {
         [threadId]: fn(s.threads[threadId] ?? EMPTY_FREEFORM_THREAD),
       };
       const mounted = new Set(s.mountedThreadIds);
+      let evictable = threadOrder.filter((id) => !mounted.has(id)).length;
       let index = 0;
-      while (
-        threadOrder.length - mountedCount(threadOrder, mounted) > MAX_THREADS &&
-        index < threadOrder.length
-      ) {
+      while (evictable > MAX_THREADS && index < threadOrder.length) {
         const candidate = threadOrder[index];
         if (mounted.has(candidate)) {
           index++;
@@ -77,6 +75,7 @@ export const useFreeformChatStore = create<FreeformChatStore>()((set) => {
         }
         threadOrder.splice(index, 1);
         delete threads[candidate];
+        evictable--;
       }
       return { threads, threadOrder };
     });
@@ -98,16 +97,14 @@ export const useFreeformChatStore = create<FreeformChatStore>()((set) => {
     setThreadMounted: (threadId, mounted) => {
       set((s) => ({
         mountedThreadIds: mounted
-          ? [...new Set([...s.mountedThreadIds, threadId])]
+          ? s.mountedThreadIds.includes(threadId)
+            ? s.mountedThreadIds
+            : [...s.mountedThreadIds, threadId]
           : s.mountedThreadIds.filter((id) => id !== threadId),
       }));
     },
   };
 });
-
-function mountedCount(order: string[], mounted: ReadonlySet<string>): number {
-  return order.reduce((count, id) => (mounted.has(id) ? count + 1 : count), 0);
-}
 
 export function useFreeformThread(threadId: string): FreeformThreadState {
   return useFreeformChatStore(


### PR DESCRIPTION
Stacked on #3835 (pairs with PostHog/posthog#74603). Client-side fixes from the same review pass.

- **Star/unstar settles on the last CLICK, not the last request to resolve.** The mutation wrote the resolved value in `onSuccess`, so two rapid toggles resolving out of order reverted the sidebar to the earlier intent. Converted to the standard optimistic pattern (`onMutate` + rollback, invalidate on `onSettled`).
- **`freeformChatStore` never evicts a mounted thread.** A patch burst to background threads could drop the open canvas's browse position / runtime error. The store now keeps a mounted set and `FreeformCanvasView` registers on mount.
- **`CanvasBuildStatus` surfaces a failed build of the CURRENT head** even when an older pinned/published finished build appears first in the list (array position no longer hides a failed newest publish), via a new version-identity helper `currentHeadBuildFailure`.
- **Expired artifact-URL recovery no longer wedges on an identical re-minted URL.** A refresh now invalidates the builds query AND remounts the artifact frame (refresh nonce → iframe key) so it revalidates against the live token endpoint, instead of requiring the URL string to differ.
- **`ensureHomeCanvas` narrows its create-race fallback to the 409 is_home uniqueness case** (other failures surface instead of masquerading as a race), and **`publishHomeSeed` retries once on a 409 version_conflict** after re-reading the head — backed by a new `ProjectApiError` carrying the HTTP status.

Tests: a race-order test for stars (red→green), eviction protection tests for mounted threads, version-identity build-failure tests, and create/create-409 / seed-retry tests for the home-canvas paths. 182 core + 293 ui canvas tests green; Biome and `tsc` clean.

Generated-By: PostHog Code
Task-Id: 966e8e8c-5e53-4c4e-bca7-e3643cd42517

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*