### PR TITLE
fix(deps): bump simple-git, tar, minimatch to patch critical CVEs (CVSS 9.8, 9.2, 8.7)

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -188,9 +188,9 @@
     "fflate": "^0.8.2",
     "hono": "^4.11.7",
     "jsonwebtoken": "^9.0.2",
-    "minimatch": "^10.0.3",
+    "minimatch": "^10.2.5",
     "@modelcontextprotocol/sdk": "1.29.0",
-    "tar": "^7.5.0",
+    "tar": "^7.5.22",
     "uuid": "13.0.0",
     "yoga-wasm-web": "^0.3.3",
     "zod": "^4.2.0"

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "@posthog/shared": "workspace:*",
     "git-url-parse": "^16.1.0",
-    "simple-git": "^3.30.0"
+    "simple-git": "^3.36.0"
   }
 }


### PR DESCRIPTION
Automated dependency bump to address 9 publicly-disclosed advisories in 3 direct dependencies. No code changes outside the manifests; run `pnpm install` to refresh the lockfile.

## simple-git 3.30.0 → 3.36.0 (packages/git)

- [GHSA-hffm-xvc3-vprc](https://github.com/advisories/GHSA-hffm-xvc3-vprc) (CVE-2026-6951, CVSS 9.8): RCE via `--config` option bypass (incomplete fix for CVE-2022-25912)
- [GHSA-r275-fr43-pm7q](https://github.com/advisories/GHSA-r275-fr43-pm7q) (CVE-2026-28292, CVSS 9.8): RCE via `blockUnsafeOperationsPlugin` bypass with uppercase `PROTOCOL.ALLOW`
- [GHSA-jcxm-m3jx-f287](https://github.com/advisories/GHSA-jcxm-m3jx-f287) (CVE-2026-28291, CVSS 8.1): Command execution via upload-pack option-parsing bypass (`-vu`, `-4u`, etc.)

All three advisories are fixed in 3.36.0.

## tar 7.5.7 → 7.5.22 (packages/agent)

- [GHSA-23hp-3jrh-7fpw](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) (CVE-2026-59873, CVSS 9.2): Gzip bomb DoS — no bounds on decompressed archive size
- [GHSA-8x88-c5mf-7j5w](https://github.com/advisories/GHSA-8x88-c5mf-7j5w) (CVE-2026-59874, CVSS 8.7): Infinite loop via negative tar entry size in `tar.replace()`
- [GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m) (Moderate): Stack-overflow DoS via long-path tar with member selection

All fixed by 7.5.22 (latest stable).

## minimatch 10.1.2 → 10.2.5 (packages/agent)

- [GHSA-3ppc-4f35-3m26](https://github.com/advisories/GHSA-3ppc-4f35-3m26) (CVE-2026-26996, CVSS 8.7): ReDoS via repeated wildcards — O(4^N) complexity
- [GHSA-23c5-xmqv-rm74](https://github.com/advisories/GHSA-23c5-xmqv-rm74) (High): ReDoS via nested `*()` extglobs
- [GHSA-7r86-cg39-jmmj](https://github.com/advisories/GHSA-7r86-cg39-jmmj) (High): ReDoS via multiple GLOBSTAR segments

10.2.5 is clean; it is already in the lockfile as a transitive dep — this aligns the declared range.

## Lockfile

After merging, run `pnpm install` at the repo root to resolve the new versions and update `pnpm-lock.yaml`.

---

Detected by [osv-scanner](https://google.github.io/osv-scanner/) via [Aeon](https://github.com/aeonframework/aeon).
