### PR TITLE
feat(sessions): default messaging mode to steer

### DIFF
--- a/packages/ui/src/features/sessions/hooks/useMessagingMode.test.tsx
+++ b/packages/ui/src/features/sessions/hooks/useMessagingMode.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { useMessagingModeStore } from "../messagingModeStore";
+import {
+  type AgentSession,
+  sessionStoreSetters,
+  useSessionStore,
+} from "../sessionStore";
+import { useMessagingMode } from "./useMessagingMode";
+
+function seedSession(overrides: Partial<AgentSession>): void {
+  sessionStoreSetters.setSession({
+    taskRunId: "run-1",
+    taskId: "task-1",
+    taskTitle: "Test",
+    channel: "agent-event:run-1",
+    events: [],
+    startedAt: 0,
+    status: "connected",
+    isPromptPending: false,
+    isCompacting: false,
+    promptStartedAt: null,
+    pendingPermissions: new Map(),
+    pausedDurationMs: 0,
+    messageQueue: [],
+    optimisticItems: [],
+    ...overrides,
+  });
+}
+
+describe("useMessagingMode", () => {
+  beforeEach(() => {
+    useMessagingModeStore.setState({ modesByTaskId: {} });
+    useSettingsStore.setState({
+      defaultMessagingMode: "queue",
+      defaultCloudMessagingMode: "steer",
+    });
+    useSessionStore.setState((state) => {
+      state.sessions = {};
+      state.taskIdIndex = {};
+    });
+  });
+
+  it("per-task override wins over any default", () => {
+    seedSession({ isCloud: true });
+    useMessagingModeStore.getState().setMode("task-1", "queue");
+    const { result } = renderHook(() => useMessagingMode("task-1"));
+    expect(result.current).toBe("queue");
+  });
+
+  it("returns global cloud default for cloud sessions", () => {
+    seedSession({ isCloud: true });
+    const { result } = renderHook(() => useMessagingMode("task-1"));
+    expect(result.current).toBe("steer");
+  });
+
+  it("returns global local default for local sessions", () => {
+    seedSession({ isCloud: false });
+    const { result } = renderHook(() => useMessagingMode("task-1"));
+    expect(result.current).toBe("queue");
+  });
+
+  it("returns global local default when no session exists for the task", () => {
+    const { result } = renderHook(() => useMessagingMode("task-1"));
+    expect(result.current).toBe("queue");
+  });
+
+  it("returns global local default when taskId is undefined", () => {
+    seedSession({ isCloud: true });
+    const { result } = renderHook(() => useMessagingMode(undefined));
+    expect(result.current).toBe("queue");
+  });
+
+  it("respects a changed cloud messaging mode default", () => {
+    seedSession({ isCloud: true });
+    useSettingsStore.getState().setDefaultCloudMessagingMode("queue");
+    const { result } = renderHook(() => useMessagingMode("task-1"));
+    expect(result.current).toBe("queue");
+  });
+});

--- a/packages/ui/src/features/sessions/hooks/useMessagingMode.test.tsx
+++ b/packages/ui/src/features/sessions/hooks/useMessagingMode.test.tsx
@@ -1,6 +1,6 @@
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
-import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { useMessagingModeStore } from "../messagingModeStore";
 import {
   type AgentSession,

--- a/packages/ui/src/features/sessions/hooks/useMessagingMode.ts
+++ b/packages/ui/src/features/sessions/hooks/useMessagingMode.ts
@@ -4,15 +4,21 @@ import {
   useMessagingModeStore,
 } from "@posthog/ui/features/sessions/messagingModeStore";
 import { useSessionStore } from "@posthog/ui/features/sessions/sessionStore";
+import { useSessionIsCloud } from "@posthog/ui/features/sessions/useSession";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 
-/** Effective messaging mode for a task: per-task override, else global default. */
+/**
+ * Effective messaging mode for a task: per-task override, else cloud sessions
+ * default to steer (mid-turn messages keep cloud runs on track without waiting
+ * for the turn to end), else the global default from settings.
+ */
 export function useMessagingMode(taskId: string | undefined): MessagingMode {
   const override = useMessagingModeStore((s) =>
     taskId ? s.modesByTaskId[taskId] : undefined,
   );
+  const isCloud = useSessionIsCloud(taskId);
   const globalDefault = useSettingsStore((s) => s.defaultMessagingMode);
-  return override ?? globalDefault;
+  return override ?? (isCloud ? "steer" : globalDefault);
 }
 
 /**

--- a/packages/ui/src/features/sessions/hooks/useMessagingMode.ts
+++ b/packages/ui/src/features/sessions/hooks/useMessagingMode.ts
@@ -8,17 +8,19 @@ import { useSessionIsCloud } from "@posthog/ui/features/sessions/useSession";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 
 /**
- * Effective messaging mode for a task: per-task override, else cloud sessions
- * default to steer (mid-turn messages keep cloud runs on track without waiting
- * for the turn to end), else the global default from settings.
+ * Effective messaging mode for a task: per-task override, else the global
+ * default for the session's run target — cloud sessions have their own
+ * default (steer ships enabled for cloud), local sessions use the local one.
  */
 export function useMessagingMode(taskId: string | undefined): MessagingMode {
   const override = useMessagingModeStore((s) =>
     taskId ? s.modesByTaskId[taskId] : undefined,
   );
   const isCloud = useSessionIsCloud(taskId);
-  const globalDefault = useSettingsStore((s) => s.defaultMessagingMode);
-  return override ?? (isCloud ? "steer" : globalDefault);
+  const globalDefault = useSettingsStore((s) =>
+    isCloud ? s.defaultCloudMessagingMode : s.defaultMessagingMode,
+  );
+  return override ?? globalDefault;
 }
 
 /**

--- a/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -95,6 +95,7 @@ export function GeneralSettings() {
     autoConvertLongText,
     defaultInitialTaskMode,
     defaultMessagingMode,
+    defaultCloudMessagingMode,
     defaultReasoningEffort,
     diffOpenMode,
     sendMessagesWith,
@@ -105,6 +106,7 @@ export function GeneralSettings() {
     setAutoConvertLongText,
     setDefaultInitialTaskMode,
     setDefaultMessagingMode,
+    setDefaultCloudMessagingMode,
     setDefaultReasoningEffort,
     setDiffOpenMode,
     setSendMessagesWith,
@@ -174,6 +176,18 @@ export function GeneralSettings() {
       setDefaultMessagingMode(value);
     },
     [defaultMessagingMode, setDefaultMessagingMode],
+  );
+
+  const handleDefaultCloudMessagingModeChange = useCallback(
+    (value: DefaultMessagingMode) => {
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "default_cloud_messaging_mode",
+        new_value: value,
+        old_value: defaultCloudMessagingMode,
+      });
+      setDefaultCloudMessagingMode(value);
+    },
+    [defaultCloudMessagingMode, setDefaultCloudMessagingMode],
   );
 
   const handleDefaultReasoningEffortChange = useCallback(
@@ -318,12 +332,31 @@ export function GeneralSettings() {
 
       <SettingRow
         label="Default messaging mode"
-        description="Mode new sessions start in. Steer applies messages mid-turn. Queue holds them until the turn ends."
+        description="Mode new local sessions start in. Steer applies messages mid-turn. Queue holds them until the turn ends."
       >
         <Select.Root
           value={defaultMessagingMode}
           onValueChange={(value) =>
             handleDefaultMessagingModeChange(value as DefaultMessagingMode)
+          }
+          size="1"
+        >
+          <Select.Trigger className="min-w-[100px]" />
+          <Select.Content>
+            <Select.Item value="queue">Queue</Select.Item>
+            <Select.Item value="steer">Steer</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </SettingRow>
+
+      <SettingRow
+        label="Default cloud messaging mode"
+        description="Mode new cloud sessions start in. Steer applies messages mid-turn. Queue holds them until the turn ends."
+      >
+        <Select.Root
+          value={defaultCloudMessagingMode}
+          onValueChange={(value) =>
+            handleDefaultCloudMessagingModeChange(value as DefaultMessagingMode)
           }
           size="1"
         >

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -319,7 +319,7 @@ export const useSettingsStore = create<SettingsStore>()(
       lastUsedInitialTaskMode: "plan",
       lastPlanApprovalMode: null,
       defaultReasoningEffort: "last_used",
-      defaultMessagingMode: "steer",
+      defaultMessagingMode: "queue",
       setDefaultRunMode: (mode) => set({ defaultRunMode: mode }),
       setLastUsedRunMode: (mode) => set({ lastUsedRunMode: mode }),
       setLastUsedLocalWorkspaceMode: (mode) =>

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -319,7 +319,7 @@ export const useSettingsStore = create<SettingsStore>()(
       lastUsedInitialTaskMode: "plan",
       lastPlanApprovalMode: null,
       defaultReasoningEffort: "last_used",
-      defaultMessagingMode: "queue",
+      defaultMessagingMode: "steer",
       setDefaultRunMode: (mode) => set({ defaultRunMode: mode }),
       setLastUsedRunMode: (mode) => set({ lastUsedRunMode: mode }),
       setLastUsedLocalWorkspaceMode: (mode) =>

--- a/packages/ui/src/features/settings/settingsStore.ts
+++ b/packages/ui/src/features/settings/settingsStore.ts
@@ -123,7 +123,9 @@ interface SettingsStore {
   lastPlanApprovalMode: ExecutionMode | null;
   defaultReasoningEffort: DefaultReasoningEffort;
   defaultMessagingMode: DefaultMessagingMode;
+  defaultCloudMessagingMode: DefaultMessagingMode;
   setDefaultMessagingMode: (mode: DefaultMessagingMode) => void;
+  setDefaultCloudMessagingMode: (mode: DefaultMessagingMode) => void;
   setDefaultRunMode: (mode: DefaultRunMode) => void;
   setLastUsedRunMode: (mode: "local" | "cloud") => void;
   setLastUsedLocalWorkspaceMode: (mode: LocalWorkspaceMode) => void;
@@ -320,6 +322,7 @@ export const useSettingsStore = create<SettingsStore>()(
       lastPlanApprovalMode: null,
       defaultReasoningEffort: "last_used",
       defaultMessagingMode: "queue",
+      defaultCloudMessagingMode: "steer",
       setDefaultRunMode: (mode) => set({ defaultRunMode: mode }),
       setLastUsedRunMode: (mode) => set({ lastUsedRunMode: mode }),
       setLastUsedLocalWorkspaceMode: (mode) =>
@@ -369,6 +372,8 @@ export const useSettingsStore = create<SettingsStore>()(
       setDefaultReasoningEffort: (effort) =>
         set({ defaultReasoningEffort: effort }),
       setDefaultMessagingMode: (mode) => set({ defaultMessagingMode: mode }),
+      setDefaultCloudMessagingMode: (mode) =>
+        set({ defaultCloudMessagingMode: mode }),
 
       // Notifications
       ...NOTIFICATION_DEFAULTS,
@@ -568,6 +573,7 @@ export const useSettingsStore = create<SettingsStore>()(
         lastPlanApprovalMode: state.lastPlanApprovalMode,
         defaultReasoningEffort: state.defaultReasoningEffort,
         defaultMessagingMode: state.defaultMessagingMode,
+        defaultCloudMessagingMode: state.defaultCloudMessagingMode,
 
         // Notifications
         desktopNotifications: state.desktopNotifications,


### PR DESCRIPTION
## Problem

New sessions currently start with messages in **queue** mode, steer mode in cloud is very stable. Let's use that