### PR TITLE
feat: name the task a comment belongs to so mentions reach its feed

### DIFF
--- a/packages/core/src/comments/anchors.ts
+++ b/packages/core/src/comments/anchors.ts
@@ -59,6 +59,9 @@ export type CommentAnchor = z.infer<typeof commentAnchorSchema>;
 export const commentContextSchema = z.object({
   anchor: commentAnchorSchema,
   threadState: z.enum(["resolved", "open"]).optional(),
+  // The task the commented resource belongs to. Artifact and canvas ids live in a run's
+  // JSON rather than a table, so the server can't get back to the task without being told.
+  taskId: z.string().optional(),
 });
 
 export type CommentContext = z.infer<typeof commentContextSchema>;

--- a/packages/ui/src/features/canvas/components/TaskCommentsList.tsx
+++ b/packages/ui/src/features/canvas/components/TaskCommentsList.tsx
@@ -123,6 +123,7 @@ function ResourceThreadRow({
   thread,
   source,
   root,
+  taskId,
   members,
   selected,
   pulsing,
@@ -132,13 +133,14 @@ function ResourceThreadRow({
   thread: TaskCommentThread;
   source: CommentSource;
   root: ResourceComment;
+  taskId: string;
   members: UserBasic[];
   selected: boolean;
   pulsing: boolean;
   resolution?: HighlightResolution;
   onOpen: () => void;
 }) {
-  const createComment = useCreateComment(source.target);
+  const createComment = useCreateComment(source.target, taskId);
   const setResolved = useSetCommentResolved(source.target);
 
   return (
@@ -278,7 +280,7 @@ export function TaskCommentsList({
 
   const taskTarget = useMemo(() => taskCommentTarget(task.id), [task.id]);
   const taskSourceKey = commentTargetKey(taskTarget);
-  const createTaskComment = useCreateComment(taskTarget);
+  const createTaskComment = useCreateComment(taskTarget, task.id);
 
   const threads = useMemo(() => {
     const reviewByUrl = new Map(prReviews.byUrl);
@@ -531,6 +533,7 @@ export function TaskCommentsList({
                 thread={thread}
                 source={thread.origin.source}
                 root={thread.origin.root}
+                taskId={task.id}
                 members={members}
                 selected={thread.id === focusedThreadId}
                 pulsing={thread.id === pulseThreadId}

--- a/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
+++ b/packages/ui/src/features/sessions/components/ArtifactPreview.tsx
@@ -108,7 +108,7 @@ export function ArtifactPreview({
   );
   const commentsQuery = useCommentsQuery(commentTarget);
   const { members } = useOrgMembers();
-  const createComment = useCreateComment(commentTarget);
+  const createComment = useCreateComment(commentTarget, taskId);
   const requestCommentFocus = useCommentNavigationStore(
     (state) => state.requestCommentFocus,
   );

--- a/packages/ui/src/features/sessions/components/useComments.ts
+++ b/packages/ui/src/features/sessions/components/useComments.ts
@@ -133,15 +133,26 @@ export function useCommentsForTargetsQuery(
   });
 }
 
-export function useCreateComment(target: CommentTarget) {
+/**
+ * @param taskId Names the task the resource belongs to, so a mention on it reaches that
+ * task's activity feed — the server can't resolve an artifact or canvas id back to a task.
+ */
+export function useCreateComment(target: CommentTarget, taskId?: string) {
   const service = useService<SessionService>(SESSION_SERVICE);
   const queryClient = useQueryClient();
   const caches = commentCachesCoveringTarget(target);
+  const contextWithTask = (context: unknown) =>
+    taskId ? { ...(context as Record<string, unknown>), taskId } : context;
 
   return useMutation({
     mutationFn: (
       request: Omit<CreateResourceCommentRequest, "scope" | "itemId">,
-    ) => service.createResourceComment({ ...request, ...target }),
+    ) =>
+      service.createResourceComment({
+        ...request,
+        ...target,
+        context: contextWithTask(request.context),
+      }),
     onMutate: async (request) => {
       await queryClient.cancelQueries(caches);
       const previous = queryClient.getQueriesData<ResourceComment[]>(caches);
@@ -151,7 +162,7 @@ export function useCreateComment(target: CommentTarget) {
         content: request.content,
         created_at: new Date().toISOString(),
         item_id: target.itemId,
-        item_context: request.context,
+        item_context: contextWithTask(request.context),
         scope: target.scope,
         source_comment: request.sourceCommentId ?? null,
         completed_at: null,


### PR DESCRIPTION
## Why

A comment on an artifact or canvas points at an id that lives in a run's JSON, not in a table the server can join against, so the backend had no way to work out which task the comment belonged to. Mentions on those comments reached people by email and the web inbox but never by this app's Activity page — the one surface where the comment is actually readable.

## Changes

The task id now rides along in `item_context` (declared on `commentContextSchema`, which strips unknown keys, so it has to be part of the schema to survive a round-trip). `useCreateComment` takes the task id and merges it in at the single choke point all three call sites go through, so the optimistic row and the request agree.

It is client-supplied, so the backend checks it against the team before acting on it and re-checks visibility when the feed is read.

Stacked on `feat/artifact-comments` (#3970). Pairs with PostHog/posthog#75910, which consumes it — this is inert until that lands, since `item_context` is free-form JSON.

## Testing

`TaskCommentsList` and `ArtifactPreview` suites pass (39 tests), typecheck and lint clean on `@posthog/ui` and `@posthog/core`. No manual testing — no running app in this environment. The behaviour this enables is only observable once the backend side is deployed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
