### PR TITLE
docs: replace readme header with monorepo migration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 > [!IMPORTANT]
-> Interested in the PostHog desktop app? [Join the waitlist](https://posthog.com/code) or hop into our [Discord](https://discord.gg/aSrHKVNVdR).
-
-**[Download the latest version](https://github.com/PostHog/code/releases/latest)**
-
-Found a bug or have feedback? [Open an issue](https://github.com/PostHog/code/issues/new) on GitHub.
+> This repository has migrated to the [PostHog monorepo](https://github.com/PostHog/posthog/tree/master/products/desktop). Development, issues and pull requests now live there.
 
 # PostHog
 


### PR DESCRIPTION
## Problem

The repo has been imported into the PostHog monorepo (PostHog/posthog#72483), but the README still opens with the waitlist, Discord, download and issue links, which point people at a repo that's no longer where development happens.

## Changes

Replaced that header block with a single `> [!IMPORTANT]` alert saying the repo migrated to the monorepo, linking to `products/desktop/` in PostHog/posthog.

## How did you test this?

Markdown-only change, previewed the rendered alert. No code paths touched.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
