### PR TITLE
fix(canvas): fix the Activity bell's hover card resurfacing, and wedging, after it navigates

### DIFF
--- a/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
@@ -74,26 +74,51 @@ describe("ChannelNav", () => {
 
     const activity = screen.getByLabelText("Activity");
     expect(activity).toBeEnabled();
+    expect(activity).not.toHaveAttribute("aria-haspopup");
     await user.hover(activity);
 
     await new Promise((resolve) => setTimeout(resolve, 400));
     expect(screen.queryByText("Recent activity card")).not.toBeInTheDocument();
   });
 
-  it("does not resurface the hover card after the bell navigated to Activity", async () => {
+  it("leaves no popover state on the bell after it navigates to Activity", async () => {
     const user = userEvent.setup();
     const { rerender } = render(<ChannelNav />);
+    const bell = () => screen.getByLabelText("Activity");
 
-    await user.click(screen.getByLabelText("Activity"));
+    await user.hover(bell());
+    await screen.findByText("Recent activity card", {}, { timeout: 1_000 });
+    await user.click(bell());
     mocks.view = { type: "activity" };
     rerender(<ChannelNav />);
-    expect(screen.queryByText("Recent activity card")).not.toBeInTheDocument();
 
-    // Opening a notification from the Activity page navigates to its task.
+    expect(screen.queryByText("Recent activity card")).not.toBeInTheDocument();
+    expect(bell()).not.toHaveAttribute("data-popup-open");
+    expect(bell()).not.toHaveAttribute("data-pressed");
+  });
+
+  it("neither resurfaces nor wedges the hover card once the bell has navigated", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<ChannelNav />);
+    const bell = () => screen.getByLabelText("Activity");
+
+    await user.hover(bell());
+    await user.click(bell());
+    mocks.view = { type: "activity" };
+    rerender(<ChannelNav />);
+    await user.unhover(bell());
+
+    // Opening a notification from the Activity page navigates to its task: the
+    // card must not come along for the ride.
     mocks.view = { type: "task-detail" };
     rerender(<ChannelNav />);
-
     await new Promise((resolve) => setTimeout(resolve, 400));
     expect(screen.queryByText("Recent activity card")).not.toBeInTheDocument();
+
+    // ...and hover must still work there.
+    await user.hover(bell());
+    expect(
+      await screen.findByText("Recent activity card", {}, { timeout: 1_000 }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
@@ -79,4 +79,21 @@ describe("ChannelNav", () => {
     await new Promise((resolve) => setTimeout(resolve, 400));
     expect(screen.queryByText("Recent activity card")).not.toBeInTheDocument();
   });
+
+  it("does not resurface the hover card after the bell navigated to Activity", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<ChannelNav />);
+
+    await user.click(screen.getByLabelText("Activity"));
+    mocks.view = { type: "activity" };
+    rerender(<ChannelNav />);
+    expect(screen.queryByText("Recent activity card")).not.toBeInTheDocument();
+
+    // Opening a notification from the Activity page navigates to its task.
+    mocks.view = { type: "task-detail" };
+    rerender(<ChannelNav />);
+
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(screen.queryByText("Recent activity card")).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelNav.test.tsx
@@ -108,14 +108,11 @@ describe("ChannelNav", () => {
     rerender(<ChannelNav />);
     await user.unhover(bell());
 
-    // Opening a notification from the Activity page navigates to its task: the
-    // card must not come along for the ride.
     mocks.view = { type: "task-detail" };
     rerender(<ChannelNav />);
     await new Promise((resolve) => setTimeout(resolve, 400));
     expect(screen.queryByText("Recent activity card")).not.toBeInTheDocument();
 
-    // ...and hover must still work there.
     await user.hover(bell());
     expect(
       await screen.findByText("Recent activity card", {}, { timeout: 1_000 }),

--- a/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -138,12 +138,6 @@ function NavButton({
   );
 }
 
-// Only mounted off the Activity page, so the card's open state is born fresh on
-// every visit. That matters because refusing an open is not free: quill's
-// trigger applies it internally before we see it, so a `false` we hand back
-// leaves the trigger stuck in its pressed state with hover-open dead until it
-// remounts. Nothing here refuses one — the click prevents the trigger's own
-// open, and the Activity page renders the bell without a popover at all.
 function ActivityHoverPopover({ trigger }: { trigger: ReactElement }) {
   const [open, setOpen] = useState(false);
 

--- a/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -41,8 +41,8 @@ import { useAppView } from "@posthog/ui/router/useAppView";
 import { track } from "@posthog/ui/shell/analytics";
 import {
   type ComponentPropsWithRef,
+  type ReactElement,
   type ReactNode,
-  useRef,
   useState,
 } from "react";
 import { ActivityHoverCard } from "./ActivityHoverCard";
@@ -138,6 +138,54 @@ function NavButton({
   );
 }
 
+// Only mounted off the Activity page, so the card's open state is born fresh on
+// every visit. That matters because refusing an open is not free: quill's
+// trigger applies it internally before we see it, so a `false` we hand back
+// leaves the trigger stuck in its pressed state with hover-open dead until it
+// remounts. Nothing here refuses one — the click prevents the trigger's own
+// open, and the Activity page renders the bell without a popover at all.
+function ActivityHoverPopover({ trigger }: { trigger: ReactElement }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        openOnHover
+        delay={300}
+        closeDelay={100}
+        onClick={(event) => event.preventBaseUIHandler()}
+        render={trigger}
+      />
+      {open && (
+        <ActivityHoverCard side="bottom" onClose={() => setOpen(false)} />
+      )}
+    </Popover>
+  );
+}
+
+function ActivityNavItem({
+  isActive,
+  unreadCount,
+  onNavigate,
+}: {
+  isActive: boolean;
+  unreadCount: number;
+  onNavigate: () => void;
+}) {
+  const bell = (
+    <NavButton
+      icon={<BellIcon size={16} weight={isActive ? "fill" : "regular"} />}
+      label="Activity"
+      isActive={isActive}
+      onClick={onNavigate}
+      badge={<CountBadge count={unreadCount} className={ICON_BADGE_CLASS} />}
+    />
+  );
+
+  if (isActive) return bell;
+  return <ActivityHoverPopover trigger={bell} />;
+}
+
 export function ChannelNav() {
   const view = useAppView();
   const loopsEnabled = useFeatureFlag(LOOPS_FLAG, import.meta.env.DEV);
@@ -162,15 +210,6 @@ export function ChannelNav() {
   const isActivity = view.type === "activity";
   const isCommandCenter = view.type === "command-center";
 
-  // Clicking the bell navigates to Activity, but quill's trigger runs its own
-  // open after our handler and still inside the same click, so `isActivity` is
-  // false and the card records itself as open. The Activity page then only hides
-  // it, and it resurfaces over the next page you open. Swallowing that one open
-  // is what the ref is for — the sidebar's Activity row does the same.
-  const [activityOpen, setActivityOpen] = useState(false);
-  const suppressClickOpenRef = useRef(false);
-  const activityCardOpen = activityOpen && !isActivity;
-
   return (
     // One provider for the row: once any tooltip is up, moving to its
     // neighbour reveals that one immediately instead of serving the warm-up
@@ -191,50 +230,11 @@ export function ChannelNav() {
             <CountBadge count={counts.pulls} className={ICON_BADGE_CLASS} />
           }
         />
-        <Popover
-          open={activityCardOpen}
-          onOpenChange={(open) => {
-            const suppressed = open && suppressClickOpenRef.current;
-            suppressClickOpenRef.current = false;
-            if (suppressed) return;
-            setActivityOpen(!isActivity && open);
-          }}
-        >
-          <PopoverTrigger
-            openOnHover
-            delay={300}
-            closeDelay={100}
-            render={
-              <NavButton
-                icon={
-                  <BellIcon
-                    size={16}
-                    weight={isActivity ? "fill" : "regular"}
-                  />
-                }
-                label="Activity"
-                isActive={isActivity}
-                onClick={() => {
-                  suppressClickOpenRef.current = true;
-                  setActivityOpen(false);
-                  withTrack("activity", navigateToActivity)();
-                }}
-                badge={
-                  <CountBadge
-                    count={unseenActivity}
-                    className={ICON_BADGE_CLASS}
-                  />
-                }
-              />
-            }
-          />
-          {activityCardOpen && (
-            <ActivityHoverCard
-              side="bottom"
-              onClose={() => setActivityOpen(false)}
-            />
-          )}
-        </Popover>
+        <ActivityNavItem
+          isActive={isActivity}
+          unreadCount={unseenActivity}
+          onNavigate={withTrack("activity", navigateToActivity)}
+        />
         <NavIcon
           icon={
             <Lightning

--- a/packages/ui/src/features/canvas/components/ChannelNav.tsx
+++ b/packages/ui/src/features/canvas/components/ChannelNav.tsx
@@ -39,7 +39,12 @@ import {
 } from "@posthog/ui/router/navigationBridge";
 import { useAppView } from "@posthog/ui/router/useAppView";
 import { track } from "@posthog/ui/shell/analytics";
-import { type ComponentPropsWithRef, type ReactNode, useState } from "react";
+import {
+  type ComponentPropsWithRef,
+  type ReactNode,
+  useRef,
+  useState,
+} from "react";
 import { ActivityHoverCard } from "./ActivityHoverCard";
 
 const INBOX_REFETCH_INTERVAL_MS = 60_000;
@@ -136,7 +141,6 @@ function NavButton({
 export function ChannelNav() {
   const view = useAppView();
   const loopsEnabled = useFeatureFlag(LOOPS_FLAG, import.meta.env.DEV);
-  const [activityOpen, setActivityOpen] = useState(false);
 
   const { counts } = useInboxAllReports({
     ignoreFilters: true,
@@ -157,6 +161,15 @@ export function ChannelNav() {
   const isInbox = view.type === "inbox";
   const isActivity = view.type === "activity";
   const isCommandCenter = view.type === "command-center";
+
+  // Clicking the bell navigates to Activity, but quill's trigger runs its own
+  // open after our handler and still inside the same click, so `isActivity` is
+  // false and the card records itself as open. The Activity page then only hides
+  // it, and it resurfaces over the next page you open. Swallowing that one open
+  // is what the ref is for — the sidebar's Activity row does the same.
+  const [activityOpen, setActivityOpen] = useState(false);
+  const suppressClickOpenRef = useRef(false);
+  const activityCardOpen = activityOpen && !isActivity;
 
   return (
     // One provider for the row: once any tooltip is up, moving to its
@@ -179,8 +192,13 @@ export function ChannelNav() {
           }
         />
         <Popover
-          open={!isActivity && activityOpen}
-          onOpenChange={(open) => setActivityOpen(!isActivity && open)}
+          open={activityCardOpen}
+          onOpenChange={(open) => {
+            const suppressed = open && suppressClickOpenRef.current;
+            suppressClickOpenRef.current = false;
+            if (suppressed) return;
+            setActivityOpen(!isActivity && open);
+          }}
         >
           <PopoverTrigger
             openOnHover
@@ -197,6 +215,7 @@ export function ChannelNav() {
                 label="Activity"
                 isActive={isActivity}
                 onClick={() => {
+                  suppressClickOpenRef.current = true;
                   setActivityOpen(false);
                   withTrack("activity", navigateToActivity)();
                 }}
@@ -209,7 +228,7 @@ export function ChannelNav() {
               />
             }
           />
-          {!isActivity && activityOpen && (
+          {activityCardOpen && (
             <ActivityHoverCard
               side="bottom"
               onClose={() => setActivityOpen(false)}


### PR DESCRIPTION
## Problem

Two things go wrong with the Activity bell in the channels nav, both every time:

1. Click the bell → you land on the Activity page. Open any notification from there and the Activity hover card pops up over the task you just navigated to.
2. After that click the bell keeps a pressed/active look, and hovering it never opens the card again.

**Why:** the bell is both a popover trigger and a nav button, and quill's trigger opens the card on click as well. Our handler runs first, then the trigger's own open lands — still inside the same click, before the route changes — so the card records itself as open. The Activity page only *hid* that (`open={!isActivity && activityOpen}`) rather than closing it, so it resurfaced on the next navigation.

The pressed-and-dead-hover half has the same root: refusing an open isn't free. Base UI applies the open to its store before handing it to us, so a `false` we hand back desyncs the trigger — it keeps `data-popup-open` / `data-pressed`, and its hover-open path bails on the stale internal state until the trigger remounts. The old `!isActivity` gate refused opens the same way, so hovering the bell *on* the Activity page wedged it too.

## Changes

Stop refusing opens rather than papering over the effects:

- The trigger's own click-open is prevented outright (`event.preventBaseUIHandler()`) — the click's one job is to navigate.
- The Activity page renders the bell with no popover wrapped around it, so there are no hover-opens to refuse there. This matches what the sidebar's Activity row already does.
- The open state now lives in the component that only mounts off the Activity page, so it starts closed on every visit. Nothing to mask, nothing left over, and `onOpenChange` is a plain mirror.

## How did you test this?

Diagnosed by probing the trigger's DOM state through the reported flow, which showed `data-popup-open`/`data-pressed` stuck on the bell and hover dead afterwards — both reproducible on `main`.

- Three regression tests in `ChannelNav.test.tsx`: no card after the bell navigates and you open a notification, hover still opens the card afterwards, and no leftover popover state on the bell. All three fail on `main`, pass here.
- Full `@posthog/ui` suite: 283 files / 2409 tests pass, including the existing hover-open, close-on-unhover, and no-card-on-the-Activity-page tests.
- `turbo run typecheck --filter=@posthog/ui` and `biome check` on the touched files: clean.

Not driven in the running Electron app — worth a click-through when you pull it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*