### PR TITLE
fix(pi): clear retry status when streaming resumes

### DIFF
--- a/packages/agent/src/pi/conversation/translatePiConversation.test.ts
+++ b/packages/agent/src/pi/conversation/translatePiConversation.test.ts
@@ -162,11 +162,17 @@ describe("createPiConversationTranslator", () => {
         delayMs: 1000,
       },
     ]);
+    const retriedMessage = assistant([{ type: "text", text: "Done" }]);
     expect(
       translator.translateEvent({
-        type: "auto_retry_end",
-        success: true,
-        attempt: 1,
+        type: "message_update",
+        message: retriedMessage,
+        assistantMessageEvent: {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: "Done",
+          partial: retriedMessage,
+        },
       }),
     ).toEqual([
       {
@@ -175,7 +181,19 @@ describe("createPiConversationTranslator", () => {
         status: "retrying",
         isComplete: true,
       },
+      {
+        type: "assistant_message_chunk",
+        timestamp: 10,
+        content: { type: "text", text: "Done" },
+      },
     ]);
+    expect(
+      translator.translateEvent({
+        type: "auto_retry_end",
+        success: true,
+        attempt: 1,
+      }),
+    ).toEqual([]);
   });
 
   it("renders terminal Pi runtime errors inline", () => {

--- a/packages/agent/src/pi/conversation/translatePiConversation.ts
+++ b/packages/agent/src/pi/conversation/translatePiConversation.ts
@@ -115,7 +115,25 @@ export function createPiConversationTranslator(): PiConversationTranslator {
   let latestRuntimeTimestamp = 0;
   let latestConversationTimestamp = 0;
   let pendingRuntimeError: AgentConversationEvent | undefined;
+  let retrying = false;
   let directBashSequence = 0;
+
+  function completeRetry(timestamp: number): AgentConversationEvent[] {
+    if (!retrying) {
+      return [];
+    }
+
+    retrying = false;
+    return [
+      {
+        type: "runtime_status",
+        timestamp,
+        status: "retrying",
+        isComplete: true,
+      },
+    ];
+  }
+
   let activeDirectBash:
     | {
         nextOutputBytes: number;
@@ -257,6 +275,7 @@ export function createPiConversationTranslator(): PiConversationTranslator {
       if (update.type === "text_delta" && update.delta) {
         streamedAssistantTimestamps.add(event.message.timestamp);
         return [
+          ...completeRetry(event.message.timestamp),
           {
             type: "assistant_message_chunk",
             timestamp: event.message.timestamp,
@@ -268,6 +287,7 @@ export function createPiConversationTranslator(): PiConversationTranslator {
       if (update.type === "thinking_delta" && update.delta) {
         streamedAssistantTimestamps.add(event.message.timestamp);
         return [
+          ...completeRetry(event.message.timestamp),
           {
             type: "assistant_thought_chunk",
             timestamp: event.message.timestamp,
@@ -407,7 +427,11 @@ export function createPiConversationTranslator(): PiConversationTranslator {
     }
 
     if (event.type === "auto_retry_start") {
+      const completedEvents = completeRetry(latestConversationTimestamp);
+      retrying = true;
+
       return [
+        ...completedEvents,
         {
           type: "runtime_status",
           timestamp: latestConversationTimestamp,
@@ -421,14 +445,9 @@ export function createPiConversationTranslator(): PiConversationTranslator {
     }
 
     if (event.type === "auto_retry_end") {
-      const events: AgentConversationEvent[] = [
-        {
-          type: "runtime_status",
-          timestamp: latestConversationTimestamp,
-          status: "retrying",
-          isComplete: true,
-        },
-      ];
+      const events: AgentConversationEvent[] = completeRetry(
+        latestConversationTimestamp,
+      );
 
       if (!event.success && event.finalError) {
         events.push({

--- a/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.test.ts
+++ b/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.test.ts
@@ -35,6 +35,15 @@ describe("formatRetryStatus", () => {
       input: {
         attempt: 2,
         maxAttempts: 3,
+        message: "Rate limited",
+        remainingMs: 2_000,
+      },
+      expected: "Rate limit reached. Retrying in 2s (attempt 2 of 3)",
+    },
+    {
+      input: {
+        attempt: 2,
+        maxAttempts: 3,
         message: "Server overloaded",
         remainingMs: 2_000,
       },

--- a/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.test.ts
+++ b/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { formatCompactionFailure } from "./StatusNotificationView";
+import {
+  formatCompactionFailure,
+  formatRetryStatus,
+} from "./StatusNotificationView";
 
 describe("formatCompactionFailure", () => {
   it.each([
@@ -14,5 +17,30 @@ describe("formatCompactionFailure", () => {
     { error: undefined, expected: "Compacting failed" },
   ])("formats $error without duplicate prefixes", ({ error, expected }) => {
     expect(formatCompactionFailure(error)).toBe(expected);
+  });
+});
+
+describe("formatRetryStatus", () => {
+  it.each([
+    {
+      input: {
+        attempt: 1,
+        maxAttempts: 3,
+        message: "Rate limit reached for gpt-5.6-terra on token ...",
+        remainingMs: 0,
+      },
+      expected: "Rate limit reached. Retrying now (attempt 1 of 3)",
+    },
+    {
+      input: {
+        attempt: 2,
+        maxAttempts: 3,
+        message: "Server overloaded",
+        remainingMs: 2_000,
+      },
+      expected: "Retrying in 2s (attempt 2 of 3)",
+    },
+  ])("renders a concise retry message", ({ input, expected }) => {
+    expect(formatRetryStatus(input)).toBe(expected);
   });
 });

--- a/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
@@ -46,7 +46,7 @@ export function formatRetryStatus({
   message?: string;
   remainingMs: number;
 }): string {
-  const rateLimited = /\b(429|rate limit|too many requests)\b/i.test(
+  const rateLimited = /\b429\b|rate[ _]limit(?:ed)?|too many requests/i.test(
     message ?? "",
   );
   const retryAt =

--- a/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/StatusNotificationView.tsx
@@ -35,6 +35,29 @@ export function formatCompactionFailure(error?: string): string {
   return detail ? `Compacting failed: ${detail}` : "Compacting failed";
 }
 
+export function formatRetryStatus({
+  attempt,
+  maxAttempts,
+  message,
+  remainingMs,
+}: {
+  attempt?: number;
+  maxAttempts?: number;
+  message?: string;
+  remainingMs: number;
+}): string {
+  const rateLimited = /\b(429|rate limit|too many requests)\b/i.test(
+    message ?? "",
+  );
+  const retryAt =
+    remainingMs > 0 ? `in ${formatDuration(remainingMs, 0)}` : "now";
+  const attemptLabel =
+    attempt && maxAttempts ? ` (attempt ${attempt} of ${maxAttempts})` : "";
+  const prefix = rateLimited ? "Rate limit reached. " : "";
+
+  return `${prefix}Retrying ${retryAt}${attemptLabel}`;
+}
+
 export function StatusNotificationView({
   status,
   isComplete,
@@ -179,14 +202,12 @@ function RetryingStatusView({
     return () => clearInterval(interval);
   }, [delayMs, startedAt]);
 
-  const attemptLabel =
-    attempt && maxAttempts
-      ? `Attempt ${attempt} of ${maxAttempts}`
-      : "Retrying";
-  const retryLabel =
-    remainingMs > 0
-      ? `${attemptLabel} in ${formatDuration(remainingMs, 1)}`
-      : `${attemptLabel} now`;
+  const retryLabel = formatRetryStatus({
+    attempt,
+    maxAttempts,
+    message,
+    remainingMs,
+  });
 
   return (
     <ChatMarker variant="separator">
@@ -194,9 +215,6 @@ function RetryingStatusView({
         <Flex align="center" gap="2">
           <ArrowsClockwise size={13} className="animate-spin text-amber-9" />
           <Text className="text-[13px] text-gray-11">{retryLabel}</Text>
-          {message && (
-            <Text className="truncate text-[13px] text-gray-10">{message}</Text>
-          )}
         </Flex>
       </ChatMarkerContent>
     </ChatMarker>


### PR DESCRIPTION
## Problem

THIS UGLY THING

<img width="1648" height="136" alt="CleanShot 2026-07-30 at 13 03 59@2x" src="https://github.com/user-attachments/assets/156b7f1e-c6f8-44cd-85eb-6361aa9c6d11" />

## Changes

- Clear Pi retry status as soon as a successful retry streams text or reasoning.
- Complete an earlier retry before showing a later retry.
- Replace raw retry errors with concise rate-limit and retry messages.

## Validation

- `pnpm --filter @posthog/agent exec vitest run src/pi/conversation/translatePiConversation.test.ts`
- `pnpm --filter @posthog/ui exec vitest run src/features/sessions/components/session-update/StatusNotificationView.test.ts`
- `pnpm --filter @posthog/agent exec tsc --noEmit`
- `pnpm --filter @posthog/ui exec tsc --noEmit`
- Pre-commit `pnpm typecheck`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
