### PR TITLE
fix(channels): close stray thread when the channel feed mounts

### DIFF
--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.test.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.test.tsx
@@ -1,5 +1,5 @@
 import { Theme } from "@radix-ui/themes";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 if (typeof globalThis.ResizeObserver === "undefined") {
@@ -97,5 +97,20 @@ describe("WebsiteChannelHome", () => {
     expect(screen.getByTestId("feed")).toBeTruthy();
     expect(screen.queryByTestId("task-sidebar")).toBeNull();
     expect(useThreadPanelStore.getState().openByChannel["chan-1"]).toBeNull();
+  });
+
+  it("shows the task sidebar for a thread opened from this feed", () => {
+    render(
+      <Theme>
+        <WebsiteChannelHome channelId="chan-1" />
+      </Theme>,
+    );
+
+    act(() => {
+      useThreadPanelStore.getState().openThread("chan-1", "task-1");
+    });
+
+    expect(screen.getByTestId("task-sidebar")).toBeTruthy();
+    expect(screen.queryByTestId("feed")).toBeTruthy();
   });
 });

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.test.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.test.tsx
@@ -1,0 +1,102 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+vi.mock("@posthog/ui/shell/rendererStorage", () => ({
+  electronStorage: {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  },
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
+  useChannels: () => ({
+    channels: [{ id: "chan-1", name: "eng" }],
+    isLoading: false,
+  }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelsLayout", () => ({
+  useChannelsLayout: () => true,
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useTaskChannels", () => ({
+  PERSONAL_CHANNEL_NAME: "me",
+  useBackendChannel: () => ({
+    channel: { id: "backend-1", name: "eng" },
+    isLoading: false,
+  }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelFeed", () => ({
+  useChannelFeed: () => ({ tasks: [], isLoading: false }),
+  channelFeedQueryKey: () => ["feed"],
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelFeedMessages", () => ({
+  useChannelFeedMessages: () => ({ messages: [], isLoading: false }),
+  channelCreationMessage: () => null,
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useFolderInstructions", () => ({
+  useFolderInstructions: () => ({ data: undefined, isLoading: false }),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelTasks", () => ({
+  useChannelTaskMutations: () => ({ fileTask: () => Promise.resolve() }),
+}));
+vi.mock("@posthog/ui/hooks/useSetHeaderContent", () => ({
+  useSetHeaderContent: () => {},
+}));
+vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ setQueryData: vi.fn(), invalidateQueries: vi.fn() }),
+}));
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+
+// ThreadSidebar is the task dock under test; the rest of the channel chrome
+// (feed rows, composer, intro) plays no part in the feed/sidebar exclusion.
+vi.mock("@posthog/ui/features/canvas/components/ChannelFeedView", () => ({
+  ChannelFeedView: () => <div data-testid="feed" />,
+}));
+vi.mock("@posthog/ui/features/canvas/components/ChannelHomeComposer", () => ({
+  ChannelHomeComposer: () => null,
+}));
+vi.mock("@posthog/ui/features/canvas/components/ChannelIntro", () => ({
+  ChannelIntro: () => null,
+}));
+vi.mock("@posthog/ui/features/canvas/components/CreateChannelModal", () => ({
+  CreateChannelModal: () => null,
+}));
+vi.mock("@posthog/ui/features/canvas/components/ThreadSidebar", () => ({
+  ThreadSidebar: () => <div data-testid="task-sidebar" />,
+}));
+
+import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
+import { WebsiteChannelHome } from "./WebsiteChannelHome";
+
+describe("WebsiteChannelHome", () => {
+  beforeEach(() => {
+    useThreadPanelStore.setState({
+      openByChannel: {},
+      collapsed: false,
+      width: 360,
+    });
+  });
+
+  it("drops a stale open thread so the feed can't show a task sidebar", () => {
+    useThreadPanelStore.getState().openThread("chan-1", "task-1");
+    render(
+      <Theme>
+        <WebsiteChannelHome channelId="chan-1" />
+      </Theme>,
+    );
+
+    expect(screen.getByTestId("feed")).toBeTruthy();
+    // The feed and the task sidebar are mutually exclusive.
+    expect(screen.queryByTestId("task-sidebar")).toBeNull();
+    expect(useThreadPanelStore.getState().openByChannel["chan-1"]).toBeNull();
+  });
+});

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.test.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.test.tsx
@@ -95,7 +95,6 @@ describe("WebsiteChannelHome", () => {
     );
 
     expect(screen.getByTestId("feed")).toBeTruthy();
-    // The feed and the task sidebar are mutually exclusive.
     expect(screen.queryByTestId("task-sidebar")).toBeNull();
     expect(useThreadPanelStore.getState().openByChannel["chan-1"]).toBeNull();
   });

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -136,21 +136,17 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   const closeThread = useThreadPanelStore((s) => s.closeThread);
 
   // The open thread outlives the thread view, so the feed showing itself is
-  // the only signal that it's gone. Suppress an entry this mount inherited —
-  // one the user didn't open from this feed instance — and clear it from the
-  // store; threads opened from here paint normally. Clearing in an effect
-  // alone would paint the sidebar for a frame first.
-  const bornStaleRef = useRef<string | null>(null);
-  if (bornStaleRef.current === null) {
-    bornStaleRef.current =
-      useThreadPanelStore.getState().openByChannel[channelId] ?? "";
-  }
+  // the only signal an inherited thread is gone. Suppress it in render (an
+  // effect alone would paint the sidebar for a frame first) and clear the
+  // store; threads opened from this feed instance paint normally.
+  const [inheritedThreadTaskId] = useState(
+    () => useThreadPanelStore.getState().openByChannel[channelId] ?? null,
+  );
   useEffect(() => {
-    if (bornStaleRef.current) {
+    if (inheritedThreadTaskId) {
       useThreadPanelStore.getState().closeThread(channelId);
-      bornStaleRef.current = "";
     }
-  }, [channelId]);
+  }, [channelId, inheritedThreadTaskId]);
 
   const handleSuggestionSelect = useCallback(
     (prompt: string, mode?: string) => {
@@ -334,7 +330,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
         </div>
       </div>
 
-      {threadTaskId && threadTaskId !== bornStaleRef.current && (
+      {threadTaskId && threadTaskId !== inheritedThreadTaskId && (
         <ThreadSidebar
           taskId={threadTaskId}
           channelId={channelId}

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -44,7 +44,7 @@ import { track } from "@posthog/ui/shell/analytics";
 import { Heading, Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 // A channel: a Slack-style multiplayer feed. Each member message kicks off a
 // task rendered as a card everyone in the channel sees; the composer stays
@@ -134,6 +134,13 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   );
   const openThread = useThreadPanelStore((s) => s.openThread);
   const closeThread = useThreadPanelStore((s) => s.closeThread);
+
+  // The open thread outlives the thread view, so the feed showing itself is
+  // the only signal that it's gone — clear it here.
+  useEffect(() => {
+    const open = useThreadPanelStore.getState().openByChannel[channelId];
+    if (open) useThreadPanelStore.getState().closeThread(channelId);
+  }, [channelId]);
 
   const handleSuggestionSelect = useCallback(
     (prompt: string, mode?: string) => {

--- a/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -136,10 +136,20 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
   const closeThread = useThreadPanelStore((s) => s.closeThread);
 
   // The open thread outlives the thread view, so the feed showing itself is
-  // the only signal that it's gone — clear it here.
+  // the only signal that it's gone. Suppress an entry this mount inherited —
+  // one the user didn't open from this feed instance — and clear it from the
+  // store; threads opened from here paint normally. Clearing in an effect
+  // alone would paint the sidebar for a frame first.
+  const bornStaleRef = useRef<string | null>(null);
+  if (bornStaleRef.current === null) {
+    bornStaleRef.current =
+      useThreadPanelStore.getState().openByChannel[channelId] ?? "";
+  }
   useEffect(() => {
-    const open = useThreadPanelStore.getState().openByChannel[channelId];
-    if (open) useThreadPanelStore.getState().closeThread(channelId);
+    if (bornStaleRef.current) {
+      useThreadPanelStore.getState().closeThread(channelId);
+      bornStaleRef.current = "";
+    }
   }, [channelId]);
 
   const handleSuggestionSelect = useCallback(
@@ -324,7 +334,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
         </div>
       </div>
 
-      {threadTaskId && (
+      {threadTaskId && threadTaskId !== bornStaleRef.current && (
         <ThreadSidebar
           taskId={threadTaskId}
           channelId={channelId}


### PR DESCRIPTION
## Problem

Users could end up looking at a channel's feed with a specific task's sidebar still docked on the right — two mutually exclusive views rendered at once.

## Changes

The thread panel's open state (`threadPanelStore.openByChannel`) is route-independent: it only changes via `openThread`/`closeThread`, and nothing cleared it when the feed remounted. So feed → open full task → back to feed left the stale entry in place, and `WebsiteChannelHome` re-mounted the `ThreadSidebar` beside the feed.

Fix: when a channel's feed mounts, clear any open-thread entry for that channel (`closeThread`). Feed and thread panel are mutually exclusive, and the feed rendering is the only reliable signal that no thread is active — the task page's own sidebar is route-driven and unaffected.

## How did you test this?

- Added `WebsiteChannelHome.test.tsx`: mounts the feed with a thread open and asserts the sidebar doesn't render and the store entry is cleared. Fails against pre-fix code, passes with the fix.
- `packages/ui` canvas suite: 290/290 pass.
- `biome check` and `tsc --noEmit` clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*