### PR TITLE
feat(pi): approve runtime MCP tool calls

### DIFF
--- a/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
+++ b/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
@@ -7,8 +7,23 @@ import { describe, expect, it, vi } from "vitest";
 import { DesktopPiRpcClientFactory } from "./desktop-pi-rpc-client-factory";
 
 const createPiRpcClient = vi.hoisted(() => vi.fn());
+const createRuntimeMcpServers = vi.hoisted(() =>
+  vi.fn(() => ({
+    posthog: {
+      args: [],
+      directTools: false,
+      headers: { "x-posthog-project-id": "1" },
+      lifecycle: "lazy",
+      transport: "streamable-http",
+      url: "http://127.0.0.1:4321/posthog",
+    },
+  })),
+);
 
-vi.mock("@posthog/agent/pi/rpc-client", () => ({ createPiRpcClient }));
+vi.mock("@posthog/agent/pi/rpc-client", () => ({
+  createPiRpcClient,
+  createRuntimeMcpServers,
+}));
 
 describe("DesktopPiRpcClientFactory", () => {
   it("routes Pi through the shared host auth proxy", async () => {
@@ -23,9 +38,23 @@ describe("DesktopPiRpcClientFactory", () => {
     const authProxy = {
       start: vi.fn(async () => "http://127.0.0.1:1234"),
     } as unknown as AuthProxyService;
+    const mcpServerSource = {
+      getMcpServerConnections: vi.fn(async () => [
+        {
+          name: "posthog",
+          type: "http" as const,
+          url: "http://127.0.0.1:4321/posthog",
+          headers: [{ name: "x-posthog-project-id", value: "1" }],
+        },
+      ]),
+    };
     const client = {} as PiRpcClient;
     createPiRpcClient.mockReturnValue(client);
-    const factory = new DesktopPiRpcClientFactory(auth, authProxy);
+    const factory = new DesktopPiRpcClientFactory(
+      auth,
+      authProxy,
+      mcpServerSource,
+    );
 
     await expect(factory.create({ cwd: "/workspace" })).resolves.toBe(client);
     expect(authProxy.start).toHaveBeenCalledWith(
@@ -33,6 +62,16 @@ describe("DesktopPiRpcClientFactory", () => {
     );
     expect(createPiRpcClient).toHaveBeenCalledWith({
       cwd: "/workspace",
+      runtimeMcpServers: {
+        posthog: {
+          args: [],
+          directTools: false,
+          headers: { "x-posthog-project-id": "1" },
+          lifecycle: "lazy",
+          transport: "streamable-http",
+          url: "http://127.0.0.1:4321/posthog",
+        },
+      },
       providerOptions: {
         region: "eu",
         baseUrl: "http://127.0.0.1:1234",

--- a/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
+++ b/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.test.ts
@@ -38,15 +38,26 @@ describe("DesktopPiRpcClientFactory", () => {
     const authProxy = {
       start: vi.fn(async () => "http://127.0.0.1:1234"),
     } as unknown as AuthProxyService;
+    const policies = [
+      {
+        serverName: "Cloudflare",
+        toolName: "search",
+        installationId: "installation-1",
+        approvalState: "needs_approval" as const,
+      },
+    ];
     const mcpServerSource = {
-      getMcpServerConnections: vi.fn(async () => [
-        {
-          name: "posthog",
-          type: "http" as const,
-          url: "http://127.0.0.1:4321/posthog",
-          headers: [{ name: "x-posthog-project-id", value: "1" }],
-        },
-      ]),
+      getMcpRuntimeConfiguration: vi.fn(async () => ({
+        servers: [
+          {
+            name: "posthog",
+            type: "http" as const,
+            url: "http://127.0.0.1:4321/posthog",
+            headers: [{ name: "x-posthog-project-id", value: "1" }],
+          },
+        ],
+        policies,
+      })),
     };
     const client = {} as PiRpcClient;
     createPiRpcClient.mockReturnValue(client);
@@ -56,12 +67,15 @@ describe("DesktopPiRpcClientFactory", () => {
       mcpServerSource,
     );
 
-    await expect(factory.create({ cwd: "/workspace" })).resolves.toBe(client);
+    await expect(
+      factory.create({ taskId: "task-1", cwd: "/workspace" }),
+    ).resolves.toBe(client);
     expect(authProxy.start).toHaveBeenCalledWith(
       getLlmGatewayUrl(getCloudUrlFromRegion("eu")),
     );
     expect(createPiRpcClient).toHaveBeenCalledWith({
       cwd: "/workspace",
+      mcpToolPolicies: policies,
       runtimeMcpServers: {
         posthog: {
           args: [],

--- a/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.ts
+++ b/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.ts
@@ -34,6 +34,7 @@ export class DesktopPiRpcClientFactory implements PiRpcClientFactory {
   ) {}
 
   async create(input: {
+    taskId: string;
     cwd: string;
     model?: string;
     sessionFile?: string;
@@ -45,13 +46,16 @@ export class DesktopPiRpcClientFactory implements PiRpcClientFactory {
 
     const baseUrl = await this.getProxyUrl(credentials.region);
 
-    const runtimeMcpServers = createRuntimeMcpServers(
-      await this.mcpServerSource.getMcpServerConnections(),
-    );
+    const mcpConfiguration =
+      await this.mcpServerSource.getMcpRuntimeConfiguration();
+    const runtimeMcpServers = createRuntimeMcpServers(mcpConfiguration.servers);
 
     return createPiRpcClient({
-      ...input,
+      cwd: input.cwd,
+      model: input.model,
+      sessionFile: input.sessionFile,
       runtimeMcpServers,
+      mcpToolPolicies: mcpConfiguration.policies,
       providerOptions: {
         region: credentials.region,
         baseUrl,

--- a/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.ts
+++ b/apps/code/src/main/platform-adapters/desktop-pi-rpc-client-factory.ts
@@ -1,11 +1,18 @@
 import {
   createPiRpcClient,
+  createRuntimeMcpServers,
   type PiRpcClient,
 } from "@posthog/agent/pi/rpc-client";
 import { getLlmGatewayUrl } from "@posthog/agent/posthog-api";
 import { type CloudRegion, getCloudUrlFromRegion } from "@posthog/shared";
-import { AGENT_AUTH } from "@posthog/workspace-server/services/agent/identifiers";
-import type { AgentAuth } from "@posthog/workspace-server/services/agent/ports";
+import {
+  AGENT_AUTH,
+  MCP_SERVER_CONNECTION_SOURCE,
+} from "@posthog/workspace-server/services/agent/identifiers";
+import type {
+  AgentAuth,
+  McpServerConnectionSource,
+} from "@posthog/workspace-server/services/agent/ports";
 import type { AuthProxyService } from "@posthog/workspace-server/services/auth-proxy/auth-proxy";
 import { AUTH_PROXY_SERVICE } from "@posthog/workspace-server/services/auth-proxy/identifiers";
 import type { PiRpcClientFactory } from "@posthog/workspace-server/services/pi-session/identifiers";
@@ -22,6 +29,8 @@ export class DesktopPiRpcClientFactory implements PiRpcClientFactory {
     @inject(AGENT_AUTH) private readonly auth: AgentAuth,
     @inject(AUTH_PROXY_SERVICE)
     private readonly authProxy: AuthProxyService,
+    @inject(MCP_SERVER_CONNECTION_SOURCE)
+    private readonly mcpServerSource: McpServerConnectionSource,
   ) {}
 
   async create(input: {
@@ -36,8 +45,13 @@ export class DesktopPiRpcClientFactory implements PiRpcClientFactory {
 
     const baseUrl = await this.getProxyUrl(credentials.region);
 
+    const runtimeMcpServers = createRuntimeMcpServers(
+      await this.mcpServerSource.getMcpServerConnections(),
+    );
+
     return createPiRpcClient({
       ...input,
+      runtimeMcpServers,
       providerOptions: {
         region: credentials.region,
         baseUrl,

--- a/apps/code/src/main/platform-adapters/desktop-pi-runtime-factory.test.ts
+++ b/apps/code/src/main/platform-adapters/desktop-pi-runtime-factory.test.ts
@@ -11,10 +11,16 @@ describe("DesktopPiRuntimeFactory", () => {
     } as unknown as PiRpcClientFactory;
     const factory = new DesktopPiRuntimeFactory(clientFactory);
 
-    const runtime = await factory.create({ cwd: "/workspace" });
+    const runtime = await factory.create({
+      taskId: "task-1",
+      cwd: "/workspace",
+    });
 
     expect(runtime).toBeInstanceOf(PiRuntime);
     expect(runtime.client).toBe(client);
-    expect(clientFactory.create).toHaveBeenCalledWith({ cwd: "/workspace" });
+    expect(clientFactory.create).toHaveBeenCalledWith({
+      taskId: "task-1",
+      cwd: "/workspace",
+    });
   });
 });

--- a/apps/code/src/main/platform-adapters/desktop-pi-runtime-factory.ts
+++ b/apps/code/src/main/platform-adapters/desktop-pi-runtime-factory.ts
@@ -14,6 +14,7 @@ export class DesktopPiRuntimeFactory implements PiRuntimeFactory {
   ) {}
 
   async create(input: {
+    taskId: string;
     cwd: string;
     model?: string;
     sessionFile?: string;

--- a/packages/agent/src/pi/rpc-client.test.ts
+++ b/packages/agent/src/pi/rpc-client.test.ts
@@ -3,7 +3,38 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { RpcClient } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
-import { createPiRpcClient } from "./rpc-client";
+import { createPiRpcClient, createRuntimeMcpServers } from "./rpc-client";
+
+describe("createRuntimeMcpServers", () => {
+  it("maps agent-server HTTP and SSE servers to Harness configuration", () => {
+    expect(
+      createRuntimeMcpServers([
+        {
+          name: "posthog",
+          type: "http",
+          url: "https://mcp.example/mcp",
+          headers: [{ name: "authorization", value: "Bearer token" }],
+        },
+        {
+          name: "legacy",
+          type: "sse",
+          url: "https://mcp.example/sse",
+          headers: [],
+        },
+      ]),
+    ).toMatchObject({
+      posthog: {
+        transport: "streamable-http",
+        url: "https://mcp.example/mcp",
+        headers: { authorization: "Bearer token" },
+      },
+      legacy: {
+        transport: "sse",
+        url: "https://mcp.example/sse",
+      },
+    });
+  });
+});
 
 describe("createPiRpcClient", () => {
   it("does not put provider credentials in the child environment", () => {
@@ -55,6 +86,47 @@ process.stdin.resume();
       await client.start();
       await vi.waitFor(async () => {
         await expect(readFile(capturePath, "utf8")).resolves.toBe("1");
+      });
+    } finally {
+      await client.stop();
+      await rm(directory, { recursive: true });
+    }
+  });
+
+  it("passes runtime MCP servers through the bootstrap channel", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pi-runtime-mcp-"));
+    const hostPath = join(directory, "host.mjs");
+    const capturePath = join(directory, "capture.json");
+    await writeFile(
+      hostPath,
+      `
+import { readFileSync, writeFileSync } from "node:fs";
+
+writeFileSync(${JSON.stringify(capturePath)}, readFileSync(3, "utf8"));
+process.stdin.resume();
+`,
+    );
+    const client = createPiRpcClient({
+      cliPath: hostPath,
+      cwd: directory,
+      providerOptions: { apiKey: "proxy-key" },
+      runtimeMcpServers: {
+        posthog: {
+          args: [],
+          directTools: false,
+          lifecycle: "lazy",
+          transport: "streamable-http",
+          url: "http://127.0.0.1:4321/posthog",
+        },
+      },
+    });
+
+    try {
+      await client.start();
+      await vi.waitFor(async () => {
+        await expect(readFile(capturePath, "utf8")).resolves.toContain(
+          '"runtimeMcpServers"',
+        );
       });
     } finally {
       await client.stop();

--- a/packages/agent/src/pi/rpc-client.test.ts
+++ b/packages/agent/src/pi/rpc-client.test.ts
@@ -134,6 +134,61 @@ process.stdin.resume();
     }
   });
 
+  it("routes MCP permission requests over the private host channel", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pi-mcp-permission-"));
+    const hostPath = join(directory, "host.mjs");
+    const capturePath = join(directory, "capture.json");
+    await writeFile(
+      hostPath,
+      `
+import { closeSync, writeFileSync } from "node:fs";
+
+closeSync(3);
+process.stdin.resume();
+process.send({
+  type: "posthog_pi_mcp_permission_request",
+  request: {
+    requestId: "call-1",
+    serverName: "Cloudflare",
+    toolName: "search",
+    installationId: "installation-1",
+    arguments: { query: "workers" },
+  },
+});
+process.on("message", (response) => {
+  if (response.type === "posthog_pi_mcp_permission_response") {
+    writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify(response));
+  }
+});
+`,
+    );
+    const requestMcpToolPermission = vi.fn();
+    const client = createPiRpcClient({
+      cliPath: hostPath,
+      cwd: directory,
+      providerOptions: { apiKey: "proxy-key" },
+    });
+    client.onMcpToolPermissionRequest((request) => {
+      requestMcpToolPermission(request);
+      client.respondMcpToolPermission(request.requestId, "allow");
+    });
+
+    try {
+      await client.start();
+      await vi.waitFor(async () => {
+        await expect(readFile(capturePath, "utf8")).resolves.toContain(
+          '"decision":"allow"',
+        );
+      });
+      expect(requestMcpToolPermission).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: "call-1" }),
+      );
+    } finally {
+      await client.stop();
+      await rm(directory, { recursive: true });
+    }
+  });
+
   it("uses the private host channel without changing Pi RPC", async () => {
     const directory = await mkdtemp(join(tmpdir(), "pi-host-channel-"));
     const hostPath = join(directory, "host.mjs");

--- a/packages/agent/src/pi/rpc-client.ts
+++ b/packages/agent/src/pi/rpc-client.ts
@@ -7,6 +7,8 @@ import {
   RpcClient,
   type RpcClientOptions,
 } from "@earendil-works/pi-coding-agent";
+import type { McpConfig } from "@posthog/harness/extensions/mcp/config";
+import type { McpServerConnection } from "@posthog/shared";
 import { safePiEnvironment } from "./rpc-environment";
 import type { PiQueueSnapshot } from "./types";
 
@@ -36,6 +38,36 @@ interface RpcClientInternals {
     signal: NodeJS.Signals | null,
   ): Error;
   rejectPendingRequests(error: Error): void;
+}
+
+export type PiRuntimeMcpServers = McpConfig["mcpServers"];
+
+export function createRuntimeMcpServers(
+  servers: McpServerConnection[],
+): PiRuntimeMcpServers {
+  return Object.fromEntries(
+    servers.map((server) => [
+      server.name,
+      {
+        transport:
+          server.type === "http"
+            ? ("streamable-http" as const)
+            : ("sse" as const),
+        url: server.url,
+        headers: Object.fromEntries(
+          (server.headers ?? []).map((header) => [header.name, header.value]),
+        ),
+        lifecycle: "lazy" as const,
+        args: [],
+        directTools: false,
+      },
+    ]),
+  );
+}
+
+interface PiRpcBootstrap {
+  providerOptions: PiRpcProviderOptions;
+  runtimeMcpServers?: PiRuntimeMcpServers;
 }
 
 interface PiHostRequest {
@@ -83,7 +115,7 @@ class SecurePiRpcClient extends RpcClient {
 
   constructor(
     private readonly secureOptions: RpcClientOptions,
-    private readonly providerOptions: PiRpcProviderOptions,
+    private readonly bootstrap: PiRpcBootstrap,
   ) {
     super(secureOptions);
   }
@@ -161,9 +193,7 @@ class SecurePiRpcClient extends RpcClient {
 
     const bootstrapPipe = child.stdio[3] as Writable | null;
     bootstrapPipe?.on("error", () => {});
-    bootstrapPipe?.end(
-      JSON.stringify({ providerOptions: this.providerOptions }),
-    );
+    bootstrapPipe?.end(JSON.stringify(this.bootstrap));
 
     await new Promise((resolve) => setTimeout(resolve, 100));
     if (child.exitCode !== null) {
@@ -265,10 +295,12 @@ export type PiRpcClientOptions = Pick<
 > & {
   sessionFile?: string;
   providerOptions: PiRpcProviderOptions;
+  runtimeMcpServers?: PiRuntimeMcpServers;
 };
 
 export function createPiRpcClient(options: PiRpcClientOptions): PiRpcClient {
-  const { sessionFile, providerOptions, ...rpcOptions } = options;
+  const { sessionFile, providerOptions, runtimeMcpServers, ...rpcOptions } =
+    options;
   const args = sessionFile ? ["--session-file", sessionFile] : [];
   const cliPath =
     rpcOptions.cliPath ??
@@ -280,6 +312,6 @@ export function createPiRpcClient(options: PiRpcClientOptions): PiRpcClient {
       cliPath,
       provider: "posthog",
     },
-    providerOptions,
+    { providerOptions, runtimeMcpServers },
   );
 }

--- a/packages/agent/src/pi/rpc-client.ts
+++ b/packages/agent/src/pi/rpc-client.ts
@@ -8,13 +8,25 @@ import {
   type RpcClientOptions,
 } from "@earendil-works/pi-coding-agent";
 import type { McpConfig } from "@posthog/harness/extensions/mcp/config";
-import type { McpServerConnection } from "@posthog/shared";
+import type {
+  McpServerConnection,
+  McpToolPermissionDecision,
+  McpToolPermissionRequest,
+  McpToolPolicy,
+} from "@posthog/shared";
 import { safePiEnvironment } from "./rpc-environment";
 import type { PiQueueSnapshot } from "./types";
 
 export type PiRpcClient = RpcClient & {
   getQueue(): Promise<PiQueueSnapshot>;
   clearQueue(): Promise<PiQueueSnapshot>;
+  onMcpToolPermissionRequest(
+    listener: (request: McpToolPermissionRequest) => void,
+  ): () => void;
+  respondMcpToolPermission(
+    requestId: string,
+    decision: McpToolPermissionDecision,
+  ): void;
 };
 
 export interface PiRpcProviderOptions {
@@ -68,12 +80,24 @@ export function createRuntimeMcpServers(
 interface PiRpcBootstrap {
   providerOptions: PiRpcProviderOptions;
   runtimeMcpServers?: PiRuntimeMcpServers;
+  mcpToolPolicies?: McpToolPolicy[];
 }
 
 interface PiHostRequest {
   type: "posthog_pi_host_request";
   id: string;
   method: "get_queue" | "clear_queue";
+}
+
+interface PiMcpPermissionRequestMessage {
+  type: "posthog_pi_mcp_permission_request";
+  request: McpToolPermissionRequest;
+}
+
+interface PiMcpPermissionResponseMessage {
+  type: "posthog_pi_mcp_permission_response";
+  requestId: string;
+  decision: McpToolPermissionDecision;
 }
 
 interface PiHostResponse {
@@ -104,6 +128,9 @@ function attachJsonlReader(
 }
 
 class SecurePiRpcClient extends RpcClient {
+  private readonly mcpPermissionListeners = new Set<
+    (request: McpToolPermissionRequest) => void
+  >();
   private readonly hostRequests = new Map<
     string,
     {
@@ -165,7 +192,10 @@ class SecurePiRpcClient extends RpcClient {
       internals.rejectPendingRequests(error);
       this.rejectHostRequests(error);
     });
-    child.on("message", (message: unknown) => this.handleHostResponse(message));
+    child.on("message", (message: unknown) => {
+      this.handleHostResponse(message);
+      this.handleMcpPermissionRequest(message);
+    });
     child.once("error", (error) => {
       if (internals.process !== child) {
         return;
@@ -274,6 +304,39 @@ class SecurePiRpcClient extends RpcClient {
     request.resolve(response.data);
   }
 
+  onMcpToolPermissionRequest(
+    listener: (request: McpToolPermissionRequest) => void,
+  ): () => void {
+    this.mcpPermissionListeners.add(listener);
+    return () => this.mcpPermissionListeners.delete(listener);
+  }
+
+  respondMcpToolPermission(
+    requestId: string,
+    decision: McpToolPermissionDecision,
+  ): void {
+    const child = (this as unknown as RpcClientProcessAccess).process;
+    child?.send({
+      type: "posthog_pi_mcp_permission_response",
+      requestId,
+      decision,
+    } satisfies PiMcpPermissionResponseMessage);
+  }
+
+  private handleMcpPermissionRequest(message: unknown): void {
+    const permissionMessage = message as Partial<PiMcpPermissionRequestMessage>;
+    if (
+      permissionMessage.type !== "posthog_pi_mcp_permission_request" ||
+      !permissionMessage.request
+    ) {
+      return;
+    }
+
+    for (const listener of this.mcpPermissionListeners) {
+      listener(permissionMessage.request);
+    }
+  }
+
   private rejectHostRequests(error: Error): void {
     for (const request of this.hostRequests.values()) {
       clearTimeout(request.timeout);
@@ -296,11 +359,17 @@ export type PiRpcClientOptions = Pick<
   sessionFile?: string;
   providerOptions: PiRpcProviderOptions;
   runtimeMcpServers?: PiRuntimeMcpServers;
+  mcpToolPolicies?: McpToolPolicy[];
 };
 
 export function createPiRpcClient(options: PiRpcClientOptions): PiRpcClient {
-  const { sessionFile, providerOptions, runtimeMcpServers, ...rpcOptions } =
-    options;
+  const {
+    sessionFile,
+    providerOptions,
+    runtimeMcpServers,
+    mcpToolPolicies,
+    ...rpcOptions
+  } = options;
   const args = sessionFile ? ["--session-file", sessionFile] : [];
   const cliPath =
     rpcOptions.cliPath ??
@@ -312,6 +381,6 @@ export function createPiRpcClient(options: PiRpcClientOptions): PiRpcClient {
       cliPath,
       provider: "posthog",
     },
-    { providerOptions, runtimeMcpServers },
+    { providerOptions, runtimeMcpServers, mcpToolPolicies },
   );
 }

--- a/packages/agent/src/pi/rpc-host.ts
+++ b/packages/agent/src/pi/rpc-host.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { createHarnessRuntime, runRpcMode } from "@posthog/harness";
+import type { McpConfig } from "@posthog/harness/extensions/mcp/config";
 import type { PosthogProviderOptions } from "@posthog/harness/extensions/posthog-provider/provider";
 import {
   POSTHOG_PI_QUEUE_ENTRY_TYPE,
@@ -10,6 +11,7 @@ import { sanitizePiHostEnvironment } from "./rpc-environment";
 
 interface PiRpcBootstrap {
   providerOptions?: PosthogProviderOptions;
+  runtimeMcpServers?: McpConfig["mcpServers"];
 }
 
 interface PiHostRequest {
@@ -39,6 +41,7 @@ const runtime = await createHarnessRuntime({
   cwd,
   sessionManager,
   ...providerOptions,
+  runtimeMcpServers: bootstrap.runtimeMcpServers,
 });
 
 const persistedQueue = readPersistedPiQueue(sessionManager.getEntries());

--- a/packages/agent/src/pi/rpc-host.ts
+++ b/packages/agent/src/pi/rpc-host.ts
@@ -3,6 +3,11 @@ import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { createHarnessRuntime, runRpcMode } from "@posthog/harness";
 import type { McpConfig } from "@posthog/harness/extensions/mcp/config";
 import type { PosthogProviderOptions } from "@posthog/harness/extensions/posthog-provider/provider";
+import type {
+  McpToolPermissionDecision,
+  McpToolPermissionRequest,
+  McpToolPolicy,
+} from "@posthog/shared";
 import {
   POSTHOG_PI_QUEUE_ENTRY_TYPE,
   readPersistedPiQueue,
@@ -12,6 +17,7 @@ import { sanitizePiHostEnvironment } from "./rpc-environment";
 interface PiRpcBootstrap {
   providerOptions?: PosthogProviderOptions;
   runtimeMcpServers?: McpConfig["mcpServers"];
+  mcpToolPolicies?: McpToolPolicy[];
 }
 
 interface PiHostRequest {
@@ -37,11 +43,38 @@ const sessionFile = argumentValue("--session-file");
 const sessionManager = sessionFile
   ? SessionManager.open(sessionFile, undefined, cwd)
   : SessionManager.create(cwd);
+function requestMcpToolPermission(
+  request: McpToolPermissionRequest,
+): Promise<McpToolPermissionDecision> {
+  return new Promise((resolve) => {
+    const onMessage = (message: unknown) => {
+      const response = message as {
+        type?: string;
+        requestId?: string;
+        decision?: McpToolPermissionDecision;
+      };
+      if (
+        response.type !== "posthog_pi_mcp_permission_response" ||
+        response.requestId !== request.requestId ||
+        !response.decision
+      ) {
+        return;
+      }
+      process.off("message", onMessage);
+      resolve(response.decision);
+    };
+    process.on("message", onMessage);
+    process.send?.({ type: "posthog_pi_mcp_permission_request", request });
+  });
+}
+
 const runtime = await createHarnessRuntime({
   cwd,
   sessionManager,
   ...providerOptions,
   runtimeMcpServers: bootstrap.runtimeMcpServers,
+  mcpToolPolicies: bootstrap.mcpToolPolicies,
+  requestMcpToolPermission,
 });
 
 const persistedQueue = readPersistedPiQueue(sessionManager.getEntries());

--- a/packages/agent/src/server/agent-server.ts
+++ b/packages/agent/src/server/agent-server.ts
@@ -21,6 +21,7 @@ import {
   type Adapter,
   buildPrOutput,
   getErrorMessage,
+  type McpServerConnection,
   mergePrUrls,
   parseMcpToolName,
   readMcpToolDescriptor,
@@ -117,7 +118,6 @@ import { RunUsageAccumulator } from "./run-usage";
 import {
   handoffLocalGitStateSchema,
   jsonRpcRequestSchema,
-  type RemoteMcpServer,
   validateCommandParams,
 } from "./schemas";
 import type { AgentServerConfig } from "./types";
@@ -438,7 +438,7 @@ export class AgentServer {
    * servers and return their session mcpServers entries. No designations →
    * no relay server, no entries.
    */
-  private async startMcpRelayServer(): Promise<RemoteMcpServer[]> {
+  private async startMcpRelayServer(): Promise<McpServerConnection[]> {
     const names = this.config.relayMcpServers ?? [];
     if (names.length === 0) return [];
     if (!this.mcpRelayServer) {
@@ -1782,7 +1782,7 @@ export class AgentServer {
     let effectiveSessionMeta: typeof sessionMeta & {
       nativeGoal?: NonNullable<ResumeState["nativeGoal"]>;
     } = sessionMeta;
-    let sessionMcpServers: RemoteMcpServer[];
+    let sessionMcpServers: McpServerConnection[];
     try {
       await this.installSkillBundleArtifacts(
         payload.task_id,

--- a/packages/agent/src/server/mcp-relay-server.ts
+++ b/packages/agent/src/server/mcp-relay-server.ts
@@ -1,8 +1,8 @@
 import crypto from "node:crypto";
 import { type ServerType, serve } from "@hono/node-server";
+import type { McpServerConnection } from "@posthog/shared";
 import { Hono } from "hono";
 import type { Logger } from "../utils/logger";
-import type { RemoteMcpServer } from "./schemas";
 
 export const DEFAULT_RELAY_TIMEOUT_MS = 60_000;
 /** Request payloads above this are rejected before any event is emitted. */
@@ -103,7 +103,7 @@ export class McpRelayServer {
   }
 
   /** Session mcpServers entries for the relay endpoints. Call after start(). */
-  get mcpServers(): RemoteMcpServer[] {
+  get mcpServers(): McpServerConnection[] {
     if (this.port === null) return [];
     return [...this.serverNames].map((name) => ({
       type: "http" as const,

--- a/packages/agent/src/server/pi-agent-server.ts
+++ b/packages/agent/src/server/pi-agent-server.ts
@@ -13,7 +13,11 @@ import { Hono } from "hono";
 import { z } from "zod/v4";
 import { POSTHOG_NOTIFICATIONS } from "../acp-extensions";
 import { OtelRunTelemetry } from "../otel-telemetry";
-import { createPiRpcClient, type PiRpcClient } from "../pi/rpc-client";
+import {
+  createPiRpcClient,
+  createRuntimeMcpServers,
+  type PiRpcClient,
+} from "../pi/rpc-client";
 import { piRpcCommandSchema, type RpcCommand } from "../pi/rpc-transport";
 import { PiRuntime } from "../pi/runtime";
 import { PostHogAPIClient } from "../posthog-api";
@@ -493,6 +497,7 @@ export class PiAgentServer {
       cwd,
       model: this.config.model,
       sessionFile: restoredSessionFile,
+      runtimeMcpServers: createRuntimeMcpServers(this.config.mcpServers ?? []),
       providerOptions: {
         apiKey: this.config.apiKey,
         baseUrl: resolveLlmGatewayUrl(

--- a/packages/agent/src/server/schemas.ts
+++ b/packages/agent/src/server/schemas.ts
@@ -1,3 +1,4 @@
+import type { McpServerConnection } from "@posthog/shared";
 import { z } from "zod/v4";
 
 export { posthogExecPermissionRegexSchema } from "../posthog-exec-permission";
@@ -20,7 +21,7 @@ export const handoffLocalGitStateSchema = z.object({
   upstreamMergeRef: nullishString,
 });
 
-const remoteMcpServerSchema = z.object({
+const remoteMcpServerSchema: z.ZodType<McpServerConnection> = z.object({
   type: z.enum(["http", "sse"]),
   name: z.string().min(1, "MCP server name is required"),
   url: z.url({ error: "MCP server url must be a valid URL" }),
@@ -28,8 +29,6 @@ const remoteMcpServerSchema = z.object({
 });
 
 export const mcpServersSchema = z.array(remoteMcpServerSchema);
-
-export type RemoteMcpServer = z.infer<typeof remoteMcpServerSchema>;
 
 export const claudeCodeConfigSchema = z.object({
   systemPrompt: z

--- a/packages/agent/src/server/types.ts
+++ b/packages/agent/src/server/types.ts
@@ -1,8 +1,7 @@
-import type { Adapter } from "@posthog/shared";
+import type { Adapter, McpServerConnection } from "@posthog/shared";
 import type { EffortLevel } from "@posthog/shared/domain-types";
 import type { AgentMode } from "../types";
 import type { RtkSavingsSummary } from "./rtk-savings";
-import type { RemoteMcpServer } from "./schemas";
 
 export interface ClaudeCodeConfig {
   systemPrompt?:
@@ -41,7 +40,7 @@ export interface AgentServerConfig {
   // manual (non-automated-origin) cloud runs. createPr=false still wins.
   autoPublish?: boolean;
   version?: string;
-  mcpServers?: RemoteMcpServer[];
+  mcpServers?: McpServerConnection[];
   /**
    * Case-insensitive JavaScript regex matched against PostHog `exec` sub-tool
    * names. Overrides the default approval regex for interactive calls.

--- a/packages/api-client/src/posthog-client.ts
+++ b/packages/api-client/src/posthog-client.ts
@@ -1,11 +1,11 @@
 import "./generated.augment";
 import type {
   Adapter,
-  CloudMcpServerImport,
   CloudMcpServerRelayDesignation,
   CloudRunSource,
   CreateTaskAutomationOptions,
   ExecutionMode,
+  McpServerConnection,
   PrAuthorshipMode,
   SourceProduct,
   SourceType,
@@ -665,7 +665,7 @@ export interface CloudRunOptions {
    * Local url-based MCP servers to make available inside the sandbox. The
    * backend merges these into the agent server's `--mcpServers` at spawn.
    */
-  importedMcpServers?: CloudMcpServerImport[];
+  importedMcpServers?: McpServerConnection[];
   relayedMcpServers?: CloudMcpServerRelayDesignation[];
 }
 

--- a/packages/core/src/local-mcp/localMcpImport.ts
+++ b/packages/core/src/local-mcp/localMcpImport.ts
@@ -1,8 +1,8 @@
 import type {
   Adapter,
-  CloudMcpServerImport,
   CloudMcpServerRelayDesignation,
   LocalMcpServerDescriptor,
+  McpServerConnection,
 } from "@posthog/shared";
 import { isPrivateIpv4Octets, isPrivateIpv6Literal } from "@posthog/shared";
 import { inject, injectable } from "inversify";
@@ -43,7 +43,7 @@ export interface LocalMcpCloudClassification {
   availability: LocalMcpCloudAvailability;
   reason: LocalMcpCloudReason;
   /** Sandbox-shaped config; present only when availability is "importable". */
-  remote?: CloudMcpServerImport;
+  remote?: McpServerConnection;
 }
 
 function parseIpv4(host: string): [number, number, number, number] | null {
@@ -147,7 +147,7 @@ export function classifyLocalMcpServer(
 const MAX_RELAYED_MCP_SERVERS = 20;
 
 export interface LocalMcpServersForRun {
-  imported: CloudMcpServerImport[];
+  imported: McpServerConnection[];
   relayed: CloudMcpServerRelayDesignation[];
 }
 

--- a/packages/core/src/pi-runtime/piSessionController.test.ts
+++ b/packages/core/src/pi-runtime/piSessionController.test.ts
@@ -1,7 +1,10 @@
 import type { PiRemoteRpcClient } from "@posthog/agent/pi/remote-rpc-client";
 import type { AuthService } from "@posthog/core/auth/auth";
 import type { TaskService } from "@posthog/core/task-detail/taskService";
-import type { AgentConversationEvent } from "@posthog/shared";
+import type {
+  AgentConversationEvent,
+  McpToolPermissionRequest,
+} from "@posthog/shared";
 import { describe, expect, it, vi } from "vitest";
 import {
   PiOperationError,
@@ -79,6 +82,40 @@ function createSession(): PiSession {
 }
 
 describe("PiSessionController", () => {
+  it("queues concurrent MCP permission requests", async () => {
+    const session = createSession();
+    let onRequest: ((request: McpToolPermissionRequest) => void) | undefined;
+    session.onMcpToolPermissionRequest = vi.fn((callback) => {
+      onRequest = callback;
+      return () => {};
+    });
+    session.respondMcpToolPermission = vi.fn(async () => {});
+    const controller = createController(session);
+    await controller.ensureConnected("task-1");
+    const first = {
+      requestId: "call-1",
+      serverName: "Cloudflare",
+      toolName: "search",
+      installationId: "installation-1",
+      arguments: {},
+    };
+    const second = { ...first, requestId: "call-2" };
+
+    onRequest?.(first);
+    onRequest?.(second);
+
+    expect(
+      controller.store.getState().sessions["task-1"]?.mcpToolPermissionRequests
+        .size,
+    ).toBe(2);
+    await controller.respondMcpToolPermission("task-1", first, "reject");
+    expect(
+      controller.store
+        .getState()
+        .sessions["task-1"]?.mcpToolPermissionRequests.has("call-2"),
+    ).toBe(true);
+  });
+
   it.each([
     {
       text: "hello",

--- a/packages/core/src/pi-runtime/piSessionController.ts
+++ b/packages/core/src/pi-runtime/piSessionController.ts
@@ -8,6 +8,8 @@ import type {
 import {
   type AgentConversationEvent,
   classifyPromptFailure,
+  type McpToolPermissionDecision,
+  type McpToolPermissionRequest,
   type PiMessagingMode,
   type PiRuntimeHealth,
   type PromptFailure,
@@ -67,6 +69,14 @@ export interface PiSession {
     onError: (error: unknown) => void,
     onCloudStatus?: (status: TaskRunStatus) => void,
   ): () => void;
+  onMcpToolPermissionRequest?(
+    onRequest: (request: McpToolPermissionRequest) => void,
+    onError: (error: unknown) => void,
+  ): () => void;
+  respondMcpToolPermission?(
+    request: McpToolPermissionRequest,
+    decision: McpToolPermissionDecision,
+  ): Promise<void>;
 }
 
 export interface PiSessionFactory {
@@ -207,6 +217,7 @@ export class PiSessionController {
     this.queueRevisions.delete(taskId);
     this.queuesToRestore.delete(taskId);
     this.activeTaskIds.delete(taskId);
+    this.updateSession(taskId, { mcpToolPermissionRequests: new Map() });
   }
 
   async retry(taskId: string): Promise<void> {
@@ -227,6 +238,21 @@ export class PiSessionController {
     } catch (error) {
       throw this.recordOperationFailure(taskId, "retry", error);
     }
+  }
+
+  async respondMcpToolPermission(
+    taskId: string,
+    request: McpToolPermissionRequest,
+    decision: McpToolPermissionDecision,
+  ): Promise<void> {
+    const session = await this.getPiSession(taskId);
+    if (!session.respondMcpToolPermission) {
+      throw new Error("MCP tool permissions are unavailable for this session");
+    }
+    await session.respondMcpToolPermission(request, decision);
+    const requests = new Map(this.getSession(taskId).mcpToolPermissionRequests);
+    requests.delete(request.requestId);
+    this.updateSession(taskId, { mcpToolPermissionRequests: requests });
   }
 
   async clearQueue(taskId: string): Promise<PiQueueSnapshot> {
@@ -525,7 +551,8 @@ export class PiSessionController {
     }
 
     let disposed = false;
-    let unsubscribe: (() => void) | undefined;
+    let unsubscribeConversation: (() => void) | undefined;
+    let unsubscribePermission: (() => void) | undefined;
     void this.getPiSession(taskId)
       .then((session) => {
         if (disposed) {
@@ -533,16 +560,29 @@ export class PiSessionController {
         }
         this.applyPersistedConfig(taskId, session);
         this.updateSession(taskId, { cloudStatus: session.cloudStatus });
-        unsubscribe = session.onConversationEvent(
+        unsubscribeConversation = session.onConversationEvent(
           (event) => this.handleEvent(taskId, event),
           (error) => this.applySessionError(taskId, error),
           (cloudStatus) => this.updateSession(taskId, { cloudStatus }),
+        );
+        unsubscribePermission = session.onMcpToolPermissionRequest?.(
+          (request) => {
+            const requests = new Map(
+              this.getSession(taskId).mcpToolPermissionRequests,
+            );
+            requests.set(request.requestId, request);
+            this.updateSession(taskId, {
+              mcpToolPermissionRequests: requests,
+            });
+          },
+          (error) => this.applySessionError(taskId, error),
         );
       })
       .catch((error) => this.applySessionError(taskId, error));
     this.subscriptions.set(taskId, () => {
       disposed = true;
-      unsubscribe?.();
+      unsubscribeConversation?.();
+      unsubscribePermission?.();
     });
   }
 
@@ -652,6 +692,7 @@ export class PiSessionController {
             : undefined,
         authRestoring: currentSession.authRestoring,
         isBashRunning: false,
+        mcpToolPermissionRequests: currentSession.mcpToolPermissionRequests,
       });
 
       await this.restoreQueueIfNeeded(taskId, session, resolvedStatus);

--- a/packages/core/src/pi-runtime/piSessionStore.ts
+++ b/packages/core/src/pi-runtime/piSessionStore.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   AgentConversationEvent,
   GatewayLimitCause,
+  McpToolPermissionRequest,
   PromptFailureKind,
   SessionStatus,
   TaskRunStatus,
@@ -41,6 +42,7 @@ export interface PiControllerSessionState {
   error?: PiSessionError;
   authRestoring: boolean;
   isBashRunning: boolean;
+  mcpToolPermissionRequests: Map<string, McpToolPermissionRequest>;
 }
 
 export interface PiSessionState {
@@ -63,6 +65,7 @@ export function createEmptyPiControllerSession(): PiControllerSessionState {
     thinkingLevelsLoaded: false,
     commands: [],
     queue: { steering: [], followUp: [] },
+    mcpToolPermissionRequests: new Map(),
     authRestoring: false,
     isBashRunning: false,
   };

--- a/packages/core/src/task-detail/taskCreationApiClient.ts
+++ b/packages/core/src/task-detail/taskCreationApiClient.ts
@@ -1,9 +1,9 @@
 import type { TaskSessionStorageAccess } from "@posthog/api-client/posthog-client";
 import type {
   Adapter,
-  CloudMcpServerImport,
   CloudMcpServerRelayDesignation,
   CloudRunSource,
+  McpServerConnection,
   PrAuthorshipMode,
 } from "@posthog/shared";
 import type { Task, TaskRun } from "@posthog/shared/domain-types";
@@ -26,7 +26,7 @@ export interface CreateTaskRunClientOptions {
   runSource?: CloudRunSource;
   signalReportId?: string;
   initialPermissionMode?: string;
-  importedMcpServers?: CloudMcpServerImport[];
+  importedMcpServers?: McpServerConnection[];
   relayedMcpServers?: CloudMcpServerRelayDesignation[];
 }
 

--- a/packages/core/src/task-detail/taskInput.ts
+++ b/packages/core/src/task-detail/taskInput.ts
@@ -2,8 +2,8 @@ import { buildCloudTaskDescription } from "@posthog/core/editor/cloud-prompt";
 import type {
   Adapter,
   AgentRuntime,
-  CloudMcpServerImport,
   CloudMcpServerRelayDesignation,
+  McpServerConnection,
   TaskCreationInput,
   WorkspaceMode,
 } from "@posthog/shared";
@@ -38,7 +38,7 @@ export interface PrepareTaskInputOptions {
   autoPublishCloudRuns?: boolean;
   rtkEnabledCloud?: boolean;
   allowNoRepo?: boolean;
-  importedMcpServers?: CloudMcpServerImport[];
+  importedMcpServers?: McpServerConnection[];
   relayedMcpServers?: CloudMcpServerRelayDesignation[];
 }
 

--- a/packages/harness/src/extensions/mcp/config.test.ts
+++ b/packages/harness/src/extensions/mcp/config.test.ts
@@ -2,7 +2,12 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { loadConfig, mergeRawConfigs, parseConfig } from "./config";
+import {
+  loadConfig,
+  mergeRawConfigs,
+  mergeRuntimeServers,
+  parseConfig,
+} from "./config";
 import { McpError } from "./errors";
 
 describe("parseConfig", () => {
@@ -103,6 +108,25 @@ describe("mergeRawConfigs", () => {
       "projectOnly",
       "shared",
     ]);
+  });
+});
+
+describe("mergeRuntimeServers", () => {
+  it("replaces file servers with runtime servers of the same name", () => {
+    const merged = mergeRuntimeServers(
+      parseConfig({ mcpServers: { shared: { command: "file" } } }, "file"),
+      {
+        shared: {
+          args: [],
+          command: "runtime",
+          directTools: false,
+          lifecycle: "lazy",
+          transport: "stdio",
+        },
+      },
+    );
+
+    expect(merged.mcpServers.shared?.command).toBe("runtime");
   });
 });
 

--- a/packages/harness/src/extensions/mcp/config.ts
+++ b/packages/harness/src/extensions/mcp/config.ts
@@ -147,6 +147,20 @@ export function emptyConfig(): McpConfig {
   return mcpConfigSchema.parse({});
 }
 
+export function mergeRuntimeServers(
+  config: McpConfig,
+  runtimeServers: Record<string, McpServerConfig> | undefined,
+): McpConfig {
+  if (!runtimeServers || Object.keys(runtimeServers).length === 0) {
+    return config;
+  }
+
+  return {
+    ...config,
+    mcpServers: { ...config.mcpServers, ...runtimeServers },
+  };
+}
+
 async function readJsonFile(path: string): Promise<unknown | null> {
   let text: string;
   try {

--- a/packages/harness/src/extensions/mcp/extension.ts
+++ b/packages/harness/src/extensions/mcp/extension.ts
@@ -30,7 +30,7 @@ import { runOAuthFlow } from "./auth-flow";
 import { McpAuthStorage } from "./auth-storage";
 import { CallbackServer } from "./callback-server";
 import type { ConfigLoader, McpConfig } from "./config";
-import { emptyConfig, loadConfig } from "./config";
+import { emptyConfig, loadConfig, mergeRuntimeServers } from "./config";
 import { describeError } from "./errors";
 import { createMcpProxyTool } from "./proxy-tool";
 import type { TransportFactory } from "./server-manager";
@@ -39,6 +39,7 @@ import { ToolBridge } from "./tool-bridge";
 import { McpToolCache } from "./tool-cache";
 
 export interface McpExtensionOptions {
+  runtimeServers?: McpConfig["mcpServers"];
   /** Override config loading (tests). Default: read mcp.json files. */
   configLoader?: ConfigLoader;
   /** Override transport creation (tests). Default: stdio/http/sse via SDK. */
@@ -228,9 +229,12 @@ export function createMcpExtension(
     pi.on("session_start", async (_event, ctx) => {
       let nextConfig: McpConfig;
       try {
-        nextConfig = await configLoader(ctx.cwd, {
-          includeProject: ctx.isProjectTrusted(),
-        });
+        nextConfig = mergeRuntimeServers(
+          await configLoader(ctx.cwd, {
+            includeProject: ctx.isProjectTrusted(),
+          }),
+          options.runtimeServers,
+        );
       } catch (err) {
         if (ctx.hasUI) {
           ctx.ui.notify(`mcp: config error — ${describeError(err)}`, "error");

--- a/packages/harness/src/extensions/posthog-mcp-policy/extension.test.ts
+++ b/packages/harness/src/extensions/posthog-mcp-policy/extension.test.ts
@@ -1,0 +1,102 @@
+import type {
+  ExtensionAPI,
+  ToolCallEvent,
+} from "@earendil-works/pi-coding-agent";
+import type { McpToolPermissionDecision } from "@posthog/shared";
+import { describe, expect, it, vi } from "vitest";
+import { createPosthogMcpPolicyExtension } from "./extension";
+
+function setup(approvalState: "approved" | "needs_approval" | "do_not_use") {
+  let handler: ((event: ToolCallEvent) => Promise<unknown>) | undefined;
+  const pi = {
+    on: vi.fn((event: string, callback: typeof handler) => {
+      if (event === "tool_call") {
+        handler = callback;
+      }
+    }),
+  } as unknown as ExtensionAPI;
+  const requestMcpToolPermission = vi.fn<
+    () => Promise<McpToolPermissionDecision>
+  >(async () => "allow");
+
+  createPosthogMcpPolicyExtension({
+    mcpToolPolicies: [
+      {
+        serverName: "Cloudflare",
+        toolName: "search",
+        installationId: "installation-1",
+        approvalState,
+      },
+    ],
+    requestMcpToolPermission,
+  })(pi);
+
+  return {
+    requestMcpToolPermission,
+    call: (toolName: string, input: Record<string, unknown> = {}) =>
+      handler?.({
+        type: "tool_call",
+        toolCallId: "call-1",
+        toolName,
+        input,
+      } as ToolCallEvent),
+  };
+}
+
+describe("posthog MCP policy extension", () => {
+  it("allows approved tools without prompting", async () => {
+    const runtime = setup("approved");
+
+    await expect(
+      runtime.call("mcp_Cloudflare_search"),
+    ).resolves.toBeUndefined();
+    expect(runtime.requestMcpToolPermission).not.toHaveBeenCalled();
+  });
+
+  it("prompts before a tool that needs approval", async () => {
+    const runtime = setup("needs_approval");
+
+    await expect(
+      runtime.call("mcp_Cloudflare_search"),
+    ).resolves.toBeUndefined();
+    expect(runtime.requestMcpToolPermission).toHaveBeenCalledWith({
+      requestId: "call-1",
+      serverName: "Cloudflare",
+      toolName: "search",
+      installationId: "installation-1",
+      arguments: {},
+    });
+  });
+
+  it("blocks a rejected approval", async () => {
+    const runtime = setup("needs_approval");
+    runtime.requestMcpToolPermission.mockResolvedValue("reject");
+
+    await expect(runtime.call("mcp_Cloudflare_search")).resolves.toEqual({
+      block: true,
+      reason: "Permission rejected for Cloudflare.search.",
+    });
+  });
+
+  it("blocks disabled tools", async () => {
+    const runtime = setup("do_not_use");
+
+    await expect(runtime.call("mcp_Cloudflare_search")).resolves.toEqual({
+      block: true,
+      reason: "The Cloudflare tool search is disabled in PostHog MCP settings.",
+    });
+  });
+
+  it("handles calls through the MCP proxy tool", async () => {
+    const runtime = setup("needs_approval");
+
+    await runtime.call("mcp", {
+      tool: "mcp_Cloudflare_search",
+      args: '{"query":"workers"}',
+    });
+
+    expect(runtime.requestMcpToolPermission).toHaveBeenCalledWith(
+      expect.objectContaining({ arguments: { query: "workers" } }),
+    );
+  });
+});

--- a/packages/harness/src/extensions/posthog-mcp-policy/extension.ts
+++ b/packages/harness/src/extensions/posthog-mcp-policy/extension.ts
@@ -1,0 +1,96 @@
+import type {
+  ExtensionAPI,
+  ExtensionFactory,
+  ToolCallEvent,
+} from "@earendil-works/pi-coding-agent";
+import type {
+  McpToolPermissionDecision,
+  McpToolPermissionRequest,
+  McpToolPolicy,
+} from "@posthog/shared";
+import { buildToolName } from "../mcp/tool-bridge";
+
+export interface PosthogMcpPolicyOptions {
+  mcpToolPolicies?: McpToolPolicy[];
+  requestMcpToolPermission?: (
+    request: McpToolPermissionRequest,
+  ) => Promise<McpToolPermissionDecision>;
+}
+
+function requestedArguments(event: ToolCallEvent): Record<string, unknown> {
+  if (event.toolName !== "mcp" || typeof event.input.args !== "string") {
+    return event.input;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(event.input.args);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return {};
+  }
+  return {};
+}
+
+function requestedToolName(event: ToolCallEvent): string | undefined {
+  if (event.toolName === "mcp") {
+    return typeof event.input.tool === "string" ? event.input.tool : undefined;
+  }
+
+  return event.toolName;
+}
+
+export function createPosthogMcpPolicyExtension(
+  options: PosthogMcpPolicyOptions = {},
+): ExtensionFactory {
+  return (pi: ExtensionAPI) => {
+    const policies = new Map(
+      (options.mcpToolPolicies ?? []).map((policy) => [
+        buildToolName("mcp", policy.serverName, policy.toolName),
+        { ...policy },
+      ]),
+    );
+
+    pi.on("tool_call", async (event) => {
+      const piToolName = requestedToolName(event);
+      const policy = piToolName ? policies.get(piToolName) : undefined;
+      if (!policy || policy.approvalState === "approved") {
+        return;
+      }
+
+      if (policy.approvalState === "do_not_use") {
+        return {
+          block: true,
+          reason: `The ${policy.serverName} tool ${policy.toolName} is disabled in PostHog MCP settings.`,
+        };
+      }
+
+      if (!options.requestMcpToolPermission) {
+        return {
+          block: true,
+          reason: `The ${policy.serverName} tool ${policy.toolName} requires approval in PostHog MCP settings.`,
+        };
+      }
+
+      const decision = await options.requestMcpToolPermission({
+        requestId: event.toolCallId,
+        serverName: policy.serverName,
+        toolName: policy.toolName,
+        installationId: policy.installationId,
+        arguments: requestedArguments(event),
+        ...(policy.description ? { description: policy.description } : {}),
+      });
+      if (decision === "reject") {
+        return {
+          block: true,
+          reason: `Permission rejected for ${policy.serverName}.${policy.toolName}.`,
+        };
+      }
+
+      policy.approvalState = "approved";
+    });
+  };
+}
+
+export default createPosthogMcpPolicyExtension();

--- a/packages/harness/src/extensions/posthog-mcp-policy/index.ts
+++ b/packages/harness/src/extensions/posthog-mcp-policy/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./extension";

--- a/packages/harness/src/extensions/registry.ts
+++ b/packages/harness/src/extensions/registry.ts
@@ -5,13 +5,16 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { HogBrandingOptions } from "./hog-branding/extension";
 import { createHogBrandingExtension } from "./hog-branding/extension";
+import type { McpConfig } from "./mcp/config";
 import { createMcpExtension } from "./mcp/extension";
 import { createPosthogProviderExtension } from "./posthog-provider/extension";
 import type { PosthogProviderOptions } from "./posthog-provider/provider";
 import { createWebAccessExtension } from "./web-access/extension";
 
 export type HarnessExtensionOptions = PosthogProviderOptions &
-  HogBrandingOptions;
+  HogBrandingOptions & {
+    runtimeMcpServers?: McpConfig["mcpServers"];
+  };
 
 interface HarnessExtension {
   name: string;
@@ -22,9 +25,11 @@ const EXTENSIONS: HarnessExtension[] = [
   { name: "hog-branding", create: createHogBrandingExtension },
   { name: "posthog-provider", create: createPosthogProviderExtension },
   { name: "web-access", create: createWebAccessExtension },
-  // createMcpExtension's options are test seams (config loader, transport
-  // factory), not HarnessExtensionOptions, so drop the registry options.
-  { name: "mcp", create: () => createMcpExtension() },
+  {
+    name: "mcp",
+    create: (options) =>
+      createMcpExtension({ runtimeServers: options.runtimeMcpServers }),
+  },
 ];
 
 export const HARNESS_EXTENSION_NAMES: readonly string[] = EXTENSIONS.map(

--- a/packages/harness/src/extensions/registry.ts
+++ b/packages/harness/src/extensions/registry.ts
@@ -7,12 +7,15 @@ import type { HogBrandingOptions } from "./hog-branding/extension";
 import { createHogBrandingExtension } from "./hog-branding/extension";
 import type { McpConfig } from "./mcp/config";
 import { createMcpExtension } from "./mcp/extension";
+import type { PosthogMcpPolicyOptions } from "./posthog-mcp-policy/extension";
+import { createPosthogMcpPolicyExtension } from "./posthog-mcp-policy/extension";
 import { createPosthogProviderExtension } from "./posthog-provider/extension";
 import type { PosthogProviderOptions } from "./posthog-provider/provider";
 import { createWebAccessExtension } from "./web-access/extension";
 
 export type HarnessExtensionOptions = PosthogProviderOptions &
-  HogBrandingOptions & {
+  HogBrandingOptions &
+  PosthogMcpPolicyOptions & {
     runtimeMcpServers?: McpConfig["mcpServers"];
   };
 
@@ -29,6 +32,10 @@ const EXTENSIONS: HarnessExtension[] = [
     name: "mcp",
     create: (options) =>
       createMcpExtension({ runtimeServers: options.runtimeMcpServers }),
+  },
+  {
+    name: "posthog-mcp-policy",
+    create: createPosthogMcpPolicyExtension,
   },
 ];
 

--- a/packages/harness/src/runtime.ts
+++ b/packages/harness/src/runtime.ts
@@ -71,6 +71,8 @@ export async function createHarnessRuntime(
     credentialStore,
     posthogOAuthCredentials,
     runtimeMcpServers: _runtimeMcpServers,
+    mcpToolPolicies: _mcpToolPolicies,
+    requestMcpToolPermission: _requestMcpToolPermission,
     ...runtimeOptions
   } = options;
   // Pi reads its application branding when the SDK is first evaluated. Keep

--- a/packages/harness/src/runtime.ts
+++ b/packages/harness/src/runtime.ts
@@ -67,8 +67,12 @@ export type HarnessRuntimeOptions = HarnessExtensionOptions & {
 export async function createHarnessRuntime(
   options: HarnessRuntimeOptions = {},
 ): Promise<AgentSessionRuntime> {
-  const { credentialStore, posthogOAuthCredentials, ...runtimeOptions } =
-    options;
+  const {
+    credentialStore,
+    posthogOAuthCredentials,
+    runtimeMcpServers: _runtimeMcpServers,
+    ...runtimeOptions
+  } = options;
   // Pi reads its application branding when the SDK is first evaluated. Keep
   // every runtime import below dynamic so this always happens first.
   installHogBrandEnv();

--- a/packages/harness/tsup.config.ts
+++ b/packages/harness/tsup.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
     "src/extensions/posthog-provider/oauth.ts",
     "src/extensions/posthog-provider/gateway.ts",
     "src/extensions/posthog-provider/gateway-auth.ts",
+    "src/extensions/posthog-mcp-policy/extension.ts",
+    "src/extensions/posthog-mcp-policy/index.ts",
     "src/extensions/background-jobs/extension.ts",
     "src/extensions/background-jobs/index.ts",
     "src/extensions/background-jobs/jobs.ts",

--- a/packages/host-router/src/pi-session-factory.ts
+++ b/packages/host-router/src/pi-session-factory.ts
@@ -44,6 +44,33 @@ class TrpcPiSession implements PiSession {
     return this.hostClient.piSession.clearQueue.mutate({ taskId: this.taskId });
   }
 
+  onMcpToolPermissionRequest(
+    onRequest: Parameters<
+      NonNullable<PiSession["onMcpToolPermissionRequest"]>
+    >[0],
+    onError: Parameters<
+      NonNullable<PiSession["onMcpToolPermissionRequest"]>
+    >[1],
+  ): () => void {
+    const subscription =
+      this.hostClient.piSession.onMcpToolPermissionRequest.subscribe(
+        { taskId: this.taskId },
+        { onData: onRequest, onError },
+      );
+    return () => subscription.unsubscribe();
+  }
+
+  respondMcpToolPermission(
+    request: Parameters<NonNullable<PiSession["respondMcpToolPermission"]>>[0],
+    decision: Parameters<NonNullable<PiSession["respondMcpToolPermission"]>>[1],
+  ): Promise<void> {
+    return this.hostClient.piSession.respondMcpToolPermission.mutate({
+      taskId: this.taskId,
+      request,
+      decision,
+    });
+  }
+
   onConversationEvent(
     onEvent: Parameters<PiSession["onConversationEvent"]>[0],
     onError: Parameters<PiSession["onConversationEvent"]>[1],

--- a/packages/host-router/src/routers/pi-session.router.ts
+++ b/packages/host-router/src/routers/pi-session.router.ts
@@ -10,6 +10,7 @@ import {
   piSessionRpcInput,
   piSessionStartOutput,
   piSessionTaskInput,
+  respondMcpToolPermissionInput,
   resumePiSessionInput,
   startPiSessionInput,
 } from "@posthog/workspace-server/services/pi-session/schemas";
@@ -63,6 +64,35 @@ export const piSessionRouter = router({
     .mutation(({ ctx, input }) =>
       getService(ctx.container).clearQueue(input.taskId),
     ),
+
+  respondMcpToolPermission: publicProcedure
+    .input(respondMcpToolPermissionInput)
+    .mutation(({ ctx, input }) =>
+      getService(ctx.container).respondMcpToolPermission(
+        input.taskId,
+        input.request,
+        input.decision,
+      ),
+    ),
+
+  onMcpToolPermissionRequest: publicProcedure
+    .input(piSessionTaskInput)
+    .subscription(async function* (opts) {
+      const service = getService(opts.ctx.container);
+      const iterable = service.toIterable("mcpPermissionRequest", {
+        signal: opts.signal,
+      });
+      for (const request of service.getPendingMcpToolPermissions(
+        opts.input.taskId,
+      )) {
+        yield request;
+      }
+      for await (const payload of iterable) {
+        if (payload.taskId === opts.input.taskId) {
+          yield payload.request;
+        }
+      }
+    }),
 
   onEvent: publicProcedure
     .input(piSessionTaskInput)

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -216,6 +216,12 @@ export type {
   LocalMcpTransport,
   McpServerConnection,
 } from "./local-mcp-domain";
+export type {
+  McpToolApprovalState,
+  McpToolPermissionDecision,
+  McpToolPermissionRequest,
+  McpToolPolicy,
+} from "./mcp-tool-policy-domain";
 export {
   formatMention,
   type MentionSegment,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -210,11 +210,11 @@ export {
 } from "./inbox-types";
 export { EXTERNAL_LINKS } from "./links";
 export type {
-  CloudMcpServerImport,
   CloudMcpServerRelayDesignation,
   LocalMcpServerDescriptor,
   LocalMcpServerScope,
   LocalMcpTransport,
+  McpServerConnection,
 } from "./local-mcp-domain";
 export {
   formatMention,

--- a/packages/shared/src/local-mcp-domain.ts
+++ b/packages/shared/src/local-mcp-domain.ts
@@ -33,7 +33,7 @@ export interface LocalMcpServerDescriptor {
  * Included in the task-run creation payload for servers classified as
  * importable.
  */
-export interface CloudMcpServerImport {
+export interface McpServerConnection {
   type: "http" | "sse";
   name: string;
   url: string;

--- a/packages/shared/src/mcp-tool-policy-domain.ts
+++ b/packages/shared/src/mcp-tool-policy-domain.ts
@@ -1,0 +1,20 @@
+export type McpToolApprovalState = "approved" | "needs_approval" | "do_not_use";
+
+export interface McpToolPolicy {
+  serverName: string;
+  toolName: string;
+  installationId: string;
+  approvalState: McpToolApprovalState;
+  description?: string;
+}
+
+export interface McpToolPermissionRequest {
+  requestId: string;
+  serverName: string;
+  toolName: string;
+  installationId: string;
+  arguments: Record<string, unknown>;
+  description?: string;
+}
+
+export type McpToolPermissionDecision = "allow" | "allow_always" | "reject";

--- a/packages/shared/src/task-creation-domain.ts
+++ b/packages/shared/src/task-creation-domain.ts
@@ -4,8 +4,8 @@ import type { CloudRunSource, PrAuthorshipMode } from "./cloud";
 import type { Task } from "./domain-types";
 import type { ExecutionMode } from "./exec-types";
 import type {
-  CloudMcpServerImport,
   CloudMcpServerRelayDesignation,
+  McpServerConnection,
 } from "./local-mcp-domain";
 import type { WorkspaceMode } from "./workspace";
 import type { Workspace } from "./workspace-domain";
@@ -88,7 +88,7 @@ export interface TaskCreationInput {
    * the cloud sandbox in the run-creation payload. Cloud-only; local sessions
    * already read the user's config directly.
    */
-  importedMcpServers?: CloudMcpServerImport[];
+  importedMcpServers?: McpServerConnection[];
   /**
    * Desktop-only local MCP servers (stdio / private URL) designated for
    * relaying into the cloud run via the creating desktop

--- a/packages/ui/src/features/pi-sessions/PiSessionView.tsx
+++ b/packages/ui/src/features/pi-sessions/PiSessionView.tsx
@@ -23,6 +23,7 @@ import type { AgentConversationEvent } from "@posthog/shared";
 import { useUsageLimitStore } from "@posthog/ui/features/billing/usageLimitStore";
 import { PromptInput } from "@posthog/ui/features/message-editor/components/PromptInput";
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
+import { PermissionSelector } from "@posthog/ui/features/permissions/PermissionSelector";
 import { CloudInitializingView } from "@posthog/ui/features/sessions/components/CloudInitializingView";
 import {
   CloudConnectionBanner,
@@ -341,6 +342,19 @@ export function PiSessionView({ taskId, taskRunId }: PiSessionViewProps) {
     return <TaskDetailSkeleton />;
   }
 
+  const mcpPermission = session.mcpToolPermissionRequests.values().next().value;
+  const respondMcpPermission = (
+    decision: "allow" | "allow_always" | "reject",
+  ) => {
+    if (!mcpPermission) {
+      return;
+    }
+    void piSessionController
+      .respondMcpToolPermission(taskId, mcpPermission, decision)
+      .catch((error) =>
+        log.error("Failed to respond to MCP permission", error),
+      );
+  };
   const controlsPending = status ? isStreaming || isBashRunning : false;
   const hasQueuedMessage =
     session.queue.steering.length + session.queue.followUp.length > 0;
@@ -391,49 +405,92 @@ export function PiSessionView({ taskId, taskRunId }: PiSessionViewProps) {
           onEdit={editQueuedMessage}
           onRemove={removeQueuedMessage}
         />
-        <PromptInput
-          sessionId={taskId}
-          taskId={taskId}
-          repoPath={repoPath}
-          placeholder="Type a message..."
-          disabled={isCompacting}
-          isLoading={controlsPending}
-          submitDisabledExternal={
-            !sessionAvailable ||
-            !status ||
-            !isOnline ||
-            hasQueuedMessage ||
-            isAuthRestoring
-          }
-          submitTooltipOverride={
-            !isOnline
-              ? "No internet connection"
-              : isAuthRestoring
-                ? "Restoring authentication"
-                : hasQueuedMessage
-                  ? "A message is already queued"
-                  : undefined
-          }
-          enableBashMode
-          enableCommands
-          modelSelector={
-            <PiSessionModelControls
-              taskId={taskId}
-              taskRunId={taskRunId}
-              session={session}
-              controller={piSessionController}
-              isOnline={isOnline}
-              onError={handleControllerError}
-            />
-          }
-          reasoningSelector={null}
-          messagingModeToggle={messagingModeToggle}
-          onToggleMessagingMode={toggleMessagingMode}
-          onPromptRecall={handlePromptRecall}
-          onSubmit={sendPrompt}
-          onBashCommand={runBashCommand}
-          onCancel={cancelPrompt}
-        />
+        {mcpPermission ? (
+          <PermissionSelector
+            toolCall={{
+              toolCallId: mcpPermission.requestId,
+              title: `The agent wants to call ${mcpPermission.toolName} (${mcpPermission.serverName})`,
+              kind: "other",
+              content: mcpPermission.description
+                ? [
+                    {
+                      type: "content",
+                      content: {
+                        type: "text",
+                        text: mcpPermission.description,
+                      },
+                    },
+                  ]
+                : [],
+              rawInput: {
+                ...mcpPermission.arguments,
+                mcpServer: mcpPermission.serverName,
+                mcpTool: mcpPermission.toolName,
+              },
+            }}
+            options={[
+              { kind: "allow_once", name: "Allow", optionId: "allow" },
+              {
+                kind: "allow_always",
+                name: "Always allow",
+                optionId: "allow_always",
+              },
+              { kind: "reject_once", name: "Reject", optionId: "reject" },
+            ]}
+            onSelect={(optionId) => {
+              if (optionId === "allow" || optionId === "allow_always") {
+                respondMcpPermission(optionId);
+                return;
+              }
+              respondMcpPermission("reject");
+            }}
+            onCancel={() => respondMcpPermission("reject")}
+          />
+        ) : (
+          <PromptInput
+            sessionId={taskId}
+            taskId={taskId}
+            repoPath={repoPath}
+            placeholder="Type a message..."
+            disabled={isCompacting}
+            isLoading={controlsPending}
+            submitDisabledExternal={
+              !sessionAvailable ||
+              !status ||
+              !isOnline ||
+              hasQueuedMessage ||
+              isAuthRestoring
+            }
+            submitTooltipOverride={
+              !isOnline
+                ? "No internet connection"
+                : isAuthRestoring
+                  ? "Restoring authentication"
+                  : hasQueuedMessage
+                    ? "A message is already queued"
+                    : undefined
+            }
+            enableBashMode
+            enableCommands
+            modelSelector={
+              <PiSessionModelControls
+                taskId={taskId}
+                taskRunId={taskRunId}
+                session={session}
+                controller={piSessionController}
+                isOnline={isOnline}
+                onError={handleControllerError}
+              />
+            }
+            reasoningSelector={null}
+            messagingModeToggle={messagingModeToggle}
+            onToggleMessagingMode={toggleMessagingMode}
+            onPromptRecall={handlePromptRecall}
+            onSubmit={sendPrompt}
+            onBashCommand={runBashCommand}
+            onCancel={cancelPrompt}
+          />
+        )}
       </Box>
     </Flex>
   );

--- a/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -87,6 +87,7 @@ import { extractCanvasInstructions } from "@posthog/ui/features/sessions/compone
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
 import {
+  collapsePiSkillInvocation,
   hasFileMentions,
   MentionChip,
   parseFileMentions,
@@ -361,9 +362,9 @@ function UserBubble({
     () => extractCustomInstructions(afterCanvasInstructions),
     [afterCanvasInstructions],
   );
-  const displayContent = customInstructions
-    ? customInstructions.stripped
-    : afterCanvasInstructions;
+  const displayContent = collapsePiSkillInvocation(
+    customInstructions ? customInstructions.stripped : afterCanvasInstructions,
+  );
   const showChannelContextTag = !!channelContext && bluebirdEnabled;
   const showCanvasInstructionsTag = !!canvasInstructions && bluebirdEnabled;
   const showHeaderChips = showChannelContextTag || showCanvasInstructionsTag;

--- a/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
@@ -20,6 +20,7 @@ import { extractCanvasInstructions } from "./canvasInstructions";
 import { extractChannelContext } from "./channelContext";
 import { extractCustomInstructions } from "./customInstructions";
 import {
+  collapsePiSkillInvocation,
   hasFileMentions,
   MentionChip,
   parseFileMentions,
@@ -92,9 +93,9 @@ export const UserMessage = memo(function UserMessage({
     () => extractCustomInstructions(afterCanvasInstructions),
     [afterCanvasInstructions],
   );
-  const displayContent = customInstructions
-    ? customInstructions.stripped
-    : afterCanvasInstructions;
+  const displayContent = collapsePiSkillInvocation(
+    customInstructions ? customInstructions.stripped : afterCanvasInstructions,
+  );
   const showChannelContextTag = !!channelContext && bluebirdEnabled;
   const showCanvasInstructionsTag = !!canvasInstructions && bluebirdEnabled;
   const openChannelContextInSplit = usePanelLayoutStore(

--- a/packages/ui/src/features/sessions/components/session-update/parseFileMentions.test.ts
+++ b/packages/ui/src/features/sessions/components/session-update/parseFileMentions.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { collapsePiSkillInvocation } from "./parseFileMentions";
+
+describe("collapsePiSkillInvocation", () => {
+  it("replaces Pi skill instructions with the command and user request", () => {
+    expect(
+      collapsePiSkillInvocation(
+        '<skill name="code-review" location="/skills/code-review/SKILL.md">\nReferences are relative to /skills/code-review.\n\n# Review\n\nInspect the diff.\n</skill>\n\nReview this pull request.',
+      ),
+    ).toBe("/code-review\n\nReview this pull request.");
+  });
+
+  it("keeps non-skill messages unchanged", () => {
+    expect(collapsePiSkillInvocation("Review this pull request.")).toBe(
+      "Review this pull request.",
+    );
+  });
+});

--- a/packages/ui/src/features/sessions/components/session-update/parseFileMentions.tsx
+++ b/packages/ui/src/features/sessions/components/session-update/parseFileMentions.tsx
@@ -16,6 +16,19 @@ const MENTION_TAG_REGEX =
 const MENTION_TAG_TEST =
   /<(?:file\s+path|folder\s+path|github_issue\s+number|github_pr\s+number|error_context\s+label)="[^"]+"/;
 const SLASH_COMMAND_START = /^\/([a-zA-Z][\w-]*)(?=\s|$)/;
+const PI_SKILL_INVOCATION =
+  /^<skill name="([^"]+)" location="[^"]+">\n[\s\S]*?\n<\/skill>(?:\n\n([\s\S]+))?$/;
+
+export function collapsePiSkillInvocation(content: string): string {
+  const match = content.match(PI_SKILL_INVOCATION);
+  if (!match) {
+    return content;
+  }
+
+  const name = unescapeXmlAttr(match[1]);
+  const userMessage = match[2]?.trim();
+  return userMessage ? `/${name}\n\n${userMessage}` : `/${name}`;
+}
 
 const inlineComponents: Components = {
   ...baseComponents,

--- a/packages/workspace-server/src/services/agent/agent.module.ts
+++ b/packages/workspace-server/src/services/agent/agent.module.ts
@@ -5,10 +5,12 @@ import {
   AGENT_AUTH_ADAPTER,
   AGENT_SERVICE,
   MCP_SERVER_CONNECTION_SOURCE,
+  MCP_TOOL_POLICY_UPDATER,
 } from "./identifiers";
 
 export const agentModule = new ContainerModule(({ bind }) => {
   bind(AGENT_SERVICE).to(AgentService).inSingletonScope();
   bind(AGENT_AUTH_ADAPTER).to(AgentAuthAdapter).inSingletonScope();
   bind(MCP_SERVER_CONNECTION_SOURCE).toService(AGENT_AUTH_ADAPTER);
+  bind(MCP_TOOL_POLICY_UPDATER).toService(AGENT_AUTH_ADAPTER);
 });

--- a/packages/workspace-server/src/services/agent/agent.module.ts
+++ b/packages/workspace-server/src/services/agent/agent.module.ts
@@ -1,9 +1,14 @@
 import { ContainerModule } from "inversify";
 import { AgentService } from "./agent";
 import { AgentAuthAdapter } from "./auth-adapter";
-import { AGENT_AUTH_ADAPTER, AGENT_SERVICE } from "./identifiers";
+import {
+  AGENT_AUTH_ADAPTER,
+  AGENT_SERVICE,
+  MCP_SERVER_CONNECTION_SOURCE,
+} from "./identifiers";
 
 export const agentModule = new ContainerModule(({ bind }) => {
   bind(AGENT_SERVICE).to(AgentService).inSingletonScope();
   bind(AGENT_AUTH_ADAPTER).to(AgentAuthAdapter).inSingletonScope();
+  bind(MCP_SERVER_CONNECTION_SOURCE).toService(AGENT_AUTH_ADAPTER);
 });

--- a/packages/workspace-server/src/services/agent/agent.ts
+++ b/packages/workspace-server/src/services/agent/agent.ts
@@ -69,6 +69,7 @@ import {
   type CloudRegion,
   type ExecutionMode,
   isAuthError,
+  type McpServerConnection,
   resolveCloudInitialPermissionMode,
   serializeError,
   TypedEventEmitter,
@@ -1318,13 +1319,10 @@ If a repository IS genuinely required, attach one in this priority order:
     return `You are resuming a previous conversation after the native session could not be restored. Here is the conversation history from the previous session:\n\n${history}\n\nContinue from where you left off when responding to the user's next message.`;
   }
 
-  private async filterReachableMcpServers<
-    T extends {
-      name: string;
-      url: string;
-      headers: Array<{ name: string; value: string }>;
-    },
-  >(servers: T[], taskRunId: string): Promise<T[]> {
+  private async filterReachableMcpServers<T extends McpServerConnection>(
+    servers: T[],
+    taskRunId: string,
+  ): Promise<T[]> {
     const probed = await Promise.all(
       servers.map(async (server) => ({
         server,
@@ -1345,10 +1343,9 @@ If a repository IS genuinely required, attach one in this priority order:
     return reachable;
   }
 
-  private async isMcpServerReachable(server: {
-    url: string;
-    headers: Array<{ name: string; value: string }>;
-  }): Promise<boolean> {
+  private async isMcpServerReachable(
+    server: Pick<McpServerConnection, "url" | "headers">,
+  ): Promise<boolean> {
     const PROBE_TIMEOUT_MS = 2_000;
     try {
       const headers: Record<string, string> = {

--- a/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -4,6 +4,7 @@ import {
   sanitizeMcpServerName,
 } from "@posthog/agent/adapters/claude/mcp/tool-metadata";
 import { getLlmGatewayUrl } from "@posthog/agent/posthog-api";
+import type { McpServerConnection } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import type { AuthProxyService } from "../auth-proxy/auth-proxy";
 import { AUTH_PROXY_SERVICE } from "../auth-proxy/identifiers";
@@ -20,13 +21,6 @@ const VALID_APPROVAL_STATES = new Set([
 ]);
 function isValidApprovalState(value: string): value is McpToolApprovalState {
   return VALID_APPROVAL_STATES.has(value);
-}
-
-export interface AcpMcpServer {
-  name: string;
-  type: "http";
-  url: string;
-  headers: Array<{ name: string; value: string }>;
 }
 
 export interface AgentPosthogConfig {
@@ -90,12 +84,21 @@ export class AgentAuthAdapter {
     return projectId === null ? null : { apiHost, projectId };
   }
 
+  async getMcpServerConnections(): Promise<McpServerConnection[]> {
+    const credentials = await this.getCurrentCredentials();
+    if (!credentials) {
+      return [];
+    }
+
+    return (await this.buildMcpServers(credentials)).servers;
+  }
+
   async buildMcpServers(credentials: Credentials): Promise<{
-    servers: AcpMcpServer[];
+    servers: McpServerConnection[];
     toolApprovals: McpToolApprovals;
     toolInstallations: McpToolInstallations;
   }> {
-    const servers: AcpMcpServer[] = [];
+    const servers: McpServerConnection[] = [];
     const mcpUrl = this.getPostHogMcpUrl(credentials.apiHost);
     // Warm the token so authenticatedFetch() has something cached, but do not
     // bake it into the MCP config — the proxy injects a fresh one on every

--- a/packages/workspace-server/src/services/agent/auth-adapter.ts
+++ b/packages/workspace-server/src/services/agent/auth-adapter.ts
@@ -4,7 +4,7 @@ import {
   sanitizeMcpServerName,
 } from "@posthog/agent/adapters/claude/mcp/tool-metadata";
 import { getLlmGatewayUrl } from "@posthog/agent/posthog-api";
-import type { McpServerConnection } from "@posthog/shared";
+import type { McpServerConnection, McpToolPolicy } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import type { AuthProxyService } from "../auth-proxy/auth-proxy";
 import { AUTH_PROXY_SERVICE } from "../auth-proxy/identifiers";
@@ -84,19 +84,32 @@ export class AgentAuthAdapter {
     return projectId === null ? null : { apiHost, projectId };
   }
 
-  async getMcpServerConnections(): Promise<McpServerConnection[]> {
+  async getMcpRuntimeConfiguration(): Promise<{
+    servers: McpServerConnection[];
+    policies: McpToolPolicy[];
+  }> {
     const credentials = await this.getCurrentCredentials();
     if (!credentials) {
-      return [];
+      return { servers: [], policies: [] };
     }
 
-    return (await this.buildMcpServers(credentials)).servers;
+    const configuration = await this.buildMcpServers(credentials, {
+      refreshTools: true,
+    });
+    return {
+      servers: configuration.servers,
+      policies: configuration.toolPolicies,
+    };
   }
 
-  async buildMcpServers(credentials: Credentials): Promise<{
+  async buildMcpServers(
+    credentials: Credentials,
+    options: { refreshTools?: boolean } = {},
+  ): Promise<{
     servers: McpServerConnection[];
     toolApprovals: McpToolApprovals;
     toolInstallations: McpToolInstallations;
+    toolPolicies: McpToolPolicy[];
   }> {
     const servers: McpServerConnection[] = [];
     const mcpUrl = this.getPostHogMcpUrl(credentials.apiHost);
@@ -142,10 +155,17 @@ export class AgentAuthAdapter {
       });
     }
 
-    const { approvals: toolApprovals, toolInstallations } =
-      await this.fetchMcpToolApprovals(credentials, installations);
+    const {
+      approvals: toolApprovals,
+      toolInstallations,
+      policies: toolPolicies,
+    } = await this.fetchMcpToolApprovals(
+      credentials,
+      installations,
+      options.refreshTools ?? false,
+    );
 
-    return { servers, toolApprovals, toolInstallations };
+    return { servers, toolApprovals, toolInstallations, toolPolicies };
   }
 
   async ensureGatewayProxy(apiHost: string): Promise<string> {
@@ -225,6 +245,22 @@ export class AgentAuthAdapter {
     return host.endsWith("/") ? host.slice(0, -1) : host;
   }
 
+  async approveMcpTool(
+    installationId: string,
+    toolName: string,
+  ): Promise<void> {
+    const credentials = await this.getCurrentCredentials();
+    if (!credentials) {
+      throw new Error("PostHog authentication is required");
+    }
+    await this.updateMcpToolApproval(
+      credentials,
+      installationId,
+      toolName,
+      "approved",
+    );
+  }
+
   async updateMcpToolApproval(
     credentials: Credentials,
     installationId: string,
@@ -253,13 +289,16 @@ export class AgentAuthAdapter {
       name: string;
       display_name: string;
     }>,
+    refreshTools: boolean,
   ): Promise<{
     approvals: McpToolApprovals;
     toolInstallations: McpToolInstallations;
+    policies: McpToolPolicy[];
   }> {
     const baseUrl = this.getPostHogApiBaseUrl(credentials.apiHost);
     const approvals: McpToolApprovals = {};
     const toolInstallations: McpToolInstallations = {};
+    const policies: McpToolPolicy[] = [];
 
     const results = await Promise.allSettled(
       installations.map(async (installation) => {
@@ -267,18 +306,30 @@ export class AgentAuthAdapter {
           installation.name || installation.display_name || installation.url,
         );
         const toolsUrl = `${baseUrl}/api/environments/${credentials.projectId}/mcp_server_installations/${installation.id}/tools/`;
+        const refreshUrl = `${toolsUrl}refresh/`;
 
-        const response = await this.authService.authenticatedFetch(
+        let response = await this.authService.authenticatedFetch(
           fetch,
-          toolsUrl,
-          { headers: { "Content-Type": "application/json" } },
+          refreshTools ? refreshUrl : toolsUrl,
+          {
+            method: refreshTools ? "POST" : "GET",
+            headers: { "Content-Type": "application/json" },
+          },
         );
+        if (!response.ok && refreshTools) {
+          response = await this.authService.authenticatedFetch(
+            fetch,
+            toolsUrl,
+            { headers: { "Content-Type": "application/json" } },
+          );
+        }
         if (!response.ok) return [];
 
         const data = (await response.json()) as {
           results?: Array<{
             tool_name: string;
             approval_state?: string;
+            description?: string;
           }>;
         };
         return (data.results ?? []).map((tool) => ({
@@ -286,6 +337,7 @@ export class AgentAuthAdapter {
           installationId: installation.id,
           toolName: tool.tool_name,
           approvalState: tool.approval_state,
+          description: tool.description,
         }));
       }),
     );
@@ -309,10 +361,19 @@ export class AgentAuthAdapter {
           installationId: tool.installationId,
           toolName: tool.toolName,
         };
+        if (tool.approvalState && isValidApprovalState(tool.approvalState)) {
+          policies.push({
+            serverName: tool.serverName,
+            toolName: tool.toolName,
+            installationId: tool.installationId,
+            approvalState: tool.approvalState,
+            ...(tool.description ? { description: tool.description } : {}),
+          });
+        }
       }
     }
 
-    return { approvals, toolInstallations };
+    return { approvals, toolInstallations, policies };
   }
 
   private async fetchMcpInstallations(credentials: Credentials): Promise<

--- a/packages/workspace-server/src/services/agent/identifiers.ts
+++ b/packages/workspace-server/src/services/agent/identifiers.ts
@@ -3,6 +3,9 @@ export const AGENT_AUTH_ADAPTER = Symbol.for(
   "posthog.workspace.agentAuthAdapter",
 );
 export const AGENT_LOGGER = Symbol.for("posthog.workspace.agentLogger");
+export const MCP_SERVER_CONNECTION_SOURCE = Symbol.for(
+  "posthog.workspace.mcpServerConnectionSource",
+);
 export const AGENT_SLEEP_COORDINATOR = Symbol.for(
   "posthog.workspace.agentSleepCoordinator",
 );

--- a/packages/workspace-server/src/services/agent/identifiers.ts
+++ b/packages/workspace-server/src/services/agent/identifiers.ts
@@ -6,6 +6,9 @@ export const AGENT_LOGGER = Symbol.for("posthog.workspace.agentLogger");
 export const MCP_SERVER_CONNECTION_SOURCE = Symbol.for(
   "posthog.workspace.mcpServerConnectionSource",
 );
+export const MCP_TOOL_POLICY_UPDATER = Symbol.for(
+  "posthog.workspace.mcpToolPolicyUpdater",
+);
 export const AGENT_SLEEP_COORDINATOR = Symbol.for(
   "posthog.workspace.agentSleepCoordinator",
 );

--- a/packages/workspace-server/src/services/agent/ports.ts
+++ b/packages/workspace-server/src/services/agent/ports.ts
@@ -1,4 +1,8 @@
-import type { CloudRegion, McpServerConnection } from "@posthog/shared";
+import type {
+  CloudRegion,
+  McpServerConnection,
+  McpToolPolicy,
+} from "@posthog/shared";
 
 // Narrow ports inverting AgentService's dependencies on core/host services so it
 // can live in workspace-server without importing @posthog/core or apps/code.
@@ -21,8 +25,15 @@ export interface AgentSleepCoordinator {
   release(activityId: string): void;
 }
 
+export interface McpToolPolicyUpdater {
+  approveMcpTool(installationId: string, toolName: string): Promise<void>;
+}
+
 export interface McpServerConnectionSource {
-  getMcpServerConnections(): Promise<McpServerConnection[]>;
+  getMcpRuntimeConfiguration(): Promise<{
+    servers: McpServerConnection[];
+    policies: McpToolPolicy[];
+  }>;
 }
 
 export interface AgentMcpServerConnectionConfig {

--- a/packages/workspace-server/src/services/agent/ports.ts
+++ b/packages/workspace-server/src/services/agent/ports.ts
@@ -1,4 +1,4 @@
-import type { CloudRegion } from "@posthog/shared";
+import type { CloudRegion, McpServerConnection } from "@posthog/shared";
 
 // Narrow ports inverting AgentService's dependencies on core/host services so it
 // can live in workspace-server without importing @posthog/core or apps/code.
@@ -19,6 +19,10 @@ export interface AgentLogger {
 export interface AgentSleepCoordinator {
   acquire(activityId: string): void;
   release(activityId: string): void;
+}
+
+export interface McpServerConnectionSource {
+  getMcpServerConnections(): Promise<McpServerConnection[]>;
 }
 
 export interface AgentMcpServerConnectionConfig {

--- a/packages/workspace-server/src/services/pi-session/identifiers.ts
+++ b/packages/workspace-server/src/services/pi-session/identifiers.ts
@@ -6,7 +6,9 @@ import type { PiRuntime } from "@posthog/agent/pi/runtime";
 
 export interface PiRpcClientFactory {
   create(
-    input: Pick<PiRpcClientOptions, "cwd" | "model" | "sessionFile">,
+    input: Pick<PiRpcClientOptions, "cwd" | "model" | "sessionFile"> & {
+      taskId: string;
+    },
   ): Promise<PiRpcClient>;
 }
 
@@ -16,6 +18,7 @@ export const PI_RPC_CLIENT_FACTORY = Symbol.for(
 
 export interface PiRuntimeFactory {
   create(input: {
+    taskId: string;
     cwd: string;
     model?: string;
     sessionFile?: string;

--- a/packages/workspace-server/src/services/pi-session/pi-session.test.ts
+++ b/packages/workspace-server/src/services/pi-session/pi-session.test.ts
@@ -161,6 +161,7 @@ describe("PiSessionService task session config", () => {
       {} as PiRuntimeFactory,
       {} as ITaskMetadataRepository,
       {} as ProcessTrackingService,
+      { approveMcpTool: vi.fn() },
       rootLogger,
     );
 
@@ -187,6 +188,8 @@ describe("PiSessionService start", () => {
       }),
       setThinkingLevel,
       prompt,
+      onMcpToolPermissionRequest: vi.fn(),
+      respondMcpToolPermission: vi.fn(),
     } as unknown as PiRpcClient;
     const runtimeFactory = {
       create: vi.fn(async () => ({
@@ -203,10 +206,12 @@ describe("PiSessionService start", () => {
       register: vi.fn(),
       unregister: vi.fn(),
     } as unknown as ProcessTrackingService;
+    const mcpToolPolicyUpdater = { approveMcpTool: vi.fn() };
     const service = new PiSessionService(
       runtimeFactory,
       taskMetadataRepository,
       processTracking,
+      mcpToolPolicyUpdater,
       rootLogger,
     );
 
@@ -220,6 +225,29 @@ describe("PiSessionService start", () => {
     expect(setThinkingLevel).toHaveBeenCalledWith("high");
     expect(setThinkingLevel.mock.invocationCallOrder[0]).toBeLessThan(
       prompt.mock.invocationCallOrder[0],
+    );
+
+    const request = {
+      requestId: "call-1",
+      serverName: "Cloudflare",
+      toolName: "search",
+      installationId: "installation-1",
+      arguments: { query: "workers" },
+    };
+    const onRequest = (
+      client.onMcpToolPermissionRequest as ReturnType<typeof vi.fn>
+    ).mock.calls[0]?.[0];
+    onRequest(request);
+    expect(service.getPendingMcpToolPermissions("task-1")).toEqual([request]);
+    await service.respondMcpToolPermission("task-1", request, "allow");
+
+    expect(mcpToolPolicyUpdater.approveMcpTool).toHaveBeenCalledWith(
+      "installation-1",
+      "search",
+    );
+    expect(client.respondMcpToolPermission).toHaveBeenCalledWith(
+      "call-1",
+      "allow",
     );
   });
 });
@@ -248,6 +276,7 @@ describe("PiSessionService RPC request pinning", () => {
             requestResolvers.push(resolve);
           }),
       ),
+      onMcpToolPermissionRequest: vi.fn(),
       getQueue: vi.fn(
         () =>
           new Promise<{ steering: string[]; followUp: string[] }>((resolve) => {
@@ -263,6 +292,7 @@ describe("PiSessionService RPC request pinning", () => {
         sessionFile: "/tmp/second.jsonl",
       }),
       send: vi.fn(),
+      onMcpToolPermissionRequest: vi.fn(),
     } as unknown as PiRpcClient;
     const thirdClient = {
       start: vi.fn().mockResolvedValue(undefined),
@@ -272,6 +302,7 @@ describe("PiSessionService RPC request pinning", () => {
         sessionFile: "/tmp/third.jsonl",
       }),
       send: vi.fn(),
+      onMcpToolPermissionRequest: vi.fn(),
     } as unknown as PiRpcClient;
     const clients = [firstClient, secondClient, thirdClient];
     const runtimeFactory = {
@@ -306,6 +337,7 @@ describe("PiSessionService RPC request pinning", () => {
       runtimeFactory,
       taskMetadataRepository,
       processTracking,
+      { approveMcpTool: vi.fn() },
       rootLogger,
     );
 

--- a/packages/workspace-server/src/services/pi-session/pi-session.ts
+++ b/packages/workspace-server/src/services/pi-session/pi-session.ts
@@ -16,12 +16,16 @@ import {
 import { ROOT_LOGGER, type RootLogger } from "@posthog/di/logger";
 import {
   type AgentConversationEvent,
+  type McpToolPermissionDecision,
+  type McpToolPermissionRequest,
   type PiRuntimeHealth,
   TypedEventEmitter,
 } from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import { TASK_METADATA_REPOSITORY } from "../../db/identifiers";
 import type { ITaskMetadataRepository } from "../../db/repositories/task-metadata-repository";
+import { MCP_TOOL_POLICY_UPDATER } from "../agent/identifiers";
+import type { McpToolPolicyUpdater } from "../agent/ports";
 import { PROCESS_TRACKING_SERVICE } from "../process-tracking/identifiers";
 import type { ProcessTrackingService } from "../process-tracking/process-tracking";
 import { PI_RUNTIME_FACTORY, type PiRuntimeFactory } from "./identifiers";
@@ -56,10 +60,15 @@ type PiSessionEvent = Parameters<Parameters<PiRpcClient["onEvent"]>[0]>[0];
 
 interface PiSessionEvents {
   event: { taskId: string; event: AgentConversationEvent };
+  mcpPermissionRequest: {
+    taskId: string;
+    request: McpToolPermissionRequest;
+  };
 }
 
 interface ManagedPiSession {
   client: PiRpcClient;
+  pendingMcpPermissions: Map<string, McpToolPermissionRequest>;
   runtime: PiRuntime;
   state: PiPoolSessionState;
   lastUsedAt: number;
@@ -97,6 +106,8 @@ export class PiSessionService extends TypedEventEmitter<PiSessionEvents> {
     private readonly taskMetadataRepository: ITaskMetadataRepository,
     @inject(PROCESS_TRACKING_SERVICE)
     private readonly processTracking: ProcessTrackingService,
+    @inject(MCP_TOOL_POLICY_UPDATER)
+    private readonly mcpToolPolicyUpdater: McpToolPolicyUpdater,
     @inject(ROOT_LOGGER) rootLogger: RootLogger,
   ) {
     super();
@@ -115,6 +126,7 @@ export class PiSessionService extends TypedEventEmitter<PiSessionEvents> {
     await this.stopLocked(input.taskId);
 
     const runtime = await this.runtimeFactory.create({
+      taskId: input.taskId,
       cwd: input.cwd,
       model: input.model,
     });
@@ -172,6 +184,7 @@ export class PiSessionService extends TypedEventEmitter<PiSessionEvents> {
     await this.stopLocked(input.taskId);
 
     const runtime = await this.runtimeFactory.create({
+      taskId: input.taskId,
       cwd: input.cwd,
       sessionFile,
     });
@@ -196,6 +209,30 @@ export class PiSessionService extends TypedEventEmitter<PiSessionEvents> {
 
       return response;
     });
+  }
+
+  getPendingMcpToolPermissions(taskId: string): McpToolPermissionRequest[] {
+    return [...this.requireSession(taskId).pendingMcpPermissions.values()];
+  }
+
+  async respondMcpToolPermission(
+    taskId: string,
+    request: McpToolPermissionRequest,
+    decision: McpToolPermissionDecision,
+  ): Promise<void> {
+    const session = this.requireSession(taskId);
+    const pending = session.pendingMcpPermissions.get(request.requestId);
+    if (!pending) {
+      throw new Error(`No pending MCP permission ${request.requestId}`);
+    }
+    if (decision === "allow" || decision === "allow_always") {
+      await this.mcpToolPolicyUpdater.approveMcpTool(
+        pending.installationId,
+        pending.toolName,
+      );
+    }
+    session.pendingMcpPermissions.delete(request.requestId);
+    session.client.respondMcpToolPermission(request.requestId, decision);
   }
 
   getQueue(taskId: string): Promise<PiQueueSnapshot> {
@@ -356,8 +393,15 @@ export class PiSessionService extends TypedEventEmitter<PiSessionEvents> {
     taskId: string,
     runtime: PiRuntime,
   ): ManagedPiSession {
+    const pendingMcpPermissions = new Map<string, McpToolPermissionRequest>();
+    runtime.client.onMcpToolPermissionRequest((request) => {
+      pendingMcpPermissions.set(request.requestId, request);
+      this.emit("mcpPermissionRequest", { taskId, request });
+    });
+
     const session: ManagedPiSession = {
       client: runtime.client,
+      pendingMcpPermissions,
       runtime,
       state: "starting",
       lastUsedAt: Date.now(),

--- a/packages/workspace-server/src/services/pi-session/schemas.ts
+++ b/packages/workspace-server/src/services/pi-session/schemas.ts
@@ -36,6 +36,21 @@ export const resumePiSessionInput = z.object({
 
 export const piSessionTaskInput = z.object({ taskId: z.string() });
 
+export const mcpToolPermissionRequestSchema = z.object({
+  requestId: z.string(),
+  serverName: z.string(),
+  toolName: z.string(),
+  installationId: z.string(),
+  arguments: z.record(z.string(), z.unknown()),
+  description: z.string().optional(),
+});
+
+export const respondMcpToolPermissionInput = z.object({
+  taskId: z.string(),
+  request: mcpToolPermissionRequestSchema,
+  decision: z.enum(["allow", "allow_always", "reject"]),
+});
+
 export const piSessionConfigInput = z.object({ downloadUrl: z.url() });
 
 export const piSessionConfigOutput = z


### PR DESCRIPTION
## Summary
- load runtime MCP server configuration into Pi sessions
- enforce per-tool MCP approval policies and relay approval requests to the Pi session UI
- render expanded Pi skill invocations as compact command chips in the conversation

## Testing
- `pnpm typecheck`
- `pnpm --filter @posthog/agent test --run src/pi/rpc-client.test.ts`
- `pnpm --filter @posthog/core test --run src/pi-runtime/piSessionController.test.ts`
- `pnpm --filter @posthog/harness test --run src/extensions/posthog-mcp-policy/extension.test.ts`
- `pnpm --filter @posthog/workspace-server test --run src/services/pi-session/pi-session.test.ts`
- `pnpm --filter @posthog/ui test --run src/features/sessions/components/session-update/parseFileMentions.test.ts src/features/pi-sessions/PiQueuedMessagesDock.test.tsx`