### PR TITLE
fix(ci): tolerate lockfile drift in vr-cli install

### DIFF
--- a/.github/workflows/code-storybook.yml
+++ b/.github/workflows/code-storybook.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Install Visual Review CLI
         if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
-        run: cd vr-cli/products/visual_review/cli && npm ci && npm run build && npm link
+        run: cd vr-cli/products/visual_review/cli && (npm ci || npm install) && npm run build && npm link
 
       - name: Submit snapshots to Visual Review
         # Fork PRs can't read the token; their captures still ran above, so a


### PR DESCRIPTION
## Problem

The visual-regression job builds the Visual Review CLI from posthog master's checkout, unpinned. posthog#74334 bumped sharp there with a lockfile that does not resolve on Linux, so `npm ci` fails and every PR in this repo goes red on visual-regression until the upstream lockfile is fixed (posthog#75785 is open but not merged).

## Changes

Fall back to `npm install` when `npm ci` fails in the Install Visual Review CLI step. The step installs a tool, not a reproducible build artifact, so regenerating the lock at install time is safe. Once upstream is fixed, `npm ci` succeeds again and the fallback is dormant.

## How did you test this?

The identical change ran on #4028 earlier today: `npm ci` failed with the lockfile error, `npm install` took over and the job passed (https://github.com/PostHog/code/actions/runs/30596738872/job/91050657268).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?