### PR TITLE
chore(inbox): rename signal source group to "External sources"

### DIFF
--- a/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
+++ b/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
@@ -396,10 +396,10 @@ export function SignalSourceToggles({
         </Flex>
       </Flex>
 
-      {/* External connections — data-driven from the shared source registry */}
+      {/* External sources — data-driven from the shared source registry */}
       <Flex direction="column" gap="2" className="min-w-0 flex-1">
         <Text className="font-medium text-(--gray-9) text-[13px]">
-          External connections
+          External sources
         </Text>
         <Flex direction="column" gap="3">
           {EXTERNAL_INBOX_SOURCES.map((source) => {
@@ -460,7 +460,7 @@ export function SignalSourceTogglesSkeleton() {
       </Flex>
       <Flex direction="column" gap="2" className="min-w-0 flex-1">
         <Text className="font-medium text-(--gray-9) text-[13px]">
-          External connections
+          External sources
         </Text>
         <Flex direction="column" gap="3">
           {Array.from({ length: 4 }).map((_, index) => (


### PR DESCRIPTION
## Problem

The inbox signal-sources section grouped external integrations under a header that didn't match its counterpart in the main PostHog app ("Connected tools" there, "External connections" here). The naming should be consistent across both surfaces.

## Changes

Renames the signal-sources group header (and its loading skeleton) from **External connections** to **External sources**, matching the sibling "PostHog data" group and the corresponding rename in the main app.

## How did you test this?

Label-only copy change; verified via grep that both the live header and the skeleton header were updated. No behavior change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785346918313609)*