### PR TITLE
Align inbox & scout copy with self-driving docs vocabulary

### DIFF
--- a/apps/code/snapshots.yml
+++ b/apps/code/snapshots.yml
@@ -537,21 +537,17 @@ snapshots:
     git-dialogs--sync-success--light:
         hash: v1.k4693efd2.8d79d77c9338aeaa73734836f0e17fde987f6d3239914f4013889d3110e5088d.Rq-w2o1uhes_a5hUWqMXeiDkfnoPCZPt932LkEQXCco
     loops-loopslistview--comprehensive--dark:
-        hash: v1.k4693efd2.c128012b7f910839e65e8eaf14d5456c93f90d77747d0625ca35fddd8d5adf7a.fuugB5Ov6boP7fg6fWP7A7IG2yYnPUAAWLKZLuV8rZ0
+        hash: v1.k4693efd2.25744a9471ec664c70e346ac5cb330c025a031626bc486abe8820b7b6dbc1a19.Shh8Yl7SdombnNc4-uJjlIbx-n4C0MGXxtOGB1bjJTY
     loops-loopslistview--comprehensive--light:
-        hash: v1.k4693efd2.4d25a48e0bd7e60d3bbb433e246486e4c9ac95979db86e20eb8bf5cb119d1eb2.EzrENjVHwVMyV00pEA-71TeVomJtchiym5DqWFkujlA
+        hash: v1.k4693efd2.ef8e012cc506a0bf5e761ec8e89943820d4b391f7023f506da7d79586b49a356.ATiN8Y0hUmfGvr0rUytYWX-fITyHRTgeN1i_HOOGZuc
     loops-loopslistview--long-mixed-list--dark:
-        hash: v1.k4693efd2.fdbf0c24cb386c4345279db3e648efe72aa8a2a984d491361522f62074a771c9.2QmRxRMWYFFfBFrbMm0Dm9rWcvd1lfRbc0egfzoESnY
+        hash: v1.k4693efd2.c9915e22655fe1f6b77eabaf11d8876648c387ceebac6cd8be1880e7255bd7a5.y-gyTKSp7wYbuS57TABRbEyMSL9_U1wvHYvbyCeAbiQ
     loops-loopslistview--long-mixed-list--light:
-        hash: v1.k4693efd2.aa17d9b6f40fbd3914bd742951db9f90add0bd233c54170803c8483aeb45b43b.yXpqqGczOq1uW5k4Ie7ddNTnne-cFTglZ9cL800pXB4
-    loops-loopslistview--shared-page-header--dark:
-        hash: v1.k4693efd2.14ab860dcb0df51b4019f012288e45f3a2c4c23fa08e809efef8c04b5687fe36.qoMLHprZmV2wON156NBbl3sqP84a4nXgdYm1H6WpTVM
-    loops-loopslistview--shared-page-header--light:
-        hash: v1.k4693efd2.23be5408ff3b4a912a0ce0457af8638124b99a01c88a499d0f4204cee2c62487.dGBP1K08MA2Fvhml-BPl5eFra8U83JXmy04NK9wOQnM
+        hash: v1.k4693efd2.5fec9e1a3c14f1bc319cd7e5abc24b3d66ed787986a103b5330f49341d4983ad.mpD-eTS6vkSbsJdOYaHXASHQd5IiJGWRCb6uDGlzhpk
     loops-loopslistview--with-builder-sessions--dark:
-        hash: v1.k4693efd2.df4a1a4764e1de7b69905814b09c30d9b43f705f5e66c7ad83829c567d4faa1a.jthufoX_KPbbxScjj3pPBA4lEtT9Ym6zUCH-v1759GM
+        hash: v1.k4693efd2.06b404e4016ba0eb86769331a574bc640be1ad26ebf3a04d0256334d1da041a3.fPfF8c2wNFREfy8dVRdsw7W9Fpqj7HEtuaERMroNHMA
     loops-loopslistview--with-builder-sessions--light:
-        hash: v1.k4693efd2.eb65c38bb0de7efedbc0d7a6c27a6695528e2e6b60949617e7d22335b1e68c8b.fJr9uykvc8S7LI_ASXk5KRqxXCwIqh6ld9zfzs4shP0
+        hash: v1.k4693efd2.30f89915a12cadf313216403fb0f3e221f3c33cee763f0692ae2b96b4332e2b9.j00vexnH4QS0wJAHn7pQNpeITYYRtOxlvB2ngyzqU0c
     primitives-pageheader--title-only--dark:
         hash: v1.k4693efd2.f7f8c560b1e5cf20050189e10fc0f129e555ba672300a7a09bef5827c171a743.yP9Pp_k51agu_9Ri55Y7uCAPBQ1UTeUQJA9U9dPMKfQ
     primitives-pageheader--title-only--light:

--- a/apps/mobile/src/app/inbox/[...id].tsx
+++ b/apps/mobile/src/app/inbox/[...id].tsx
@@ -463,7 +463,7 @@ export default function ReportDetailScreen() {
 
         {/* Title */}
         <Text className="mb-2 font-semibold text-[18px] text-gray-12">
-          {report.title ?? "Untitled signal"}
+          {report.title ?? "Untitled report"}
         </Text>
 
         {/* Meta row */}
@@ -638,7 +638,7 @@ export default function ReportDetailScreen() {
       <DismissReportSheet
         visible={dismissOpen}
         reportId={report.id}
-        reportTitle={report.title?.trim() ? report.title : "Untitled signal"}
+        reportTitle={report.title?.trim() ? report.title : "Untitled report"}
         onClose={() => setDismissOpen(false)}
         onDismissed={handleDismissed}
       />

--- a/apps/mobile/src/features/inbox/components/ArchivedReportList.tsx
+++ b/apps/mobile/src/features/inbox/components/ArchivedReportList.tsx
@@ -55,7 +55,7 @@ const ArchivedRow = memo(function ArchivedRow({
           numberOfLines={2}
           ellipsizeMode="tail"
         >
-          {report.title ?? "Untitled signal"}
+          {report.title ?? "Untitled report"}
         </Text>
 
         <View className="mt-1 flex-row flex-wrap items-center gap-2">

--- a/apps/mobile/src/features/inbox/components/ReportListRow.tsx
+++ b/apps/mobile/src/features/inbox/components/ReportListRow.tsx
@@ -70,7 +70,7 @@ function ReportListRowComponent({ report, onPress }: ReportListRowProps) {
           numberOfLines={2}
           ellipsizeMode="tail"
         >
-          {report.title ?? "Untitled signal"}
+          {report.title ?? "Untitled report"}
         </Text>
 
         <View className="mt-1 flex-row items-center gap-2">

--- a/packages/ui/src/features/inbox/CLAUDE.md
+++ b/packages/ui/src/features/inbox/CLAUDE.md
@@ -4,13 +4,13 @@ The Inbox is the PostHog surface for **Self-driving**: agents that watch product
 
 ## Product Model
 
-The renderer still talks to backend endpoints and TypeScript types with the legacy `signals` naming. User-facing copy should say **Self-driving**, **Responder**, **report**, **run**, or **finding** depending on context. Do not rename backend paths or shared API fields unless the PostHog Cloud backend has changed too.
+The renderer still talks to backend endpoints and TypeScript types with the legacy `signals` naming. User-facing copy should say **Self-driving**, **agent**, **report**, **run**, or **signal** depending on context. Do not rename backend paths or shared API fields unless the PostHog Cloud backend has changed too.
 
 The main objects are:
 
 - `SignalReport`: the unit shown in all Inbox tabs.
 - Findings: the source observations that contributed to a report, fetched separately for detail screens.
-- Artefacts: structured agent output attached to a report, such as priority, actionability, suggested reviewers, repo selection, and findings from research.
+- Artefacts: structured agent output attached to a report, such as priority, actionability, suggested reviewers, repo selection, and signals from research.
 - Report tasks: links from a report to tasks created for research or implementation.
 
 ## Information Architecture
@@ -53,7 +53,7 @@ same artefact-lift pattern as `priority`/`actionability`/`already_addressed` —
 so cards avoid an N+1 per-card artefact fetch. Unknown reason codes fall back to
 the raw value; cards with no dismissal artefact simply omit the chip.
 
-Responder configuration is **not** an Inbox tab. It is the top-level Responders sidebar item at `/code/agents`. The legacy `/code/inbox/agents` route redirects there.
+Agent configuration is **not** an Inbox tab. It is the top-level Agents sidebar item at `/code/agents`. The legacy `/code/inbox/agents` route redirects there.
 
 Reviewer scope is a UI preference stored in `inboxReviewerScopeStore`. It filters the list between reports suggested for the current user and reports for someone else. It does not change tab membership; the tab predicates are independent.
 
@@ -90,7 +90,7 @@ Tab membership and counts live in `utils/reportMembership.ts`. Keep that file as
 Detail screens layer additional data on top of the base report:
 
 - `useInboxReportById(reportId)` for the report record.
-- `useInboxReportSignals(reportId)` for contributing findings.
+- `useInboxReportSignals(reportId)` for contributing signals.
 - `useInboxReportArtefacts(reportId)` for structured outputs such as suggested reviewers and repo selection.
 - `useReportTasks(reportId, status)` for linked research/implementation tasks.
 
@@ -102,7 +102,7 @@ The Inbox reads from PostHog Cloud's Self-driving backend, currently implemented
 
 - `GET /api/projects/{teamId}/signals/reports/`: paginated report list. Supports filters such as status, ordering, source product, suggested reviewers, and priority.
 - `GET /api/projects/{teamId}/signals/reports/{id}/`: single report detail.
-- `GET /api/projects/{teamId}/signals/reports/{id}/signals/`: contributing findings.
+- `GET /api/projects/{teamId}/signals/reports/{id}/signals/`: contributing signals.
 - `GET /api/projects/{teamId}/signals/reports/{id}/artefacts/`: structured report artefacts.
 - `GET /api/projects/{teamId}/signals/reports/{id}/tasks/`: tasks linked to a report.
 
@@ -112,7 +112,7 @@ Card headlines are derived client-side from `summary` by `utils/reportPresentati
 
 ## Configuration Surface
 
-Responder setup lives in `features/agents/components/AgentsView.tsx`, which mounts `ConfigureAgentsSection`. This surface composes existing GitHub, Slack, source-toggle, and MCP configuration pieces. Keep setup copy outcome-focused: the user is asking Self-driving to figure out what matters, not choosing internal artefact types.
+Agent setup lives in `features/agents/components/AgentsView.tsx`, which mounts `ConfigureAgentsSection`. This surface composes existing GitHub, Slack, source-toggle, and MCP configuration pieces. Keep setup copy outcome-focused: the user is asking Self-driving to figure out what matters, not choosing internal artefact types.
 
 Onboarding/setup should be task-backed when it starts work. Do not model it as a static checklist if the intended behavior is to launch an agent task.
 
@@ -124,7 +124,7 @@ Shared primitives exist to keep the surfaces consistent:
 
 - `InboxDetailPageHeader` for detail headers.
 - `DetailSection` for content sections inside detail screens.
-- `SignalsList` and the existing detail `SignalCard` for contributing findings.
+- `SignalsList` and the existing detail `SignalCard` for contributing signals.
 - Badge and metadata helpers in `components/utils/` and `InboxMetaRow`.
 - `SOURCE_PRODUCT_META` for source-product labels and icons.
 
@@ -134,7 +134,7 @@ When adding or changing UI, reuse those primitives first. Avoid encoding one-off
 
 - Do not reuse the deleted legacy `ReportListRow`, `ReportDetailPane`, or old list/detail stores.
 - Do not put page-level Inbox title or navigation into the global app header; `InboxView` owns the Inbox page chrome.
-- Do not add a configure shortcut back into the Inbox header; Responders configuration is a sidebar destination.
+- Do not add a configure shortcut back into the Inbox header; Agents configuration is a sidebar destination.
 - Scout (`signals_scout`) is a real Cloud source product. Keep it covered wherever source products surface: `INBOX_SOURCE_OPTIONS`, `SOURCE_PRODUCT_META`, and the scout-name display in `SignalCard`.
 - Scout management UI (fleet configuration, run history) lives in `features/scouts/` and is backed by the PostHog Cloud scout endpoints (`/api/projects/{teamId}/signals/scout/`). Do not add scout controls that have no backing endpoint there.
 - Do not put preview shims or mock report data in `apps/code/index.html`; the app shell should stay minimal.

--- a/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
+++ b/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
@@ -110,7 +110,7 @@ function RunOutputWidget({ report }: { report: SignalReport }) {
           </Text>
           <Text className="text-[12px] text-gray-11 leading-snug">
             Research couldn't complete – check the task log below for the error.
-            The Responder may retry automatically.
+            The agent may retry automatically.
           </Text>
         </Flex>
       </Flex>
@@ -123,7 +123,7 @@ function RunOutputWidget({ report }: { report: SignalReport }) {
         content={report.summary}
         fallback={
           report.status === "in_progress"
-            ? "The Responder is investigating – partial findings will appear here as they land."
+            ? "The agent is investigating – partial signals will appear here as they land."
             : "Queued for research."
         }
         variant="detail"
@@ -325,7 +325,7 @@ function AgentRunDetailContent({ report }: { report: SignalReport }) {
               <>
                 <InboxMetaSeparator />
                 <InboxMetaText className="tabular-nums">
-                  {signals.length} finding{signals.length === 1 ? "" : "s"}
+                  {signals.length} signal{signals.length === 1 ? "" : "s"}
                 </InboxMetaText>
               </>
             )}
@@ -412,7 +412,7 @@ function AgentRunDetailContent({ report }: { report: SignalReport }) {
                 title="Evidence so far"
                 rightSlot={
                   <Text className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
-                    {signals.length || report.signal_count} finding
+                    {signals.length || report.signal_count} signal
                     {(signals.length || report.signal_count) === 1 ? "" : "s"}
                   </Text>
                 }

--- a/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -125,7 +125,7 @@ export function ConfigureAgentsSection() {
 
       <Subsection
         title="Connections"
-        description="Foundational integrations responders read from and write to."
+        description="Foundational integrations agents read from and write to."
       >
         <GitHubIntegrationSection
           hasGithubIntegration={hasGithubIntegration}
@@ -139,7 +139,7 @@ export function ConfigureAgentsSection() {
         description={
           <>
             Scheduled agents that sweep this project on a cadence and emit
-            findings to your inbox.{" "}
+            signals to your inbox.{" "}
             {/* Placeholder docs link until a dedicated scouts page exists. */}
             <a
               href="https://posthog.com/blog/self-driving-product"
@@ -156,8 +156,8 @@ export function ConfigureAgentsSection() {
       </Subsection>
 
       <Subsection
-        title="Responders"
-        description="Each source: 1. watches for signals, 2. spins up a Responder when something matters, 3. hands you solutions."
+        title="Signal sources"
+        description="Each source watches for signals and spins up work when something matters."
       >
         {isLoading ? (
           <ResponderAgentRosterSkeleton />
@@ -209,7 +209,7 @@ export function ConfigureAgentsSection() {
 
       <Subsection
         title="MCP servers"
-        description="External tools responders can read from. PostHog data is always available; this is everything else."
+        description="External tools agents can read from. PostHog data is always available; this is everything else."
       >
         <Link
           to="/settings/$category"

--- a/packages/ui/src/features/inbox/components/DataSourceSetup.tsx
+++ b/packages/ui/src/features/inbox/components/DataSourceSetup.tsx
@@ -183,7 +183,7 @@ function GitHubSetup({ onComplete, onCancel }: SetupFormProps) {
         ? "We didn't hear back from GitHub. If the browser tab was closed, click Try again."
         : connecting
           ? "Waiting for GitHub… finish authorizing in your browser, then return here."
-          : "Connect your GitHub account to import issues as Self-driving findings.";
+          : "Connect your GitHub account to import issues as Self-driving signals.";
     return (
       <SetupFormContainer title="Connect GitHub">
         <Flex direction="column" gap="3">

--- a/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -137,7 +137,7 @@ export function InboxDetailFrame({
             {evidenceCount > 0 && (
               <>
                 <InboxMetaText className="tabular-nums">
-                  {evidenceCount} finding{evidenceCount === 1 ? "" : "s"}
+                  {evidenceCount} signal{evidenceCount === 1 ? "" : "s"}
                 </InboxMetaText>
                 <InboxMetaSeparator />
               </>
@@ -151,7 +151,7 @@ export function InboxDetailFrame({
                 <InboxMetaSeparator />
                 <InboxMetaSourceStack
                   sourceProducts={report.source_products}
-                  labelPrefix="Responder · "
+                  labelPrefix="Agent · "
                 />
               </>
             )}
@@ -181,7 +181,7 @@ export function InboxDetailFrame({
             <DetailSection Icon={SummaryIcon} title={summarySection.title}>
               <SignalReportSummaryMarkdown
                 content={report.summary}
-                fallback="No summary yet – the Responder is still investigating."
+                fallback="No summary yet – the agent is still investigating."
                 variant="detail"
                 pending={report.status === "in_progress"}
               />
@@ -196,7 +196,7 @@ export function InboxDetailFrame({
                 title={evidenceSection.title}
                 rightSlot={
                   <Text className="cursor-default select-none text-[11px] text-gray-10 tabular-nums">
-                    {evidenceCount} finding
+                    {evidenceCount} signal
                     {evidenceCount === 1 ? "" : "s"}
                   </Text>
                 }

--- a/packages/ui/src/features/inbox/components/PullRequestsTab.tsx
+++ b/packages/ui/src/features/inbox/components/PullRequestsTab.tsx
@@ -24,7 +24,7 @@ export function PullRequestsTab() {
         entireProjectTitle: "No pull requests in the project right now",
         teammateTitle: "No pull requests for this reviewer right now",
         description:
-          "When a Responder ships a code change, the PR draft lands here for you to review and publish.",
+          "When an agent ships a code change, the PR draft lands here for you to review and publish.",
       }}
     />
   );

--- a/packages/ui/src/features/inbox/components/ReportCard.tsx
+++ b/packages/ui/src/features/inbox/components/ReportCard.tsx
@@ -323,7 +323,7 @@ export function ReportCard(props: ReportCardProps) {
         >
           <LightningIcon size={11} />
           <span className="tabular-nums">
-            {report.signal_count} finding
+            {report.signal_count} signal
             {report.signal_count !== 1 ? "s" : ""}
           </span>
         </Flex>

--- a/packages/ui/src/features/inbox/components/ReportsTab.tsx
+++ b/packages/ui/src/features/inbox/components/ReportsTab.tsx
@@ -15,7 +15,7 @@ export function ReportsTab() {
         entireProjectTitle: "No reports in the project yet",
         teammateTitle: "No reports for this reviewer yet",
         description:
-          "Reports are what Responders surface when there's something worth your judgment but no clean code change to draft.",
+          "Reports are what agents surface when there's something worth your judgment but no clean code change to draft.",
       }}
     />
   );

--- a/packages/ui/src/features/inbox/components/RunsTab.tsx
+++ b/packages/ui/src/features/inbox/components/RunsTab.tsx
@@ -95,10 +95,10 @@ export function RunsTab() {
             </EmptyMedia>
             <EmptyTitle>
               {scope === INBOX_SCOPE_FOR_YOU
-                ? "No Responders are working on something for you right now"
+                ? "No agents are working on something for you right now"
                 : scope === INBOX_SCOPE_ENTIRE_PROJECT
-                  ? "No Responders are working on anything in the project right now"
-                  : "No Responders are working on something for this reviewer right now"}
+                  ? "No agents are working on anything in the project right now"
+                  : "No agents are working on something for this reviewer right now"}
             </EmptyTitle>
             <EmptyDescription>
               When Self-driving kicks one off, you'll see the live run land here

--- a/packages/ui/src/features/inbox/components/utils/ExplainedDismissOptionLabels.tsx
+++ b/packages/ui/src/features/inbox/components/utils/ExplainedDismissOptionLabels.tsx
@@ -4,10 +4,10 @@ import { RadioGroup, Tooltip } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 
 const PAUSE_OPTION_TOOLTIP =
-  "Snoozes this report: it briefly leaves your inbox while more context is gathered, and it can come back if new findings match.";
+  "Snoozes this report: it briefly leaves your inbox while more context is gathered, and it can come back if new signals match.";
 
 const SUPPRESS_OPTION_TOOLTIP =
-  "Archives permanently: the report leaves your inbox and matching findings will not surface it again. Your reason is saved with the report.";
+  "Archives permanently: the report leaves your inbox and matching signals will not surface it again. Your reason is saved with the report.";
 
 function dismissReasonOptionDomId(value: DismissalReasonOptionValue): string {
   return `dismiss-report-dialog-reason-${value}`;

--- a/packages/ui/src/features/inbox/components/utils/SignalReportStatusBadge.tsx
+++ b/packages/ui/src/features/inbox/components/utils/SignalReportStatusBadge.tsx
@@ -8,10 +8,10 @@ const STATUS_TOOLTIPS: Record<string, string> = {
   resolved: "This report is resolved — its implementation pull request merged.",
   pending_input:
     "This report needs human input in PostHog before it can proceed.",
-  in_progress: "An AI agent is actively researching this report's findings.",
+  in_progress: "An AI agent is actively researching this report's signals.",
   candidate: "Queued for research. An agent will pick this up shortly.",
   potential:
-    "Gathering findings. The report will be queued once enough evidence accumulates.",
+    "Gathering signals. The report will be queued once enough evidence accumulates.",
   failed: "Research failed. The report may be retried automatically.",
   suppressed: "This report has been suppressed and is out of your inbox.",
   deleted: "This report has been deleted.",

--- a/packages/ui/src/features/scouts/components/FleetFindingsCallout.tsx
+++ b/packages/ui/src/features/scouts/components/FleetFindingsCallout.tsx
@@ -45,10 +45,10 @@ export function FleetFindingsCallout() {
       <SparkleIcon size={20} className="shrink-0 text-(--iris-9)" />
       <Flex direction="column" gap="0" className="min-w-0">
         <Text className="font-medium text-[13px] text-gray-12">
-          Scout findings
+          Scout signals
         </Text>
         <Text className="truncate text-[12px] text-gray-11 leading-snug">
-          {summary.totalCount} finding{summary.totalCount === 1 ? "" : "s"}{" "}
+          {summary.totalCount} signal{summary.totalCount === 1 ? "" : "s"}{" "}
           across {summary.scoutCount} scout
           {summary.scoutCount === 1 ? "" : "s"}
           {summary.latestEmittedAt ? (

--- a/packages/ui/src/features/scouts/components/ScoutBadges.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutBadges.tsx
@@ -27,7 +27,7 @@ export function ScoutOriginBadge({ config }: { config: ScoutConfig }) {
 export function DryRunBadge({ config }: { config: ScoutConfig }) {
   if (config.emit) return null;
   return (
-    <Tooltip content="Runs on schedule but findings are not emitted to the Signals inbox">
+    <Tooltip content="Runs on schedule but signals are not emitted to the Signals inbox">
       <Badge
         variant="soft"
         color="amber"

--- a/packages/ui/src/features/scouts/components/ScoutConfigControls.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutConfigControls.tsx
@@ -70,7 +70,7 @@ export function ScoutConfigForm({
         <Flex direction="column" className="min-w-0">
           <Text className="text-[12px] text-gray-12">Mode</Text>
           <Text className="text-[11.5px] text-gray-10">
-            Dry run executes the scout but holds back its findings
+            Dry run executes the scout but holds back its signals
           </Text>
         </Flex>
         <SettingsOptionSelect

--- a/packages/ui/src/features/scouts/components/ScoutDetailHeader.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutDetailHeader.tsx
@@ -50,12 +50,12 @@ export function ScoutDetailHeader({
         <ScoutOriginBadge config={config} />
         <DryRunBadge config={config} />
         {cloudSkillUrl ? (
-          <Tooltip content="View scout in PostHog">
+          <Tooltip content="View skill in PostHog">
             <a
               href={cloudSkillUrl}
               target="_blank"
               rel="noreferrer"
-              aria-label={`${config.skill_name} scout in PostHog`}
+              aria-label={`${config.skill_name} skill in PostHog`}
               onClick={() =>
                 track(ANALYTICS_EVENTS.SCOUT_ACTION, {
                   action_type: "open_skill_in_posthog",

--- a/packages/ui/src/features/scouts/components/ScoutDetailHeader.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutDetailHeader.tsx
@@ -50,12 +50,12 @@ export function ScoutDetailHeader({
         <ScoutOriginBadge config={config} />
         <DryRunBadge config={config} />
         {cloudSkillUrl ? (
-          <Tooltip content="View skill in PostHog">
+          <Tooltip content="View scout in PostHog">
             <a
               href={cloudSkillUrl}
               target="_blank"
               rel="noreferrer"
-              aria-label={`${config.skill_name} skill in PostHog`}
+              aria-label={`${config.skill_name} scout in PostHog`}
               onClick={() =>
                 track(ANALYTICS_EVENTS.SCOUT_ACTION, {
                   action_type: "open_skill_in_posthog",

--- a/packages/ui/src/features/scouts/components/ScoutEmissionCard.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutEmissionCard.tsx
@@ -83,7 +83,7 @@ export function ScoutEmissionCard({
           className={`shrink-0 text-gray-9 transition-transform duration-150 ${expanded ? "rotate-90" : ""}`}
         />
         <CompassIcon size={14} className="shrink-0 text-(--iris-9)" />
-        <Text className="font-medium text-[13px] text-gray-10">Finding</Text>
+        <Text className="font-medium text-[13px] text-gray-10">Signal</Text>
         <SeverityBadge severity={emission.severity} />
         <Text className="text-[11px] text-gray-10">
           confidence {Math.round(emission.confidence * 100)}%

--- a/packages/ui/src/features/scouts/components/ScoutFindingDiscussButton.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutFindingDiscussButton.tsx
@@ -56,7 +56,7 @@ export function ScoutFindingDiscussButton({
 
   const { runTask, isRunning } = useScoutChatTask({
     prompt,
-    taskLabel: "finding discussion",
+    taskLabel: "signal discussion",
     loggerScope: "scout-finding-discuss",
     chatType: "finding_discuss",
     surface: "scout_detail",
@@ -85,7 +85,7 @@ export function ScoutFindingDiscussButton({
         <button
           type="button"
           disabled={isRunning}
-          title="Discuss this finding with your agent"
+          title="Discuss this signal with your agent"
           className="inline-flex shrink-0 items-center gap-1 text-[11px] text-accent-11 no-underline transition-colors hover:text-accent-12 disabled:cursor-default disabled:opacity-60"
         >
           {isRunning ? <Spinner size="1" /> : <ChatCircleIcon size={11} />}
@@ -106,9 +106,9 @@ export function ScoutFindingDiscussButton({
           }}
         >
           <TextArea
-            aria-label="Question to discuss about this finding"
+            aria-label="Question to discuss about this signal"
             autoFocus
-            placeholder="Ask about this finding… (optional)"
+            placeholder="Ask about this signal… (optional)"
             resize="vertical"
             rows={5}
             size="2"

--- a/packages/ui/src/features/scouts/components/ScoutFindingShareButton.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutFindingShareButton.tsx
@@ -25,7 +25,7 @@ export function ScoutFindingShareButton({
     navigator.clipboard
       .writeText(url)
       .then(() => {
-        toast.success("Finding link copied");
+        toast.success("Signal link copied");
         track(ANALYTICS_EVENTS.SCOUT_ACTION, {
           action_type: "copy_finding_link",
           surface: "scout_detail",
@@ -40,7 +40,7 @@ export function ScoutFindingShareButton({
     <button
       type="button"
       onClick={handleCopyLink}
-      title="Copy a link to this finding"
+      title="Copy a link to this signal"
       className="inline-flex shrink-0 items-center gap-1 text-[11px] text-accent-11 no-underline transition-colors hover:text-accent-12"
     >
       <LinkIcon size={11} />

--- a/packages/ui/src/features/scouts/components/ScoutFindingsView.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutFindingsView.tsx
@@ -65,9 +65,9 @@ export function ScoutFindingsView() {
         <SparkleIcon size={12} className="shrink-0 text-gray-10" />
         <Text
           className="truncate whitespace-nowrap font-medium text-[13px]"
-          title="Scout findings"
+          title="Scout signals"
         >
-          Scout findings
+          Scout signals
         </Text>
       </Flex>
     ),
@@ -115,7 +115,7 @@ export function ScoutFindingsView() {
         <Flex align="center" gap="2">
           <SparkleIcon size={20} className="shrink-0 text-(--iris-9)" />
           <Text className="font-bold text-[22px] text-gray-12 leading-tight tracking-tight">
-            Scout findings
+            Scout signals
           </Text>
         </Flex>
         <Text className="max-w-2xl text-pretty text-[12.5px] text-gray-11 leading-relaxed">
@@ -132,7 +132,7 @@ export function ScoutFindingsView() {
           {summary.totalCount > 0 ? (
             <>
               <Text className="text-[12px] text-gray-10">
-                {summary.totalCount} finding
+                {summary.totalCount} signal
                 {summary.totalCount === 1 ? "" : "s"} · {summary.scoutCount}{" "}
                 scout{summary.scoutCount === 1 ? "" : "s"}
               </Text>
@@ -149,8 +149,8 @@ export function ScoutFindingsView() {
           ) : null}
         </Flex>
         <Text className="text-[12px] text-gray-9">
-          Covers findings from the most recent {SCOUT_RUNS_WINDOW_SPAN} of troop
-          runs. Older findings live on in the inbox reports they produced.
+          Covers signals from the most recent {SCOUT_RUNS_WINDOW_SPAN} of troop
+          runs. Older signals live on in the inbox reports they produced.
         </Text>
       </Flex>
 
@@ -160,7 +160,7 @@ export function ScoutFindingsView() {
             <Flex align="center" gap="2" wrap="wrap">
               <TextField.Root
                 type="search"
-                placeholder="Search findings…"
+                placeholder="Search signals…"
                 value={searchText}
                 onChange={(event) => setSearchText(event.target.value)}
                 size="2"
@@ -237,7 +237,7 @@ export function ScoutFindingsView() {
                   });
                 }}
               >
-                <Select.Trigger aria-label="Sort findings" />
+                <Select.Trigger aria-label="Sort signals" />
                 <Select.Content>
                   {SORT_OPTIONS.map((option) => (
                     <Select.Item key={option.value} value={option.value}>
@@ -260,7 +260,7 @@ export function ScoutFindingsView() {
                 className="rounded-(--radius-2) border border-(--amber-6) bg-(--amber-2) px-4 py-3 text-[12.5px]"
               >
                 <Text className="flex-1 text-(--amber-11)">
-                  Some findings couldn&apos;t be loaded, so this list may be
+                  Some signals couldn&apos;t be loaded, so this list may be
                   incomplete.
                 </Text>
                 <button
@@ -325,7 +325,7 @@ function FindingsBody({
         className="rounded-(--radius-2) border border-(--gray-6) border-dashed bg-gray-1 px-4 py-8 text-center text-[12.5px] text-gray-11"
       >
         <Text className="text-[12.5px] text-gray-11">
-          Couldn&apos;t load findings. The scout API may be unavailable or this
+          Couldn&apos;t load signals. The scout API may be unavailable or this
           project may not be enrolled yet.
         </Text>
         <button
@@ -343,8 +343,8 @@ function FindingsBody({
     return (
       <Box className="rounded-(--radius-2) border border-(--gray-6) border-dashed bg-gray-1 px-4 py-8 text-center text-[12.5px] text-gray-11">
         {isFiltering
-          ? "No findings match your search and filters."
-          : "Your scouts haven't emitted any findings yet. As they scan your project, what they surface shows up here."}
+          ? "No signals match your search and filters."
+          : "Your scouts haven't emitted any signals yet. As they scan your project, what they surface shows up here."}
       </Box>
     );
   }

--- a/packages/ui/src/features/scouts/components/ScoutRowCard.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutRowCard.tsx
@@ -83,12 +83,12 @@ export function ScoutRowCard({
             </Flex>
           )}
           {cloudSkillUrl ? (
-            <Tooltip content="View scout in PostHog">
+            <Tooltip content="View skill in PostHog">
               <a
                 href={cloudSkillUrl}
                 target="_blank"
                 rel="noreferrer"
-                aria-label={`${config.skill_name} scout in PostHog`}
+                aria-label={`${config.skill_name} skill in PostHog`}
                 onClick={() =>
                   track(ANALYTICS_EVENTS.SCOUT_ACTION, {
                     action_type: "open_skill_in_posthog",

--- a/packages/ui/src/features/scouts/components/ScoutRowCard.tsx
+++ b/packages/ui/src/features/scouts/components/ScoutRowCard.tsx
@@ -83,12 +83,12 @@ export function ScoutRowCard({
             </Flex>
           )}
           {cloudSkillUrl ? (
-            <Tooltip content="View skill in PostHog">
+            <Tooltip content="View scout in PostHog">
               <a
                 href={cloudSkillUrl}
                 target="_blank"
                 rel="noreferrer"
-                aria-label={`${config.skill_name} skill in PostHog`}
+                aria-label={`${config.skill_name} scout in PostHog`}
                 onClick={() =>
                   track(ANALYTICS_EVENTS.SCOUT_ACTION, {
                     action_type: "open_skill_in_posthog",

--- a/packages/ui/src/features/settings/sections/SignalSlackNotificationsSettings.tsx
+++ b/packages/ui/src/features/settings/sections/SignalSlackNotificationsSettings.tsx
@@ -81,7 +81,7 @@ export function SignalSlackNotificationsSettings({
           </Text>
           <Text className="text-(--gray-11) text-[13px]">
             Get pinged in your own channel when you're a suggested reviewer on a
-            new inbox item.
+            new report.
           </Text>
         </Flex>
         <Button


### PR DESCRIPTION
## Problem

The self-driving docs on posthog.com define the canonical user-facing vocabulary — **signal**, **report**, **scout**, **signal source**, **inbox**, **self-driving**. Several inbox and scout surfaces in the desktop/mobile app used different words for the same concepts, so a user moving between the docs, the web app, and PostHog Desktop would see the terminology shift under them.

Surfaced from a naming-consistency audit across the posthog.com docs, PostHog/posthog, and this repo ([Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1785347338857279)).

## Changes

User-facing display strings only — aligned to the docs vocabulary:
- **"finding" → "signal"** for scout emissions and report evidence (counts, the scout signals surface, dry-run/create copy, share/discuss actions).
- **"Responder" → "agent"** for the agent that investigates a report and opens a PR.
- **"skill" → "scout"** in scout tooltips and aria-labels.
- **"inbox item" → "report"**, and the earlier mobile **"Untitled signal" → "Untitled report"** fix.
- Updated `packages/ui/src/features/inbox/CLAUDE.md` so the naming convention matches the docs (this previously mandated "finding"/"Responder").

Backend endpoints, shared API fields, TypeScript types, deep-link params, and analytics event/property names are intentionally left on the legacy `signals`/`finding` naming — only human-visible copy changed.

## How did you test this?

Copy-only string edits (no identifier or contract changes). Verified via diff review and grep that no analytics values, API fields, deep links, or type names were touched, and that no test assertions reference the changed strings. I (the agent) did not run the app or a full typecheck.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1785347338857279)*
