### PR TITLE
fix(agent): unbreak Pi local runs in packaged desktop

### DIFF
--- a/packages/agent/src/pi/rpc-client.test.ts
+++ b/packages/agent/src/pi/rpc-client.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { RpcClient } from "@earendil-works/pi-coding-agent";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createPiRpcClient } from "./rpc-client";
 
 describe("createPiRpcClient", () => {
@@ -29,6 +29,37 @@ describe("createPiRpcClient", () => {
       (client as unknown as { options: { env?: Record<string, string> } })
         .options.env,
     ).toBeUndefined();
+  });
+
+  it("runs the RPC host with Electron's Node mode enabled", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pi-electron-node-mode-"));
+    const hostPath = join(directory, "host.mjs");
+    const capturePath = join(directory, "capture.txt");
+    await writeFile(
+      hostPath,
+      `
+import { closeSync, writeFileSync } from "node:fs";
+
+closeSync(3);
+writeFileSync(${JSON.stringify(capturePath)}, process.env.ELECTRON_RUN_AS_NODE ?? "");
+process.stdin.resume();
+`,
+    );
+    const client = createPiRpcClient({
+      cliPath: hostPath,
+      cwd: directory,
+      providerOptions: { apiKey: "proxy-key" },
+    });
+
+    try {
+      await client.start();
+      await vi.waitFor(async () => {
+        await expect(readFile(capturePath, "utf8")).resolves.toBe("1");
+      });
+    } finally {
+      await client.stop();
+      await rm(directory, { recursive: true });
+    }
   });
 
   it("uses the private host channel without changing Pi RPC", async () => {

--- a/packages/agent/src/pi/rpc-client.ts
+++ b/packages/agent/src/pi/rpc-client.ts
@@ -111,7 +111,10 @@ class SecurePiRpcClient extends RpcClient {
       [this.secureOptions.cliPath ?? "dist/cli.js", ...args],
       {
         cwd: this.secureOptions.cwd,
-        env: safePiEnvironment(process.env),
+        env: {
+          ...safePiEnvironment(process.env),
+          ELECTRON_RUN_AS_NODE: "1",
+        },
         stdio: ["pipe", "pipe", "pipe", "pipe", "ipc"],
       },
     );


### PR DESCRIPTION
## Problem

Pi local runs fail in the packaged desktop app with `Agent process exited (code=0 signal=null)`.

The RPC client launches its host through `process.execPath`. In a packaged app that is the Electron executable, but the sanitized child environment omitted `ELECTRON_RUN_AS_NODE`. Electron therefore started another desktop instance instead of executing the RPC host as Node, and the second instance exited cleanly at the single-instance lock.

## Changes

- Set `ELECTRON_RUN_AS_NODE=1` when spawning the Pi RPC host.
- Add a regression test that captures and verifies the spawned host environment.

## How did you test this?

- `pnpm --filter @posthog/agent exec vitest run src/pi/rpc-client.test.ts`
- `pnpm --filter @posthog/agent typecheck`
- `pnpm exec biome check packages/agent/src/pi/rpc-client.ts packages/agent/src/pi/rpc-client.test.ts`
- Built the packaged macOS app and verified the unpacked bundled RPC host starts through the packaged Electron executable and responds to `getState()`.
- Drove the packaged app with agent-browser snapshots through the Pi / Local / repository composer flow.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
