### PR TITLE
fix(archive): tolerate task pin sync failures

### DIFF
--- a/packages/core/src/archive/archiveOrchestration.test.ts
+++ b/packages/core/src/archive/archiveOrchestration.test.ts
@@ -113,6 +113,26 @@ describe("archiveTask", () => {
     expect(harness.deps.togglePin).toHaveBeenCalledWith(TASK_ID);
   });
 
+  it("archives when reading task pins fails", async () => {
+    harness.deps.getPinnedTaskIds = vi
+      .fn()
+      .mockRejectedValue(new Error("pins unavailable"));
+
+    await archiveTask(TASK_ID, harness.deps);
+
+    expect(harness.deps.archive).toHaveBeenCalledWith(TASK_ID);
+  });
+
+  it("archives when unpinning fails", async () => {
+    harness.deps.unpin = vi
+      .fn()
+      .mockRejectedValue(new Error("pins unavailable"));
+
+    await archiveTask(TASK_ID, harness.deps);
+
+    expect(harness.deps.archive).toHaveBeenCalledWith(TASK_ID);
+  });
+
   it("destroys terminals only after the archive succeeds", async () => {
     let clearedWhenArchiveCalled = true;
     harness.deps.archive = vi.fn().mockImplementation(async () => {

--- a/packages/core/src/archive/archiveOrchestration.test.ts
+++ b/packages/core/src/archive/archiveOrchestration.test.ts
@@ -123,7 +123,20 @@ describe("archiveTask", () => {
     expect(harness.deps.archive).toHaveBeenCalledWith(TASK_ID);
   });
 
+  it("preserves pin state when reading task pins and archiving fail", async () => {
+    harness.deps.getPinnedTaskIds = vi
+      .fn()
+      .mockRejectedValue(new Error("pins unavailable"));
+    harness.deps.archive = vi.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(archiveTask(TASK_ID, harness.deps)).rejects.toThrow("boom");
+
+    expect(harness.deps.unpin).not.toHaveBeenCalled();
+    expect(harness.deps.togglePin).not.toHaveBeenCalled();
+  });
+
   it("archives when unpinning fails", async () => {
+    harness.deps.getPinnedTaskIds = vi.fn().mockResolvedValue([TASK_ID]);
     harness.deps.unpin = vi
       .fn()
       .mockRejectedValue(new Error("pins unavailable"));

--- a/packages/core/src/archive/archiveOrchestration.ts
+++ b/packages/core/src/archive/archiveOrchestration.ts
@@ -67,8 +67,12 @@ export async function archiveTask(
   }
 
   const optimistic = options?.optimistic ?? true;
-  const pinnedTaskIds = await deps.getPinnedTaskIds();
-  const wasPinned = pinnedTaskIds.includes(taskId);
+  let wasPinned = false;
+  try {
+    wasPinned = (await deps.getPinnedTaskIds()).includes(taskId);
+  } catch (error) {
+    deps.logError("Failed to read task pin state while archiving", error);
+  }
 
   if (!options?.skipNavigate) {
     deps.navigateAwayFromTaskIfActive(taskId);
@@ -76,7 +80,11 @@ export async function archiveTask(
 
   const commandCenterSnapshot = deps.snapshotCommandCenter(taskId);
 
-  await deps.unpin(taskId);
+  try {
+    await deps.unpin(taskId);
+  } catch (error) {
+    deps.logError("Failed to unpin task while archiving", error);
+  }
   deps.removeFromCommandCenter(taskId);
 
   await deps.cache.cancelPathFilter();
@@ -118,7 +126,14 @@ export async function archiveTask(
     deps.cache.setArchivedTaskIds((old) => removeArchivedTaskId(old, taskId));
     deps.cache.setArchiveList((old) => removeArchivedTask(old, taskId));
     if (wasPinned) {
-      await deps.togglePin(taskId);
+      try {
+        await deps.togglePin(taskId);
+      } catch (pinError) {
+        deps.logError(
+          "Failed to restore task pin after archive failure",
+          pinError,
+        );
+      }
     }
     if (commandCenterSnapshot.index !== -1) {
       deps.restoreCommandCenter(taskId, commandCenterSnapshot);

--- a/packages/core/src/archive/archiveOrchestration.ts
+++ b/packages/core/src/archive/archiveOrchestration.ts
@@ -67,7 +67,7 @@ export async function archiveTask(
   }
 
   const optimistic = options?.optimistic ?? true;
-  let wasPinned = false;
+  let wasPinned: boolean | undefined;
   try {
     wasPinned = (await deps.getPinnedTaskIds()).includes(taskId);
   } catch (error) {
@@ -80,10 +80,12 @@ export async function archiveTask(
 
   const commandCenterSnapshot = deps.snapshotCommandCenter(taskId);
 
-  try {
-    await deps.unpin(taskId);
-  } catch (error) {
-    deps.logError("Failed to unpin task while archiving", error);
+  if (wasPinned) {
+    try {
+      await deps.unpin(taskId);
+    } catch (error) {
+      deps.logError("Failed to unpin task while archiving", error);
+    }
   }
   deps.removeFromCommandCenter(taskId);
 


### PR DESCRIPTION
## Problem

Task archiving fails when task pin reads or updates fail, affecting both cloud and worktree tasks. Pin synchronization is ancillary and should not prevent an archive from completing.

## Changes

I made pin reads and writes best-effort during archive orchestration. When pin state cannot be read, archiving leaves it unchanged so a later archive failure cannot accidentally unpin the task. Failed rollback pin writes are logged without replacing the original archive error.

## How did you test this?

- `pnpm --dir packages/core exec vitest run src/archive/archiveOrchestration.test.ts src/sessions/sessionServiceStopCloudRun.test.ts`
- `pnpm exec biome check packages/core/src/archive/archiveOrchestration.ts packages/core/src/archive/archiveOrchestration.test.ts`
- `pnpm --filter @posthog/core... build`
- `pnpm --filter @posthog/core typecheck`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*