### PR TITLE
fix(mobile): build react-native-worklets from source on EAS

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -24,6 +24,11 @@
     "clean": "node ../../scripts/rimraf.mjs .turbo .expo"
   },
   "expo": {
+    "autolinking": {
+      "buildFromSource": [
+        "react-native-worklets"
+      ]
+    },
     "doctor": {
       "reactNativeDirectoryCheck": {
         "exclude": [


### PR DESCRIPTION
## Problem

iOS EAS builds have been broken since the last green build on 2026-05-22. They failed in two different ways, which turned out to share a single cause: Expo's precompiled `RNWorklets` XCFramework.

### 1. Cold builds could not archive

```
Pods/Headers/Private/RNReanimated/reanimated/RuntimeDecorators/UIRuntimeDecorator.h:6:10
#include <worklets/Compat/StableApi.h>
         ^ 'worklets/Compat/StableApi.h' file not found
** ARCHIVE FAILED **
```

`RNReanimated` compiles from source, but `RNWorklets` was consumed as a precompiled XCFramework whose headers are only put in place by the `[Expo] Switch RNWorklets XCFramework for build configuration` script phase. That phase is not an input dependency of RNReanimated's compile, so the two race and reanimated loses.

Warm builds hid this by restoring a Pods cache that already contained the headers. That is why an unchanged rebuild passed while *any* change to the native fingerprint (`app.json`, `package.json`) failed every time — which also made iOS effectively untestable, since no native-affecting change could get far enough to be evaluated.

### 2. Builds that did archive could not be exported

```
IDEDistributionMethodManagerErrorDomain Code=2 "Unknown Distribution Error"
error: exportArchive exportOptionsPlist error for key "method"
       expected one {} but found app-store
```

Xcode could not enumerate any distribution method, so the allowed set was empty (`{}`) and every value was rejected — this hit `ad-hoc` on `preview` and `app-store` on `production` identically, which is why it initially looked like the Xcode 16+ export-method rename.

## Changes

Opt `RNWorklets` out of prebuilt modules via `expo.autolinking.buildFromSource` in `apps/mobile/package.json`. This is the documented opt-out in `expo-modules-autolinking`: *"A list of package name patterns to opt out of prebuilt modules."*

Note it must live at the top level of `autolinking`, not under an `ios` sub-key — nesting it there made fastlane resolve the archive destination as `generic/platform=macOS`, and xcodebuild then failed with `Unable to find a destination matching the provided destination specifier`.

## How did you test this?

Ran production-profile EAS builds off this change (dispatched with `wait=false`, so nothing was submitted to TestFlight or Play).

iOS build [`f47c1345`](https://expo.dev/accounts/posthog/projects/posthog/builds/f47c1345-342e-4f0a-b7bd-00ada83918d3) — verified from the raw build log:

- `RNWorklets ... building from source`
- no `StableApi.h` error
- `Archive Succeeded`
- no `Unknown Distribution Error`
- `Successfully exported and signed the ipa file: PostHog.ipa (24.0 MB)`

This was a cold build (the `package.json` change invalidates the native fingerprint), so it exercises exactly the path that had been failing.

Android build [`1d721015`](https://expo.dev/accounts/posthog/projects/posthog/builds/1d721015-3f85-4692-937d-34190983e83e) finished green on the same commit (production AAB, build 18), confirming no regression from the shared `buildFromSource` entry.

Trade-off worth flagging: building worklets from source instead of pulling the prebuilt XCFramework makes both platforms noticeably slower (this Android run took ~40 minutes). Correctness first — but if build times matter, the alternative is to chase a fix for the header-ordering race upstream in Expo rather than opting out.

## Context

`EXPO_USE_PRECOMPILED_MODULES=1` is set by EAS itself, and which modules actually resolve to a prebuilt artifact varies per build — several (`RNReanimated`, `RNScreens`, `RNSVG`, `RNCAsyncStorage`) 404 out of the artifact cache and silently fall back to source. That per-build variation is why this presented as intermittent rather than consistently broken, and it is worth knowing if similar header-not-found failures appear for other precompiled modules.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
