### PR TITLE
Open the diff view responsively

### DIFF
--- a/packages/ui/src/features/code-review/getDefaultReviewMode.test.ts
+++ b/packages/ui/src/features/code-review/getDefaultReviewMode.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDefaultReviewMode,
+  REVIEW_SPLIT_MIN_WINDOW_WIDTH,
+} from "./getDefaultReviewMode";
+
+describe("getDefaultReviewMode", () => {
+  it.each([
+    [REVIEW_SPLIT_MIN_WINDOW_WIDTH - 1, "expanded"],
+    [REVIEW_SPLIT_MIN_WINDOW_WIDTH, "split"],
+    [REVIEW_SPLIT_MIN_WINDOW_WIDTH + 1, "split"],
+  ] as const)("returns the review mode for a %ipx window", (width, mode) => {
+    expect(getDefaultReviewMode(width)).toBe(mode);
+  });
+});

--- a/packages/ui/src/features/code-review/getDefaultReviewMode.ts
+++ b/packages/ui/src/features/code-review/getDefaultReviewMode.ts
@@ -1,0 +1,9 @@
+import type { ReviewMode } from "./reviewNavigationStore";
+
+export const REVIEW_SPLIT_MIN_WINDOW_WIDTH = 1280;
+
+export function getDefaultReviewMode(
+  windowWidth = window.innerWidth,
+): ReviewMode {
+  return windowWidth >= REVIEW_SPLIT_MIN_WINDOW_WIDTH ? "split" : "expanded";
+}

--- a/packages/ui/src/features/code-review/hooks/useDiffStatsToggle.ts
+++ b/packages/ui/src/features/code-review/hooks/useDiffStatsToggle.ts
@@ -1,6 +1,6 @@
 import type { Task } from "@posthog/shared/domain-types";
 import { useCallback } from "react";
-import type { ReviewMode } from "../reviewNavigationStore";
+import { getDefaultReviewMode } from "../getDefaultReviewMode";
 import { useReviewNavigationStore } from "../reviewNavigationStore";
 import { useTaskDiffSummaryStats } from "./useTaskDiffSummaryStats";
 
@@ -13,10 +13,7 @@ interface DiffStatsToggleResult {
   toggle: () => void;
 }
 
-export function useDiffStatsToggle(
-  task: Task,
-  openMode: ReviewMode = "split",
-): DiffStatsToggleResult {
+export function useDiffStatsToggle(task: Task): DiffStatsToggleResult {
   const taskId = task.id;
   const { filesChanged, linesAdded, linesRemoved } =
     useTaskDiffSummaryStats(task);
@@ -28,8 +25,9 @@ export function useDiffStatsToggle(
 
   const isOpen = reviewMode !== "closed";
   const toggle = useCallback(
-    () => setReviewMode(taskId, isOpen ? "closed" : openMode),
-    [setReviewMode, taskId, isOpen, openMode],
+    () =>
+      setReviewMode(taskId, isOpen ? "closed" : getDefaultReviewMode()),
+    [setReviewMode, taskId, isOpen],
   );
 
   return {

--- a/packages/ui/src/features/code-review/hooks/useDiffStatsToggle.ts
+++ b/packages/ui/src/features/code-review/hooks/useDiffStatsToggle.ts
@@ -25,8 +25,7 @@ export function useDiffStatsToggle(task: Task): DiffStatsToggleResult {
 
   const isOpen = reviewMode !== "closed";
   const toggle = useCallback(
-    () =>
-      setReviewMode(taskId, isOpen ? "closed" : getDefaultReviewMode()),
+    () => setReviewMode(taskId, isOpen ? "closed" : getDefaultReviewMode()),
     [setReviewMode, taskId, isOpen],
   );
 

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -3,6 +3,7 @@ import {
   CaretRightIcon,
   ChartLine,
   EnvelopeSimple,
+  GitDiffIcon,
 } from "@phosphor-icons/react";
 import { workspaceIdSet } from "@posthog/core/command-center/eligibility";
 import { resolveService } from "@posthog/di/container";
@@ -341,9 +342,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
             {
               id: "open-review-panel",
               label: "Open diff view",
-              icon: (
-                <ViewVerticalIcon className="h-3 w-3 rotate-180 text-gray-11" />
-              ),
+              icon: <GitDiffIcon className="h-3 w-3 text-gray-11" />,
               action: "open-review-panel" as CommandMenuAction,
               shortcut: SHORTCUTS.TOGGLE_REVIEW_PANEL,
               onRun: openReviewPanel,

--- a/packages/ui/src/features/command/CommandMenu.tsx
+++ b/packages/ui/src/features/command/CommandMenu.tsx
@@ -35,6 +35,7 @@ import { channelGlyph } from "@posthog/ui/features/canvas/components/channelGlyp
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useTaskChannelMap } from "@posthog/ui/features/canvas/hooks/useTaskChannelMap";
+import { getDefaultReviewMode } from "@posthog/ui/features/code-review/getDefaultReviewMode";
 import { useReviewNavigationStore } from "@posthog/ui/features/code-review/reviewNavigationStore";
 import { CommandKeyHints } from "@posthog/ui/features/command/CommandKeyHints";
 import { useFileSearchStore } from "@posthog/ui/features/command/fileSearchStore";
@@ -191,7 +192,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     if (!reviewTaskId) return;
     const mode = getReviewMode(reviewTaskId);
     if (mode === "closed") {
-      setReviewMode(reviewTaskId, "split");
+      setReviewMode(reviewTaskId, getDefaultReviewMode());
     }
   }, [reviewTaskId, getReviewMode, setReviewMode]);
 

--- a/packages/ui/src/features/sessions/components/DiffStatsChip.test.tsx
+++ b/packages/ui/src/features/sessions/components/DiffStatsChip.test.tsx
@@ -23,11 +23,11 @@ vi.mock("@posthog/ui/primitives/Tooltip", () => ({
 import { DiffStatsChip } from "./DiffStatsChip";
 
 describe("DiffStatsChip", () => {
-  it("opens the diff view in split mode", () => {
+  it("uses the shared responsive diff-view toggle", () => {
     const task = { id: "task-1" } as Task;
 
     render(<DiffStatsChip task={task} />);
 
-    expect(useDiffStatsToggle).toHaveBeenCalledWith(task, "split");
+    expect(useDiffStatsToggle).toHaveBeenCalledWith(task);
   });
 });

--- a/packages/ui/src/features/sessions/components/DiffStatsChip.test.tsx
+++ b/packages/ui/src/features/sessions/components/DiffStatsChip.test.tsx
@@ -1,0 +1,33 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const { useDiffStatsToggle } = vi.hoisted(() => ({
+  useDiffStatsToggle: vi.fn(() => ({
+    filesChanged: 1,
+    linesAdded: 2,
+    linesRemoved: 3,
+    isOpen: false,
+    toggle: vi.fn(),
+  })),
+}));
+
+vi.mock("@posthog/ui/features/code-review/hooks/useDiffStatsToggle", () => ({
+  useDiffStatsToggle,
+}));
+vi.mock("@posthog/ui/primitives/Tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { DiffStatsChip } from "./DiffStatsChip";
+
+describe("DiffStatsChip", () => {
+  it("opens the diff view in split mode", () => {
+    const task = { id: "task-1" } as Task;
+
+    render(<DiffStatsChip task={task} />);
+
+    expect(useDiffStatsToggle).toHaveBeenCalledWith(task, "split");
+  });
+});

--- a/packages/ui/src/features/sessions/components/DiffStatsChip.tsx
+++ b/packages/ui/src/features/sessions/components/DiffStatsChip.tsx
@@ -14,7 +14,7 @@ interface DiffStatsChipProps {
 
 export function DiffStatsChip({ task }: DiffStatsChipProps) {
   const { filesChanged, linesAdded, linesRemoved, isOpen, toggle } =
-    useDiffStatsToggle(task, "expanded");
+    useDiffStatsToggle(task, "split");
 
   if (filesChanged === 0) return null;
 

--- a/packages/ui/src/features/sessions/components/DiffStatsChip.tsx
+++ b/packages/ui/src/features/sessions/components/DiffStatsChip.tsx
@@ -14,7 +14,7 @@ interface DiffStatsChipProps {
 
 export function DiffStatsChip({ task }: DiffStatsChipProps) {
   const { filesChanged, linesAdded, linesRemoved, isOpen, toggle } =
-    useDiffStatsToggle(task, "split");
+    useDiffStatsToggle(task);
 
   if (filesChanged === 0) return null;
 

--- a/packages/ui/src/features/task-detail/components/TaskHeaderActions.tsx
+++ b/packages/ui/src/features/task-detail/components/TaskHeaderActions.tsx
@@ -110,7 +110,7 @@ function LocalHandoffButton({ taskId, task }: { taskId: string; task: Task }) {
 
 function TaskDiffStatsBadge({ task }: { task: Task }) {
   const { filesChanged, linesAdded, linesRemoved, isOpen, toggle } =
-    useDiffStatsToggle(task, "split");
+    useDiffStatsToggle(task);
   return (
     <Tooltip
       content={isOpen ? "Close diff view" : "Open diff view"}

--- a/packages/ui/src/shell/GlobalEventHandlers.tsx
+++ b/packages/ui/src/shell/GlobalEventHandlers.tsx
@@ -9,6 +9,7 @@ import { useHostTRPC } from "@posthog/host-router/react";
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
+import { getDefaultReviewMode } from "@posthog/ui/features/code-review/getDefaultReviewMode";
 import { useReviewNavigationStore } from "@posthog/ui/features/code-review/reviewNavigationStore";
 import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
@@ -189,7 +190,10 @@ export function GlobalEventHandlers({
   const handleToggleReview = useCallback(() => {
     if (!currentTaskId) return;
     const mode = getReviewMode(currentTaskId);
-    setReviewMode(currentTaskId, mode === "closed" ? "split" : "closed");
+    setReviewMode(
+      currentTaskId,
+      mode === "closed" ? getDefaultReviewMode() : "closed",
+    );
   }, [currentTaskId, getReviewMode, setReviewMode]);
 
   useHotkeys(


### PR DESCRIPTION
## Problem

The “Open review” footer action and keyboard shortcut should behave consistently, while still choosing a layout that fits the available window space.

**Why:** A side column preserves conversation context on wide windows, but leaves too little room on smaller screens. I also didn't like how the keyboard shortcut had different behavior than the click.

## Changes

Both the footer action and keyboard/command entry points now use one responsive rule: split view at 1280px and wider, expanded view below 1280px. Also use the existing Git diff icon for the “Open diff view” command.

## How did you test this?

Visual regression test babyyy

Demo: https://screen.studio/share/S7kfY2sL

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*