### PR TITLE
fix(agent): hide effort controls for Kimi sessions

### DIFF
--- a/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
@@ -84,6 +84,12 @@ function getModelConfigOption(response: {
   return response.configOptions?.find((opt) => opt.id === "model");
 }
 
+function getEffortConfigOption(response: {
+  configOptions?: Array<{ id: string; currentValue?: unknown }> | null;
+}) {
+  return response.configOptions?.find((opt) => opt.id === "effort");
+}
+
 // Real temp dirs: createSession validates cwd and SettingsManager reads
 // settings from disk; CLAUDE_CONFIG_DIR keeps both away from the real home.
 const cwd = mkdtempSync(path.join(os.tmpdir(), "claude-agent-test-cwd-"));
@@ -356,6 +362,21 @@ describe("ClaudeAcpAgent session creation", () => {
     } else {
       expect(warnSpy).not.toHaveBeenCalled();
     }
+  });
+
+  it("does not expose effort controls when a new session starts with Kimi K3", async () => {
+    const agent = makeAgent();
+
+    const response = await agent.newSession({
+      cwd,
+      mcpServers: [],
+      _meta: { taskRunId: "run-kimi", model: "moonshotai/kimi-k3" },
+    });
+
+    expect(getModelConfigOption(response)?.currentValue).toBe(
+      "moonshotai/kimi-k3",
+    );
+    expect(getEffortConfigOption(response)).toBeUndefined();
   });
 
   // The timeout *message* (RequestError "... timed out after ...") is covered

--- a/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/packages/agent/src/adapters/claude/claude-agent.ts
@@ -2252,6 +2252,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       settingsManager.getSettings().model,
       meta?.model,
     ]);
+    modelOptions.currentModelId = resolvedModelId;
     session.modelId = resolvedModelId;
     session.lastContextWindowSize =
       this.getContextWindowForModel(resolvedModelId);


### PR DESCRIPTION
## Problem

Kimi K3 does not support selectable effort levels. New tasks correctly omit the selector, but a running session could show the default model's effort controls because its config was built from stale model state.

**Why:** Selecting one of those invalid values can make a later task request fail validation

## Changes

Build session config from the model actually resolved for execution, so Kimi sessions keep the effort control hidden