### PR TITLE
fix(notifications): do not notify task viewers

### DIFF
--- a/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
+++ b/packages/core/src/sessions/cloudTaskUpdateNotifications.test.ts
@@ -93,7 +93,7 @@ function snapshotUpdate(
   };
 }
 
-function createHarness() {
+function createHarness(isTaskAuthor = true) {
   const sessions: Record<string, AgentSession> = {};
   const store = {
     getSessions: () => sessions,
@@ -197,6 +197,8 @@ function createHarness() {
   const service = new SessionService(deps);
   service.watchCloudTask(TASK_ID, RUN_ID, "https://us.posthog.com", 1);
   if (!onUpdate) throw new Error("watchCloudTask did not subscribe");
+  const session = sessions[RUN_ID];
+  if (session) session.isTaskAuthor = isTaskAuthor;
 
   return {
     sendUpdate: (update: CloudTaskUpdatePayload) => onUpdate?.(update),
@@ -208,6 +210,25 @@ function createHarness() {
 }
 
 describe("cloud task update notifications", () => {
+  it("does not notify a non-owner watching the task", () => {
+    const harness = createHarness(false);
+
+    harness.sendUpdate(
+      logsUpdate(
+        [
+          sessionPrompt(1),
+          permissionRequest("request-1", "tool-1"),
+          turnComplete(),
+        ],
+        3,
+      ),
+    );
+
+    expect(harness.notifyPromptComplete).not.toHaveBeenCalled();
+    expect(harness.notifyPermissionRequest).not.toHaveBeenCalled();
+    expect(harness.enqueueSpeech).not.toHaveBeenCalled();
+  });
+
   it("does not notify for turn_completes replayed in a snapshot", () => {
     const harness = createHarness();
 

--- a/packages/core/src/sessions/sessionFactory.ts
+++ b/packages/core/src/sessions/sessionFactory.ts
@@ -9,6 +9,7 @@ export function createBaseSession(
     taskRunId,
     taskId,
     taskTitle,
+    isTaskAuthor: true,
     channel: `agent-event:${taskRunId}`,
     events: [],
     startedAt: Date.now(),

--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -424,6 +424,7 @@ export interface ReconcileTaskConnectionParams {
   session: ReconcileSessionState | undefined;
   repoPath: string | null;
   isCloud: boolean;
+  isTaskAuthor?: boolean;
   isSuspended?: boolean;
   isOnline: boolean;
   cloudAuth: CloudConnectionAuth;
@@ -2917,13 +2918,15 @@ export class SessionService {
               stopReason === "end_turn" &&
               session.messageQueue.length === 0
             ) {
-              this.d.notifyPromptComplete(
-                session.taskTitle,
-                stopReason,
-                session.taskId,
-                turnStartedAtTs ? acpMsg.ts - turnStartedAtTs : undefined,
-              );
-              this.speakDeterministic(taskRunId, session, "done");
+              if (session.isTaskAuthor !== false) {
+                this.d.notifyPromptComplete(
+                  session.taskTitle,
+                  stopReason,
+                  session.taskId,
+                  turnStartedAtTs ? acpMsg.ts - turnStartedAtTs : undefined,
+                );
+                this.speakDeterministic(taskRunId, session, "done");
+              }
             }
             this.d.taskViewedApi.markActivity(session.taskId);
             this.finalizeTurnContent(taskRunId, "turn_complete", acpMsg.ts);
@@ -3087,7 +3090,11 @@ export class SessionService {
           : this.drainQueuedMessages(taskRunId, session);
 
       // Only notify when nothing is sendable - queued messages start a new turn
-      if (stopReason && !hasSendableMessages) {
+      if (
+        stopReason &&
+        !hasSendableMessages &&
+        session.isTaskAuthor !== false
+      ) {
         this.d.notifyPromptComplete(
           session.taskTitle,
           stopReason,
@@ -3333,8 +3340,10 @@ export class SessionService {
 
     this.d.store.setPendingPermissions(taskRunId, newPermissions);
     this.d.taskViewedApi.markActivity(session.taskId);
-    this.d.notifyPermissionRequest(session.taskTitle, session.taskId);
-    this.speakDeterministic(taskRunId, session, "needs_input");
+    if (session.isTaskAuthor !== false) {
+      this.d.notifyPermissionRequest(session.taskTitle, session.taskId);
+      this.speakDeterministic(taskRunId, session, "needs_input");
+    }
   }
 
   private handleCloudPermissionRequest(
@@ -3391,8 +3400,10 @@ export class SessionService {
 
     this.d.store.setPendingPermissions(taskRunId, newPermissions);
     this.d.taskViewedApi.markActivity(session.taskId);
-    this.d.notifyPermissionRequest(session.taskTitle, session.taskId);
-    this.speakDeterministic(taskRunId, session, "needs_input");
+    if (session.isTaskAuthor !== false) {
+      this.d.notifyPermissionRequest(session.taskTitle, session.taskId);
+      this.speakDeterministic(taskRunId, session, "needs_input");
+    }
   }
 
   private surfacePersistedPendingPermissions(
@@ -5562,6 +5573,7 @@ export class SessionService {
     runStatus?: TaskRunStatus,
     initialReasoningEffort?: string,
     runState?: Record<string, unknown>,
+    isTaskAuthor = true,
   ): () => void {
     const taskRunId = runId;
     const persistedConfigOptions = this.d.getPersistedConfigOptions(taskRunId);
@@ -5626,6 +5638,9 @@ export class SessionService {
       // Ensure configOptions is populated on revisit
       const existing = this.d.store.getSessionByTaskId(taskId);
       if (existing) {
+        if (existing.isTaskAuthor !== isTaskAuthor) {
+          this.d.store.updateSession(existing.taskRunId, { isTaskAuthor });
+        }
         const existingMode = getConfigOptionByCategory(
           existing.configOptions,
           "mode",
@@ -5752,6 +5767,7 @@ export class SessionService {
       const session = createBaseSession(taskRunId, taskId, taskTitle);
       session.status = "disconnected";
       session.isCloud = true;
+      session.isTaskAuthor = isTaskAuthor;
       session.adapter = adapter;
       session.configOptions = buildInitialConfigOptions(
         initialMode,
@@ -5765,6 +5781,9 @@ export class SessionService {
     } else {
       // Ensure cloud flag and configOptions are set on existing sessions
       const updates: Partial<AgentSession> = {};
+      if (existing.isTaskAuthor !== isTaskAuthor) {
+        updates.isTaskAuthor = isTaskAuthor;
+      }
       if (!existing.isCloud) updates.isCloud = true;
       if (existing.adapter !== adapter) updates.adapter = adapter;
       if (!existing.configOptions?.length || existing.adapter !== adapter) {
@@ -6795,6 +6814,7 @@ export class SessionService {
       session,
       repoPath,
       isCloud,
+      isTaskAuthor = true,
       isSuspended,
       isOnline,
       cloudAuth,
@@ -6810,6 +6830,7 @@ export class SessionService {
         task,
         cloudAuth,
         onCloudStatusChange,
+        isTaskAuthor,
       );
     }
 
@@ -6896,6 +6917,7 @@ export class SessionService {
     task: Task,
     cloudAuth: CloudConnectionAuth,
     onCloudStatusChange?: () => void,
+    isTaskAuthor = true,
   ): () => void {
     this.updateSessionTaskTitle(
       task.id,
@@ -6933,6 +6955,7 @@ export class SessionService {
       task.latest_run?.status,
       initialReasoningEffort,
       task.latest_run?.state,
+      isTaskAuthor,
     );
   }
 

--- a/packages/shared/src/sessions.ts
+++ b/packages/shared/src/sessions.ts
@@ -50,6 +50,7 @@ export interface AgentSession {
   taskRunId: string;
   taskId: string;
   taskTitle: string;
+  isTaskAuthor?: boolean;
   channel: string;
   events: AcpMessage[];
   startedAt: number;

--- a/packages/ui/src/features/sessions/hooks/useSessionConnection.test.tsx
+++ b/packages/ui/src/features/sessions/hooks/useSessionConnection.test.tsx
@@ -9,7 +9,11 @@ const mocks = vi.hoisted(() => {
     startActivityHeartbeat: vi.fn(() => () => {}),
     reconcileTaskConnection: vi.fn(() => () => {}),
   };
-  return { sessionService, unregisterMountedTask };
+  return {
+    currentUser: { uuid: "user-1" } as { uuid: string } | undefined,
+    sessionService,
+    unregisterMountedTask,
+  };
 });
 
 vi.mock("@posthog/di/react", () => ({
@@ -39,7 +43,7 @@ vi.mock("@posthog/ui/features/auth/authClient", () => ({
 }));
 
 vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
-  useCurrentUser: () => ({ data: { uuid: "user-1" } }),
+  useCurrentUser: () => ({ data: mocks.currentUser }),
 }));
 
 vi.mock("./useChatTitleGenerator", () => ({
@@ -64,7 +68,9 @@ function connectionProps(taskId: string) {
 
 describe("useSessionConnection mounted-task registration", () => {
   beforeEach(() => {
+    mocks.currentUser = { uuid: "user-1" };
     mocks.sessionService.registerMountedTask.mockClear();
+    mocks.sessionService.reconcileTaskConnection.mockClear();
     mocks.unregisterMountedTask.mockClear();
   });
 
@@ -98,5 +104,37 @@ describe("useSessionConnection mounted-task registration", () => {
 
     unmount();
     expect(mocks.unregisterMountedTask).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [
+      "the current user is still loading",
+      undefined,
+      { uuid: "author" },
+      undefined,
+    ],
+    ["the task has no author", { uuid: "user-1" }, undefined, undefined],
+    [
+      "the current user is the author",
+      { uuid: "user-1" },
+      { uuid: "user-1" },
+      true,
+    ],
+    [
+      "another user authored the task",
+      { uuid: "user-1" },
+      { uuid: "user-2" },
+      false,
+    ],
+  ])("sets authorship when %s", (_case, currentUser, createdBy, expected) => {
+    mocks.currentUser = currentUser;
+    const props = connectionProps("task-1");
+    props.task.created_by = createdBy as Task["created_by"];
+
+    renderHook(() => useSessionConnection(props));
+
+    expect(mocks.sessionService.reconcileTaskConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ isTaskAuthor: expected }),
+    );
   });
 });

--- a/packages/ui/src/features/sessions/hooks/useSessionConnection.test.tsx
+++ b/packages/ui/src/features/sessions/hooks/useSessionConnection.test.tsx
@@ -34,6 +34,14 @@ vi.mock("@posthog/ui/features/auth/store", () => ({
     }),
 }));
 
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useOptionalAuthenticatedClient: () => ({}),
+}));
+
+vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
+  useCurrentUser: () => ({ data: { uuid: "user-1" } }),
+}));
+
 vi.mock("./useChatTitleGenerator", () => ({
   useChatTitleGenerator: vi.fn(),
 }));

--- a/packages/ui/src/features/sessions/hooks/useSessionConnection.ts
+++ b/packages/ui/src/features/sessions/hooks/useSessionConnection.ts
@@ -104,7 +104,9 @@ export function useSessionConnection({
       repoPath,
       isCloud,
       isTaskAuthor:
-        !!currentUser?.uuid && currentUser.uuid === task.created_by?.uuid,
+        currentUser?.uuid && task.created_by?.uuid
+          ? currentUser.uuid === task.created_by.uuid
+          : undefined,
       // While the user is away, freeze local reconciling too — otherwise the
       // idle-kill auto-reconnect would respawn the agent process seconds
       // after the server reclaimed it. Cloud reconcile ignores this flag.

--- a/packages/ui/src/features/sessions/hooks/useSessionConnection.ts
+++ b/packages/ui/src/features/sessions/hooks/useSessionConnection.ts
@@ -5,7 +5,9 @@ import {
 } from "@posthog/core/sessions/sessionService";
 import { useService } from "@posthog/di/react";
 import type { Task } from "@posthog/shared/domain-types";
+import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
+import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
 import type { AgentSession } from "@posthog/ui/features/sessions/sessionStore";
 import { useConnectivity } from "@posthog/ui/hooks/useConnectivity";
 import { useUserPresence } from "@posthog/ui/hooks/useUserPresence";
@@ -33,6 +35,8 @@ export function useSessionConnection({
   isSuspended,
 }: UseSessionConnectionOptions) {
   const queryClient = useQueryClient();
+  const client = useOptionalAuthenticatedClient();
+  const { data: currentUser } = useCurrentUser({ client });
   const { isOnline } = useConnectivity();
   const cloudAuthState = useAuthStateValue((state) => state);
   const sessionService = useService<SessionService>(SESSION_SERVICE);
@@ -99,6 +103,8 @@ export function useSessionConnection({
       session: connectionSession,
       repoPath,
       isCloud,
+      isTaskAuthor:
+        !!currentUser?.uuid && currentUser.uuid === task.created_by?.uuid,
       // While the user is away, freeze local reconciling too — otherwise the
       // idle-kill auto-reconnect would respawn the agent process seconds
       // after the server reclaimed it. Cloud reconcile ignores this flag.
@@ -119,6 +125,7 @@ export function useSessionConnection({
     connectionSession,
     repoPath,
     isCloud,
+    currentUser?.uuid,
     isSuspended,
     userPresent,
     isOnline,


### PR DESCRIPTION
## Problem

Opening a cloud task starts a technical watcher so the app can show live updates. That watcher stays active across navigation and could also trigger completion or needs-input notifications, even when the viewer did not create the task.

There is no user-facing follow or notification subscription involved.

## Changes

| Behavior | Before | After |
| --- | --- | --- |
| Open another persons task | Starts live updates and could later trigger task notifications | Starts live updates only |
| Task finishes or needs input | Any client with the technical watcher could notify | Only the task creator is notified |
| Navigate away from the task | The watcher remains active | Unchanged; live updates continue without granting notification eligibility |

The session now records whether the current user created the task. Completion, permission, and spoken notifications check that value before notifying. The live-update watcher itself is unchanged.

## How did you test this?

- Added regression coverage proving that a non-author watcher receives updates without completion, permission, or spoken notifications.
- Core notification tests passed.
- Session connection tests passed.
- Core and UI typechecks passed.
- Biome and host-boundary checks passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*