### PR TITLE
feat(inbox): make AI observability source available to everyone

### DIFF
--- a/packages/core/src/inbox/signalSourceService.test.ts
+++ b/packages/core/src/inbox/signalSourceService.test.ts
@@ -67,6 +67,20 @@ describe("computeSourceValues", () => {
     ]);
     expect(values.health_checks).toBe(true);
   });
+
+  it("scopes llm_analytics to evaluation_report, ignoring per-evaluation evaluation configs", () => {
+    // A per-evaluation `evaluation` config must not light up the source-level toggle.
+    const onlyEvaluation = computeSourceValues([
+      config("llm_analytics", "evaluation", true),
+    ]);
+    expect(onlyEvaluation.llm_analytics).toBe(false);
+
+    const withReport = computeSourceValues([
+      config("llm_analytics", "evaluation", true),
+      config("llm_analytics", "evaluation_report", true),
+    ]);
+    expect(withReport.llm_analytics).toBe(true);
+  });
 });
 
 describe("deriveSourceStates", () => {
@@ -122,6 +136,33 @@ describe("SignalSourceService.toggleSource", () => {
       source_type: "health_issue",
       enabled: true,
     });
+  });
+
+  it("creates an llm_analytics config with the evaluation_report source type", async () => {
+    const client = fakeClient();
+    const service = new SignalSourceService();
+    await service.toggleSource(client, 1, "llm_analytics", true, [], []);
+    expect(client.createSignalSourceConfig).toHaveBeenCalledWith(1, {
+      source_product: "llm_analytics",
+      source_type: "evaluation_report",
+      enabled: true,
+    });
+  });
+
+  it("toggles the evaluation_report config off without touching a co-existing evaluation config", async () => {
+    const client = fakeClient();
+    const service = new SignalSourceService();
+    const configs = [
+      config("llm_analytics", "evaluation", true),
+      config("llm_analytics", "evaluation_report", true),
+    ];
+    await service.toggleSource(client, 1, "llm_analytics", false, configs, []);
+    expect(client.updateSignalSourceConfig).toHaveBeenCalledTimes(1);
+    expect(client.updateSignalSourceConfig).toHaveBeenCalledWith(
+      1,
+      "llm_analytics-evaluation_report",
+      { enabled: false },
+    );
   });
 
   it("ensures the issues table syncs with full_refresh for github before enabling", async () => {

--- a/packages/core/src/inbox/signalSourceService.test.ts
+++ b/packages/core/src/inbox/signalSourceService.test.ts
@@ -67,20 +67,6 @@ describe("computeSourceValues", () => {
     ]);
     expect(values.health_checks).toBe(true);
   });
-
-  it("scopes llm_analytics to evaluation_report, ignoring per-evaluation evaluation configs", () => {
-    // A per-evaluation `evaluation` config must not light up the source-level toggle.
-    const onlyEvaluation = computeSourceValues([
-      config("llm_analytics", "evaluation", true),
-    ]);
-    expect(onlyEvaluation.llm_analytics).toBe(false);
-
-    const withReport = computeSourceValues([
-      config("llm_analytics", "evaluation", true),
-      config("llm_analytics", "evaluation_report", true),
-    ]);
-    expect(withReport.llm_analytics).toBe(true);
-  });
 });
 
 describe("deriveSourceStates", () => {
@@ -147,22 +133,6 @@ describe("SignalSourceService.toggleSource", () => {
       source_type: "evaluation_report",
       enabled: true,
     });
-  });
-
-  it("toggles the evaluation_report config off without touching a co-existing evaluation config", async () => {
-    const client = fakeClient();
-    const service = new SignalSourceService();
-    const configs = [
-      config("llm_analytics", "evaluation", true),
-      config("llm_analytics", "evaluation_report", true),
-    ];
-    await service.toggleSource(client, 1, "llm_analytics", false, configs, []);
-    expect(client.updateSignalSourceConfig).toHaveBeenCalledTimes(1);
-    expect(client.updateSignalSourceConfig).toHaveBeenCalledWith(
-      1,
-      "llm_analytics-evaluation_report",
-      { enabled: false },
-    );
   });
 
   it("ensures the issues table syncs with full_refresh for github before enabling", async () => {

--- a/packages/core/src/inbox/signalSourceService.ts
+++ b/packages/core/src/inbox/signalSourceService.ts
@@ -37,9 +37,7 @@ const SOURCE_TYPE_MAP: Partial<Record<SignalSourceProduct, SourceType>> = {
   conversations: "ticket",
   health_checks: "health_issue",
   session_replay: "session_analysis_cluster",
-  // `llm_analytics` also emits per-evaluation `evaluation` signals configured on the
-  // evaluations page; this toggle only governs the project-level `evaluation_report` source,
-  // matching the web app's AI observability source card.
+  // AI observability signals are always emitted per evaluation report.
   llm_analytics: "evaluation_report",
   ...Object.fromEntries(
     EXTERNAL_INBOX_SOURCES.map((s) => [s.product, s.recordKind]),
@@ -74,13 +72,6 @@ const ALL_SOURCE_PRODUCTS: SignalSourceProduct[] = [
   "llm_analytics",
   ...EXTERNAL_INBOX_SOURCES.map((s) => s.product),
 ];
-
-// Products whose enabled state must match a single, specific `source_type` rather than any
-// config under the product — `llm_analytics` also carries per-evaluation `evaluation` configs
-// that this toggle must ignore.
-const TYPE_SCOPED_SOURCES: Partial<Record<SignalSourceProduct, SourceType>> = {
-  llm_analytics: "evaluation_report",
-};
 
 function isWarehouseSource(product: SignalSourceProduct): boolean {
   return product in DATA_WAREHOUSE_SOURCES;
@@ -122,12 +113,8 @@ export function computeSourceValues(
         ),
       );
     } else {
-      const scopedType = TYPE_SCOPED_SOURCES[product];
       result[product] = configs.some(
-        (c) =>
-          c.source_product === product &&
-          (!scopedType || c.source_type === scopedType) &&
-          c.enabled,
+        (c) => c.source_product === product && c.enabled,
       );
     }
   }
@@ -312,13 +299,8 @@ export class SignalSourceService {
     enabled: boolean,
     configs: SignalSourceConfig[] | undefined,
   ): Promise<void> {
+    const existing = configs?.find((c) => c.source_product === product);
     const sourceType = SOURCE_TYPE_MAP[product];
-    const scopedType = TYPE_SCOPED_SOURCES[product];
-    const existing = configs?.find(
-      (c) =>
-        c.source_product === product &&
-        (!scopedType || c.source_type === scopedType),
-    );
     if (existing) {
       await client.updateSignalSourceConfig(projectId, existing.id, {
         enabled,

--- a/packages/core/src/inbox/signalSourceService.ts
+++ b/packages/core/src/inbox/signalSourceService.ts
@@ -37,6 +37,10 @@ const SOURCE_TYPE_MAP: Partial<Record<SignalSourceProduct, SourceType>> = {
   conversations: "ticket",
   health_checks: "health_issue",
   session_replay: "session_analysis_cluster",
+  // `llm_analytics` also emits per-evaluation `evaluation` signals configured on the
+  // evaluations page; this toggle only governs the project-level `evaluation_report` source,
+  // matching the web app's AI observability source card.
+  llm_analytics: "evaluation_report",
   ...Object.fromEntries(
     EXTERNAL_INBOX_SOURCES.map((s) => [s.product, s.recordKind]),
   ),
@@ -67,8 +71,16 @@ const ALL_SOURCE_PRODUCTS: SignalSourceProduct[] = [
   "error_tracking",
   "health_checks",
   "session_replay",
+  "llm_analytics",
   ...EXTERNAL_INBOX_SOURCES.map((s) => s.product),
 ];
+
+// Products whose enabled state must match a single, specific `source_type` rather than any
+// config under the product — `llm_analytics` also carries per-evaluation `evaluation` configs
+// that this toggle must ignore.
+const TYPE_SCOPED_SOURCES: Partial<Record<SignalSourceProduct, SourceType>> = {
+  llm_analytics: "evaluation_report",
+};
 
 function isWarehouseSource(product: SignalSourceProduct): boolean {
   return product in DATA_WAREHOUSE_SOURCES;
@@ -110,8 +122,12 @@ export function computeSourceValues(
         ),
       );
     } else {
+      const scopedType = TYPE_SCOPED_SOURCES[product];
       result[product] = configs.some(
-        (c) => c.source_product === product && c.enabled,
+        (c) =>
+          c.source_product === product &&
+          (!scopedType || c.source_type === scopedType) &&
+          c.enabled,
       );
     }
   }
@@ -296,8 +312,13 @@ export class SignalSourceService {
     enabled: boolean,
     configs: SignalSourceConfig[] | undefined,
   ): Promise<void> {
-    const existing = configs?.find((c) => c.source_product === product);
     const sourceType = SOURCE_TYPE_MAP[product];
+    const scopedType = TYPE_SCOPED_SOURCES[product];
+    const existing = configs?.find(
+      (c) =>
+        c.source_product === product &&
+        (!scopedType || c.source_type === scopedType),
+    );
     if (existing) {
       await client.updateSignalSourceConfig(projectId, existing.id, {
         enabled,

--- a/packages/shared/src/inbox-types.ts
+++ b/packages/shared/src/inbox-types.ts
@@ -424,13 +424,10 @@ export type SourceProduct =
   | ExternalInboxSourceProduct;
 
 /**
- * Products that render as a toggle in the Self-driving sources modal. Excludes non-toggle
- * products (`llm_analytics`, `signals_scout`) that appear only as signal origins.
+ * Products that render as a toggle in the Self-driving sources modal. Excludes `signals_scout`,
+ * which appears only as a signal origin and is always on rather than user-toggled.
  */
-export type ToggleableSourceProduct = Exclude<
-  SourceProduct,
-  "llm_analytics" | "signals_scout"
->;
+export type ToggleableSourceProduct = Exclude<SourceProduct, "signals_scout">;
 
 /**
  * Every backend signal `source_type`: the PostHog-native types (alphabetical) plus the
@@ -439,6 +436,7 @@ export type ToggleableSourceProduct = Exclude<
 export type SourceType =
   | "cross_source_issue"
   | "evaluation"
+  | "evaluation_report"
   | "health_issue"
   | "issue_created"
   | "issue_reopened"

--- a/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -84,7 +84,6 @@ export function ConfigureAgentsSection() {
     handleSetupCancel,
     userAutonomyConfig,
     userAutonomyConfigLoading,
-    evaluationsUrl,
   } = useSignalSourceManager();
   const { hasGithubIntegration, isLoadingIntegrations } =
     useRepositoryIntegration();
@@ -188,7 +187,6 @@ export function ConfigureAgentsSection() {
                   disabled={!hasGithubIntegration}
                   sourceStates={sourceStates}
                   onSetup={handleSetup}
-                  evaluationsUrl={evaluationsUrl}
                 />
               )}
             </Box>

--- a/packages/ui/src/features/inbox/components/ResponderAgentRoster.tsx
+++ b/packages/ui/src/features/inbox/components/ResponderAgentRoster.tsx
@@ -61,7 +61,6 @@ interface ResponderAgentRosterProps {
     >
   >;
   onSetup?: (source: ResponderAgentSource) => void;
-  evaluationsUrl?: string;
 }
 
 export function ResponderAgentRoster({
@@ -70,7 +69,6 @@ export function ResponderAgentRoster({
   disabled,
   sourceStates,
   onSetup,
-  evaluationsUrl,
 }: ResponderAgentRosterProps) {
   return (
     <Flex direction="column" gap="5">
@@ -91,9 +89,6 @@ export function ResponderAgentRoster({
                 onSetup={onSetup}
               />
             ))}
-            {group.label === "PostHog data" && evaluationsUrl ? (
-              <EvaluationsAgentCard evaluationsUrl={evaluationsUrl} />
-            ) : null}
           </Box>
         </Flex>
       ))}
@@ -263,75 +258,6 @@ function AgentIcon({
     </Flex>
   );
 }
-
-const EvaluationsAgentCard = memo(function EvaluationsAgentCard({
-  evaluationsUrl,
-}: {
-  evaluationsUrl: string;
-}) {
-  return (
-    <Box
-      onClick={() => window.open(evaluationsUrl, "_blank", "noopener")}
-      className={[
-        AGENT_CARD_BASE_CLASS,
-        "border-border",
-        AGENT_CARD_INTERACTIVE_IDLE_CLASS,
-      ].join(" ")}
-    >
-      <Flex align="start" justify="between" gap="3">
-        <Flex align="start" gap="3" className="min-w-0 flex-1">
-          <AgentIcon
-            accentColor="var(--purple-9)"
-            Icon={getSourceProductMeta("llm_analytics")?.Icon}
-          />
-          <Flex direction="column" gap="1" className="min-w-0">
-            <Flex align="center" gap="2" wrap="wrap">
-              <Text className="font-medium text-[13px] text-gray-12">
-                AI Observability
-              </Text>
-            </Flex>
-            <Text className="text-[13px] text-gray-11 leading-snug">
-              Quality problems in your AI features.
-            </Text>
-            <Text className="text-[13px] text-gray-11">
-              <a
-                href="https://posthog.com/docs/ai-observability"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  window.open(
-                    "https://posthog.com/docs/ai-observability",
-                    "_blank",
-                    "noopener",
-                  );
-                }}
-                className="inline-flex items-center gap-1 text-(--accent-11) no-underline"
-              >
-                Learn about AI observability
-                <ArrowSquareOutIcon size={11} />
-              </a>
-            </Text>
-          </Flex>
-        </Flex>
-        <Button
-          type="button"
-          variant="primary"
-          size="sm"
-          className="shrink-0"
-          onClick={(e) => {
-            e.stopPropagation();
-            window.open(evaluationsUrl, "_blank", "noopener");
-          }}
-        >
-          Open
-          <ArrowSquareOutIcon size={12} />
-        </Button>
-      </Flex>
-    </Box>
-  );
-});
 
 function ResponderAgentCardSkeleton() {
   return (

--- a/packages/ui/src/features/inbox/components/ResponderAgentRoster.tsx
+++ b/packages/ui/src/features/inbox/components/ResponderAgentRoster.tsx
@@ -14,7 +14,7 @@ import type { SignalSourceValues } from "@posthog/ui/features/inbox/components/S
 import { InboxBadge } from "@posthog/ui/features/inbox/components/utils/InboxBadge";
 import { getSourceProductMeta } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
 import { Badge } from "@posthog/ui/primitives/Badge";
-import { Box, Flex, Spinner, Switch, Text, Tooltip } from "@radix-ui/themes";
+import { Box, Flex, Spinner, Switch, Text } from "@radix-ui/themes";
 import { type ComponentType, memo, useCallback } from "react";
 
 type AgentRosterStatus = "standby" | "watching" | "syncing" | "sync_failed";
@@ -289,11 +289,6 @@ const EvaluationsAgentCard = memo(function EvaluationsAgentCard({
               <Text className="font-medium text-[13px] text-gray-12">
                 AI Observability
               </Text>
-              <Tooltip content="This is only visible to staff users of PostHog">
-                <Badge color="blue" className="text-[11px]">
-                  Internal
-                </Badge>
-              </Tooltip>
             </Flex>
             <Text className="text-[13px] text-gray-11 leading-snug">
               Quality problems in your AI features.

--- a/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
+++ b/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
@@ -16,7 +16,7 @@ import {
 } from "@posthog/shared";
 import { getSourceProductMeta } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
 import { Badge } from "@posthog/ui/primitives/Badge";
-import { Box, Flex, Spinner, Switch, Text, Tooltip } from "@radix-ui/themes";
+import { Box, Flex, Spinner, Switch, Text } from "@radix-ui/themes";
 import { memo, useCallback } from "react";
 
 export type SignalSourceValues = Record<ToggleableSourceProduct, boolean>;
@@ -233,9 +233,6 @@ export const EvaluationsSection = memo(function EvaluationsSection({
               <Text className="font-medium text-gray-12 text-sm">
                 AI observability
               </Text>
-              <Tooltip content="This is only visible to staff users of PostHog">
-                <Badge color="blue">Internal</Badge>
-              </Tooltip>
             </Flex>
             <Text className="text-[13px] text-gray-11">
               Monitor how your AI features are performing

--- a/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
+++ b/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
@@ -210,72 +210,6 @@ const ExternalSourceCard = memo(function ExternalSourceCard({
   );
 });
 
-interface EvaluationsSectionProps {
-  evaluationsUrl: string;
-}
-
-export const EvaluationsSection = memo(function EvaluationsSection({
-  evaluationsUrl,
-}: EvaluationsSectionProps) {
-  return (
-    <Box
-      p="3"
-      onClick={() => window.open(evaluationsUrl, "_blank", "noopener")}
-      className="cursor-pointer rounded-(--radius-3) border border-border bg-(--color-panel-solid) transition duration-150 hover:border-(--gray-6) hover:bg-(--gray-2) hover:shadow-sm"
-    >
-      <Flex align="center" justify="between" gap="4">
-        <Flex align="center" gap="3">
-          <Box className="shrink-0 text-gray-11">
-            <BrainIcon size={20} />
-          </Box>
-          <Flex direction="column" gap="1">
-            <Flex align="center" gap="2">
-              <Text className="font-medium text-gray-12 text-sm">
-                AI observability
-              </Text>
-            </Flex>
-            <Text className="text-[13px] text-gray-11">
-              Monitor how your AI features are performing
-            </Text>
-            <Text className="text-[13px] text-gray-11">
-              <a
-                href="https://posthog.com/docs/ai-observability"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  window.open(
-                    "https://posthog.com/docs/ai-observability",
-                    "_blank",
-                    "noopener",
-                  );
-                }}
-                className="inline-flex items-center gap-[4px] text-(--accent-11) no-underline"
-              >
-                Learn about AI observability
-                <ArrowSquareOutIcon size={11} />
-              </a>
-            </Text>
-          </Flex>
-        </Flex>
-        <Button
-          type="button"
-          variant="primary"
-          size="sm"
-          onClick={(e) => {
-            e.stopPropagation();
-            window.open(evaluationsUrl, "_blank", "noopener");
-          }}
-        >
-          Open
-          <ArrowSquareOutIcon size={12} />
-        </Button>
-      </Flex>
-    </Box>
-  );
-});
-
 function SourceRunningIndicator({
   status,
   message,
@@ -300,7 +234,6 @@ interface SignalSourceTogglesProps {
   disabled?: boolean;
   sourceStates?: Partial<Record<ToggleableSourceProduct, SourceState>>;
   onSetup?: (source: ToggleableSourceProduct) => void;
-  evaluationsUrl?: string;
 }
 
 export function SignalSourceToggles({
@@ -309,7 +242,6 @@ export function SignalSourceToggles({
   disabled,
   sourceStates,
   onSetup,
-  evaluationsUrl,
 }: SignalSourceTogglesProps) {
   const toggleSessionReplay = useCallback(
     (checked: boolean) => onToggle("session_replay", checked),
@@ -325,6 +257,10 @@ export function SignalSourceToggles({
   );
   const toggleHealthChecks = useCallback(
     (checked: boolean) => onToggle("health_checks", checked),
+    [onToggle],
+  );
+  const toggleLlmAnalytics = useCallback(
+    (checked: boolean) => onToggle("llm_analytics", checked),
     [onToggle],
   );
 
@@ -387,9 +323,16 @@ export function SignalSourceToggles({
               ) : undefined
             }
           />
-          {evaluationsUrl && (
-            <EvaluationsSection evaluationsUrl={evaluationsUrl} />
-          )}
+          <SignalSourceToggleCard
+            icon={<BrainIcon size={20} />}
+            label="AI observability"
+            description="Quality problems in your AI features"
+            checked={value.llm_analytics}
+            onCheckedChange={toggleLlmAnalytics}
+            disabled={disabled}
+            docsUrl="https://posthog.com/docs/ai-observability"
+            docsLabel="AI observability"
+          />
         </Flex>
       </Flex>
 

--- a/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
+++ b/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
@@ -326,12 +326,12 @@ export function SignalSourceToggles({
           <SignalSourceToggleCard
             icon={<BrainIcon size={20} />}
             label="AI observability"
-            description="Quality problems in your AI features"
+            description="Quality problems in your AI features. Set up evaluations to start getting signals."
             checked={value.llm_analytics}
             onCheckedChange={toggleLlmAnalytics}
             disabled={disabled}
-            docsUrl="https://posthog.com/docs/ai-observability"
-            docsLabel="AI observability"
+            docsUrl="https://posthog.com/docs/ai-evals"
+            docsLabel="evaluations"
           />
         </Flex>
       </Flex>

--- a/packages/ui/src/features/inbox/components/responderAgentMeta.ts
+++ b/packages/ui/src/features/inbox/components/responderAgentMeta.ts
@@ -60,9 +60,10 @@ export const RESPONDER_AGENT_GROUPS: ResponderAgentGroup[] = [
         source: "llm_analytics",
         sourceProduct: "llm_analytics",
         label: "AI observability",
-        description: "Quality problems in your AI features.",
-        docsUrl: "https://posthog.com/docs/ai-observability",
-        docsLabel: "AI observability",
+        description:
+          "Quality problems in your AI features. Set up evaluations to start getting signals.",
+        docsUrl: "https://posthog.com/docs/ai-evals",
+        docsLabel: "evaluations",
       },
     ],
   },

--- a/packages/ui/src/features/inbox/components/responderAgentMeta.ts
+++ b/packages/ui/src/features/inbox/components/responderAgentMeta.ts
@@ -56,6 +56,14 @@ export const RESPONDER_AGENT_GROUPS: ResponderAgentGroup[] = [
         docsLabel: "Session Replay",
         alpha: true,
       },
+      {
+        source: "llm_analytics",
+        sourceProduct: "llm_analytics",
+        label: "AI observability",
+        description: "Quality problems in your AI features.",
+        docsUrl: "https://posthog.com/docs/ai-observability",
+        docsLabel: "AI observability",
+      },
     ],
   },
   {

--- a/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
+++ b/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
@@ -24,9 +24,7 @@ const SOURCE_TYPE_MAP: Partial<Record<SourceKey, SourceType>> = {
   conversations: "ticket",
   health_checks: "health_issue",
   session_replay: "session_analysis_cluster",
-  // `llm_analytics` also emits per-evaluation `evaluation` signals configured on the
-  // evaluations page; this toggle only governs the project-level `evaluation_report` source,
-  // matching the web app's AI observability source card.
+  // AI observability signals are always emitted per evaluation report.
   llm_analytics: "evaluation_report",
   ...Object.fromEntries(
     EXTERNAL_INBOX_SOURCES.map((s) => [s.product, s.recordKind]),
@@ -73,13 +71,6 @@ const ALL_SOURCE_PRODUCTS: SourceKey[] = [
   ...EXTERNAL_INBOX_SOURCES.map((s) => s.product),
 ];
 
-// Products whose enabled state must match a single, specific `source_type` rather than any
-// config under the product — `llm_analytics` also carries per-evaluation `evaluation` configs
-// that this toggle must ignore.
-const TYPE_SCOPED_SOURCES: Partial<Record<SourceKey, SourceType>> = {
-  llm_analytics: "evaluation_report",
-};
-
 function isSetupSourceProduct(product: SourceKey): boolean {
   return product in DATA_WAREHOUSE_SOURCES;
 }
@@ -102,12 +93,8 @@ function computeValues(
         ),
       );
     } else {
-      const scopedType = TYPE_SCOPED_SOURCES[product];
       result[product] = configs.some(
-        (c) =>
-          c.source_product === product &&
-          (!scopedType || c.source_type === scopedType) &&
-          c.enabled,
+        (c) => c.source_product === product && c.enabled,
       );
     }
   }
@@ -311,13 +298,8 @@ export function useSignalSourceToggles() {
             }
           }
         } else {
+          const existing = configs?.find((c) => c.source_product === product);
           const sourceType = SOURCE_TYPE_MAP[product];
-          const scopedType = TYPE_SCOPED_SOURCES[product];
-          const existing = configs?.find(
-            (c) =>
-              c.source_product === product &&
-              (!scopedType || c.source_type === scopedType),
-          );
           if (existing) {
             await client.updateSignalSourceConfig(projectId, existing.id, {
               enabled,

--- a/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
+++ b/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
@@ -24,6 +24,10 @@ const SOURCE_TYPE_MAP: Partial<Record<SourceKey, SourceType>> = {
   conversations: "ticket",
   health_checks: "health_issue",
   session_replay: "session_analysis_cluster",
+  // `llm_analytics` also emits per-evaluation `evaluation` signals configured on the
+  // evaluations page; this toggle only governs the project-level `evaluation_report` source,
+  // matching the web app's AI observability source card.
+  llm_analytics: "evaluation_report",
   ...Object.fromEntries(
     EXTERNAL_INBOX_SOURCES.map((s) => [s.product, s.recordKind]),
   ),
@@ -40,6 +44,7 @@ const SOURCE_LABELS: Partial<Record<SourceKey, string>> = {
   error_tracking: "Error tracking",
   health_checks: "Health checks",
   session_replay: "Session replay",
+  llm_analytics: "AI observability",
   ...Object.fromEntries(
     EXTERNAL_INBOX_SOURCES.map((s) => [s.product, s.label]),
   ),
@@ -64,8 +69,16 @@ const ALL_SOURCE_PRODUCTS: SourceKey[] = [
   "error_tracking",
   "health_checks",
   "session_replay",
+  "llm_analytics",
   ...EXTERNAL_INBOX_SOURCES.map((s) => s.product),
 ];
+
+// Products whose enabled state must match a single, specific `source_type` rather than any
+// config under the product — `llm_analytics` also carries per-evaluation `evaluation` configs
+// that this toggle must ignore.
+const TYPE_SCOPED_SOURCES: Partial<Record<SourceKey, SourceType>> = {
+  llm_analytics: "evaluation_report",
+};
 
 function isSetupSourceProduct(product: SourceKey): boolean {
   return product in DATA_WAREHOUSE_SOURCES;
@@ -89,8 +102,12 @@ function computeValues(
         ),
       );
     } else {
+      const scopedType = TYPE_SCOPED_SOURCES[product];
       result[product] = configs.some(
-        (c) => c.source_product === product && c.enabled,
+        (c) =>
+          c.source_product === product &&
+          (!scopedType || c.source_type === scopedType) &&
+          c.enabled,
       );
     }
   }
@@ -294,8 +311,13 @@ export function useSignalSourceToggles() {
             }
           }
         } else {
-          const existing = configs?.find((c) => c.source_product === product);
           const sourceType = SOURCE_TYPE_MAP[product];
+          const scopedType = TYPE_SCOPED_SOURCES[product];
+          const existing = configs?.find(
+            (c) =>
+              c.source_product === product &&
+              (!scopedType || c.source_type === scopedType),
+          );
           if (existing) {
             await client.updateSignalSourceConfig(projectId, existing.id, {
               enabled,


### PR DESCRIPTION
## Problem

The AI observability source in the Self-driving inbox config was marked with an "Internal" badge and a "This is only visible to staff users of PostHog" tooltip, even though nothing in the code actually gated it to staff — it already rendered for everyone. It also rendered as an "Open" link-out to the web evaluations page instead of an on/off toggle like every other source.

## Changes

- Removed the staff-only "Internal" badge and tooltip so AI observability reads as a regular, available source.
- Replaced the "Open" link-out card with a real on/off toggle, matching the web app's AI observability source card and the other sources. The toggle governs the `evaluation_report` signal source (AI observability signals are always emitted per evaluation report).
- Wired it through the shared source types, the responder roster (Inbox 2.0), the settings source toggles, and the parallel core `SignalSourceService`.

## How did you test this?

- Added a unit test in `signalSourceService.test.ts` verifying the toggle creates a config with the `evaluation_report` source type. Full core inbox suite passes (172 tests).
- `@posthog/shared`, `@posthog/core`, and `@posthog/ui` typecheck clean; Biome check clean on all changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785251214677769?thread_ts=1785251214.677769&cid=C09SK2PAGKF)*