### PR TITLE
fix(agent): redact MCP credentials from session logs

### DIFF
--- a/packages/agent/src/session-log-writer.test.ts
+++ b/packages/agent/src/session-log-writer.test.ts
@@ -47,6 +47,45 @@ describe("SessionLogWriter", () => {
       expect(entries).toHaveLength(2);
     });
 
+    it("redacts MCP authorization headers before persistence", async () => {
+      const sessionId = "s1";
+      logWriter.register(sessionId, { taskId: "t1", runId: sessionId });
+
+      logWriter.appendRawLine(
+        sessionId,
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/new",
+          params: {
+            mcpServers: [
+              {
+                name: "posthog",
+                headers: [
+                  { name: "Authorization", value: "Bearer protocol-secret" },
+                  { name: "x-posthog-project-id", value: "123" },
+                ],
+              },
+            ],
+          },
+        }),
+      );
+      await logWriter.flush(sessionId);
+
+      const entries: StoredNotification[] = mockAppendLog.mock.calls[0][2];
+      expect(JSON.stringify(entries)).not.toContain("protocol-secret");
+      expect(entries[0].notification.params).toEqual({
+        mcpServers: [
+          {
+            name: "posthog",
+            headers: [
+              { name: "Authorization", value: "[REDACTED]" },
+              { name: "x-posthog-project-id", value: "123" },
+            ],
+          },
+        ],
+      });
+    });
+
     it("ignores unregistered sessions", async () => {
       logWriter.appendRawLine("unknown", JSON.stringify({ method: "test" }));
       await logWriter.flush("unknown");

--- a/packages/agent/src/session-log-writer.ts
+++ b/packages/agent/src/session-log-writer.ts
@@ -73,6 +73,31 @@ interface SessionState {
   pendingRawInputSnapshots: Map<string, StoredNotification>;
 }
 
+function redactAuthorizationHeaders(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactAuthorizationHeaders);
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.name === "string" &&
+    record.name.toLowerCase() === "authorization" &&
+    "value" in record
+  ) {
+    return { ...record, value: "[REDACTED]" };
+  }
+
+  return Object.fromEntries(
+    Object.entries(record).map(([key, nestedValue]) => [
+      key,
+      redactAuthorizationHeaders(nestedValue),
+    ]),
+  );
+}
+
 export class SessionLogWriter {
   /**
    * When consecutive in-progress tool updates for one call span more than this
@@ -212,7 +237,9 @@ export class SessionLogWriter {
       const entry: StoredNotification = {
         type: "notification",
         timestamp,
-        notification: message,
+        notification: redactAuthorizationHeaders(
+          message,
+        ) as StoredNotification["notification"],
       };
 
       this.emitToSinks(sessionId, entry);


### PR DESCRIPTION
## Problem

MCP configuration can include authorization credentials. Protocol messages containing that configuration are persisted in task session logs, where the credentials are unnecessary