### PR TITLE
fix: prevent async PR title placeholders from persisting

### DIFF
--- a/apps/code/src/renderer/di/bindings.ts
+++ b/apps/code/src/renderer/di/bindings.ts
@@ -108,10 +108,12 @@ import {
 } from "@posthog/core/sessions/sessionService";
 import type {
   FileReadClient,
+  GithubPrTitleClient,
   TitleGeneratorLogger,
 } from "@posthog/core/sessions/titleGeneratorIdentifiers";
 import {
   TITLE_GENERATOR_FILE_READ_CLIENT,
+  TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT,
   TITLE_GENERATOR_LOGGER,
 } from "@posthog/core/sessions/titleGeneratorIdentifiers";
 import { type ISetupStore, SETUP_STORE } from "@posthog/core/setup/identifiers";
@@ -336,6 +338,7 @@ export interface RendererBindings {
   [CLOUD_ARTIFACT_READ_FILE_AS_BASE64]: ReadFileAsBase64;
   [LLM_GATEWAY_SERVICE]: LlmGatewayService;
   [TITLE_GENERATOR_FILE_READ_CLIENT]: FileReadClient;
+  [TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT]: GithubPrTitleClient;
   [TITLE_GENERATOR_LOGGER]: TitleGeneratorLogger;
 
   // --- desktop-services.ts ---

--- a/apps/code/src/renderer/di/container.ts
+++ b/apps/code/src/renderer/di/container.ts
@@ -60,6 +60,7 @@ import {
 import { sessionsModule } from "@posthog/core/sessions/sessions.module";
 import {
   TITLE_GENERATOR_FILE_READ_CLIENT,
+  TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT,
   TITLE_GENERATOR_LOGGER,
 } from "@posthog/core/sessions/titleGeneratorIdentifiers";
 import { SKILLS_WORKSPACE_CLIENT } from "@posthog/core/skills/identifiers";
@@ -450,6 +451,10 @@ container.bind(LLM_GATEWAY_SERVICE).toConstantValue({
 container.bind(TITLE_GENERATOR_FILE_READ_CLIENT).toConstantValue({
   readAbsoluteFile: (filePath: string) =>
     trpcClient.fs.readAbsoluteFile.query({ filePath }),
+});
+container.bind(TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT).toConstantValue({
+  getGithubPullRequestTitle: async (input) =>
+    (await hostTrpcClient.git.getGithubPullRequest.query(input))?.title ?? null,
 });
 container
   .bind(TITLE_GENERATOR_LOGGER)

--- a/apps/web/src/web-container.ts
+++ b/apps/web/src/web-container.ts
@@ -125,7 +125,9 @@ import {
 import { sessionsModule } from "@posthog/core/sessions/sessions.module";
 import {
   type FileReadClient,
+  type GithubPrTitleClient,
   TITLE_GENERATOR_FILE_READ_CLIENT,
+  TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT,
   TITLE_GENERATOR_LOGGER,
   TITLE_GENERATOR_SERVICE,
   type TitleGeneratorLogger,
@@ -309,6 +311,7 @@ import { WebOAuthFlowService } from "./web-oauth-flow";
 import { webDiffWorkerFactory, webReviewHost } from "./web-review-host";
 import {
   webBundleLocalSkill,
+  webGithubPrTitleClient,
   webReadFileAsBase64,
   webResolveSkillBundleDependencies,
   webTitleGeneratorFileReadClient,
@@ -380,6 +383,7 @@ interface WebBindings {
   [CLOUD_ARTIFACT_RESOLVE_SKILL_DEPENDENCIES]: ResolveSkillBundleDependencies;
   [TITLE_GENERATOR_SERVICE]: TitleGeneratorService;
   [TITLE_GENERATOR_FILE_READ_CLIENT]: FileReadClient;
+  [TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT]: GithubPrTitleClient;
   [TITLE_GENERATOR_LOGGER]: TitleGeneratorLogger;
   [LLM_GATEWAY_SERVICE]: LlmGatewayService;
   [LLM_GATEWAY_HOST]: LlmGatewayHost;
@@ -724,6 +728,9 @@ container
 container
   .bind(TITLE_GENERATOR_FILE_READ_CLIENT)
   .toConstantValue(webTitleGeneratorFileReadClient);
+container
+  .bind(TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT)
+  .toConstantValue(webGithubPrTitleClient);
 container
   .bind(TITLE_GENERATOR_LOGGER)
   .toConstantValue(webTitleGeneratorLogger(scoped()));

--- a/apps/web/src/web-sessions-clients.ts
+++ b/apps/web/src/web-sessions-clients.ts
@@ -5,6 +5,7 @@ import type {
 } from "@posthog/core/sessions/cloudArtifactIdentifiers";
 import type {
   FileReadClient,
+  GithubPrTitleClient,
   TitleGeneratorLogger,
 } from "@posthog/core/sessions/titleGeneratorIdentifiers";
 import { TEAM_SKILLS_SERVICE } from "@posthog/core/skills/identifiers";
@@ -28,6 +29,26 @@ import { bundleExportedSkill } from "./web-skill-bundler";
 // is a synthetic key into the in-memory store (not a filesystem path).
 export const webReadFileAsBase64: ReadFileAsBase64 = (filePath: string) =>
   Promise.resolve(getWebAttachmentBase64(filePath));
+
+export const webGithubPrTitleClient: GithubPrTitleClient = {
+  getGithubPullRequestTitle: async ({ owner, repo, number }) => {
+    const response = await fetch(
+      `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${number}`,
+      { headers: { Accept: "application/vnd.github+json" } },
+    );
+    if (!response.ok) return null;
+    const payload: unknown = await response.json();
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      !("title" in payload) ||
+      typeof payload.title !== "string"
+    ) {
+      return null;
+    }
+    return payload.title;
+  },
+};
 
 // A skill referenced in a cloud-task message is a TEAM skill (the web / menu
 // lists team skills). Fetch its content from the PostHog API and zip it in the

--- a/apps/web/src/web-sessions-clients.ts
+++ b/apps/web/src/web-sessions-clients.ts
@@ -32,10 +32,18 @@ export const webReadFileAsBase64: ReadFileAsBase64 = (filePath: string) =>
 
 export const webGithubPrTitleClient: GithubPrTitleClient = {
   getGithubPullRequestTitle: async ({ owner, repo, number }) => {
-    const response = await fetch(
-      `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${number}`,
-      { headers: { Accept: "application/vnd.github+json" } },
-    );
+    let response: Response;
+    try {
+      response = await fetch(
+        `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${number}`,
+        {
+          headers: { Accept: "application/vnd.github+json" },
+          signal: AbortSignal.timeout(5_000),
+        },
+      );
+    } catch {
+      return null;
+    }
     if (!response.ok) return null;
     const payload: unknown = await response.json();
     if (

--- a/packages/core/src/message-editor/githubIssueChip.test.ts
+++ b/packages/core/src/message-editor/githubIssueChip.test.ts
@@ -3,6 +3,7 @@ import {
   GITHUB_ISSUE_STATE_COLORS,
   githubIssueStateColor,
   githubIssueToMentionChip,
+  isLoadingGithubRefTitle,
 } from "./githubIssueChip";
 
 describe("githubIssueToMentionChip", () => {
@@ -36,5 +37,18 @@ describe("githubIssueStateColor", () => {
     expect(githubIssueStateColor("MERGED")).toBe(
       GITHUB_ISSUE_STATE_COLORS.MERGED,
     );
+  });
+});
+
+describe("isLoadingGithubRefTitle", () => {
+  it.each(["Loading...", "Loading…"])(
+    "detects the unresolved title %s",
+    (title) => {
+      expect(isLoadingGithubRefTitle(title)).toBe(true);
+    },
+  );
+
+  it("allows resolved GitHub titles", () => {
+    expect(isLoadingGithubRefTitle("Fix the loading... state")).toBe(false);
   });
 });

--- a/packages/core/src/message-editor/githubIssueChip.ts
+++ b/packages/core/src/message-editor/githubIssueChip.ts
@@ -50,3 +50,7 @@ export function buildGithubRefPlaceholderChip(
     ? githubPullRequestToMentionChip(source)
     : githubIssueToMentionChip(source);
 }
+
+export function isLoadingGithubRefTitle(title: string): boolean {
+  return /^Loading(?:\.{3}|…)$/i.test(title.trim());
+}

--- a/packages/core/src/sessions/titleGeneratorIdentifiers.ts
+++ b/packages/core/src/sessions/titleGeneratorIdentifiers.ts
@@ -2,6 +2,14 @@ export interface FileReadClient {
   readAbsoluteFile(filePath: string): Promise<string | null>;
 }
 
+export interface GithubPrTitleClient {
+  getGithubPullRequestTitle(input: {
+    owner: string;
+    repo: string;
+    number: number;
+  }): Promise<string | null>;
+}
+
 export interface TitleGeneratorLogger {
   error(message: string, data?: unknown): void;
 }
@@ -11,6 +19,9 @@ export const TITLE_GENERATOR_SERVICE = Symbol.for(
 );
 export const TITLE_GENERATOR_FILE_READ_CLIENT = Symbol.for(
   "posthog.core.sessions.titleGeneratorFileReadClient",
+);
+export const TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT = Symbol.for(
+  "posthog.core.sessions.titleGeneratorGithubPrTitleClient",
 );
 export const TITLE_GENERATOR_LOGGER = Symbol.for(
   "posthog.core.sessions.titleGeneratorLogger",

--- a/packages/core/src/sessions/titleGeneratorService.test.ts
+++ b/packages/core/src/sessions/titleGeneratorService.test.ts
@@ -256,6 +256,22 @@ describe("generateTitleAndSummary", () => {
     );
   });
 
+  it("uses the existing GitHub PR title when the model omits it", async () => {
+    prompt.mockResolvedValue({
+      content:
+        "TITLE: Review pull request #123\nSUMMARY: Reviewing the existing pull request.",
+    });
+
+    const result = await makeService().generateTitleAndSummary(
+      '<github_pr number="123" title="Fix login redirect" url="https://github.com/org/repo/pull/123" />',
+    );
+
+    expect(result).toEqual({
+      title: "Review PR #123: Fix login redirect",
+      summary: "Reviewing the existing pull request.",
+    });
+  });
+
   it("returns null on error", async () => {
     prompt.mockRejectedValue(new Error("network error"));
     const result = await makeService().generateTitleAndSummary("some content");

--- a/packages/core/src/sessions/titleGeneratorService.test.ts
+++ b/packages/core/src/sessions/titleGeneratorService.test.ts
@@ -274,6 +274,16 @@ describe("generateTitleAndSummary", () => {
     });
   });
 
+  it("decodes the PR title from structured metadata", async () => {
+    prompt.mockResolvedValue({ content: "SUMMARY: Reviewing the PR." });
+
+    const result = await makeService().generateTitleAndSummary(
+      '<github_pr number="123" title="Fix &quot;login&quot; &amp; redirect" url="https://github.com/org/repo/pull/123" />',
+    );
+
+    expect(result?.title).toBe('Review PR #123: Fix "login" & redirect');
+  });
+
   it("returns null on error", async () => {
     prompt.mockRejectedValue(new Error("network error"));
     const result = await makeService().generateTitleAndSummary("some content");

--- a/packages/core/src/sessions/titleGeneratorService.test.ts
+++ b/packages/core/src/sessions/titleGeneratorService.test.ts
@@ -4,19 +4,24 @@ import type { FileReadClient } from "./titleGeneratorIdentifiers";
 import { TitleGeneratorService } from "./titleGeneratorService";
 
 const readAbsoluteFile = vi.fn<FileReadClient["readAbsoluteFile"]>();
+const getGithubPullRequestTitle = vi.fn();
 const prompt = vi.fn();
 
 function makeService(): TitleGeneratorService {
   const gateway = { prompt } as unknown as LlmGatewayService;
   const fileReadClient: FileReadClient = { readAbsoluteFile };
-  return new TitleGeneratorService(gateway, fileReadClient, {
-    error: vi.fn(),
-  });
+  return new TitleGeneratorService(
+    gateway,
+    fileReadClient,
+    { getGithubPullRequestTitle },
+    { error: vi.fn() },
+  );
 }
 
 describe("enrichDescriptionWithFileContent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getGithubPullRequestTitle.mockResolvedValue(null);
   });
 
   it("returns description unchanged when it contains real text", async () => {
@@ -197,6 +202,7 @@ describe("enrichDescriptionWithFileContent", () => {
 describe("generateTitleAndSummary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getGithubPullRequestTitle.mockResolvedValue(null);
   });
 
   it("truncates title to 255 chars", async () => {
@@ -283,6 +289,62 @@ describe("generateTitleAndSummary", () => {
 
     expect(result?.title).toBe('Review PR #123: Fix "login" & redirect');
   });
+
+  it.each(["Loading...", "Loading…"])(
+    "resolves the unresolved GitHub PR title %s",
+    async (title) => {
+      getGithubPullRequestTitle.mockResolvedValue(
+        "fix: enforce PR titles in task names",
+      );
+      prompt.mockResolvedValue({
+        content: "SUMMARY: Reviewing the existing pull request.",
+      });
+
+      const result = await makeService().generateTitleAndSummary(
+        `<github_pr number="123" title="${title}" url="https://github.com/org/repo/pull/123" />`,
+      );
+
+      expect(result?.title).toBe(
+        "Review PR #123: fix: enforce PR titles in task names",
+      );
+      expect(getGithubPullRequestTitle).toHaveBeenCalledWith({
+        owner: "org",
+        repo: "repo",
+        number: 123,
+      });
+      expect(prompt).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          system: expect.not.stringContaining("TITLE:"),
+        }),
+      );
+    },
+  );
+
+  it.each([
+    { name: "returns no title", resolve: () => Promise.resolve(null) },
+    {
+      name: "rejects",
+      resolve: () => Promise.reject(new Error("IPC disconnected")),
+    },
+  ])(
+    "uses a safe PR fallback when GitHub lookup $name",
+    async ({ resolve }) => {
+      getGithubPullRequestTitle.mockImplementation(resolve);
+      prompt.mockResolvedValue({
+        content: "SUMMARY: Reviewing the existing pull request.",
+      });
+
+      const result = await makeService().generateTitleAndSummary(
+        '<github_pr number="123" title="Loading..." url="https://github.com/org/repo/pull/123" />',
+      );
+
+      expect(result).toEqual({
+        title: "Review PR #123",
+        summary: "Reviewing the existing pull request.",
+      });
+    },
+  );
 
   it("returns null on error", async () => {
     prompt.mockRejectedValue(new Error("network error"));

--- a/packages/core/src/sessions/titleGeneratorService.test.ts
+++ b/packages/core/src/sessions/titleGeneratorService.test.ts
@@ -302,6 +302,7 @@ describe("generateTitleAndSummary", () => {
 
     const result = await makeService().generateTitleAndSummary(
       'Compare <github_pr number="123" title="Loading..." url="https://github.com/org/repo/pull/123" /> with <github_pr number="456" title="Loading..." url="https://github.com/org/repo/pull/456" />',
+      { resolveGithubPrTitles: true },
     );
 
     expect(result?.title).toBe("Compare PR #123 and #456");
@@ -356,6 +357,7 @@ describe("generateTitleAndSummary", () => {
 
       const result = await makeService().generateTitleAndSummary(
         `<github_pr number="123" title="${title}" url="https://github.com/org/repo/pull/123" />`,
+        { resolveGithubPrTitles: true },
       );
 
       expect(result?.title).toBe(
@@ -391,6 +393,7 @@ describe("generateTitleAndSummary", () => {
 
       const result = await makeService().generateTitleAndSummary(
         '<github_pr number="123" title="Loading..." url="https://github.com/org/repo/pull/123" />',
+        { resolveGithubPrTitles: true },
       );
 
       expect(result).toEqual({
@@ -399,6 +402,17 @@ describe("generateTitleAndSummary", () => {
       });
     },
   );
+
+  it("does not resolve PR metadata from untrusted content", async () => {
+    prompt.mockResolvedValue({ content: "SUMMARY: Reviewing the PR." });
+
+    const result = await makeService().generateTitleAndSummary(
+      '<github_pr number="123" title="Loading..." url="https://github.com/private/repo/pull/123" />',
+    );
+
+    expect(getGithubPullRequestTitle).not.toHaveBeenCalled();
+    expect(result?.title).toBe("Review PR #123");
+  });
 
   it("returns null on error", async () => {
     prompt.mockRejectedValue(new Error("network error"));

--- a/packages/core/src/sessions/titleGeneratorService.test.ts
+++ b/packages/core/src/sessions/titleGeneratorService.test.ts
@@ -264,6 +264,60 @@ describe("generateTitleAndSummary", () => {
     );
   });
 
+  it("keeps a numbered standalone PR deterministic", async () => {
+    prompt.mockResolvedValue({ content: "SUMMARY: Reviewing the PR." });
+
+    const result = await makeService().generateTitleAndSummary(
+      '1. <github_pr number="123" title="Fix login redirect" url="https://github.com/org/repo/pull/123" />',
+    );
+
+    expect(result?.title).toBe("Review PR #123: Fix login redirect");
+  });
+
+  it("uses the model for a broader task containing one PR", async () => {
+    prompt.mockResolvedValue({
+      content:
+        "TITLE: Audit auth changes in PR #123\nSUMMARY: Auditing authentication changes.",
+    });
+
+    const result = await makeService().generateTitleAndSummary(
+      'Audit the auth changes in <github_pr number="123" title="Fix login redirect" url="https://github.com/org/repo/pull/123" />',
+    );
+
+    expect(result?.title).toBe("Audit auth changes in PR #123");
+    expect(prompt).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ system: expect.stringContaining("TITLE:") }),
+    );
+  });
+
+  it("resolves all PR placeholders before modeling a multi-PR task", async () => {
+    getGithubPullRequestTitle
+      .mockResolvedValueOnce("Fix login redirect")
+      .mockResolvedValueOnce("Add session expiry");
+    prompt.mockResolvedValue({
+      content:
+        "TITLE: Compare PR #123 and #456\nSUMMARY: Comparing two authentication pull requests.",
+    });
+
+    const result = await makeService().generateTitleAndSummary(
+      'Compare <github_pr number="123" title="Loading..." url="https://github.com/org/repo/pull/123" /> with <github_pr number="456" title="Loading..." url="https://github.com/org/repo/pull/456" />',
+    );
+
+    expect(result?.title).toBe("Compare PR #123 and #456");
+    expect(getGithubPullRequestTitle).toHaveBeenCalledTimes(2);
+    expect(prompt).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          content: expect.stringMatching(
+            /title="Fix login redirect"[\s\S]*title="Add session expiry"/,
+          ),
+        }),
+      ],
+      expect.objectContaining({ system: expect.stringContaining("TITLE:") }),
+    );
+  });
+
   it("uses the existing GitHub PR title when the model omits it", async () => {
     prompt.mockResolvedValue({
       content:

--- a/packages/core/src/sessions/titleGeneratorService.test.ts
+++ b/packages/core/src/sessions/titleGeneratorService.test.ts
@@ -236,22 +236,24 @@ describe("generateTitleAndSummary", () => {
     });
   });
 
-  it("instructs the model to include existing GitHub PR titles", async () => {
+  it("only asks the model for a summary for existing GitHub PRs", async () => {
     prompt.mockResolvedValue({
-      content:
-        "TITLE: Review PR #123: Fix login redirect\nSUMMARY: Reviewing the existing pull request.",
+      content: "SUMMARY: Reviewing the existing pull request.",
     });
 
-    await makeService().generateTitleAndSummary(
+    const result = await makeService().generateTitleAndSummary(
       '<github_pr number="123" title="Fix login redirect" url="https://github.com/org/repo/pull/123" />',
     );
 
+    expect(result?.title).toBe("Review PR #123: Fix login redirect");
     expect(prompt).toHaveBeenCalledWith(
-      expect.anything(),
+      [
+        expect.objectContaining({
+          content: expect.stringContaining("ONLY generate a summary"),
+        }),
+      ],
       expect.objectContaining({
-        system: expect.stringContaining(
-          "the generated TITLE MUST include both the PR number and the PR title verbatim",
-        ),
+        system: expect.not.stringContaining("TITLE:"),
       }),
     );
   });

--- a/packages/core/src/sessions/titleGeneratorService.ts
+++ b/packages/core/src/sessions/titleGeneratorService.ts
@@ -4,7 +4,7 @@ import {
   type LlmGatewayService,
 } from "@posthog/core/llm-gateway/llm-gateway";
 import { xmlToContent } from "@posthog/core/message-editor/content";
-import { parseGithubIssueUrl } from "@posthog/core/message-editor/githubIssueUrl";
+import { parseXmlAttrs } from "@posthog/core/message-editor/skillTags";
 import { getFileName, isBinaryFile } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import {
@@ -26,16 +26,13 @@ const ATTACHED_FILES_REGEX =
 const PASTED_TEXT_SNIPPET_LIMIT = 500;
 
 function getGithubPrTaskTitle(content: string): string | null {
-  const pr = xmlToContent(content).segments.find(
-    (segment) => segment.type === "chip" && segment.chip.type === "github_pr",
-  );
-  if (!pr || pr.type !== "chip") return null;
+  const match = content.match(/<github_pr\b([^>]*?)\s*\/>/);
+  if (!match) return null;
 
-  const parsed = parseGithubIssueUrl(pr.chip.id);
-  const title = pr.chip.label.replace(/^#\d+\s+-\s+/, "").trim();
-  if (parsed?.kind !== "pr" || !title) return null;
+  const { number, title } = parseXmlAttrs(match[1]);
+  if (!/^\d+$/.test(number) || !title.trim()) return null;
 
-  return `Review PR #${parsed.number}: ${title}`.slice(0, 255);
+  return `Review PR #${number}: ${title.trim()}`.slice(0, 255);
 }
 
 const SYSTEM_PROMPT = `You are a title and summary generator. Output using exactly this format:

--- a/packages/core/src/sessions/titleGeneratorService.ts
+++ b/packages/core/src/sessions/titleGeneratorService.ts
@@ -37,6 +37,7 @@ interface GithubPrGenerationContext {
 async function prepareGithubPrGenerationContext(
   content: string,
   githubPrTitleClient: GithubPrTitleClient,
+  resolveGithubPrTitles: boolean,
 ): Promise<GithubPrGenerationContext> {
   const tagRegex = /<github_pr\b([^>]*?)\s*\/>/g;
   const matches = [...content.matchAll(tagRegex)];
@@ -48,7 +49,8 @@ async function prepareGithubPrGenerationContext(
     matches.map(async (match) => {
       const attrs = parseXmlAttrs(match[1]);
       let title = (attrs.title ?? "").trim();
-      if (!title || isLoadingGithubRefTitle(title)) {
+      const needsResolution = !title || isLoadingGithubRefTitle(title);
+      if (resolveGithubPrTitles && needsResolution) {
         const parsed = parseGithubIssueUrl(attrs.url);
         if (parsed?.kind === "pr") {
           try {
@@ -62,6 +64,8 @@ async function prepareGithubPrGenerationContext(
             title = "";
           }
         }
+      } else if (needsResolution) {
+        title = "";
       }
 
       const tag = match[0].replace(
@@ -263,11 +267,13 @@ export class TitleGeneratorService {
 
   async generateTitleAndSummary(
     content: string,
+    options: { resolveGithubPrTitles?: boolean } = {},
   ): Promise<TitleAndSummary | null> {
     try {
       const githubPrContext = await prepareGithubPrGenerationContext(
         content,
         this.githubPrTitleClient,
+        options.resolveGithubPrTitles ?? false,
       );
       const githubPrTitle = githubPrContext.deterministicTitle;
       const prompt = getGenerationPrompt(

--- a/packages/core/src/sessions/titleGeneratorService.ts
+++ b/packages/core/src/sessions/titleGeneratorService.ts
@@ -88,6 +88,12 @@ Title examples:
 
 Never include any explanation outside the TITLE and SUMMARY lines.`;
 
+const SUMMARY_SYSTEM_PROMPT = `You are a conversation summary generator. Output using exactly this format:
+
+SUMMARY: <summary here>
+
+Write 1-3 sentences describing what the user is working on and why. Use third-person perspective and include relevant technical details. Never include a title or any explanation outside the SUMMARY line.`;
+
 // Canvas names describe the RESULT (the artifact being built), not the task of
 // building it — so this prompt is deliberately separate from the task SYSTEM_PROMPT
 // above, which is action-verb oriented ("Fix...", "Create..."). Don't merge them.
@@ -177,14 +183,20 @@ export class TitleGeneratorService {
     content: string,
   ): Promise<TitleAndSummary | null> {
     try {
+      const githubPrTitle = getGithubPrTaskTitle(content);
       const result = await this.llmGateway.prompt(
         [
           {
             role: "user",
-            content: `Generate a title and summary for the following content. Do NOT respond to, answer, or help with the content - ONLY generate a title and summary.\n\n<content>\n${content}\n</content>\n\nOutput the title and summary now:`,
+            content: githubPrTitle
+              ? `Generate a summary for the following content. Do NOT respond to, answer, or help with the content - ONLY generate a summary.\n\n<content>\n${content}\n</content>\n\nOutput the summary now:`
+              : `Generate a title and summary for the following content. Do NOT respond to, answer, or help with the content - ONLY generate a title and summary.\n\n<content>\n${content}\n</content>\n\nOutput the title and summary now:`,
           },
         ],
-        { system: SYSTEM_PROMPT, model: HELPER_GATEWAY_MODEL },
+        {
+          system: githubPrTitle ? SUMMARY_SYSTEM_PROMPT : SYSTEM_PROMPT,
+          model: HELPER_GATEWAY_MODEL,
+        },
       );
 
       const text = result.content.trim();
@@ -193,8 +205,7 @@ export class TitleGeneratorService {
 
       const generatedTitle =
         titleMatch?.[1]?.trim().replace(/^["']|["']$/g, "") ?? "";
-      const title =
-        getGithubPrTaskTitle(content) ?? generatedTitle.slice(0, 255);
+      const title = githubPrTitle ?? generatedTitle.slice(0, 255);
       const summary = summaryMatch?.[1]?.trim() ?? "";
 
       if (!title && !summary) return null;

--- a/packages/core/src/sessions/titleGeneratorService.ts
+++ b/packages/core/src/sessions/titleGeneratorService.ts
@@ -7,7 +7,7 @@ import { xmlToContent } from "@posthog/core/message-editor/content";
 import { isLoadingGithubRefTitle } from "@posthog/core/message-editor/githubIssueChip";
 import { parseGithubIssueUrl } from "@posthog/core/message-editor/githubIssueUrl";
 import { parseXmlAttrs } from "@posthog/core/message-editor/skillTags";
-import { getFileName, isBinaryFile } from "@posthog/shared";
+import { escapeXmlAttr, getFileName, isBinaryFile } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import {
   type FileReadClient,
@@ -29,35 +29,73 @@ const ATTACHED_FILES_REGEX =
   /^(?:(?:\d+\.\s*)?\[Attached files:[^\]]*\]|Attached files:.*)$/gm;
 const PASTED_TEXT_SNIPPET_LIMIT = 500;
 
-async function getGithubPrTaskTitle(
+interface GithubPrGenerationContext {
+  content: string;
+  deterministicTitle: string | null;
+}
+
+async function prepareGithubPrGenerationContext(
   content: string,
   githubPrTitleClient: GithubPrTitleClient,
-): Promise<string | null> {
-  const match = content.match(/<github_pr\b([^>]*?)\s*\/>/);
-  if (!match) return null;
-
-  const { number, title, url } = parseXmlAttrs(match[1]);
-  if (!/^\d+$/.test(number)) return null;
-
-  let resolvedTitle = title.trim();
-  if (!resolvedTitle || isLoadingGithubRefTitle(resolvedTitle)) {
-    const parsed = parseGithubIssueUrl(url);
-    if (parsed?.kind === "pr") {
-      try {
-        resolvedTitle =
-          (await githubPrTitleClient.getGithubPullRequestTitle({
-            owner: parsed.owner,
-            repo: parsed.repo,
-            number: parsed.number,
-          })) ?? "";
-      } catch {
-        resolvedTitle = "";
-      }
-    }
+): Promise<GithubPrGenerationContext> {
+  const tagRegex = /<github_pr\b([^>]*?)\s*\/>/g;
+  const matches = [...content.matchAll(tagRegex)];
+  if (matches.length === 0) {
+    return { content, deterministicTitle: null };
   }
 
-  const suffix = resolvedTitle ? `: ${resolvedTitle}` : "";
-  return `Review PR #${number}${suffix}`.slice(0, 255);
+  const resolved = await Promise.all(
+    matches.map(async (match) => {
+      const attrs = parseXmlAttrs(match[1]);
+      let title = (attrs.title ?? "").trim();
+      if (!title || isLoadingGithubRefTitle(title)) {
+        const parsed = parseGithubIssueUrl(attrs.url);
+        if (parsed?.kind === "pr") {
+          try {
+            title =
+              (await githubPrTitleClient.getGithubPullRequestTitle({
+                owner: parsed.owner,
+                repo: parsed.repo,
+                number: parsed.number,
+              })) ?? "";
+          } catch {
+            title = "";
+          }
+        }
+      }
+
+      const tag = match[0].replace(
+        /\btitle="[^"]*"/,
+        `title="${escapeXmlAttr(title)}"`,
+      );
+      return { number: attrs.number, tag, title };
+    }),
+  );
+
+  let matchIndex = 0;
+  const resolvedContent = content.replaceAll(
+    tagRegex,
+    () => resolved[matchIndex++].tag,
+  );
+  const remainingContent = content
+    .replaceAll(tagRegex, "")
+    .replace(/^\s*\d+\.\s*$/gm, "")
+    .trim();
+  const standalonePr =
+    resolved.length === 1 &&
+    remainingContent.length === 0 &&
+    /^\d+$/.test(resolved[0].number);
+
+  if (!standalonePr) {
+    return { content: resolvedContent, deterministicTitle: null };
+  }
+
+  const { number, title } = resolved[0];
+  const suffix = title ? `: ${title}` : "";
+  return {
+    content: resolvedContent,
+    deterministicTitle: `Review PR #${number}${suffix}`.slice(0, 255),
+  };
 }
 
 const SYSTEM_PROMPT = `You are a title and summary generator. Output using exactly this format:
@@ -76,7 +114,7 @@ Title rules:
 - Remove: the, this, my, a, an
 - If possible, start with action verbs (Fix, Implement, Analyze, Debug, Update, Research, Review)
 - Keep exact: technical terms, numbers, filenames, HTTP codes, PR numbers
-- GitHub PR rule: If the content contains a <github_pr> with a non-empty title, the generated TITLE MUST include both the PR number and the PR title verbatim. This rule overrides the 6-word title limit. Never replace the PR title with a generic phrase. Before responding, verify that both values appear in TITLE.
+- GitHub PR context: When PR metadata is part of a broader task or multiple PRs are present, title the overall task rather than letting the first PR define its scope. Include relevant PR numbers when useful; full PR titles do not need to be copied verbatim.
 - Never assume tech stack
 - Only output "Untitled" if the input is completely null/missing, not just unclear
 - If the input is a URL (e.g. a GitHub issue link, PR link, or any web URL), generate a title based on what you can infer from the URL structure (repo name, issue/PR number, etc.). Never say you cannot access URLs or ask the user for more information.
@@ -227,11 +265,15 @@ export class TitleGeneratorService {
     content: string,
   ): Promise<TitleAndSummary | null> {
     try {
-      const githubPrTitle = await getGithubPrTaskTitle(
+      const githubPrContext = await prepareGithubPrGenerationContext(
         content,
         this.githubPrTitleClient,
       );
-      const prompt = getGenerationPrompt(content, !!githubPrTitle);
+      const githubPrTitle = githubPrContext.deterministicTitle;
+      const prompt = getGenerationPrompt(
+        githubPrContext.content,
+        !!githubPrTitle,
+      );
       const result = await this.llmGateway.prompt(
         [
           {

--- a/packages/core/src/sessions/titleGeneratorService.ts
+++ b/packages/core/src/sessions/titleGeneratorService.ts
@@ -4,12 +4,16 @@ import {
   type LlmGatewayService,
 } from "@posthog/core/llm-gateway/llm-gateway";
 import { xmlToContent } from "@posthog/core/message-editor/content";
+import { isLoadingGithubRefTitle } from "@posthog/core/message-editor/githubIssueChip";
+import { parseGithubIssueUrl } from "@posthog/core/message-editor/githubIssueUrl";
 import { parseXmlAttrs } from "@posthog/core/message-editor/skillTags";
 import { getFileName, isBinaryFile } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import {
   type FileReadClient,
+  type GithubPrTitleClient,
   TITLE_GENERATOR_FILE_READ_CLIENT,
+  TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT,
   TITLE_GENERATOR_LOGGER,
   type TitleGeneratorLogger,
 } from "./titleGeneratorIdentifiers";
@@ -25,14 +29,35 @@ const ATTACHED_FILES_REGEX =
   /^(?:(?:\d+\.\s*)?\[Attached files:[^\]]*\]|Attached files:.*)$/gm;
 const PASTED_TEXT_SNIPPET_LIMIT = 500;
 
-function getGithubPrTaskTitle(content: string): string | null {
+async function getGithubPrTaskTitle(
+  content: string,
+  githubPrTitleClient: GithubPrTitleClient,
+): Promise<string | null> {
   const match = content.match(/<github_pr\b([^>]*?)\s*\/>/);
   if (!match) return null;
 
-  const { number, title } = parseXmlAttrs(match[1]);
-  if (!/^\d+$/.test(number) || !title.trim()) return null;
+  const { number, title, url } = parseXmlAttrs(match[1]);
+  if (!/^\d+$/.test(number)) return null;
 
-  return `Review PR #${number}: ${title.trim()}`.slice(0, 255);
+  let resolvedTitle = title.trim();
+  if (!resolvedTitle || isLoadingGithubRefTitle(resolvedTitle)) {
+    const parsed = parseGithubIssueUrl(url);
+    if (parsed?.kind === "pr") {
+      try {
+        resolvedTitle =
+          (await githubPrTitleClient.getGithubPullRequestTitle({
+            owner: parsed.owner,
+            repo: parsed.repo,
+            number: parsed.number,
+          })) ?? "";
+      } catch {
+        resolvedTitle = "";
+      }
+    }
+  }
+
+  const suffix = resolvedTitle ? `: ${resolvedTitle}` : "";
+  return `Review PR #${number}${suffix}`.slice(0, 255);
 }
 
 const SYSTEM_PROMPT = `You are a title and summary generator. Output using exactly this format:
@@ -148,6 +173,8 @@ export class TitleGeneratorService {
     private readonly llmGateway: LlmGatewayService,
     @inject(TITLE_GENERATOR_FILE_READ_CLIENT)
     private readonly fileReadClient: FileReadClient,
+    @inject(TITLE_GENERATOR_GITHUB_PR_TITLE_CLIENT)
+    private readonly githubPrTitleClient: GithubPrTitleClient,
     @inject(TITLE_GENERATOR_LOGGER)
     private readonly log: TitleGeneratorLogger,
   ) {}
@@ -200,7 +227,10 @@ export class TitleGeneratorService {
     content: string,
   ): Promise<TitleAndSummary | null> {
     try {
-      const githubPrTitle = getGithubPrTaskTitle(content);
+      const githubPrTitle = await getGithubPrTaskTitle(
+        content,
+        this.githubPrTitleClient,
+      );
       const prompt = getGenerationPrompt(content, !!githubPrTitle);
       const result = await this.llmGateway.prompt(
         [

--- a/packages/core/src/sessions/titleGeneratorService.ts
+++ b/packages/core/src/sessions/titleGeneratorService.ts
@@ -216,12 +216,16 @@ export class TitleGeneratorService {
       );
 
       const text = result.content.trim();
-      const titleMatch = text.match(/^TITLE:\s*(.+?)(?:\n|$)/m);
       const summaryMatch = text.match(/^SUMMARY:\s*([\s\S]+)$/m);
 
-      const generatedTitle =
-        titleMatch?.[1]?.trim().replace(/^["']|["']$/g, "") ?? "";
-      const title = githubPrTitle ?? generatedTitle.slice(0, 255);
+      const title =
+        githubPrTitle ??
+        text
+          .match(/^TITLE:\s*(.+?)(?:\n|$)/m)?.[1]
+          ?.trim()
+          .replace(/^["']|["']$/g, "")
+          .slice(0, 255) ??
+        "";
       const summary = summaryMatch?.[1]?.trim() ?? "";
 
       if (!title && !summary) return null;

--- a/packages/core/src/sessions/titleGeneratorService.ts
+++ b/packages/core/src/sessions/titleGeneratorService.ts
@@ -91,6 +91,26 @@ SUMMARY: <summary here>
 
 Write 1-3 sentences describing what the user is working on and why. Use third-person perspective and include relevant technical details. Never include a title or any explanation outside the SUMMARY line.`;
 
+function getGenerationPrompt(
+  content: string,
+  summaryOnly: boolean,
+): {
+  user: string;
+  system: string;
+} {
+  if (summaryOnly) {
+    return {
+      user: `Generate a summary for the following content. Do NOT respond to, answer, or help with the content - ONLY generate a summary.\n\n<content>\n${content}\n</content>\n\nOutput the summary now:`,
+      system: SUMMARY_SYSTEM_PROMPT,
+    };
+  }
+
+  return {
+    user: `Generate a title and summary for the following content. Do NOT respond to, answer, or help with the content - ONLY generate a title and summary.\n\n<content>\n${content}\n</content>\n\nOutput the title and summary now:`,
+    system: SYSTEM_PROMPT,
+  };
+}
+
 // Canvas names describe the RESULT (the artifact being built), not the task of
 // building it — so this prompt is deliberately separate from the task SYSTEM_PROMPT
 // above, which is action-verb oriented ("Fix...", "Create..."). Don't merge them.
@@ -181,17 +201,16 @@ export class TitleGeneratorService {
   ): Promise<TitleAndSummary | null> {
     try {
       const githubPrTitle = getGithubPrTaskTitle(content);
+      const prompt = getGenerationPrompt(content, !!githubPrTitle);
       const result = await this.llmGateway.prompt(
         [
           {
             role: "user",
-            content: githubPrTitle
-              ? `Generate a summary for the following content. Do NOT respond to, answer, or help with the content - ONLY generate a summary.\n\n<content>\n${content}\n</content>\n\nOutput the summary now:`
-              : `Generate a title and summary for the following content. Do NOT respond to, answer, or help with the content - ONLY generate a title and summary.\n\n<content>\n${content}\n</content>\n\nOutput the title and summary now:`,
+            content: prompt.user,
           },
         ],
         {
-          system: githubPrTitle ? SUMMARY_SYSTEM_PROMPT : SYSTEM_PROMPT,
+          system: prompt.system,
           model: HELPER_GATEWAY_MODEL,
         },
       );

--- a/packages/core/src/sessions/titleGeneratorService.ts
+++ b/packages/core/src/sessions/titleGeneratorService.ts
@@ -4,6 +4,7 @@ import {
   type LlmGatewayService,
 } from "@posthog/core/llm-gateway/llm-gateway";
 import { xmlToContent } from "@posthog/core/message-editor/content";
+import { parseGithubIssueUrl } from "@posthog/core/message-editor/githubIssueUrl";
 import { getFileName, isBinaryFile } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import {
@@ -23,6 +24,19 @@ import {
 const ATTACHED_FILES_REGEX =
   /^(?:(?:\d+\.\s*)?\[Attached files:[^\]]*\]|Attached files:.*)$/gm;
 const PASTED_TEXT_SNIPPET_LIMIT = 500;
+
+function getGithubPrTaskTitle(content: string): string | null {
+  const pr = xmlToContent(content).segments.find(
+    (segment) => segment.type === "chip" && segment.chip.type === "github_pr",
+  );
+  if (!pr || pr.type !== "chip") return null;
+
+  const parsed = parseGithubIssueUrl(pr.chip.id);
+  const title = pr.chip.label.replace(/^#\d+\s+-\s+/, "").trim();
+  if (parsed?.kind !== "pr" || !title) return null;
+
+  return `Review PR #${parsed.number}: ${title}`.slice(0, 255);
+}
 
 const SYSTEM_PROMPT = `You are a title and summary generator. Output using exactly this format:
 
@@ -177,11 +191,10 @@ export class TitleGeneratorService {
       const titleMatch = text.match(/^TITLE:\s*(.+?)(?:\n|$)/m);
       const summaryMatch = text.match(/^SUMMARY:\s*([\s\S]+)$/m);
 
+      const generatedTitle =
+        titleMatch?.[1]?.trim().replace(/^["']|["']$/g, "") ?? "";
       const title =
-        titleMatch?.[1]
-          ?.trim()
-          .replace(/^["']|["']$/g, "")
-          .slice(0, 255) ?? "";
+        getGithubPrTaskTitle(content) ?? generatedTitle.slice(0, 255);
       const summary = summaryMatch?.[1]?.trim() ?? "";
 
       if (!title && !summary) return null;

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -336,7 +336,9 @@ describe("useChatTitleGenerator", () => {
         '1. <file path="/tmp/code.ts" />',
         [],
       );
-      expect(mockGenerateTitle).toHaveBeenCalledWith("enriched content");
+      expect(mockGenerateTitle).toHaveBeenCalledWith("enriched content", {
+        resolveGithubPrTitles: true,
+      });
     });
   });
 

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -10,6 +10,9 @@ const mockEnrichDescription = vi.hoisted(() =>
 const mockGenerateTitle = vi.hoisted(() => vi.fn());
 const mockGetQueriesData = vi.hoisted(() => vi.fn(() => [] as unknown[]));
 const mockIsAuthenticated = vi.hoisted(() => ({ value: true }));
+const mockCurrentUser = vi.hoisted(() => ({
+  value: { id: 1 } as { id: number } | undefined,
+}));
 const mockUpdateTask = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockSetQueriesData = vi.hoisted(() => vi.fn());
 const mockSetQueryData = vi.hoisted(() => vi.fn());
@@ -46,6 +49,10 @@ vi.mock("@posthog/ui/features/auth/store", () => ({
         ? { status: "authenticated", cloudRegion: "us-east-1" }
         : { status: "anonymous", cloudRegion: null },
     ),
+}));
+
+vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
+  useCurrentUser: () => ({ data: mockCurrentUser.value }),
 }));
 
 vi.mock("@posthog/core/sessions/sessionEvents", () => ({
@@ -116,6 +123,11 @@ function createTask(overrides: Partial<Task> = {}): Task {
     created_at: "2026-05-28T00:00:00.000Z",
     updated_at: "2026-05-28T00:00:00.000Z",
     origin_product: "user_created",
+    created_by: {
+      id: 1,
+      uuid: "user-1",
+      email: "user@example.com",
+    },
     ...overrides,
   } as Task;
 }
@@ -136,6 +148,7 @@ describe("useChatTitleGenerator", () => {
     vi.clearAllMocks();
     useTitleGenerationStore.setState({ byTaskId: {} });
     mockIsAuthenticated.value = true;
+    mockCurrentUser.value = { id: 1 };
     mockPrompts.value = [];
     mockSessionSummary.value = undefined;
     mockTitleAttachmentPaths.value = [];
@@ -149,6 +162,14 @@ describe("useChatTitleGenerator", () => {
     renderHook(() =>
       useChatTitleGenerator(createTask({ title: "Custom task title" })),
     );
+    expect(mockGenerateTitle).not.toHaveBeenCalled();
+  });
+
+  it("waits for task creator identity before generating", () => {
+    mockCurrentUser.value = undefined;
+
+    renderHook(() => useChatTitleGenerator(createTask()));
+
     expect(mockGenerateTitle).not.toHaveBeenCalled();
   });
 
@@ -169,6 +190,34 @@ describe("useChatTitleGenerator", () => {
     await waitFor(() => {
       expect(mockUpdateTask).toHaveBeenCalledWith(TASK_ID, {
         title: "Fix login bug",
+      });
+    });
+    expect(mockGenerateTitle).toHaveBeenCalledWith("Fix the login bug", {
+      resolveGithubPrTitles: true,
+    });
+  });
+
+  it("does not resolve GitHub metadata from a teammate's description", async () => {
+    mockGenerateTitle.mockResolvedValue({
+      title: "Review PR #123",
+      summary: "Reviewing a pull request",
+    });
+
+    renderHook(() =>
+      useChatTitleGenerator(
+        createTask({
+          created_by: {
+            id: 2,
+            uuid: "user-2",
+            email: "teammate@example.com",
+          },
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(mockGenerateTitle).toHaveBeenCalledWith("Fix the login bug", {
+        resolveGithubPrTitles: false,
       });
     });
   });

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -232,12 +232,11 @@ describe("useChatTitleGenerator", () => {
     );
   });
 
-  it("persists the PR title even when the model returns a generic title", async () => {
+  it("persists the PR title when the model only returns a summary", async () => {
     const prPrompt =
       '<github_pr number="123" title="Fix login redirect" url="https://github.com/org/repo/pull/123" />';
     const prompt = vi.fn().mockResolvedValue({
-      content:
-        "TITLE: Review pull request #123\nSUMMARY: Reviewing the existing pull request.",
+      content: "SUMMARY: Reviewing the existing pull request.",
     });
     const generator = new TitleGeneratorService(
       { prompt } as unknown as LlmGatewayService,

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -1,3 +1,5 @@
+import type { LlmGatewayService } from "@posthog/core/llm-gateway/llm-gateway";
+import { TitleGeneratorService } from "@posthog/core/sessions/titleGeneratorService";
 import type { Task } from "@posthog/shared/domain-types";
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -228,6 +230,40 @@ describe("useChatTitleGenerator", () => {
       { queryKey: ["tasks", "summaries"] },
       expect.any(Function),
     );
+  });
+
+  it("persists the PR title even when the model returns a generic title", async () => {
+    const prPrompt =
+      '<github_pr number="123" title="Fix login redirect" url="https://github.com/org/repo/pull/123" />';
+    const prompt = vi.fn().mockResolvedValue({
+      content:
+        "TITLE: Review pull request #123\nSUMMARY: Reviewing the existing pull request.",
+    });
+    const generator = new TitleGeneratorService(
+      { prompt } as unknown as LlmGatewayService,
+      { readAbsoluteFile: vi.fn() },
+      { error: vi.fn() },
+    );
+    mockGenerateTitle.mockImplementation((content: string) =>
+      generator.generateTitleAndSummary(content),
+    );
+    mockPrompts.value = [prPrompt];
+
+    renderHook(() =>
+      useChatTitleGenerator(
+        createTask({
+          title: "@#123 - Fix login redirect",
+          description: prPrompt,
+        }),
+      ),
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateTask).toHaveBeenCalledWith(TASK_ID, {
+        title: "Review PR #123: Fix login redirect",
+      });
+    });
+    expect(prompt).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.test.ts
@@ -241,6 +241,7 @@ describe("useChatTitleGenerator", () => {
     const generator = new TitleGeneratorService(
       { prompt } as unknown as LlmGatewayService,
       { readAbsoluteFile: vi.fn() },
+      { getGithubPullRequestTitle: vi.fn().mockResolvedValue(null) },
       { error: vi.fn() },
     );
     mockGenerateTitle.mockImplementation((content: string) =>

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
@@ -110,7 +110,9 @@ export function useChatTitleGenerator(task: Task): void {
           rawContent,
           attachmentPaths,
         );
-        const result = await titleGenerator.generateTitleAndSummary(content);
+        const result = await titleGenerator.generateTitleAndSummary(content, {
+          resolveGithubPrTitles: shouldGenerateFromPrompts,
+        });
         if (result) {
           // Drop the stash once a title has been successfully produced so the
           // map doesn't grow across a long-lived session. Keeping it on failure

--- a/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
+++ b/packages/ui/src/features/sessions/hooks/useChatTitleGenerator.ts
@@ -15,6 +15,7 @@ import { useService } from "@posthog/di/react";
 import type { Task } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import {
   sessionStoreSetters,
   useSessionStore,
@@ -49,6 +50,7 @@ export function useChatTitleGenerator(task: Task): void {
   );
   const queryClient = useQueryClient();
   const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
   const isAuthenticated = useAuthStateValue(
     (state) => state.status === "authenticated" && !!state.cloudRegion,
   );
@@ -62,7 +64,7 @@ export function useChatTitleGenerator(task: Task): void {
   });
 
   useEffect(() => {
-    if (!isAuthenticated) return;
+    if (!isAuthenticated || (task.created_by && !currentUser)) return;
 
     const bookkeeping = titleGenerationStoreApi.get(taskId);
     if (bookkeeping.inFlight) return;
@@ -111,7 +113,9 @@ export function useChatTitleGenerator(task: Task): void {
           attachmentPaths,
         );
         const result = await titleGenerator.generateTitleAndSummary(content, {
-          resolveGithubPrTitles: shouldGenerateFromPrompts,
+          resolveGithubPrTitles:
+            shouldGenerateFromPrompts ||
+            (!!currentUser && task.created_by?.id === currentUser.id),
         });
         if (result) {
           // Drop the stash once a title has been successfully produced so the
@@ -197,5 +201,6 @@ export function useChatTitleGenerator(task: Task): void {
     queryClient,
     sessionService,
     titleGenerator,
+    currentUser,
   ]);
 }


### PR DESCRIPTION
## Problem

Pasting a GitHub PR starts an async title lookup while showing a temporary `Loading...` chip. Users can submit the task before that lookup finishes. Task creation then unmounts the editor, so the resolved chip never reaches the task description and `Loading...` can become the permanent task title.

## Changes

https://github.com/user-attachments/assets/001ab8c1-b8ee-433d-946f-aedf551f03b8



- Resolve placeholder PR titles again during background task-title generation
- Keep task submission immediate while the GitHub lookup runs
- Build resolved PR task titles deterministically from structured metadata
- Fall back safely to `Review PR #<number>` when GitHub is unavailable
- Ask the model only for the conversation summary once the PR title is known
- Support PR title resolution in desktop and web hosts

## How did you test this?

- Core title generator tests, including null and rejected GitHub lookups
- UI title persistence tests
- Biome checks
- Core, UI, desktop, and web typechecks
- Multi-perspective QA review

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*