### PR TITLE
feat(mobile): default messaging mode to steer (port #3983)

### DIFF
--- a/apps/mobile/src/features/tasks/stores/messagingModeStore.test.ts
+++ b/apps/mobile/src/features/tasks/stores/messagingModeStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   type MessagingMode,
+  migrateMessagingModeState,
   useMessagingModeStore,
 } from "./messagingModeStore";
 
@@ -28,12 +29,15 @@ describe("messagingModeStore", () => {
     );
   });
 
-  it("falls back to the global default when a task has no override", () => {
-    useMessagingModeStore.getState().setDefaultMode("queue");
-    expect(useMessagingModeStore.getState().getEffectiveMode("t1")).toBe(
-      "queue",
-    );
-  });
+  it.each(["queue", "steer"] as const)(
+    "falls back to the global default (%s) when a task has no override",
+    (mode) => {
+      useMessagingModeStore.getState().setDefaultMode(mode);
+      expect(useMessagingModeStore.getState().getEffectiveMode("t1")).toBe(
+        mode,
+      );
+    },
+  );
 
   it("prefers a per-task override over the global default", () => {
     useMessagingModeStore.getState().setMode("t1", "queue");
@@ -53,6 +57,8 @@ describe("messagingModeStore", () => {
     );
   });
 
+  // Exercises the migration through the persisted store's wired `migrate`
+  // option, complementing the direct unit tests below.
   describe("migration", () => {
     it.each([
       {
@@ -88,6 +94,30 @@ describe("messagingModeStore", () => {
       );
       expect(migrated.modesByTaskId).toEqual({ t1: "queue", t2: "steer" });
       expect(migrated.defaultMode).toBe("steer");
+    });
+  });
+});
+
+describe("migrateMessagingModeState", () => {
+  it("moves v0 installs to steer while keeping per-task overrides", () => {
+    const migrated = migrateMessagingModeState(
+      { modesByTaskId: { t1: "queue" }, defaultMode: "queue" },
+      0,
+    );
+    expect(migrated).toEqual({
+      modesByTaskId: { t1: "queue" },
+      defaultMode: "steer",
+    });
+  });
+
+  it("leaves already-migrated state untouched", () => {
+    const state = { modesByTaskId: {}, defaultMode: "queue" as const };
+    expect(migrateMessagingModeState(state, 1)).toEqual(state);
+  });
+
+  it("tolerates missing persisted state", () => {
+    expect(migrateMessagingModeState(undefined, 0)).toEqual({
+      defaultMode: "steer",
     });
   });
 });

--- a/apps/mobile/src/features/tasks/stores/messagingModeStore.ts
+++ b/apps/mobile/src/features/tasks/stores/messagingModeStore.ts
@@ -13,6 +13,20 @@ interface MessagingModeState {
   getEffectiveMode: (taskId: string | undefined) => MessagingMode;
 }
 
+/**
+ * Mobile sessions are all cloud, where steer is stable, so the default moved to
+ * steer. Existing installs persisted "queue" under v0 and would keep it, so v1
+ * rehydrates them to steer. Per-task overrides are untouched; an explicit
+ * "queue" default is indistinguishable from the old default, so it is reset too.
+ */
+export function migrateMessagingModeState(
+  persisted: unknown,
+  version: number,
+): Partial<MessagingModeState> {
+  const state = (persisted ?? {}) as Partial<MessagingModeState>;
+  return version < 1 ? { ...state, defaultMode: "steer" } : state;
+}
+
 export const useMessagingModeStore = create<MessagingModeState>()(
   persist(
     (set, get) => ({
@@ -35,18 +49,7 @@ export const useMessagingModeStore = create<MessagingModeState>()(
       name: "messaging-mode-storage",
       storage: createJSONStorage(() => AsyncStorage),
       version: 1,
-      // Pre-v1 installs persisted the old "queue" default, so flip them to the
-      // new "steer" default once. Per-task overrides are left untouched.
-      migrate: (persisted, version) => {
-        const state = persisted as Pick<
-          MessagingModeState,
-          "modesByTaskId" | "defaultMode"
-        >;
-        if (version < 1 && state.defaultMode === "queue") {
-          return { ...state, defaultMode: "steer" };
-        }
-        return state;
-      },
+      migrate: migrateMessagingModeState,
       partialize: (state) => ({
         modesByTaskId: state.modesByTaskId,
         defaultMode: state.defaultMode,


### PR DESCRIPTION
Ports desktop PR #3983 (`feat(sessions): default messaging mode to steer`) to the React Native app.

## Why

Steer mode is very stable in cloud. Mobile runs **cloud sessions only**, so new sessions should default to steer instead of queue.

## What changed

Desktop introduced a separate `defaultCloudMessagingMode` key alongside the local one. Mobile has a single run target, so that split collapses: mobile's one `defaultMode` simply becomes **steer**.

- `messagingModeStore.ts` — initial `defaultMode` is now `"steer"`. Because `defaultMode` is persisted to AsyncStorage (`messaging-mode-storage`), changing the initial value alone would only affect fresh installs. Bumped the persist `version` to `1` and added `migrateMessagingModeState`, which rehydrates existing installs to steer. Per-task overrides in `modesByTaskId` are untouched and still win over the default.
- `settings/index.tsx` — reworded the "Messaging mode" row description to make clear it applies to new cloud sessions. Kept a single row (mobile has no local target, so no second "cloud" row like desktop) and the existing `SelectSheet` interaction.
- `messagingModeStore.test.ts` — updated default-resolution tests (now steer) and added coverage for the migration.

## Migration tradeoff

The store collapses "never touched the setting" and "explicitly chose Queue" into one persisted field, so they're indistinguishable. Per the desktop approach, the migration moves everyone to steer — a small, one-time UX change for the narrow set of users who had deliberately selected Queue.

## Testing

- `pnpm --filter @posthog/mobile test` — 549 passed
- `pnpm --filter @posthog/mobile lint` — clean
- `tsc --noEmit` — no new errors in touched files

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*