### PR TITLE
chore: fix effort options for reopened Kimi tasks

### DIFF
--- a/packages/core/src/sessions/sessionService.ts
+++ b/packages/core/src/sessions/sessionService.ts
@@ -20,6 +20,7 @@ import {
   getBackoffDelay,
   getCloudUrlFromRegion,
   getConfigOptionByCategory,
+  getReasoningEffortOptions,
   isFatalSessionError,
   isJsonRpcNotification,
   isJsonRpcRequest,
@@ -5539,10 +5540,15 @@ export class SessionService {
         ],
       };
     };
+    const modelEffortOptions = preferredModel
+      ? getReasoningEffortOptions(adapter, preferredModel)
+      : undefined;
     const extras = previewOptions
-      .filter(
-        (opt) => opt.category === "model" || opt.category === "thought_level",
-      )
+      .filter((opt) => {
+        if (opt.category === "model") return true;
+        if (opt.category !== "thought_level") return false;
+        return modelEffortOptions !== null;
+      })
       .map((opt) => {
         if (opt.category === "model") {
           return applyPreferredValue(opt, preferredModel, existingModelOption);
@@ -5560,6 +5566,12 @@ export class SessionService {
     if (extras.length === 0) return;
 
     const previewCategories = new Set(extras.map((option) => option.category));
+    // The preview endpoint describes its default model. When the run uses an
+    // effort-less model, explicitly replace (and therefore remove) any stale
+    // thought-level option instead of inheriting the default model's choices.
+    if (preferredModel && modelEffortOptions === null) {
+      previewCategories.add("thought_level");
+    }
     const merged = [
       ...existingOptions.filter(
         (option) => !previewCategories.has(option.category),

--- a/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -5465,6 +5465,86 @@ describe("SessionService", () => {
       });
     });
 
+    it("does not inherit effort options from the preview default for an effort-less model", async () => {
+      const service = getSessionService();
+      const session = createMockSession({
+        taskRunId: "run-kimi-123",
+        taskId: "task-kimi-123",
+        isCloud: true,
+        adapter: "claude",
+        configOptions: [
+          {
+            id: "mode",
+            name: "Approval Preset",
+            type: "select",
+            category: "mode",
+            currentValue: "plan",
+            options: [],
+          },
+        ],
+      });
+      mockSessionStoreSetters.getSessions.mockReturnValue({
+        "run-kimi-123": session,
+      });
+      mockTrpcAgent.getPreviewConfigOptions.query.mockResolvedValueOnce([
+        {
+          id: "model",
+          name: "Model",
+          type: "select",
+          category: "model",
+          currentValue: "claude-opus-4-8",
+          options: [
+            { value: "claude-opus-4-8", name: "Opus 4.8" },
+            { value: "moonshotai/kimi-k3", name: "Kimi K3" },
+          ],
+        },
+        {
+          id: "effort",
+          name: "Effort",
+          type: "select",
+          category: "thought_level",
+          currentValue: "high",
+          options: [
+            { value: "low", name: "Low" },
+            { value: "high", name: "High" },
+            { value: "max", name: "Max" },
+          ],
+        },
+      ]);
+
+      service.watchCloudTask(
+        "task-kimi-123",
+        "run-kimi-123",
+        "https://api.example.com",
+        7,
+        undefined,
+        undefined,
+        "plan",
+        "claude",
+        "moonshotai/kimi-k3",
+      );
+
+      await vi.waitFor(() => {
+        const configUpdate = (
+          mockSessionStoreSetters.updateSession.mock.calls as Array<
+            [string, { configOptions?: SessionConfigOption[] }]
+          >
+        )
+          .filter(([runId]) => runId === "run-kimi-123")
+          .map(([, patch]) => patch.configOptions)
+          .find((options) =>
+            options?.some((option) => option.category === "model"),
+          );
+        expect(
+          configUpdate?.find((option) => option.category === "model")
+            ?.currentValue,
+        ).toBe("moonshotai/kimi-k3");
+        expect(
+          configUpdate?.some((option) => option.category === "thought_level"),
+        ).toBe(false);
+      });
+    });
+
     it("keeps model-specific max reasoning when generic preview options omit it", async () => {
       const service = getSessionService();
       const session = createMockSession({


### PR DESCRIPTION
## Problem

Reopened cloud tasks could show reasoning-effort choices that the selected model does not support.

## Changes

- Resolve effort capability from the task run's actual model when merging cloud preview options.
- Remove stale effort controls for effort-less models such as Kimi K3.

**Why:** The new-task composer and reopened task controls should expose the same valid model settings.
