### PR TITLE
fix(canvas): float the workspace mode selector over the channel feed

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -856,8 +856,10 @@ export function ChannelFeedView({
         <ChatMessageScrollerViewport ref={viewportRef}>
           {/* Horizontal padding is load-bearing: ThreadItem's actions float at
               the row's top-right corner (absolute, past the row edge). Without a
-              gutter they hug the scroll container and get clipped. */}
-          <ChatMessageScrollerContent className="mx-auto w-full gap-0 py-4">
+              gutter they hug the scroll container and get clipped. The deeper
+              bottom padding clears the composer's floating workspace-mode
+              selector, which hangs over the end of the feed. */}
+          <ChatMessageScrollerContent className="mx-auto w-full gap-0 pt-4 pb-10">
             {intro}
             {entries.map((entry, index) => {
               const previous = entries[index - 1];

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -371,11 +371,11 @@ export const ChannelHomeComposer = forwardRef<
   const submitComposer = canvasArmed ? handleCanvasSubmit : submit;
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="relative flex w-full flex-col">
       {/* Canvas generation always runs in the cloud, so the local/cloud pick
           doesn't apply while canvas mode is armed. */}
       {!canvasArmed && (
-        <div className="mb-2 flex items-center gap-2">
+        <div className="absolute bottom-full left-0 mb-2 flex items-center gap-2">
           <WorkspaceModeSelect
             value={workspaceMode}
             onChange={setWorkspaceMode}

--- a/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -373,9 +373,11 @@ export const ChannelHomeComposer = forwardRef<
   return (
     <div className="relative flex w-full flex-col">
       {/* Canvas generation always runs in the cloud, so the local/cloud pick
-          doesn't apply while canvas mode is armed. */}
+          doesn't apply while canvas mode is armed. The row floats over the feed,
+          and the trigger's own fill is translucent, so it carries an opaque
+          backdrop at the button's radius to stop messages showing through. */}
       {!canvasArmed && (
-        <div className="absolute bottom-full left-0 mb-2 flex items-center gap-2">
+        <div className="absolute bottom-full left-0 mb-2 flex items-center gap-2 rounded-sm bg-card">
           <WorkspaceModeSelect
             value={workspaceMode}
             onChange={setWorkspaceMode}

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -303,7 +303,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
           onOpenTask={handleOpenTask}
           onOpenThread={handleOpenThread}
         />
-        <div className="mx-auto w-full px-4 pb-4">
+        <div className="mx-auto w-full px-4 pt-2 pb-4">
           <ChannelHomeComposer
             ref={composerRef}
             channelId={channelId}


### PR DESCRIPTION
## Problem

In a context's message feed, the local/cloud workspace selector sat in its own row inside the composer's opaque, full-width band. With no top padding on that band, scrolling the feed clipped messages at the selector chip rather than at the input box, so the selector read as a strip of chrome bolted onto the bottom of the feed instead of a control belonging to the composer.

**Why:** raised as visual polish — the selector should look like it's hovering just above the input box, not occupying its own full-width container.

## Changes

- Position the selector row absolutely at `bottom-full` of the composer (the same pattern the new-task composer already uses), so it floats over the feed and only the input box sits on solid background.
- Add a small top gutter to the composer band so the input box isn't flush against clipped feed content.

Side effect: arming canvas mode hides the selector without the input box jumping, since the row no longer takes layout space.

## How did you test this?

CSS-only change; verified `biome check` (including `useSortedClasses`) passes on both touched files. Not exercised in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*