### PR TITLE
test: verify PR output remains immutable

### DIFF
--- a/packages/shared/src/pr-urls.test.ts
+++ b/packages/shared/src/pr-urls.test.ts
@@ -137,4 +137,12 @@ describe("buildPrOutput", () => {
       pr_urls: [A],
     });
   });
+
+  it("does not mutate the existing output", () => {
+    const existing = { pr_url: B, pr_urls: [B] };
+
+    buildPrOutput(existing, [A]);
+
+    expect(existing).toEqual({ pr_url: B, pr_urls: [B] });
+  });
 });


### PR DESCRIPTION
## Problem

The PR output utility should remain a pure transformation so callers can safely reuse their existing output objects.

## Changes

Add a regression test confirming `buildPrOutput` does not mutate its input.

## How did you test this?

- `git diff --check`
- Automated test not run: repository dependencies are not installed, so `biome` and `vitest` are unavailable.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*