### PR TITLE
fix(spaces): hold sidebar peek open while space Filter menu is open

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -39,6 +39,7 @@ import { useChannelItems } from "@posthog/ui/features/canvas/hooks/useChannelIte
 import { useCommandCenterStore } from "@posthog/ui/features/command-center/commandCenterStore";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
+import { useHoldSidebarPeek } from "@posthog/ui/features/sidebar/useHoldSidebarPeek";
 import { useTaskContextMenu } from "@posthog/ui/features/tasks/useTaskContextMenu";
 import { useRenameTask } from "@posthog/ui/features/tasks/useTaskMutations";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
@@ -84,6 +85,10 @@ function RecentSectionHeader({
   onStatusChange: (value: TaskRunStatus | null) => void;
   filtersActive: boolean;
 }) {
+  // Hold the sidebar's hover-peek open while the Filter menu is open, so a
+  // pointer moving toward the menu can't collapse the peeked panel and strand
+  // the dropdown's portal anchor (matches TasksHeader/ProjectSwitcher).
+  const handleFilterOpenChange = useHoldSidebarPeek();
   return (
     <>
       <div className="flex items-center gap-0.5 pr-1">
@@ -99,7 +104,7 @@ function RecentSectionHeader({
         >
           <MagnifyingGlass size={12} />
         </button>
-        <DropdownMenu>
+        <DropdownMenu onOpenChange={handleFilterOpenChange}>
           <DropdownMenuTrigger
             render={
               <button


### PR DESCRIPTION
## Problem

In the Spaces/Channels layout, the space sidebar's "Recent" list has a Filter control (Created by / Status). When the left sidebar is only hover-peeked (collapsed, not pinned), opening that Filter menu and moving the pointer toward it collapses the peeked panel and strands the dropdown's portal anchor — so you can't actually pick a filter condition. Reported from a Slack thread.

## Changes

Wire `ChannelSidebar`'s Filter `DropdownMenu` to `useHoldSidebarPeek()` via `onOpenChange`, holding the peek open while the menu is open. This matches the pattern already used by every other sidebar-spawned menu (`TasksHeader`, `ProjectSwitcher`) since the peek-hold fix landed; the space sidebar's filter dropdown was the one that missed it when the flag-gated Spaces layout was added.

## How did you test this?

- `pnpm --filter @posthog/ui typecheck` — clean
- `biome lint` on the changed file — clean
- `pnpm --filter @posthog/ui test` — 2377 passed (incl. `sidebarPeekStore` / `useHoldSidebarPeek` suites)

Not manually verified in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785350401878919?thread_ts=1785350401.878919&cid=C09G8Q32R6F)*