### PR TITLE
feat(mobile): default new sessions to steer (port #3983)

### DIFF
--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -418,7 +418,7 @@ export default function SettingsScreen() {
           />
           <SettingsRow
             label="Messaging mode"
-            description="What happens when you send while a turn is running"
+            description="Mode new sessions start in. Steer applies messages mid-turn. Queue holds them until the turn ends."
             onPress={() => setMessagingModeSheetOpen(true)}
             rightSlot={
               <>

--- a/apps/mobile/src/features/tasks/stores/messagingModeStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/messagingModeStore.test.ts
@@ -1,31 +1,41 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { useMessagingModeStore } from "./messagingModeStore";
+import {
+  type MessagingMode,
+  useMessagingModeStore,
+} from "./messagingModeStore";
 
 const INITIAL_STATE = useMessagingModeStore.getState();
+
+const migrate = useMessagingModeStore.persist.getOptions().migrate as (
+  persisted: unknown,
+  version: number,
+) => {
+  modesByTaskId: Record<string, MessagingMode>;
+  defaultMode: MessagingMode;
+};
 
 describe("messagingModeStore", () => {
   beforeEach(() => {
     useMessagingModeStore.setState(
-      { ...INITIAL_STATE, modesByTaskId: {}, defaultMode: "queue" },
+      { ...INITIAL_STATE, modesByTaskId: {}, defaultMode: "steer" },
       true,
     );
   });
 
-  it("defaults to Queue", () => {
-    expect(useMessagingModeStore.getState().getEffectiveMode("t1")).toBe(
-      "queue",
-    );
-  });
-
-  it("falls back to the global default when a task has no override", () => {
-    useMessagingModeStore.getState().setDefaultMode("steer");
+  it("defaults to Steer", () => {
     expect(useMessagingModeStore.getState().getEffectiveMode("t1")).toBe(
       "steer",
     );
   });
 
+  it("falls back to the global default when a task has no override", () => {
+    useMessagingModeStore.getState().setDefaultMode("queue");
+    expect(useMessagingModeStore.getState().getEffectiveMode("t1")).toBe(
+      "queue",
+    );
+  });
+
   it("prefers a per-task override over the global default", () => {
-    useMessagingModeStore.getState().setDefaultMode("steer");
     useMessagingModeStore.getState().setMode("t1", "queue");
     expect(useMessagingModeStore.getState().getEffectiveMode("t1")).toBe(
       "queue",
@@ -37,9 +47,47 @@ describe("messagingModeStore", () => {
   });
 
   it("treats an undefined taskId as the global default", () => {
-    useMessagingModeStore.getState().setDefaultMode("steer");
+    useMessagingModeStore.getState().setDefaultMode("queue");
     expect(useMessagingModeStore.getState().getEffectiveMode(undefined)).toBe(
-      "steer",
+      "queue",
     );
+  });
+
+  describe("migration", () => {
+    it.each([
+      {
+        name: "flips a pre-v1 queue default to steer",
+        version: 0,
+        from: "queue",
+        expected: "steer",
+      },
+      {
+        name: "does not clobber a queue default set at the current version",
+        version: 1,
+        from: "queue",
+        expected: "queue",
+      },
+      {
+        name: "leaves a pre-v1 steer default untouched",
+        version: 0,
+        from: "steer",
+        expected: "steer",
+      },
+    ] as const)("$name", ({ version, from, expected }) => {
+      const migrated = migrate(
+        { modesByTaskId: {}, defaultMode: from },
+        version,
+      );
+      expect(migrated.defaultMode).toBe(expected);
+    });
+
+    it("preserves per-task overrides through migration", () => {
+      const migrated = migrate(
+        { modesByTaskId: { t1: "queue", t2: "steer" }, defaultMode: "queue" },
+        0,
+      );
+      expect(migrated.modesByTaskId).toEqual({ t1: "queue", t2: "steer" });
+      expect(migrated.defaultMode).toBe("steer");
+    });
   });
 });

--- a/apps/mobile/src/features/tasks/stores/messagingModeStore.ts
+++ b/apps/mobile/src/features/tasks/stores/messagingModeStore.ts
@@ -17,7 +17,7 @@ export const useMessagingModeStore = create<MessagingModeState>()(
   persist(
     (set, get) => ({
       modesByTaskId: {},
-      defaultMode: "queue",
+      defaultMode: "steer",
       setMode: (taskId, mode) =>
         set((state) => ({
           modesByTaskId: { ...state.modesByTaskId, [taskId]: mode },
@@ -34,6 +34,19 @@ export const useMessagingModeStore = create<MessagingModeState>()(
     {
       name: "messaging-mode-storage",
       storage: createJSONStorage(() => AsyncStorage),
+      version: 1,
+      // Pre-v1 installs persisted the old "queue" default, so flip them to the
+      // new "steer" default once. Per-task overrides are left untouched.
+      migrate: (persisted, version) => {
+        const state = persisted as Pick<
+          MessagingModeState,
+          "modesByTaskId" | "defaultMode"
+        >;
+        if (version < 1 && state.defaultMode === "queue") {
+          return { ...state, defaultMode: "steer" };
+        }
+        return state;
+      },
       partialize: (state) => ({
         modesByTaskId: state.modesByTaskId,
         defaultMode: state.defaultMode,


### PR DESCRIPTION
## Problem

Ports desktop PR #3983 ("default messaging mode to steer") to the mobile app. New sessions currently start in **queue** mode; steer mode is stable in cloud, so new sessions should start in steer.

Desktop split its single default into separate local/cloud defaults and pointed cloud at steer. **Mobile is cloud-only** — every mobile task is a cloud session — so there's no split to make: the single default simply becomes `steer`.

## Changes

- `messagingModeStore`: initial `defaultMode` is now `"steer"`.
- **Migration for existing installs.** Flipping the initial value alone changes nothing for current users, who already have `"queue"` persisted. Added a persist `version: 1` + `migrate` that moves a pre-v1 install off the old `"queue"` default to `"steer"` once. Per-task overrides in `modesByTaskId` are left untouched, and a `"queue"` default set at the current version is not re-migrated.
- Reworded the settings row description to reflect the new behaviour: "Mode new sessions start in. Steer applies messages mid-turn. Queue holds them until the turn ends."

No new setting-change analytics event was added: mobile has no existing setting-change analytics shape, and no other settings row emits one, so introducing a bespoke event for this single row would be inconsistent and out of scope.

## How did you test this?

- `messagingModeStore.test.ts`: new-install default, one-time migration from a previously-defaulted install, that a `"queue"` default at the current version is not clobbered, and that per-task overrides survive migration.
- Ran the full mobile Vitest suite (549 passing), `tsc --noEmit` (no new errors vs. baseline), and `biome check`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
